### PR TITLE
fix(security): P0 hardening — Tauri CSP, dev-host, version sync, vendor-fork guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,11 @@ jobs:
       - name: pnpm audit (high + critical)
         run: pnpm audit --audit-level=high
 
+      # QNBS-v3: vendored y-webrtc fork has no upstream updater — assert its C-1 crypto
+      # patches (PBKDF2 600k, extractable=false, return-on-reject) haven't regressed (issue #60).
+      - name: Verify vendored collab-transport fork
+        run: pnpm run verify:vendor
+
       # QNBS-v3: osv-scanner.toml (in src-tauri/) suppresses accepted RUSTSEC advisories for Cargo.lock;
       # scan both lockfiles so npm + Rust advisories are caught on every push
       - name: OSV vulnerability scan

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "i18n:bundle": "node scripts/build-i18n.mjs",
     "i18n:check": "node scripts/check-i18n-keys.mjs && node scripts/build-i18n.mjs && node scripts/content-guard.mjs",
     "content:guard": "node scripts/content-guard.mjs",
+    "verify:vendor": "node scripts/verify-vendor-fork.mjs",
     "parity:check": "tsx scripts/audit-feature-parity.ts",
     "graphify": "node scripts/graphify-cli.mjs",
     "graphify:install": "node scripts/graphify-cli.mjs install",

--- a/packages/collab-transport/VENDOR-DIFF.md
+++ b/packages/collab-transport/VENDOR-DIFF.md
@@ -1,0 +1,41 @@
+# Vendor Fork Baseline — `@domain/collab-transport`
+
+This package is a **vendored fork** of `y-webrtc`. Renovate/Dependabot cannot
+update it automatically, so its security deltas are tracked here and enforced by
+[`scripts/verify-vendor-fork.mjs`](../../scripts/verify-vendor-fork.mjs) in CI.
+
+Audit log & checklist: [issue #60](https://github.com/qnbs/StoryCraft-Studio/issues/60).
+
+## Baseline
+
+| Field | Value |
+|-------|-------|
+| Upstream | [`y-webrtc` v10.3.0](https://github.com/yjs/y-webrtc) (npm tag `v10.3.0`) |
+| Vendored package | `@domain/collab-transport` **`10.3.0-sc1`** |
+| Vendored on | 2026-05-28 (commit `63afa69`) |
+| Patched files | `src/crypto.js`, `src/y-webrtc.js` |
+
+The `-sc1` suffix marks the first StoryCraft patch revision on top of upstream
+`10.3.0`. On any new upstream release, diff `crypto.js` + `y-webrtc.js` against the
+new tag, cherry-pick fixes, re-apply the C-1 patches below, and bump to
+`<upstream>-sc1`.
+
+## C-1 security patches (vs upstream `crypto.js`)
+
+These are the **only** intentional security deviations from upstream. Each is
+asserted by `verify-vendor-fork.mjs`; a regression fails CI.
+
+| # | Patch | Location | Rationale |
+|---|-------|----------|-----------|
+| 1 | PBKDF2 iterations `100000` → `600000` | `crypto.js` `deriveKey` (`iterations: 600000`) | OWASP 2024 minimum for PBKDF2-SHA-256. |
+| 2 | Derived AES-GCM key `extractable: false` | `crypto.js` `deriveKey` (4th arg after `{name:'AES-GCM',length:256}`) | Prevents key export via `crypto.subtle.exportKey` (SEC-RULE-5). |
+| 3 | `return` before `promise.reject(...)` on unknown algorithm | `crypto.js` `decrypt()` | Upstream swallowed the rejection silently; the `return` makes `decrypt()` actually abort on a tampered/unknown algorithm header. |
+
+## Maintenance
+
+1. Pull the new upstream tag and `diff` it against `src/crypto.js` + `src/y-webrtc.js`.
+2. Re-apply patches 1–3; verify all imports referenced by `y-webrtc.js` exist under `src/`
+   (missing relative imports break Vercel builds — `UNRESOLVED_IMPORT`).
+3. Bump `package.json` `version` to `<upstream>-sc1` and update the **Baseline** table.
+4. Update `EXPECTED_VERSION` in `scripts/verify-vendor-fork.mjs`.
+5. Run `pnpm run verify:vendor` and `pnpm exec vitest run tests/unit/collaborationService.test.ts`.

--- a/scripts/sync-sw-version.mjs
+++ b/scripts/sync-sw-version.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 /**
- * Keeps `public/sw.js` APP_VERSION in sync with root package.json (single source of truth).
- * Run via predev/prebuild — idempotent if already aligned.
+ * Keeps `public/sw.js` APP_VERSION and `src-tauri/tauri.conf.json` version in sync
+ * with root package.json (single source of truth). Run via predev/prebuild —
+ * idempotent if already aligned.
  */
 import { readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
@@ -10,6 +11,8 @@ import { fileURLToPath } from 'node:url';
 const root = join(dirname(fileURLToPath(import.meta.url)), '..');
 const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
 const version = typeof pkg.version === 'string' ? pkg.version : '0.0.0';
+
+// QNBS-v3: sync service-worker APP_VERSION so PWA cache busts on every release.
 const swPath = join(root, 'public', 'sw.js');
 const sw = readFileSync(swPath, 'utf8');
 const next = sw.replace(
@@ -19,4 +22,14 @@ const next = sw.replace(
 if (next !== sw) {
   writeFileSync(swPath, next);
   process.stdout.write(`[sync-sw-version] public/sw.js → APP_VERSION = ${version}\n`);
+}
+
+// QNBS-v3: keep Tauri bundle version aligned with package.json — drift shipped wrong
+// desktop version metadata (1.17.0 vs 1.19.0). Same idempotent auto-fix as sw.js.
+const tauriConfPath = join(root, 'src-tauri', 'tauri.conf.json');
+const tauriConf = readFileSync(tauriConfPath, 'utf8');
+const nextTauri = tauriConf.replace(/"version":\s*"[^"]*"/, `"version": "${version}"`);
+if (nextTauri !== tauriConf) {
+  writeFileSync(tauriConfPath, nextTauri);
+  process.stdout.write(`[sync-sw-version] src-tauri/tauri.conf.json → version = ${version}\n`);
 }

--- a/scripts/verify-vendor-fork.mjs
+++ b/scripts/verify-vendor-fork.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * Static invariant guard for the vendored y-webrtc fork (@domain/collab-transport).
+ *
+ * Renovate/Dependabot cannot update this fork, so the C-1 security patches in
+ * crypto.js have no upstream owner. This script fails CI if any of those patches
+ * silently regress, or if the vendored version drifts from the documented baseline.
+ * It performs NO network access — purely a source-level assertion (issue #60).
+ *
+ * Run via `pnpm run verify:vendor` and in the CI security job.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const pkgDir = join(root, 'packages', 'collab-transport');
+const cryptoPath = join(pkgDir, 'src', 'crypto.js');
+const pkgPath = join(pkgDir, 'package.json');
+
+const EXPECTED_VERSION = '10.3.0-sc1';
+
+const crypto = readFileSync(cryptoPath, 'utf8');
+const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+
+/** @type {{ name: string, ok: boolean, detail: string }[]} */
+const checks = [];
+const assert = (name, ok, detail) => checks.push({ name, ok, detail });
+
+// C-1 patch 1 — PBKDF2 iterations at the OWASP 2024 SHA-256 minimum.
+assert(
+  'PBKDF2 iterations = 600000',
+  /iterations:\s*600000\b/.test(crypto),
+  'crypto.js deriveKey must use 600000 iterations (OWASP 2024 minimum)',
+);
+
+// C-1 patch 2 — derived AES-GCM key is non-extractable (extractable=false is the
+// 4th positional arg to deriveKey, immediately after the {name:'AES-GCM',length:256} block).
+assert(
+  'derived key extractable = false',
+  /length:\s*256\s*\}\s*,\s*false\s*,/.test(crypto),
+  'crypto.js deriveKey must pass extractable=false for the AES-GCM key',
+);
+
+// C-1 patch 3 — unknown-algorithm path returns the rejection (no silent swallow).
+assert(
+  'decrypt rejects unknown algorithm',
+  /return\s+promise\.reject\(/.test(crypto),
+  'crypto.js decrypt() must `return` promise.reject on unknown algorithm',
+);
+
+// Version baseline — keeps the fork pinned to the audited upstream tag.
+assert(
+  `version = ${EXPECTED_VERSION}`,
+  pkg.version === EXPECTED_VERSION,
+  `package.json version must be ${EXPECTED_VERSION} (got ${pkg.version})`,
+);
+
+let failed = false;
+for (const c of checks) {
+  if (c.ok) {
+    process.stdout.write(`  ok   ${c.name}\n`);
+  } else {
+    failed = true;
+    process.stdout.write(`  FAIL ${c.name}\n        → ${c.detail}\n`);
+  }
+}
+
+if (failed) {
+  process.stderr.write(
+    '\n[verify-vendor-fork] vendored y-webrtc fork drifted from its security baseline.\n' +
+      'Re-apply the C-1 patches and update VENDOR-DIFF.md. See issue #60.\n',
+  );
+  process.exit(1);
+}
+
+process.stdout.write('[verify-vendor-fork] all invariants hold.\n');

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "StoryCraft Studio",
-  "version": "1.17.0",
+  "version": "1.19.0",
   "identifier": "com.storycraft.studio",
   "build": {
     "frontendDist": "../dist",
@@ -23,7 +23,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; connect-src 'self' https://generativelanguage.googleapis.com https://api.openai.com https://api.x.ai http://localhost:11434 http://127.0.0.1:11434 http://localhost:1234 http://127.0.0.1:1234 http://localhost:8000 http://127.0.0.1:8000 https://openrouter.ai https://api.openrouter.ai https://api.groq.com wss://y-webrtc-signaling.fly.dev wss: ws:; img-src 'self' data: blob:; media-src 'self'; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self';"
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; connect-src 'self' https://generativelanguage.googleapis.com https://api.openai.com https://api.x.ai http://localhost:11434 http://127.0.0.1:11434 http://localhost:1234 http://127.0.0.1:1234 http://localhost:8000 http://127.0.0.1:8000 https://openrouter.ai https://api.openrouter.ai https://api.groq.com wss://y-webrtc-signaling.fly.dev wss://signaling.yjs.dev; img-src 'self' data: blob:; media-src 'self'; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none';"
     }
   },
   "bundle": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,14 +28,16 @@ export default defineConfig({
     entries: [path.resolve(__dirname, 'index.html')],
   },
 
+  // QNBS-v3: secure-by-default bind to loopback; opt into network exposure
+  // (e.g. Codespaces port-forwarding) only via explicit VITE_DEV_HOST=0.0.0.0.
   server: {
     port: 3000,
-    host: '0.0.0.0',
+    host: process.env['VITE_DEV_HOST'] === '0.0.0.0' ? '0.0.0.0' : '127.0.0.1',
   },
 
   preview: {
     port: 4173,
-    host: '0.0.0.0',
+    host: process.env['VITE_DEV_HOST'] === '0.0.0.0' ? '0.0.0.0' : '127.0.0.1',
   },
 
   plugins: [


### PR DESCRIPTION
## **User description**
## Summary

P0 security bundle from the full-scale audit, scoped to the **genuinely real, low-risk** items. Several audit phases were dropped after verification (crypto already C-1 hardened, `pnpm audit` clean, the 6 "dead" flags are all wired, projectSlice split would break unified redux-undo).

### Changes
1. **Tauri CSP** (`src-tauri/tauri.conf.json`) — removed unrestricted `wss:`/`ws:` wildcards (WebSocket hijacking risk); whitelisted `wss://signaling.yjs.dev` (second default y-webrtc signaling URL) so collab failover still works; added `frame-ancestors 'none'`.
2. **Tauri version sync** — `1.17.0`→`1.19.0`; `scripts/sync-sw-version.mjs` now keeps `tauri.conf.json` aligned with `package.json` (idempotent, via existing predev/prebuild).
3. **Dev server** (`vite.config.ts`) — `server`/`preview` host default to `127.0.0.1`; network binding opt-in via `VITE_DEV_HOST=0.0.0.0`.
4. **Vendor-fork guard** — `VENDOR-DIFF.md` baseline + `scripts/verify-vendor-fork.mjs` static invariant guard (asserts PBKDF2 600k, extractable=false, return-on-reject, version `10.3.0-sc1`); wired into CI security job as `verify:vendor`. (issue #60)

### ⚠️ Action required for Codespaces
To keep `pnpm run dev` reachable through port-forwarding, set `VITE_DEV_HOST=0.0.0.0` in the Codespace env. Without it the dev server binds loopback only.

### Note
Users configuring a **custom** signaling URL in Settings are not covered by the desktop CSP — intended locked-down behavior for the Tauri surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Harden the desktop app and make local dev access opt-in**

### What Changed
- The desktop app now blocks embedded pages from framing it and removes broad WebSocket access from its security policy, while still allowing the default collaboration signaling service to connect.
- The app version shown in the desktop bundle now stays in sync with the main package version, preventing version mismatch on release.
- The dev and preview servers now bind to `127.0.0.1` by default, so they are not exposed to the network unless `VITE_DEV_HOST=0.0.0.0` is set.
- CI now checks the vendored collaboration package for known security-sensitive changes so regressions are caught before release.

### Impact
`✅ Lower risk of desktop app framing attacks`
`✅ Fewer exposed local dev servers`
`✅ Correct desktop version displayed on release`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
