### PR TITLE
fix(ci): unblock OSV (paste unmaintained) + silence Vercel rate-limit status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **CI unblock — OSV `paste` advisory + Vercel rate-limit noise** (2026-06-03):
+  - `src-tauri/osv-scanner.toml` — ignore `RUSTSEC-2024-0436` (`paste` 1.0.15 *unmaintained*; build-time proc-macro helper, no runtime exposure, no fix release). The advisory was newly published and was failing the required **Security Audit** check on every branch (e.g. Dependabot PR #78).
+  - `vercel.json` — `"github": { "silent": true }` so Vercel still deploys but no longer posts commit statuses; the free-tier **"Deployment rate limited — retry in 24 hours"** preview failure can no longer show as a hard fail on PRs. (Vercel was never a *required* status check, so this is purely cosmetic-noise removal.)
+
 ### Added
 
 - **WorkerBus v2 Phase 3 — Rust TaskSupervisor + native `text.analyze`** (2026-06-03):

--- a/src-tauri/osv-scanner.toml
+++ b/src-tauri/osv-scanner.toml
@@ -75,6 +75,17 @@ id = "RUSTSEC-2024-0370"
 ignoreUntil = "2026-11-30T00:00:00Z"
 reason = "proc-macro-error 1.0.4: unmaintained build-time proc-macro helper; no runtime exposure; no newer version exists"
 
+# ─── paste ───────────────────────────────────────────────────────────────────
+# Build-time declarative-macro helper (token pasting) pulled in transitively by
+# the Tauri/Rust macro stack. Advisory classification is "unmaintained" — no CVE,
+# no CVSS score, no fixed version (1.0.15 is the final release; crate is archived).
+# Compile-time only; there is no runtime footprint or exploitable attack surface.
+
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0436"
+ignoreUntil = "2026-11-30T00:00:00Z"
+reason = "paste 1.0.15: unmaintained build-time proc-macro helper; no runtime exposure; final version, no fix available"
+
 # ─── unic-* Unicode data crates ──────────────────────────────────────────────
 # unic-* 0.9.0 is the final version of this crate series (archived).
 # Advisory classification is "unmaintained" — no CVE, no CVSS score.

--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,9 @@
   "buildCommand": "NODE_OPTIONS=--max-old-space-size=3072 pnpm run build:edge",
   "outputDirectory": "dist",
   "framework": null,
+  "github": {
+    "silent": true
+  },
   "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }],
   "headers": [
     {


### PR DESCRIPTION
## **User description**
## Why

Two CI-infra issues are blocking the open Dependabot PRs (#74–#80):

1. **`RUSTSEC-2024-0436` (`paste` 1.0.15 — *unmaintained*)** was newly published in the OSV DB and now fails the **required** Security Audit (OSV) check on every branch — first surfaced on the cargo PR #78. `paste` is a build-time proc-macro helper: no runtime exposure, no CVSS, no fix release (1.0.15 is final). Added to `src-tauri/osv-scanner.toml` with the same justified pattern already used for `proc-macro-error`, `unic-*`, and the GTK3 bindings.
2. **Vercel preview** deployments hit the free-tier 24h rate limit and post a red "fail" status on PRs. Vercel was **never a required status check** (required = Security Audit, Build, Quality Gate 22/24), so it never actually blocked merges — but to remove the cosmetic hard-fail noise, `vercel.json` now sets `"github": { "silent": true }`: deployments still run, no commit statuses/comments are posted.

## Effect
- Unblocks the required Security Audit on all branches (incl. the Dependabot PRs once rebased onto `main`).
- Removes the Vercel rate-limit red-X noise on PRs without disabling deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Unblock security checks and remove noisy Vercel PR failures**

### What Changed
- The required Security Audit check no longer fails on the newly published `paste` advisory, which unblocks affected branches and Dependabot PRs.
- Vercel preview deployments still run, but they no longer post red failure statuses or comments when the free-tier rate limit is hit.
- The changelog now records both CI fixes under the unreleased section.

### Impact
`✅ Fewer blocked dependency updates`
`✅ Fewer false PR failures`
`✅ Cleaner CI status on pull requests`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
