### PR TITLE
chore: v1.21.0 Integrity & Hardening Cycle (F-1…F-9)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,9 @@ jobs:
       - name: Lint (Biome)
         run: pnpm run lint
 
+      - name: Suppression-debt ratchet (biome-ignore count)
+        run: node scripts/check-suppressions.mjs
+
       - name: i18n key parity (vs en)
         run: pnpm run i18n:check
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,60 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+> Post-v1.20.0 work toward **v1.21.0 (in development)** — not yet released/tagged.
+
 ### Added
 
-- **WebGPU detector service (2026-05-18):** New `services/ai/webGpuDetectorService.ts` — `detectWebGpuDetails()` queries `navigator.gpu.requestAdapter()`, reads `adapter.limits.maxBufferSize` for VRAM tier heuristic (≥8 GB = high, ≥4 GB = medium, else low). AiProviderCard gains live GPU status badge, WebLLM model dropdown, and ONNX model dropdown. `LOCAL_INFERENCE_PROVIDERS` + `isLocalInferenceProvider()` added to `orchestrationProviders.ts`. 12 new settings i18n keys across all 5 locales (1408 → 1414 total).
-
-- **ONNX Runtime Web Layer-2 in ai-core (2026-05-18):** `packages/ai-core/src/index.ts` adds an ONNX WASM fallback layer between WebLLM and Transformers.js. `LocalAiLayer` type includes `'onnx'`. `ONNX_SUPPORTED_MODELS` exported. `vite.config.ts` gains `vendor-ai-onnx` manual chunk to keep onnxruntime-web + @xenova/transformers under Workbox's 8 MiB SW cache limit.
-
-- **Yjs AES-256-GCM encryption foundation (2026-05-18):** `collaborationService.ts` gains `encryptUpdate()`, `decryptUpdate()`, `deriveEncryptionKey()` (PBKDF2 600 000 iterations, SHA-256, AES-256-GCM), and `getEncryptionStatus()` (`'encrypted' | 'psk-only' | 'plaintext'`). `CollaborationPanel.tsx` shows green/amber encryption status badge post-connect. 3 new collab i18n keys.
-
-- **Tauri v2 auto-updater pipeline (2026-05-18):** `tauri-build.yml` gains a `Generate latest.json` step that builds the Tauri v2 update manifest from signed `.sig` files and uploads it to GitHub Release. `docs/TAURI-UPDATER.md` extended with a full GitHub Secrets table. `docs/TAURI-CI.md` gains a 7-step first-release checklist.
-
-- **Cross-Project-Search v2 (2026-05-18):** DB_VERSION 7→8 with new `projects-index-store`. New `crossProjectIndexService.ts` — `indexProject()`, `listIndexedProjects()`, `removeProjectIndex()` (privacy-preserving: no manuscript plaintext). `searchAcrossProjectIndex()` added to `crossProjectSearchService.ts`. `CrossProjectSearchPanel.tsx` runs two-phase search (index first, then current project). 3 new `crossSearch.*` i18n keys (1414 total).
-
-- **Mobile-aware E2E helpers (2026-05-17):** `clickNavItem(page, name)` in `tests/e2e/helpers.ts` — tries desktop `#sidebar` (hidden md:flex), then mobile bottom-tab-bar (`[data-tour="nav-mobile"]`), then the "More" sheet; eliminates all `sidebar(page)` calls that fail on Pixel 5 viewport. `selectFirstEnabledWriterSection` now switches to the context tab on mobile before locating the section selector.
-- **ARIA tablist on WriterView mobile segmented control:** Each tab button gains `role="tab"`, `aria-selected`, `aria-controls`, `data-testid="writer-tab-{context|tools|result}"`; container gains `role="tablist"`; panel divs gain `role="tabpanel"` + `aria-labelledby` — axe-compliant and stably selectable in Playwright.
-- **Mobile VC button in WriterViewUI:** `md:hidden` version of the version-control toggle button with `data-testid="writer-version-control-btn"` and `aria-expanded` — mirrors the desktop button that is hidden on Pixel 5 viewport.
-- **Stable test anchors:** `data-testid="snapshot-label-input"` on the snapshot-label `<Input>` in `VersionControlPanel.tsx`; `data-testid="export-preview"` on the `<pre>` export preview in `ExportView.tsx`.
-- **OSV vulnerability scan in CI security job:** `google/osv-scanner-action@v2` step wired after `pnpm audit` — `osv-scanner.toml` existed but was never executed; advisories now caught on every push/PR.
-- **JUnit E2E artifact:** Playwright JUnit reporter output (`tests/e2e/results/junit.xml`) uploaded as `e2e-junit` artifact — enables per-test check annotations on GitHub PRs.
+- **Sepia dark mode — "Candlelit Manuscript" variant:** New warm low-light theme variant joining the light/dark/sepia families; body-class themed via `--sc-*` tokens (no `dark:` prefix). (`1321478`)
+- **Deep E2E coverage layer:** Non-blocking `e2e-deep` job — feature-flag matrix (`tests/e2e/deep/feature-flag-matrix.spec.ts`) parametrized across `test-matrix.ts`, plus error-path specs (offline AI, rapid nav, all-flags-on). Explicit per-flag specs seed state via `setFeatureFlags()`. (`663ca2f`)
+- **Chinese (zh) locale + pt/el Beta translation batches:** zh Simplified brought under the 5% English-placeholder target; pt/el Beta translation batches landed. (`364025e`, `e8cddcb`)
+- **Whisper WASM STT download UI + VAD→Whisper bridge:** `VoiceModelDownloadModal` ships; `VoiceActivityCoordinator` wires `WebRtcVadEngine` PCM frames into `WasmSttEngine` (MIN_SPEECH_CHUNKS gate + MAX_BUFFER_MS flush) behind `enableVoiceWasm`. (`e8cddcb`, `364025e`)
 
 ### Changed
 
-- **i18n Comprehensive Sweep (2026-05-18):** All remaining hardcoded user-facing strings eliminated across 5 locales — **1 440 keys** total (up from 1 414). Fixes include: `help.tryTour` (was rendering raw key `"try.Help"` in the command palette), `initialProject.chapter1` (`"Chapter 1"` in projectSlice + AdvancedImportExport — extended `resetProject` payload with optional `chapter1Title`), `manuscript.resizer.left/right` (hardcoded German string `"Linkes Panel anpassen"` remained in source), `writer.stopGenerating / tools.selectLabel / versionControl.tooltip`, `settings.ai.temperature.precise/balanced/creative`, `export.pasteSection.heading` (`"Google Docs / Notion"`), `outline.result.body`, `characters.uploadImage / editorTabsAriaLabel`, `worlds.uploadImage / editorTabsAriaLabel`, `templates.tabs.myTemplates / community`, `error.boundary.title/description/reset/reload/report`, `manuscript.spellcheck.didYouMean/applyFix`, `manuscript.grammar.checkButton`, `manuscript.zenMode.enter/exit/label`, and `writer.studio.controls.custom/customTonePlaceholder`.
-
-- **ErrorBoundary fully localized (2026-05-18):** `components/ui/ErrorBoundary.tsx` refactored with inner `ErrorFallback` functional component — accesses `useTranslation()` hook to render title, description, and all buttons (Reset View, Reload Page, Report issue) in the active locale. Import path corrected to `hooks/useTranslation`; `onReset` passed conditionally to satisfy `exactOptionalPropertyTypes`.
-
-- **Unit-test coverage — 1 641 tests / 150 test files (2026-05-18):** Measured **62.86 % statements · 49.06 % branches · 54.10 % functions · 64.68 % lines**. Vitest thresholds at statements 53 / branches 37 / functions 50 / lines 55 — all passing.
-
-- **Unit-test coverage — Phase 4.5 thresholds met (2026-05-17):** Measured **63.32 % lines · 61.5 % statements · 47.1 % branches · 53.2 % functions** (1 561 tests). Vitest thresholds at lines 55 / statements 53 / branches 37 / functions 50.
-- **Stryker mutation gate enforced:** `thresholds.break` raised `null` → `30`; `timeoutMS` lowered 180 000 → 120 000 ms; CI mutation job `continue-on-error` → `false`, `timeout-minutes: 20` → `30`.
-- **Lighthouse performance promoted to error:** `categories:performance` `warn:0.5` → `error:0.4`; `categories:seo` added as `warn:0.8`; FCP tightened 6 000 → 5 000 ms; LCP tightened 8 000 → 7 000 ms.
-- **CI concurrency fix:** `cancel-in-progress` restricted to PRs only — main-branch deploys no longer cancelled by a concurrent push.
-- **Artifact retention aligned:** `dist` 7 → 3 days; `lighthouse-report` and `storybook` 14 → 7 days.
+- **CSP connect-src — documented BYOK tradeoff (ADR-0004):** Explicit cloud-provider endpoints in `index.html` `connect-src` removed as redundant; the intentional `https:` scheme-source (required by the shipped `openAiCompatibleBaseUrl` BYOK feature) is retained and documented. Tauri CSP stays strict (no `https:` blanket). Regression test in `tests/unit/csp.test.ts`.
+- **Coverage batches A–C:** Incremental unit-test coverage additions; thresholds held at lines 74 / functions 67 / branches 60 / statements 72. (`364025e`)
+- **Dependency bumps:** `@huggingface/transformers` 3.8.1 → 4.2.0 (ai-core; v4 API surface verified — see ADR/notes), `@biomejs/biome` → 2.4.16, `@mlc-ai/web-llm` → 0.2.84, `vite` → 8.0.16, `@google/genai` → 2.8.0, `@tanstack/react-virtual` → 3.14.2.
 
 ### Fixed
 
-- **TypeScript 6 strict hardening (2026-05-18):** `'grok-3'` and `'grok-3-mini'` added to `AiModel` union in `types.ts` (TS2322 in `aiProviderService.test.ts`); double-cast `(x as unknown as Record<string, unknown>)['key']` pattern for `CollaborationService` private member access (TS2352); bracket notation `['gpu']` / `['__TAURI__']` required by TypeScript 6 index-signature enforcement (TS4111); PBKDF2 `Uint8Array<ArrayBuffer>` generic in `collaborationService.ts` for Web Crypto API strict typing.
+- **Command palette footer contrast (a11y):** `text-muted` → `text-secondary` for WCAG 2.2 AA contrast. (`672e56d`)
+- **Voice settings tab + auto-save false-positive + help locale cleanup.** (`e049f08`)
+- **E2E / CI stabilization:** viewport-aware nav locators, ProForge empty-state visibility on Desktop Chrome, Voice WASM section, Early-Access hyphenated German label, and 17 unit-test fixes across SettingsView/HelpView/VoiceSettingsSection. (`43602c2`, `f16ba42`, `3cf9387`, `fe598ed`, `d73397e`)
 
-- **Test mocks (2026-05-18):** `tests/unit/ErrorBoundary.test.tsx` gains `vi.mock('../../hooks/useTranslation', …)` with an EN string map so rendered-text assertions survive the i18n refactor. `tests/unit/AdvancedImportExport.test.tsx` heading assertion updated from hardcoded `'Google Docs / Notion'` to `'export.pasteSection.heading'` (consistent with the `t: (k) => k` mock pattern already used in that file).
+### Docs
 
-- **E2E Desktop + Mobile Chrome (2026-05-17):** `writer`, `snapshots`, `a11y`, `export` spec files migrated to 2026 Golden Hierarchy selectors (getByRole > getByTestId; no CSS, no XPath). Fixes CI exit-code 1 after WriterView component split.
-
-- **WebLLM model selector (Phase 3B):** `packages/ai-core` now exports `WEBLLM_SUPPORTED_MODELS` (4 curated MLC-packaged checkpoints: Llama 3.2 1B, Llama 3.2 3B, Phi-3.5 Mini, Gemma 2 2B), `WebLlmModelId`, and `WebLlmProgressReport` types. `runLocalTextGeneration` accepts an optional `modelId` and `onProgress` callback for per-model download-progress tracking. `services/localAiFacade.ts` forwards both parameters. `types.ts` expands the `AiModel` union with the four specific MLC model IDs. Settings → AI (Advanced) now shows a dynamic model dropdown populated from `WEBLLM_SUPPORTED_MODELS`, a pre-download button, a WCAG 2.2 `role="progressbar"` progress bar, and a `useRef` mounted guard that prevents `setState`-on-unmount. All 5 locale `settings.json` files gain the 3 new i18n keys (`settings.ai.webllm.model`, `settings.ai.webllm.downloadProgress`, `settings.ai.webllm.downloading`).
-
-- **Cross-project search service (Phase 3A):** New `services/crossProjectSearchService.ts` — `searchAcrossProjects(query, projectData)` fuzzy-searches project title, logline, manuscript sections, and character names/fields using `normalizeSearch()` from `fuzzyScore.ts`; returns `CrossProjectSearchResult[]` sorted by score. Results include `projectId`, `projectTitle`, `matchType`, `excerpt` (truncated to 120 chars with `…`), and `score`. v1 scope is single-project (multi-project search requires a DB_VERSION bump + IDB migration — deferred to v2). `app/transientUiStore.ts` gains `isCrossProjectSearchOpen` + `setCrossProjectSearchOpen`. The `labs-cross-project-search` command in `services/commands/commandDefinitions.tsx` now opens the search panel instead of a stub toast. All 5 locale `common.json` files gain 7 `crossSearch.*` keys.
-
-- **Collaboration security warning (Phase 3C):** `CollaborationPanel.tsx` displays a pre-connection security-warning banner (`role="alert"`, `aria-live="polite"`, WCAG 2.2 AA) that is only visible before connecting. The banner explains that the public y-webrtc signaling relay can observe connection metadata, includes a keyboard-accessible self-hosting link, and disappears once connected. All 5 locale `common.json` files gain `collab.securityWarning`, `collab.securityWarningDetail`, and `collab.selfHostLinkLabel`.
-
-- **E2E tests for new features:** `tests/e2e/commands.spec.ts` — palette open/close (Ctrl+K / Escape), "dashboard" text search surfaces nav command, Enter-to-navigate, fuzzy "wrt" match. `tests/e2e/collaboration.spec.ts` — security warning `[role=alert]` is visible pre-connection and non-empty. Both specs are CI-only (`test.skip(!isCI)`).
-
-### Changed
-
-- **Unit-test coverage — Phase 1 thresholds met:** 17 new test files added (733 tests total); Vitest coverage thresholds bumped to `{ lines: 35, functions: 30, branches: 22, statements: 33 }` (previously 25/21/17/24). Measured coverage: **36.47 % lines · 35.53 % statements · 24.96 % branches · 30.22 % functions** — all Phase 1 targets exceeded. New files cover: `commands/` (fuzzyScore, palettePreferences, commandSystem), project thunks (writing, character, binder, management), hooks (useDashboard, useManuscriptView, useGlobalKeyboardShortcuts, useCharacterView, useOutlineGenerator), `aiProviderService` fallback chain, `dbService` snapshots, `dbService` binder assets, and `crossProjectSearchService`.
-
-- **Stryker mutation targets expanded (Phase 4):** `stryker.conf.json` `mutate` array now includes `services/commands/fuzzyScore.ts`, `services/commands/palettePreferences.ts`, and `services/commands/commandBuilder.ts` in addition to the existing `codexService.ts` and `dbMigration.ts`.
+- **Integrity & hardening cycle (v1.21):** README version badge corrected to released v1.20.0 + refreshed metrics; misfiled v1.19-era CHANGELOG entries migrated to `[1.19.0]`; TODO sprint rollover. ADR-0004 (CSP/BYOK). `docs/VENDORED-DEPS.md` + `docs/COVERAGE-POLICY.md` governance. Suppression-count ratchet gate (baseline 181).
 
 ---
 
@@ -143,10 +113,69 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Sequential shell execution rule** codified in all 4 instruction files (`CLAUDE.md` project root, `.github/copilot-instructions.md`, `.cursorrules`, `infra/low-end-ci/DAILY-DRIVER.md`) — ONE Bash call per response, no parallel shell calls on this 3.7 GB RAM hardware.
 
+- **WebGPU detector service (2026-05-18):** New `services/ai/webGpuDetectorService.ts` — `detectWebGpuDetails()` queries `navigator.gpu.requestAdapter()`, reads `adapter.limits.maxBufferSize` for VRAM tier heuristic (≥8 GB = high, ≥4 GB = medium, else low). AiProviderCard gains live GPU status badge, WebLLM model dropdown, and ONNX model dropdown. `LOCAL_INFERENCE_PROVIDERS` + `isLocalInferenceProvider()` added to `orchestrationProviders.ts`. 12 new settings i18n keys across all 5 locales (1408 → 1414 total).
+
+- **ONNX Runtime Web Layer-2 in ai-core (2026-05-18):** `packages/ai-core/src/index.ts` adds an ONNX WASM fallback layer between WebLLM and Transformers.js. `LocalAiLayer` type includes `'onnx'`. `ONNX_SUPPORTED_MODELS` exported. `vite.config.ts` gains `vendor-ai-onnx` manual chunk to keep onnxruntime-web + @xenova/transformers under Workbox's 8 MiB SW cache limit.
+
+- **Yjs AES-256-GCM encryption foundation (2026-05-18):** `collaborationService.ts` gains `encryptUpdate()`, `decryptUpdate()`, `deriveEncryptionKey()` (PBKDF2 600 000 iterations, SHA-256, AES-256-GCM), and `getEncryptionStatus()` (`'encrypted' | 'psk-only' | 'plaintext'`). `CollaborationPanel.tsx` shows green/amber encryption status badge post-connect. 3 new collab i18n keys.
+
+- **Tauri v2 auto-updater pipeline (2026-05-18):** `tauri-build.yml` gains a `Generate latest.json` step that builds the Tauri v2 update manifest from signed `.sig` files and uploads it to GitHub Release. `docs/TAURI-UPDATER.md` extended with a full GitHub Secrets table. `docs/TAURI-CI.md` gains a 7-step first-release checklist.
+
+- **Cross-Project-Search v2 (2026-05-18):** DB_VERSION 7→8 with new `projects-index-store`. New `crossProjectIndexService.ts` — `indexProject()`, `listIndexedProjects()`, `removeProjectIndex()` (privacy-preserving: no manuscript plaintext). `searchAcrossProjectIndex()` added to `crossProjectSearchService.ts`. `CrossProjectSearchPanel.tsx` runs two-phase search (index first, then current project). 3 new `crossSearch.*` i18n keys (1414 total).
+
+- **Mobile-aware E2E helpers (2026-05-17):** `clickNavItem(page, name)` in `tests/e2e/helpers.ts` — tries desktop `#sidebar` (hidden md:flex), then mobile bottom-tab-bar (`[data-tour="nav-mobile"]`), then the "More" sheet; eliminates all `sidebar(page)` calls that fail on Pixel 5 viewport. `selectFirstEnabledWriterSection` now switches to the context tab on mobile before locating the section selector.
+
+- **ARIA tablist on WriterView mobile segmented control:** Each tab button gains `role="tab"`, `aria-selected`, `aria-controls`, `data-testid="writer-tab-{context|tools|result}"`; container gains `role="tablist"`; panel divs gain `role="tabpanel"` + `aria-labelledby` — axe-compliant and stably selectable in Playwright.
+
+- **Mobile VC button in WriterViewUI:** `md:hidden` version of the version-control toggle button with `data-testid="writer-version-control-btn"` and `aria-expanded` — mirrors the desktop button that is hidden on Pixel 5 viewport.
+
+- **Stable test anchors:** `data-testid="snapshot-label-input"` on the snapshot-label `<Input>` in `VersionControlPanel.tsx`; `data-testid="export-preview"` on the `<pre>` export preview in `ExportView.tsx`.
+
+- **OSV vulnerability scan in CI security job:** `google/osv-scanner-action@v2` step wired after `pnpm audit` — `osv-scanner.toml` existed but was never executed; advisories now caught on every push/PR.
+
+- **JUnit E2E artifact:** Playwright JUnit reporter output (`tests/e2e/results/junit.xml`) uploaded as `e2e-junit` artifact — enables per-test check annotations on GitHub PRs.
+
 ### Changed
 
 - `services/logger.ts` — backward-compat `logger` export, `getRecentLogs()`, `formatLogsForReport()`, and `clearLogs()` retained; in-memory cache kept at 200 entries as fast path for `formatLogsForReport`.
 - `packages/collab-transport` replaces pnpm-patched `y-webrtc` dependency; `patchedDependencies` entry removed from `package.json`.
+
+- **i18n Comprehensive Sweep (2026-05-18):** All remaining hardcoded user-facing strings eliminated across 5 locales — **1 440 keys** total (up from 1 414). Fixes include: `help.tryTour` (was rendering raw key `"try.Help"` in the command palette), `initialProject.chapter1` (`"Chapter 1"` in projectSlice + AdvancedImportExport — extended `resetProject` payload with optional `chapter1Title`), `manuscript.resizer.left/right` (hardcoded German string `"Linkes Panel anpassen"` remained in source), `writer.stopGenerating / tools.selectLabel / versionControl.tooltip`, `settings.ai.temperature.precise/balanced/creative`, `export.pasteSection.heading` (`"Google Docs / Notion"`), `outline.result.body`, `characters.uploadImage / editorTabsAriaLabel`, `worlds.uploadImage / editorTabsAriaLabel`, `templates.tabs.myTemplates / community`, `error.boundary.title/description/reset/reload/report`, `manuscript.spellcheck.didYouMean/applyFix`, `manuscript.grammar.checkButton`, `manuscript.zenMode.enter/exit/label`, and `writer.studio.controls.custom/customTonePlaceholder`.
+
+- **ErrorBoundary fully localized (2026-05-18):** `components/ui/ErrorBoundary.tsx` refactored with inner `ErrorFallback` functional component — accesses `useTranslation()` hook to render title, description, and all buttons (Reset View, Reload Page, Report issue) in the active locale. Import path corrected to `hooks/useTranslation`; `onReset` passed conditionally to satisfy `exactOptionalPropertyTypes`.
+
+- **Unit-test coverage — 1 641 tests / 150 test files (2026-05-18):** Measured **62.86 % statements · 49.06 % branches · 54.10 % functions · 64.68 % lines**. Vitest thresholds at statements 53 / branches 37 / functions 50 / lines 55 — all passing.
+
+- **Unit-test coverage — Phase 4.5 thresholds met (2026-05-17):** Measured **63.32 % lines · 61.5 % statements · 47.1 % branches · 53.2 % functions** (1 561 tests). Vitest thresholds at lines 55 / statements 53 / branches 37 / functions 50.
+
+- **Stryker mutation gate enforced:** `thresholds.break` raised `null` → `30`; `timeoutMS` lowered 180 000 → 120 000 ms; CI mutation job `continue-on-error` → `false`, `timeout-minutes: 20` → `30`.
+
+- **Lighthouse performance promoted to error:** `categories:performance` `warn:0.5` → `error:0.4`; `categories:seo` added as `warn:0.8`; FCP tightened 6 000 → 5 000 ms; LCP tightened 8 000 → 7 000 ms.
+
+- **CI concurrency fix:** `cancel-in-progress` restricted to PRs only — main-branch deploys no longer cancelled by a concurrent push.
+
+- **Artifact retention aligned:** `dist` 7 → 3 days; `lighthouse-report` and `storybook` 14 → 7 days.
+
+- **Unit-test coverage — Phase 1 thresholds met:** 17 new test files added (733 tests total); Vitest coverage thresholds bumped to `{ lines: 35, functions: 30, branches: 22, statements: 33 }` (previously 25/21/17/24). Measured coverage: **36.47 % lines · 35.53 % statements · 24.96 % branches · 30.22 % functions** — all Phase 1 targets exceeded. New files cover: `commands/` (fuzzyScore, palettePreferences, commandSystem), project thunks (writing, character, binder, management), hooks (useDashboard, useManuscriptView, useGlobalKeyboardShortcuts, useCharacterView, useOutlineGenerator), `aiProviderService` fallback chain, `dbService` snapshots, `dbService` binder assets, and `crossProjectSearchService`.
+
+- **Stryker mutation targets expanded (Phase 4):** `stryker.conf.json` `mutate` array now includes `services/commands/fuzzyScore.ts`, `services/commands/palettePreferences.ts`, and `services/commands/commandBuilder.ts` in addition to the existing `codexService.ts` and `dbMigration.ts`.
+
+### Fixed
+
+- **TypeScript 6 strict hardening (2026-05-18):** `'grok-3'` and `'grok-3-mini'` added to `AiModel` union in `types.ts` (TS2322 in `aiProviderService.test.ts`); double-cast `(x as unknown as Record<string, unknown>)['key']` pattern for `CollaborationService` private member access (TS2352); bracket notation `['gpu']` / `['__TAURI__']` required by TypeScript 6 index-signature enforcement (TS4111); PBKDF2 `Uint8Array<ArrayBuffer>` generic in `collaborationService.ts` for Web Crypto API strict typing.
+
+- **Test mocks (2026-05-18):** `tests/unit/ErrorBoundary.test.tsx` gains `vi.mock('../../hooks/useTranslation', …)` with an EN string map so rendered-text assertions survive the i18n refactor. `tests/unit/AdvancedImportExport.test.tsx` heading assertion updated from hardcoded `'Google Docs / Notion'` to `'export.pasteSection.heading'` (consistent with the `t: (k) => k` mock pattern already used in that file).
+
+- **E2E Desktop + Mobile Chrome (2026-05-17):** `writer`, `snapshots`, `a11y`, `export` spec files migrated to 2026 Golden Hierarchy selectors (getByRole > getByTestId; no CSS, no XPath). Fixes CI exit-code 1 after WriterView component split.
+
+- **WebLLM model selector (Phase 3B):** `packages/ai-core` now exports `WEBLLM_SUPPORTED_MODELS` (4 curated MLC-packaged checkpoints: Llama 3.2 1B, Llama 3.2 3B, Phi-3.5 Mini, Gemma 2 2B), `WebLlmModelId`, and `WebLlmProgressReport` types. `runLocalTextGeneration` accepts an optional `modelId` and `onProgress` callback for per-model download-progress tracking. `services/localAiFacade.ts` forwards both parameters. `types.ts` expands the `AiModel` union with the four specific MLC model IDs. Settings → AI (Advanced) now shows a dynamic model dropdown populated from `WEBLLM_SUPPORTED_MODELS`, a pre-download button, a WCAG 2.2 `role="progressbar"` progress bar, and a `useRef` mounted guard that prevents `setState`-on-unmount. All 5 locale `settings.json` files gain the 3 new i18n keys (`settings.ai.webllm.model`, `settings.ai.webllm.downloadProgress`, `settings.ai.webllm.downloading`).
+
+- **Cross-project search service (Phase 3A):** New `services/crossProjectSearchService.ts` — `searchAcrossProjects(query, projectData)` fuzzy-searches project title, logline, manuscript sections, and character names/fields using `normalizeSearch()` from `fuzzyScore.ts`; returns `CrossProjectSearchResult[]` sorted by score. Results include `projectId`, `projectTitle`, `matchType`, `excerpt` (truncated to 120 chars with `…`), and `score`. v1 scope is single-project (multi-project search requires a DB_VERSION bump + IDB migration — deferred to v2). `app/transientUiStore.ts` gains `isCrossProjectSearchOpen` + `setCrossProjectSearchOpen`. The `labs-cross-project-search` command in `services/commands/commandDefinitions.tsx` now opens the search panel instead of a stub toast. All 5 locale `common.json` files gain 7 `crossSearch.*` keys.
+
+- **Collaboration security warning (Phase 3C):** `CollaborationPanel.tsx` displays a pre-connection security-warning banner (`role="alert"`, `aria-live="polite"`, WCAG 2.2 AA) that is only visible before connecting. The banner explains that the public y-webrtc signaling relay can observe connection metadata, includes a keyboard-accessible self-hosting link, and disappears once connected. All 5 locale `common.json` files gain `collab.securityWarning`, `collab.securityWarningDetail`, and `collab.selfHostLinkLabel`.
+
+- **E2E tests for new features:** `tests/e2e/commands.spec.ts` — palette open/close (Ctrl+K / Escape), "dashboard" text search surfaces nav command, Enter-to-navigate, fuzzy "wrt" match. `tests/e2e/collaboration.spec.ts` — security warning `[role=alert]` is visible pre-connection and non-empty. Both specs are CI-only (`test.skip(!isCI)`).
+
 
 ## [1.18.1] — 2026-05-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **CSP connect-src — documented BYOK tradeoff (ADR-0004):** Explicit cloud-provider endpoints in `index.html` `connect-src` removed as redundant; the intentional `https:` scheme-source (required by the shipped `openAiCompatibleBaseUrl` BYOK feature) is retained and documented. Tauri CSP stays strict (no `https:` blanket). Regression test in `tests/unit/csp.test.ts`.
 - **Coverage batches A–C:** Incremental unit-test coverage additions; thresholds held at lines 74 / functions 67 / branches 60 / statements 72. (`364025e`)
-- **Dependency bumps:** `@huggingface/transformers` 3.8.1 → 4.2.0 (ai-core; v4 API surface verified — see ADR/notes), `@biomejs/biome` → 2.4.16, `@mlc-ai/web-llm` → 0.2.84, `vite` → 8.0.16, `@google/genai` → 2.8.0, `@tanstack/react-virtual` → 3.14.2.
+- **Dependency bumps:** `@huggingface/transformers` 3.8.1 → 4.2.0 — **major bump verified (WS-3)**: the APIs ai-core/voice consume are unchanged in v4.2.0 (`pipeline(task, model, { dtype, device })`, `env.backends.onnx.wasm.proxy`, `RawAudio`/`read_audio` exports); `pnpm typecheck` clean and 63 ai-core/voice integration tests green; no source changes required. Production bundling (rolldown tree-shaking / `vendor-ai-onnx` chunk) is exercised by the CI `build` + `smoke:prod` jobs. Also `@biomejs/biome` → 2.4.16, `@mlc-ai/web-llm` → 0.2.84, `vite` → 8.0.16, `@google/genai` → 2.8.0, `@tanstack/react-virtual` → 3.14.2.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Docs
 
-- **Integrity & hardening cycle (v1.21):** README version badge corrected to released v1.20.0 + refreshed metrics; misfiled v1.19-era CHANGELOG entries migrated to `[1.19.0]`; TODO sprint rollover. ADR-0004 (CSP/BYOK). `docs/VENDORED-DEPS.md` + `docs/COVERAGE-POLICY.md` governance. Suppression-count ratchet gate (baseline 181).
+- **Integrity & hardening cycle (v1.21, audit F-1…F-9):** README badge → released v1.20.0 + refreshed metrics (433 test files / 2 357 i18n keys); 28 misfiled v1.19-era CHANGELOG entries migrated to `[1.19.0]`; TODO sprint rollover. ADR-0004 (CSP/BYOK). New suppression-count ratchet gate (`scripts/check-suppressions.mjs`, wired into CI `quality`) + first abatement tranche — 22 `noExplicitAny` suppressions removed, baseline ratcheted 181 → 159. Bundle-budget single source of truth (`bundle:budget` = `--max-kb 6500 --max-entry-kb 4000`, script defaults aligned). Governance docs: `VENDOR-FORKS.md` gains a CVE/OSV-coverage section (the vendored y-webrtc source is invisible to OSV — manual upstream-advisory process documented), new `docs/COVERAGE-POLICY.md` (threshold ratchet rule).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@
   <img src="https://img.shields.io/badge/TypeScript-7.x_(tsgo)-3178C6?logo=typescript&logoColor=white" alt="TypeScript 7 (tsgo)">
   <img src="https://img.shields.io/badge/AI-Gemini_%7C_OpenAI_%7C_Ollama_%7C_WebLLM-4285F4?logo=google" alt="Gemini · OpenAI · Ollama · WebLLM">
   <img src="https://img.shields.io/badge/Local_AI-WebGPU_%7C_ONNX_%7C_Transformers.js-8B5CF6" alt="WebGPU · ONNX · Transformers.js">
-  <img src="https://img.shields.io/badge/Version-v1.21.0-6366F1" alt="v1.21.0">
+  <img src="https://img.shields.io/badge/Version-v1.20.0-6366F1" alt="v1.20.0">
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
-  <img src="https://img.shields.io/badge/i18n-11_locales-2348_keys-0EA5E9" alt="i18n 11 locales — 2348 keys">
-  <img src="https://img.shields.io/badge/Tests-~5000_%2B_%2F_427_files-22C55E" alt="~5000+ tests / 427 files">
+  <img src="https://img.shields.io/badge/i18n-11_locales-2357_keys-0EA5E9" alt="i18n 11 locales — 2357 keys">
+  <img src="https://img.shields.io/badge/Tests-~5000_%2B_%2F_433_files-22C55E" alt="~5000+ tests / 433 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/StoryCraft-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/StoryCraft-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -232,9 +232,9 @@ See [`docs/PROFORGE-PIPELINE.md`](docs/PROFORGE-PIPELINE.md) for full architectu
 
 A single-keystroke toggle that collapses all sidebars and chrome, leaving only the manuscript editor. Exit with `Escape` or the same toggle key. State is stored in the Zustand `transientUiStore` (`flowMode` flag) so it resets on page load.
 
-### 🗣️ Voice Dictation & WASM Voice Engines _(v1.17 foundation + v1.19.0 WASM scaffold + v1.21 model download UI)_
+### 🗣️ Voice Dictation & WASM Voice Engines _(v1.17 foundation + v1.19.0 WASM scaffold + v1.21 model download UI — in development)_
 
-Built-in speech-to-text via the browser's Web Speech API. Dictate scenes hands-free directly into the manuscript editor or into the Command Palette search field. **v1.19.0** adds WASM STT/VAD engine scaffolds; **v1.21** ships the full model download flow:
+Built-in speech-to-text via the browser's Web Speech API. Dictate scenes hands-free directly into the manuscript editor or into the Command Palette search field. **v1.19.0** adds WASM STT/VAD engine scaffolds; **v1.21 (in development)** ships the full model download flow:
 
 - **`WasmSttEngine`** (`services/voice/wasmSttEngine.ts`) — Whisper.cpp WASM interface scaffold (model download, chunked inference, 99+ language detection).
 - **`SileroVadEngine`** (`services/voice/sileroVadEngine.ts`) — Silero VAD v4 via ONNX Runtime Web (~2 MB model, lazy-loaded, replaces energy-threshold VAD).
@@ -598,10 +598,10 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `deploy`     | `main` only          | GitHub Pages after **`build` + `e2e`** succeed |
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
-**Current test metrics (2026-06-01, v1.19.0+):**
-- **~5 000+ unit tests** across **427 test files** — all passing (2026-06-07)
+**Current test metrics (2026-06-10):**
+- **~5 000+ unit tests** across **433 test files** — all passing
 - Coverage thresholds: lines ≥ 74 · branches ≥ 60 · functions ≥ 67 · statements ≥ 72 — enforced in CI (see Codecov badge for live metrics)
-- i18n: **2 340 keys × 11 locales** (en/de/fr/es/it + ar/he RTL Beta + ja/zh/pt/el Beta)
+- i18n: **2 357 keys × 11 locales** (en/de/fr/es/it + ar/he RTL Beta + ja/zh/pt/el Beta)
 
 **CI-cloud-first workflow (recommended):** On constrained hardware run **`pnpm run lint && pnpm run i18n:check && pnpm run typecheck`** locally, then push and let CI handle coverage, E2E, Lighthouse, and Stryker. Authoritative numbers come from CI artifacts (Codecov, JUnit). After CI goes green, update the README badges and `AUDIT.md` quality-gate line from the reported metrics. See **[`docs/CI.md`](docs/CI.md) § Cloud CI-first vs local development** for the full post-merge doc-update checklist.
 

--- a/TODO.md
+++ b/TODO.md
@@ -8,18 +8,18 @@ Status: 🔄 in progress | ⬜ open | ✅ done
 
 ---
 
-## v1.21.0 — Integrity & Hardening Cycle (2026-06-10) — IN PROGRESS
+## v1.21.0 — Integrity & Hardening Cycle (2026-06-10) — DELIVERED (PR #104, pending merge)
 
 > Master Plan: `.claude/plans/master-prompt-storycraft-studio-glistening-pnueli.md` (Deep Audit 2026-06-09, findings F-1…F-9).
 > NOTE: prior sprint blocks are retained inline below (file convention), not moved to `docs/history/`.
 
 ### WS — Integrity & Hardening
-- 🔄 **WS-1** — Doc integrity: README badge v1.21.0→v1.20.0 + metrics (433 test files / 2 357 i18n keys); 28 misfiled CHANGELOG entries migrated `[Unreleased]`→`[1.19.0]`; this TODO rollover.
-- ⬜ **WS-2** — CSP `connect-src`: Option B (documented BYOK `https:` tradeoff) + ADR-0004 + `tests/unit/csp.test.ts`; Tauri CSP stays strict (no `https:` blanket).
-- ⬜ **WS-3** — Verify `@huggingface/transformers` 4.2.0 major bump against ai-core integration points (embeddings, ONNX, RAG).
-- ⬜ **WS-4** — Suppression-debt ratchet gate (`scripts/check-suppressions.mjs`, baseline 181) wired into CI + ≥20-site `noExplicitAny` abatement in `services/` (→ ≤161).
-- ⬜ **WS-5** — Bundle-budget single source of truth (Entry 4 000 KB / Total 6 500 KB).
-- ⬜ **WS-6** — `docs/VENDORED-DEPS.md` (y-webrtc fork CVE process + OSV coverage) + `docs/COVERAGE-POLICY.md` ratchet rule.
+- ✅ **WS-1** (F-1/F-3/F-5, `bc53bbc`) — README badge v1.21.0→v1.20.0 + metrics (433 test files / 2 357 i18n keys); 28 misfiled CHANGELOG entries migrated `[Unreleased]`→`[1.19.0]`; this TODO rollover.
+- ✅ **WS-2** (F-2, `5e7e49e`) — CSP `connect-src` Option B: removed redundant cloud endpoints, kept `https:` for shipped BYOK; ADR-0004 + `tests/unit/csp.test.ts` (6/6); Tauri CSP stays strict.
+- ✅ **WS-3** (F-6, `6ce236f`) — `@huggingface/transformers` 4.2.0 verified against ai-core/voice: APIs unchanged, typecheck clean, 63 tests green; no source change.
+- ✅ **WS-4** (F-4, `f3cc74f`+`6cc3e7d`) — suppression-debt ratchet gate (`scripts/check-suppressions.mjs`, baseline 181) wired into CI; abated **22** `noExplicitAny` (3 production + 19 test mocks — `services/` had none) → baseline **159**.
+- ✅ **WS-5** (F-8, `8e5bd4a`) — bundle-budget single source of truth: `--max-kb 6500 --max-entry-kb 4000`, script defaults aligned; corrected the inaccurate "~4000 KB entry" claim (real entry ≈ 496 KB).
+- ✅ **WS-6** (F-7/F-9, `3e0aa82`) — `VENDOR-FORKS.md` CVE/OSV-coverage section (vendored y-webrtc invisible to OSV → manual process) + new `docs/COVERAGE-POLICY.md` ratchet rule.
 
 ### Carried over from v1.20.0
 - ⬜ **P1-1** — WebLLM Worker Offload: full GPU isolation in dedicated worker (not started, 5–7 days).

--- a/TODO.md
+++ b/TODO.md
@@ -24,7 +24,7 @@ Status: 🔄 in progress | ⬜ open | ✅ done
 ### Carried over from v1.20.0
 - ⬜ **P1-1** — WebLLM Worker Offload: full GPU isolation in dedicated worker (not started, 5–7 days).
 - 🔄 **P1-2** — Whisper WASM STT end-to-end: download UI ✅ + VAD→STT bridge ✅; remaining = full E2E integration test (CI-only).
-- ⬜ **P1-7** — Bundle Budget monitoring (limits unified via WS-5).
+- ✅ **P1-7** — Bundle Budget single source of truth (F-8): `package.json` `bundle:budget` = `--max-kb 6500 --max-entry-kb 4000`; `scripts/check-bundle-budget.mjs` defaults match. Real sizes (CI 2026-06-09): entry `index-*` ≈ 496 KB; largest vendor chunk `lib-*` ≈ 6 054 KB (~446 KB headroom under the 6500 per-chunk ceiling).
 - ⬜ **P2-2..P2-4** — v2.0 foundation (Cloud-Sync conflict resolution, Plugin Registry Beta, ADRs 0005+).
 
 ---
@@ -53,7 +53,7 @@ Status: 🔄 in progress | ⬜ open | ✅ done
 
 ### P3 — Architektur-Hardening & Performance
 - ✅ **P1-6** — Race-Condition Audit: Redux-Undo + Zustand reconcile (`listenerMiddleware.ts` clears `manuscriptPinnedBinderNodeId` when node no longer exists after project change/undo/redo). Commit `a799bc9`.
-- ⬜ **P1-7** — Bundle Budget: Entry ≤ 4000 KB, Total ≤ 6500 KB. Aktuell ~4000 KB Entry (nahe Limit). Monitoring via CI.
+- ✅ **P1-7** — Bundle Budget: ceilings unified in one place (`bundle:budget` = `--max-kb 6500 --max-entry-kb 4000`; script defaults match). Correction: the prior "~4000 KB Entry (nahe Limit)" note was inaccurate — the `index-*` entry is ~496 KB; the binding constraint is the `lib-*` vendor chunk (~6 054 KB vs the 6500 per-chunk ceiling). See WS-5 / F-8.
 - ⬜ **P2-1** — Error Boundaries + Logging: Alle 19 Views, Kein console.error
 
 ### P4 — v2.0 Foundation

--- a/TODO.md
+++ b/TODO.md
@@ -8,6 +8,27 @@ Status: 🔄 in progress | ⬜ open | ✅ done
 
 ---
 
+## v1.21.0 — Integrity & Hardening Cycle (2026-06-10) — IN PROGRESS
+
+> Master Plan: `.claude/plans/master-prompt-storycraft-studio-glistening-pnueli.md` (Deep Audit 2026-06-09, findings F-1…F-9).
+> NOTE: prior sprint blocks are retained inline below (file convention), not moved to `docs/history/`.
+
+### WS — Integrity & Hardening
+- 🔄 **WS-1** — Doc integrity: README badge v1.21.0→v1.20.0 + metrics (433 test files / 2 357 i18n keys); 28 misfiled CHANGELOG entries migrated `[Unreleased]`→`[1.19.0]`; this TODO rollover.
+- ⬜ **WS-2** — CSP `connect-src`: Option B (documented BYOK `https:` tradeoff) + ADR-0004 + `tests/unit/csp.test.ts`; Tauri CSP stays strict (no `https:` blanket).
+- ⬜ **WS-3** — Verify `@huggingface/transformers` 4.2.0 major bump against ai-core integration points (embeddings, ONNX, RAG).
+- ⬜ **WS-4** — Suppression-debt ratchet gate (`scripts/check-suppressions.mjs`, baseline 181) wired into CI + ≥20-site `noExplicitAny` abatement in `services/` (→ ≤161).
+- ⬜ **WS-5** — Bundle-budget single source of truth (Entry 4 000 KB / Total 6 500 KB).
+- ⬜ **WS-6** — `docs/VENDORED-DEPS.md` (y-webrtc fork CVE process + OSV coverage) + `docs/COVERAGE-POLICY.md` ratchet rule.
+
+### Carried over from v1.20.0
+- ⬜ **P1-1** — WebLLM Worker Offload: full GPU isolation in dedicated worker (not started, 5–7 days).
+- 🔄 **P1-2** — Whisper WASM STT end-to-end: download UI ✅ + VAD→STT bridge ✅; remaining = full E2E integration test (CI-only).
+- ⬜ **P1-7** — Bundle Budget monitoring (limits unified via WS-5).
+- ⬜ **P2-2..P2-4** — v2.0 foundation (Cloud-Sync conflict resolution, Plugin Registry Beta, ADRs 0005+).
+
+---
+
 ## v1.20.0 — Deep Correction & Release Hardening (2026-06-06)
 
 > Master Plan: `docs/AUDIT-2026-06-06-Deep-Correction-Plan.md` (aus `.kimi/plans/obsidian-swamp-thing-tempest.md`)
@@ -18,7 +39,7 @@ Status: 🔄 in progress | ⬜ open | ✅ done
   - LoRA: datasetBuilder (19) + evaluationService (16)
   - Voice: intentEngine (17) + feedbackService (23) + audioNavigator (21)
 - ✅ **P0-4** — Native File Associations + Single-Instance: `.storycraft`/`.scst` extensions registered, deep link handler in `services/tauriDeepLink.ts`, Rust `RunEvent::Opened`/`RunEvent::SecondInstance` handlers in `lib.rs`.
-- 🔄 **P0-3** — Quality Gates stabil: lint ✅ · typecheck ✅ · i18n:check ✅ (2026-06-07). parity:check + bundle:budget + smoke:prod benötigen Build → CI-only auf Low-End. Warte auf nächsten CI-Run für Bestätigung.
+- ✅ **P0-3** — Quality Gates stabil: lint ✅ · typecheck ✅ · i18n:check ✅ · parity:check + bundle:budget + smoke:prod green on `main` (CI confirmed through PR #103, merged 2026-06-09).
 
 ### P1 — AI Resilience & Core Reliability
 - ⬜ **P1-1** — WebLLM Worker Offload: Full GPU-Isolation in Dedicated Worker (nicht gestartet, 5–7 Tage)
@@ -27,15 +48,7 @@ Status: 🔄 in progress | ⬜ open | ✅ done
   - **Hinweis:** Rust TaskSupervisor UI (ManuscriptStatsPanel) ist separat in WorkerBus v2 Phase 3 (siehe unten).
 
 ### P2 — Global Readiness & i18n
-- 🔄 **P1-5** — Beta-Sprachen: ja/zh/pt/el ≤ 5% English-Placeholders. **Stand (2026-06-07):**
-  - ✅ `scripts/bulk-translate-locales.mjs` — kostenloser Google-Translate-Endpoint mit Rate-Limiting, Retry, Checkpointing, Glossary
-  - ✅ `locales/translation-glossary.json` — feste Übersetzungen für Produktbegriffe
-  - ✅ `docs/BULK-TRANSLATION.md` — vollständige Anleitung für User
-  - ✅ Übersetzte Files: portal.json (40) + sidebar.json (23) + dashboard.json (107) + common.json (509)
-  - EN-Placeholder-Rate reduziert: **100% → ~71.5%** (660–668 Keys übersetzt pro Sprache)
-  - ⬜ Verbleibend: settings.json (648), writer.json (80), manuscript.json (67), characters.json (71), etc.
-  - ⬜ Ziel ≤5% erfordert ~1550 weitere Übersetzungen pro Sprache
-  - Command: `node scripts/bulk-translate-locales.mjs --lang=ja,zh,pt,el --all --delay=400`
+- ✅ **P1-5** — Beta-Sprachen ja/zh/pt/el ≤ 5% English-Placeholders **erreicht** (verifiziert 2026-06-09: pt 2.2% · el 2.8% · ja 0.9% · zh 0.5%). Tooling: `scripts/bulk-translate-locales.mjs` (Google-Translate-Endpoint mit Rate-Limiting/Retry/Checkpointing/Glossary) + `locales/translation-glossary.json` + `docs/BULK-TRANSLATION.md`. Command: `node scripts/bulk-translate-locales.mjs --lang=ja,zh,pt,el --all --delay=400`.
 - ✅ **P1-4** — Error Boundaries + Logging: Alle 19+ Views in `App.tsx` mit `ErrorBoundary`/`ViewErrorBoundary` gewrappt (WelcomePortal früher Return-Path + alle Modals/Portals). Commits `f810d51` + `6305d64`.
 
 ### P3 — Architektur-Hardening & Performance

--- a/VENDOR-FORKS.md
+++ b/VENDOR-FORKS.md
@@ -31,3 +31,28 @@ upstream monitoring and patch porting.
 - Asserts version string matches expected `-scN` suffix
 
 Wired into CI security job as `verify:vendor`.
+
+## CVE / advisory monitoring (audit finding F-7)
+
+**Coverage boundary — read this before assuming OSV protects the fork.** The CI security job
+(`.github/workflows/ci.yml` → *OSV vulnerability scan*) runs
+`google/osv-scanner-action` against `--lockfile=pnpm-lock.yaml` and `--lockfile=src-tauri/Cargo.lock`
+(`src-tauri/osv-scanner.toml` is only the Rust *ignore* list, not a scan-path config).
+
+| Surface | Scanned by OSV? | How |
+|---------|-----------------|-----|
+| Fork's transitive npm deps (`lib0`, `simple-peer`, `y-protocols`, `yjs`) | ✅ Yes | They resolve into the root `pnpm-lock.yaml`, which OSV scans. |
+| Vendored **y-webrtc source** (`packages/collab-transport/src/*.js`) | ❌ **No** | The fork removed `y-webrtc` from the dependency graph, so OSV has no package@version to match advisories against. A CVE filed against upstream `y-webrtc@10.3.0` would **not** be flagged automatically. |
+
+**Manual process (the gap above):** because the upstream code is now first-party source, OSV cannot
+see advisories against it. Therefore, on every fork-maintenance review (and at minimum quarterly):
+
+1. Check the upstream advisory feeds directly — npm `npm audit`/advisories for `y-webrtc`, the
+   [GitHub Security Advisories for `yjs/y-webrtc`](https://github.com/yjs/y-webrtc/security/advisories),
+   and the project's release notes — for anything at or below our base `10.3.0`.
+2. If a relevant advisory exists, port the upstream fix into the vendored `src/` alongside the three
+   encryption patches, run the `packages/collab-transport` test suite + `pnpm run verify:vendor`,
+   bump the `-scN` suffix, and record it in `VENDOR-DIFF.md`.
+3. The fork's npm dependencies need no manual step — rely on the OSV `pnpm-lock.yaml` scan + Dependabot.
+
+> Coverage policy for unit tests lives in [`docs/COVERAGE-POLICY.md`](docs/COVERAGE-POLICY.md).

--- a/app/listenerMiddleware.ts
+++ b/app/listenerMiddleware.ts
@@ -378,8 +378,7 @@ listenerMiddleware.startListening({
   effect: async () => {
     // QNBS-v3: guard for SSR / worker contexts where window is not defined
     if (typeof window !== 'undefined') {
-      // biome-ignore lint/suspicious/noExplicitAny: window augmentation for cross-service gate
-      (window as any).__storycraft_adaptive_ai__ = true;
+      window.__storycraft_adaptive_ai__ = true;
     }
     try {
       const { generateDeviceProfile } = await import('../services/ai/localAiDeviceProfiler');
@@ -400,8 +399,7 @@ listenerMiddleware.startListening({
   effect: async () => {
     // QNBS-v3: guard for SSR / worker contexts where window is not defined
     if (typeof window !== 'undefined') {
-      // biome-ignore lint/suspicious/noExplicitAny: window augmentation for cross-service gate
-      (window as any).__storycraft_adaptive_ai__ = false;
+      window.__storycraft_adaptive_ai__ = false;
     }
     try {
       const [aiCore, profiler] = await Promise.all([
@@ -428,8 +426,7 @@ listenerMiddleware.startListening({
 export function initAdaptiveAiOnStartup(enabled: boolean): void {
   if (!enabled) return;
   if (typeof window !== 'undefined') {
-    // biome-ignore lint/suspicious/noExplicitAny: window augmentation for cross-service gate
-    (window as any).__storycraft_adaptive_ai__ = true;
+    window.__storycraft_adaptive_ai__ = true;
   }
   // Profile generation is handled by useAdaptiveAi on first mount
   logger.info('Adaptive AI engine: window gate set on cold start');

--- a/docs/COVERAGE-POLICY.md
+++ b/docs/COVERAGE-POLICY.md
@@ -1,0 +1,52 @@
+# Coverage Ratchet Policy
+
+Single source of truth for **when and how Vitest coverage thresholds change** (audit finding F-9).
+The thresholds themselves live in [`vitest.config.ts`](../vitest.config.ts) (`coverage.thresholds`);
+this document is the *policy* around them.
+
+## Why this exists
+
+Coverage thresholds were once set **above** the value CI actually measured (target
+`L76/F68/B61/S74` that was "never actually met on CI"), which inverts the gate: every run that
+should pass goes red, and the only "fix" is to lower the bar. That correction loop (`L72/F64/B58/S70`,
+2026-05-31) is the failure mode this policy prevents. A threshold must always sit **below** the
+measured value, with a margin that absorbs run-to-run variance (Node 22 vs 24, flaky branch counting).
+
+## The rule
+
+1. **Never lower a threshold to make CI green** (hard rule HR-1). A drop in measured coverage is a
+   signal to add tests, not to move the goalpost. The only legitimate decrease is removing a metric
+   that no longer applies (e.g. excluding generated/vendored code from the denominator — document it
+   in the `vitest.config.ts` comment).
+2. **Ratchet up at most once per minor release.** After a release's tests land and CI reports stable
+   numbers, raise each threshold to **(CI-measured − 1 to 2 points)**. The margin is mandatory; do
+   not set a threshold equal to or above the measured value.
+3. **Measure on CI, not locally.** Full coverage (`vitest run --coverage`) is RAM-heavy and is a
+   CI-only job on constrained hardware. Take the authoritative numbers from the CI `quality` job /
+   Codecov, never from a local partial run.
+4. **Record the move.** Every change to `coverage.thresholds` updates the history comment in
+   `vitest.config.ts` with the date, the CI-measured value it was derived from, and the new floor.
+
+## Current state (2026-06-09)
+
+| Metric | Threshold (floor) | CI-measured (last full run) | Margin |
+|--------|-------------------|-----------------------------|--------|
+| Lines | 74 | 76.59 | ~2.6 |
+| Statements | 72 | 74.60 | ~2.6 |
+| Functions | 67 | 69.08 | ~2.1 |
+| Branches | 60 | 62.31 | ~2.3 |
+
+**P1 stretch target:** `L85 / B75 / F80` — reached by ratcheting per the rule above, never by a
+one-time jump that would risk inverting the gate again.
+
+## Procedure for the next ratchet
+
+1. Merge the release's test additions; let CI run the full coverage matrix (Node 22 + 24).
+2. Read the lower of the two nodes' measured values per metric.
+3. Set each threshold to `floor(measured − 1.5)`.
+4. Update the `vitest.config.ts` history comment (date + source value + new floor).
+5. Open the bump in its own commit so the ratchet is auditable: `test(coverage): ratchet thresholds → …`.
+
+> Related: the suppression-debt ratchet ([`scripts/check-suppressions.mjs`](../scripts/check-suppressions.mjs),
+> `suppressions-baseline.json`) follows the same monotonic principle for `biome-ignore` counts —
+> baseline may only fall. Vendored-dependency CVE process: [`VENDOR-FORKS.md`](../VENDOR-FORKS.md).

--- a/docs/SECURITY-THREAT-MODEL.md
+++ b/docs/SECURITY-THREAT-MODEL.md
@@ -116,7 +116,22 @@ Goal: Intercept/decrypt collaboration traffic
 | `aiPolicy.ts` | S | Provider allowlist, localStorageOnly gate | ✅ Complete |
 | `logger.ts` | I,R | GDPR sanitization, no key logging | ✅ Complete |
 | `sw.js` | I | Network-only for AI hosts | ✅ Complete |
-| `tauri.conf.json` | I | CSP with explicit connect-src | ✅ Complete |
+| `tauri.conf.json` | I | Strict CSP — explicit `connect-src` allowlist, no `https:` blanket | ✅ Complete |
+| `index.html` (web PWA) | I | CSP `connect-src 'self' https:` — broad HTTPS by design for BYOK; no `http:`/`ws:` wildcards | ⚠️ Documented tradeoff ([ADR-0004](adr/0004-csp-connect-src-byok-tradeoff.md)) |
+
+### CSP connect-src: web-vs-Tauri asymmetry (ADR-0004)
+
+The web PWA's `connect-src` intentionally allows the `https:` scheme-source because the shipped BYOK
+feature `openAiCompatibleBaseUrl` (Settings → AI → custom base URL) lets users target arbitrary
+self-hosted/third-party OpenAI-compatible proxies that cannot be statically enumerated in a `<meta>`
+CSP. The redundant explicit cloud-provider entries were removed (they changed nothing under `https:`
+and implied a hardening the policy did not provide). **Residual risk:** a `fetch` driven in the web
+PWA (e.g. via AI prompt injection) can reach any HTTPS origin. Mitigations: no secrets in
+`connect-src`-reachable globals; keys encrypted at rest and only attached to the user's chosen
+provider request; AI output never `eval`'d; host HTTP-header CSP tightens production further.
+`http:`/`ws:` scheme-wildcards remain disallowed (cleartext exfiltration blocked). The native **Tauri**
+CSP stays strict (no `https:`). Closing this fully = build-time CSP generation (Option C, v2.0).
+Regression test: `tests/unit/csp.test.ts`.
 
 ## Security Checklist
 
@@ -125,7 +140,7 @@ Goal: Intercept/decrypt collaboration traffic
 - [x] IV uniqueness per operation (random 12-byte)
 - [x] No API keys in localStorage/sessionStorage
 - [x] No console.log of sensitive data
-- [x] CSP restricts connect-src to known hosts
+- [x] CSP connect-src: Tauri strict (known hosts); web PWA `https:` by design for BYOK, no `http:`/`ws:` wildcards (ADR-0004)
 - [x] Collaboration requires password in production
 - [x] Plugin system permission-gated
 - [x] Plugin system Worker-isolated (P0-2) — `workers/plugin.worker.ts`

--- a/docs/adr/0004-csp-connect-src-byok-tradeoff.md
+++ b/docs/adr/0004-csp-connect-src-byok-tradeoff.md
@@ -1,0 +1,83 @@
+# ADR 0004 — CSP `connect-src` and the BYOK `https:` tradeoff
+
+- **Status:** Accepted
+- **Date:** 2026-06-10
+- **Deciders:** Maintainer + Claude Code
+- **Context tags:** security, csp, networking, byok, tauri
+
+## Context
+
+The web PWA's `index.html` Content-Security-Policy `connect-src` directive contained both a
+`https:` scheme-source **and** an explicit allowlist of cloud-provider endpoints
+(`https://generativelanguage.googleapis.com`, `https://api.openai.com`, `https://api.x.ai`,
+`https://api.groq.com`, `https://openrouter.ai`, `https://api.openrouter.ai`).
+
+A scheme-source of `https:` matches **every** HTTPS origin. So the explicit per-provider entries
+allowed *nothing the `https:` source did not already allow* — they were dead allowlist entries that
+visually implied an egress hardening the policy did not actually provide. A 2026-06-09 audit (F-2)
+flagged the explicit list, added in commit `364025e`, as functionally inert: the data-exfiltration
+vector it appeared to close (an attacker forcing a `fetch` to an arbitrary HTTPS endpoint, e.g. via
+AI prompt injection) remained open for all HTTPS targets.
+
+The obvious "fix" — drop `https:` and keep only the explicit allowlist — **breaks a shipped
+feature**. StoryCraft ships **BYOK** (bring-your-own-key) with a user-configurable
+`openAiCompatibleBaseUrl` (Settings → AI → custom base URL; see `features/settings/settingsSlice.ts`,
+`components/settings/AiProviderCard.tsx`, `services/ai/storyCraftCompletionFetch.ts`,
+`services/aiProviderService.ts`, `types.ts`). Users point the app at arbitrary self-hosted or
+third-party OpenAI-compatible proxies. Those origins are user data — they cannot be statically
+enumerated in a `<meta>` CSP shipped in the bundle. A strict allowlist would silently break every
+user running a custom proxy.
+
+The native **Tauri** build is different: `src-tauri/tauri.conf.json` already ships a strict
+`connect-src` with no `https:` blanket (only the enumerated provider + localhost + wss origins).
+The desktop app has OS-level egress controls and a narrower threat model, so the broad scheme is not
+needed there.
+
+## Decision
+
+**Option B — keep `https:`, remove the redundant explicit cloud endpoints, document the tradeoff.**
+
+- The web PWA `connect-src` keeps `'self' https:` plus the sources `https:` does **not** cover:
+  `http://localhost|127.0.0.1` (Ollama :11434, LM Studio :1234, local AI :8000) and the explicit
+  `wss://` Yjs signaling endpoints. No `http:` or `ws:` scheme-wildcards.
+- The explicit `https://…` provider endpoints are removed — they are strictly redundant under
+  `https:` and their presence misrepresented the policy's strength.
+- The native **Tauri** `connect-src` stays strict (no `https:`). The asymmetry is intentional and
+  documented: only the web PWA accepts the broad scheme, and only because of BYOK custom base URLs.
+- A regression test (`tests/unit/csp.test.ts`) asserts the invariant: web CSP contains `https:` and
+  no `http:`/`ws:` scheme-wildcards; Tauri CSP contains no `https:` blanket.
+
+## Consequences
+
+- **Positive:** the policy now states the truth — `https:` is the actual egress boundary, justified
+  by a real shipped feature, instead of an allowlist that implied otherwise. Tauri keeps strict
+  egress. `http:`/`ws:` scheme-wildcards remain disallowed, so cleartext exfiltration is still blocked.
+- **Negative (accepted residual risk):** an attacker who can drive a `fetch` in the web PWA (e.g.
+  successful AI prompt injection into a code path that issues a request) can reach any HTTPS origin.
+  Mitigations: no secrets are placed in `connect-src`-reachable globals; API keys are encrypted at
+  rest and only attached to the user-configured provider request; AI output is never `eval`'d
+  (`CLAUDE.md` Key Constraints); the host (Vercel/CF) tightens CSP further via HTTP response headers
+  in production. Closing this fully requires build-time CSP generation from the provider registry +
+  a validated custom-endpoint allowlist (Option C), deferred to v2.0.
+- **Maintenance rule:** when adding a new **localhost** or **wss** endpoint, update **both**
+  `index.html` and `src-tauri/tauri.conf.json`, and extend `tests/unit/csp.test.ts`. New **cloud
+  HTTPS** providers need no `connect-src` change on web (covered by `https:`) but **do** need an
+  explicit entry in the strict Tauri `connect-src`.
+
+## Rejected alternatives
+
+- **Option A — strict allowlist (drop `https:`):** breaks the shipped `openAiCompatibleBaseUrl` BYOK
+  feature for every user running a self-hosted or alternate proxy. Rejected.
+- **Option C — dynamic/build-time CSP generation** from the provider registry plus a
+  settings-validated custom endpoint: the correct long-term fix but significant new build machinery;
+  deferred to v2.0.
+- **Keep the redundant explicit endpoints:** rejected — they change nothing under `https:` and
+  misrepresent the policy.
+
+## References
+
+- `index.html` (web CSP meta), `src-tauri/tauri.conf.json` (native CSP)
+- `tests/unit/csp.test.ts` (regression test)
+- `docs/SECURITY-THREAT-MODEL.md` (web-vs-Tauri egress asymmetry)
+- Audit 2026-06-09 finding F-2; commit `364025e`
+- [[0002-local-ai-stack-layering]], [[0003-workerbus-hybrid-routing]]

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -9,6 +9,7 @@ than editing history.
 | [0001](0001-state-management-boundaries.md) | State-management boundaries: Redux Toolkit vs Zustand | Accepted |
 | [0002](0002-local-ai-stack-layering.md) | Local-AI stack layering and fallback chain | Accepted |
 | [0003](0003-workerbus-hybrid-routing.md) | WorkerBus v2 hybrid routing and the Rust TaskSupervisor | Accepted |
+| [0004](0004-csp-connect-src-byok-tradeoff.md) | CSP `connect-src` and the BYOK `https:` tradeoff | Accepted |
 
 **Format:** Context → Decision → Consequences (incl. rejected alternatives). Keep each ADR to one
 decision. Link related records with `[[slug]]`.

--- a/index.html
+++ b/index.html
@@ -50,12 +50,22 @@
       - script-src: nur eigene Skripte (Vite ES modules, kein inline nötig)
       - style-src: eigene + unsafe-inline (React inline-styles) + fonts.googleapis.com für CJK/Greek
       - font-src: self + fonts.gstatic.com für CJK/Greek (Google Fonts)
-      - connect-src: Gemini, OpenAI, xAI, Groq, OpenRouter, Ollama (localhost:11434),
-                    LM Studio (localhost:1234), local AI (localhost:8000),
-                    Yjs signaling WebSockets (explicit endpoints only — no wildcards),
-                    https: — intentional broad HTTPS allowance for user-configured
-                    openAiCompatibleBaseUrl (arbitrary remote proxy endpoints that
-                    cannot be statically enumerated in the CSP)
+      - connect-src: 'self'
+                    + https:  — intentional broad HTTPS scheme-source. REQUIRED by the
+                      shipped BYOK feature `openAiCompatibleBaseUrl` (Settings → AI →
+                      custom base URL): users point StoryCraft at arbitrary self-hosted
+                      or third-party OpenAI-compatible proxies that cannot be statically
+                      enumerated in a meta CSP. Because `https:` already covers every
+                      HTTPS origin, the explicit cloud-provider endpoints (Gemini,
+                      OpenAI, xAI, Groq, OpenRouter) were REMOVED as dead allowlist
+                      entries — keeping them implied a hardening that `https:` negates.
+                      Decision recorded in docs/adr/0004-csp-connect-src-byok-tradeoff.md.
+                    + http://localhost|127.0.0.1 (:11434 Ollama, :1234 LM Studio,
+                      :8000 local AI) — NOT covered by `https:`, so kept explicit.
+                    + wss:// Yjs signaling — explicit endpoints only, no ws: wildcard.
+                    The native Tauri build (src-tauri/tauri.conf.json) keeps a STRICT
+                    connect-src with no `https:` blanket; only the web PWA accepts the
+                    broader scheme for BYOK. See ADR-0004 for the web-vs-Tauri rationale.
       - img-src: data: URLs für Base64-Bilder erlaubt
       - Produktions-CSP wird über HTTP-Header des Hosts verschärft
     -->
@@ -66,7 +76,7 @@
             style-src   'self' 'unsafe-inline' https://fonts.googleapis.com;
             font-src    'self' https://fonts.gstatic.com data:;
             img-src     'self' data: blob:;
-            connect-src 'self' https: https://generativelanguage.googleapis.com https://api.openai.com https://api.x.ai https://api.groq.com https://openrouter.ai https://api.openrouter.ai http://localhost:11434 http://127.0.0.1:11434 http://localhost:1234 http://127.0.0.1:1234 http://localhost:8000 http://127.0.0.1:8000 wss://y-webrtc-signaling.fly.dev wss://signaling.yjs.dev;
+            connect-src 'self' https: http://localhost:11434 http://127.0.0.1:11434 http://localhost:1234 http://127.0.0.1:1234 http://localhost:8000 http://127.0.0.1:8000 wss://y-webrtc-signaling.fly.dev wss://signaling.yjs.dev;
             worker-src  'self' blob:;
             manifest-src 'self';
             object-src  'none';

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "i18n:check": "node scripts/check-i18n-keys.mjs && node scripts/build-i18n.mjs && node scripts/content-guard.mjs",
     "content:guard": "node scripts/content-guard.mjs",
     "parity:check": "tsx scripts/audit-feature-parity.ts",
+    "suppressions:check": "node scripts/check-suppressions.mjs",
     "graphify": "node scripts/graphify-cli.mjs",
     "graphify:install": "node scripts/graphify-cli.mjs install",
     "graphify:update": "node scripts/graphify-update.mjs",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "test:storybook": "test-storybook",
     "test:vrt": "PLAYWRIGHT_REUSE_SERVER=true playwright test tests/e2e/visual-regression.spec.ts --project=chromium",
     "analyze": "ANALYZE=true vite build",
-    "bundle:budget": "node scripts/check-bundle-budget.mjs --max-kb 7000 --max-entry-kb 4500",
+    "bundle:budget": "node scripts/check-bundle-budget.mjs --max-kb 6500 --max-entry-kb 4000",
     "dev:tauri": "tauri dev",
     "ci:quick": "bash infra/low-end-ci/scripts/ci-quick.sh",
     "ci:quick:unit": "bash infra/low-end-ci/scripts/ci-quick.sh --unit",

--- a/scripts/check-bundle-budget.mjs
+++ b/scripts/check-bundle-budget.mjs
@@ -1,9 +1,20 @@
 #!/usr/bin/env node
 /**
- * Fail CI if any emitted JS chunk under dist/assets exceeds --max-kb (default 7000),
- * and if the main entry chunk exceeds --max-entry-kb (default 4500).
- * Local ML stacks (@mlc-ai/web-llm, onnxruntime-web, @xenova/transformers) routinely emit multi‑MB
- * vendor chunks; keep this ceiling above that bundle while still catching accidental regressions.
+ * Bundle-budget gate (audit finding F-8 — single source of truth).
+ *
+ * Two independent ceilings, both measured on RAW (uncompressed) per-file KB under dist/assets:
+ *   --max-kb       (default 6500): any NON-entry JS chunk (`lib-*`, vendor, lazy views).
+ *   --max-entry-kb (default 4000): the `index-*` entry chunk only.
+ *
+ * The package.json `bundle:budget` script passes these same values explicitly — defaults and
+ * invocation are kept in lockstep so there is ONE budget, not two. Do not diverge them.
+ *
+ * Headroom at 2026-06-09 (main CI build, run 27241741348):
+ *   - entry `index-*.js` ≈ 496 KB  → ~3 500 KB under the 4000 ceiling (entry is small; the ceiling
+ *     is generous on purpose — local-AI views are lazy-loaded, not in the entry).
+ *   - largest chunk `lib-*.js` ≈ 6 054 KB → ~446 KB under the 6500 ceiling. This vendor bundle
+ *     (@mlc-ai/web-llm + onnxruntime-web + transformers) is the real constraint; the 6500 ceiling
+ *     catches an accidental >446 KB regression there while still passing today.
  * Run after `pnpm run build`.
  */
 import fs from 'node:fs';
@@ -15,8 +26,8 @@ const root = path.join(__dirname, '..');
 const assetsDir = path.join(root, 'dist', 'assets');
 
 const argv = process.argv.slice(2);
-let maxKb = 7000;
-let maxEntryKb = 4500;
+let maxKb = 6500;
+let maxEntryKb = 4000;
 for (let i = 0; i < argv.length; i++) {
   if (argv[i] === '--max-kb' && argv[i + 1]) {
     maxKb = Number(argv[i + 1]);

--- a/scripts/check-suppressions.mjs
+++ b/scripts/check-suppressions.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+/**
+ * Suppression-debt ratchet gate (audit finding F-4).
+ *
+ * Counts `biome-ignore` directives across the TS/TSX source tree, grouped by rule, and fails CI
+ * when the total exceeds the committed baseline in `suppressions-baseline.json`. The baseline may
+ * only ever DECREASE — this stops the suppression count (162x noExplicitAny at baseline time) from
+ * silently growing the way it did Mar→Jun 2026 (137 → 186). No gate previously prevented that.
+ *
+ * Run:    node scripts/check-suppressions.mjs            # gate (exit 1 if total > baseline)
+ *         node scripts/check-suppressions.mjs --update   # rewrite baseline to current (after abatement)
+ *
+ * Writes a full per-rule breakdown to `reports/suppressions.json`.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.join(__dirname, '..');
+
+// Directories that never contain first-party source we want to count.
+const IGNORE_DIRS = new Set([
+  'node_modules',
+  'dist',
+  'dist-storybook',
+  'storybook-static',
+  'coverage',
+  '.git',
+  'reports',
+  'graphify-out',
+  '.codegraph',
+  'playwright-report',
+  'test-results',
+  'src-tauri', // Rust + target/, no .ts
+]);
+
+const SRC_EXT = new Set(['.ts', '.tsx']);
+const BIOME_IGNORE = /biome-ignore(?:-start|-end)?\s+([a-zA-Z][\w/]*)/;
+
+/** Recursively collect first-party .ts/.tsx files. */
+function collect(dir, out) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      if (IGNORE_DIRS.has(entry.name)) continue;
+      collect(path.join(dir, entry.name), out);
+    } else if (SRC_EXT.has(path.extname(entry.name))) {
+      out.push(path.join(dir, entry.name));
+    }
+  }
+  return out;
+}
+
+const files = collect(root, []);
+/** @type {Record<string, number>} */
+const byRule = {};
+let total = 0;
+for (const file of files) {
+  const text = fs.readFileSync(file, 'utf8');
+  for (const line of text.split('\n')) {
+    if (!line.includes('biome-ignore')) continue;
+    const m = line.match(BIOME_IGNORE);
+    const rule = m ? m[1] : 'unknown';
+    byRule[rule] = (byRule[rule] ?? 0) + 1;
+    total++;
+  }
+}
+
+const sorted = Object.fromEntries(Object.entries(byRule).sort((a, b) => b[1] - a[1]));
+const report = {
+  total,
+  byRule: sorted,
+  files: files.length,
+  generatedAt: new Date().toISOString(),
+};
+const reportsDir = path.join(root, 'reports');
+fs.mkdirSync(reportsDir, { recursive: true });
+fs.writeFileSync(
+  path.join(reportsDir, 'suppressions.json'),
+  `${JSON.stringify(report, null, 2)}\n`,
+);
+
+const baselinePath = path.join(root, 'suppressions-baseline.json');
+
+if (process.argv.includes('--update')) {
+  fs.writeFileSync(baselinePath, `${JSON.stringify({ total, byRule: sorted }, null, 2)}\n`);
+  console.log(`[suppressions] baseline updated → ${total} total across ${files.length} files`);
+  process.exit(0);
+}
+
+if (!fs.existsSync(baselinePath)) {
+  console.error(
+    '[suppressions] missing suppressions-baseline.json — run with --update to create it.',
+  );
+  process.exit(1);
+}
+
+const baseline = JSON.parse(fs.readFileSync(baselinePath, 'utf8'));
+console.log(
+  `[suppressions] total ${total} (baseline ${baseline.total}) across ${files.length} files`,
+);
+for (const [rule, n] of Object.entries(sorted))
+  console.log(`  ${n.toString().padStart(4)}  ${rule}`);
+
+if (total > baseline.total) {
+  console.error(
+    `\n[suppressions] FAIL — ${total} > baseline ${baseline.total} (+${total - baseline.total}). ` +
+      'Remove a suppression or fix the root cause; do not raise the baseline (ratchet-only).',
+  );
+  process.exit(1);
+}
+if (total < baseline.total) {
+  console.log(
+    `[suppressions] ${baseline.total - total} below baseline — run \`node scripts/check-suppressions.mjs --update\` to ratchet it down.`,
+  );
+}
+console.log('[suppressions] OK');

--- a/services/localAiFacade.ts
+++ b/services/localAiFacade.ts
@@ -53,8 +53,7 @@ export async function generateLocalText(
   try {
     // QNBS-v3: When adaptive AI engine is enabled, use its task config for optimal backend/model.
     const adaptiveEnabled =
-      typeof window !== 'undefined' &&
-      (window as unknown as Record<string, boolean>)['__storycraft_adaptive_ai__'] === true;
+      typeof window !== 'undefined' && window.__storycraft_adaptive_ai__ === true;
 
     let result: LocalAiResponse;
     let usedBackend = 'heuristic';

--- a/suppressions-baseline.json
+++ b/suppressions-baseline.json
@@ -1,0 +1,14 @@
+{
+  "total": 181,
+  "byRule": {
+    "lint/suspicious/noExplicitAny": 162,
+    "lint/correctness/useExhaustiveDependencies": 6,
+    "lint/a11y/useSemanticElements": 5,
+    "lint/security/noDangerouslySetInnerHtml": 2,
+    "lint/complexity/useArrowFunction": 2,
+    "lint/suspicious/noThenProperty": 1,
+    "lint/a11y/useAriaPropsSupportedByRole": 1,
+    "lint/correctness/noEmptyPattern": 1,
+    "lint/correctness/noConstructorReturn": 1
+  }
+}

--- a/suppressions-baseline.json
+++ b/suppressions-baseline.json
@@ -1,7 +1,7 @@
 {
-  "total": 181,
+  "total": 159,
   "byRule": {
-    "lint/suspicious/noExplicitAny": 162,
+    "lint/suspicious/noExplicitAny": 140,
     "lint/correctness/useExhaustiveDependencies": 6,
     "lint/a11y/useSemanticElements": 5,
     "lint/security/noDangerouslySetInnerHtml": 2,

--- a/tests/unit/ConnectionLayer.test.tsx
+++ b/tests/unit/ConnectionLayer.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
+import type { RootState } from '../../app/store';
 import type { PlotConnection, Subplot } from '../../types';
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────
@@ -13,39 +14,39 @@ const makeMockState = (overrides?: {
   isDrawingConnection?: boolean;
   drawFromSectionId?: string | null;
   selectedConnectionId?: string | null;
-}) => ({
-  project: {
-    present: {
-      data: {
-        manuscript: [],
-        plotConnections: overrides?.connections ?? [],
-        plotSubplots: overrides?.subplots ?? [],
-        plotTensionOverrides: {},
-        characters: { ids: [], entities: {} },
-        worlds: { ids: [], entities: {} },
-        outline: [],
-        logline: '',
-        title: '',
+}) =>
+  ({
+    project: {
+      present: {
+        data: {
+          manuscript: [],
+          plotConnections: overrides?.connections ?? [],
+          plotSubplots: overrides?.subplots ?? [],
+          plotTensionOverrides: {},
+          characters: { ids: [], entities: {} },
+          worlds: { ids: [], entities: {} },
+          outline: [],
+          logline: '',
+          title: '',
+        },
       },
     },
-  },
-  plotBoard: {
-    selectedConnectionId: overrides?.selectedConnectionId ?? null,
-    isDrawingConnection: overrides?.isDrawingConnection ?? false,
-    drawFromSectionId: overrides?.drawFromSectionId ?? null,
-    activeMode: 'canvas',
-    activeSubplotFilter: null,
-    zoom: 1,
-    panX: 0,
-    panY: 0,
-    snapToGrid: false,
-  },
-});
+    plotBoard: {
+      selectedConnectionId: overrides?.selectedConnectionId ?? null,
+      isDrawingConnection: overrides?.isDrawingConnection ?? false,
+      drawFromSectionId: overrides?.drawFromSectionId ?? null,
+      activeMode: 'canvas',
+      activeSubplotFilter: null,
+      zoom: 1,
+      panX: 0,
+      panY: 0,
+      snapToGrid: false,
+    },
+  }) as unknown as RootState;
 
 vi.mock('../../app/hooks', () => ({
   useAppDispatch: () => mockDispatch,
-  // biome-ignore lint/suspicious/noExplicitAny: test mock — required for selector mock assignability
-  useAppSelectorShallow: vi.fn((selector: (s: any) => unknown) => selector(makeMockState())),
+  useAppSelectorShallow: vi.fn((selector: (s: RootState) => unknown) => selector(makeMockState())),
 }));
 
 import { ConnectionLayer } from '../../components/scene-board/ConnectionLayer';
@@ -110,8 +111,7 @@ describe('ConnectionLayer', () => {
 
   it('renders a path group for each connection', async () => {
     const { useAppSelectorShallow } = await import('../../app/hooks');
-    // biome-ignore lint/suspicious/noExplicitAny: test mock — required for selector mock assignability
-    vi.mocked(useAppSelectorShallow).mockImplementation((selector: (s: any) => unknown) =>
+    vi.mocked(useAppSelectorShallow).mockImplementation((selector: (s: RootState) => unknown) =>
       selector(makeMockState({ connections: [conn1] })),
     );
 
@@ -130,8 +130,7 @@ describe('ConnectionLayer', () => {
 
   it('skips connections whose section positions are missing from layout', async () => {
     const { useAppSelectorShallow } = await import('../../app/hooks');
-    // biome-ignore lint/suspicious/noExplicitAny: test mock — required for selector mock assignability
-    vi.mocked(useAppSelectorShallow).mockImplementation((selector: (s: any) => unknown) =>
+    vi.mocked(useAppSelectorShallow).mockImplementation((selector: (s: RootState) => unknown) =>
       selector(
         makeMockState({
           connections: [
@@ -161,8 +160,7 @@ describe('ConnectionLayer', () => {
 
   it('dispatches setSelectedConnection when a hit-test path is clicked', async () => {
     const { useAppSelectorShallow } = await import('../../app/hooks');
-    // biome-ignore lint/suspicious/noExplicitAny: test mock — required for selector mock assignability
-    vi.mocked(useAppSelectorShallow).mockImplementation((selector: (s: any) => unknown) =>
+    vi.mocked(useAppSelectorShallow).mockImplementation((selector: (s: RootState) => unknown) =>
       selector(makeMockState({ connections: [conn1] })),
     );
 
@@ -185,8 +183,7 @@ describe('ConnectionLayer', () => {
 
   it('shows draw-mode preview path when isDrawingConnection is true', async () => {
     const { useAppSelectorShallow } = await import('../../app/hooks');
-    // biome-ignore lint/suspicious/noExplicitAny: test mock — required for selector mock assignability
-    vi.mocked(useAppSelectorShallow).mockImplementation((selector: (s: any) => unknown) =>
+    vi.mocked(useAppSelectorShallow).mockImplementation((selector: (s: RootState) => unknown) =>
       selector(makeMockState({ isDrawingConnection: true, drawFromSectionId: 's1' })),
     );
 
@@ -205,8 +202,7 @@ describe('ConnectionLayer', () => {
 
   it('does not show preview path when cursorCanvasPos is null', async () => {
     const { useAppSelectorShallow } = await import('../../app/hooks');
-    // biome-ignore lint/suspicious/noExplicitAny: test mock — required for selector mock assignability
-    vi.mocked(useAppSelectorShallow).mockImplementation((selector: (s: any) => unknown) =>
+    vi.mocked(useAppSelectorShallow).mockImplementation((selector: (s: RootState) => unknown) =>
       selector(makeMockState({ isDrawingConnection: true, drawFromSectionId: 's1' })),
     );
 
@@ -225,8 +221,7 @@ describe('ConnectionLayer', () => {
 
   it('renders label text when connection has a label', async () => {
     const { useAppSelectorShallow } = await import('../../app/hooks');
-    // biome-ignore lint/suspicious/noExplicitAny: test mock — required for selector mock assignability
-    vi.mocked(useAppSelectorShallow).mockImplementation((selector: (s: any) => unknown) =>
+    vi.mocked(useAppSelectorShallow).mockImplementation((selector: (s: RootState) => unknown) =>
       selector(
         makeMockState({
           connections: [{ ...conn1, label: 'Key link' }],
@@ -250,8 +245,7 @@ describe('ConnectionLayer', () => {
   it('uses subplot color when connection has subplotId', async () => {
     const { useAppSelectorShallow } = await import('../../app/hooks');
     const subplot: Subplot = { id: 'sp-1', name: 'Love arc', color: '#a855f7', sectionIds: [] };
-    // biome-ignore lint/suspicious/noExplicitAny: test mock — required for selector mock assignability
-    vi.mocked(useAppSelectorShallow).mockImplementation((selector: (s: any) => unknown) =>
+    vi.mocked(useAppSelectorShallow).mockImplementation((selector: (s: RootState) => unknown) =>
       selector(
         makeMockState({
           connections: [{ ...conn1, subplotId: 'sp-1' }],
@@ -275,8 +269,7 @@ describe('ConnectionLayer', () => {
 
   it('uses parallel stroke-dasharray for parallel connection type', async () => {
     const { useAppSelectorShallow } = await import('../../app/hooks');
-    // biome-ignore lint/suspicious/noExplicitAny: test mock — required for selector mock assignability
-    vi.mocked(useAppSelectorShallow).mockImplementation((selector: (s: any) => unknown) =>
+    vi.mocked(useAppSelectorShallow).mockImplementation((selector: (s: RootState) => unknown) =>
       selector(makeMockState({ connections: [{ ...conn1, type: 'parallel' }] })),
     );
 

--- a/tests/unit/ProgressTrackerView.test.tsx
+++ b/tests/unit/ProgressTrackerView.test.tsx
@@ -1,43 +1,43 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { RootState } from '../../app/store';
 import { ProgressTrackerView } from '../../components/ProgressTrackerView';
 
 const mockDispatch = vi.fn();
 const mockSessionActive = { startedAt: Date.now(), startWordCount: 100 };
 const today = new Date().toISOString().slice(0, 10);
 
-const makeMockState = (progressTrackerOverride = {}) => ({
-  project: {
-    present: {
-      data: {
-        manuscript: [{ id: 'ms1', content: 'hello world test' }],
-        writingHistory: [
-          { date: today, words: 300 },
-          { date: '2024-01-01', words: 500 },
-        ],
+const makeMockState = (progressTrackerOverride = {}) =>
+  ({
+    project: {
+      present: {
+        data: {
+          manuscript: [{ id: 'ms1', content: 'hello world test' }],
+          writingHistory: [
+            { date: today, words: 300 },
+            { date: '2024-01-01', words: 500 },
+          ],
+        },
       },
     },
-  },
-  progressTracker: {
-    dailyGoalWords: 500,
-    weeklyGoalWords: 2500,
-    activeSession: null,
-    streakDays: 3,
-    longestStreak: 7,
-    totalWordsAllTime: 1200,
-    ...progressTrackerOverride,
-  },
-  settings: { language: 'en', theme: 'dark' },
-});
+    progressTracker: {
+      dailyGoalWords: 500,
+      weeklyGoalWords: 2500,
+      activeSession: null,
+      streakDays: 3,
+      longestStreak: 7,
+      totalWordsAllTime: 1200,
+      ...progressTrackerOverride,
+    },
+    settings: { language: 'en', theme: 'dark' },
+  }) as unknown as RootState;
 
 let mockState = makeMockState();
 
 vi.mock('../../app/hooks', () => ({
   useAppDispatch: vi.fn(() => mockDispatch),
-  // biome-ignore lint/suspicious/noExplicitAny: test mock
-  useAppSelector: vi.fn((selector: (s: any) => unknown) => selector(mockState as any)),
-  // biome-ignore lint/suspicious/noExplicitAny: test mock
-  useAppSelectorShallow: vi.fn((selector: (s: any) => unknown) => selector(mockState as any)),
+  useAppSelector: vi.fn((selector: (s: RootState) => unknown) => selector(mockState)),
+  useAppSelectorShallow: vi.fn((selector: (s: RootState) => unknown) => selector(mockState)),
 }));
 
 vi.mock('../../hooks/useTranslation', () => ({
@@ -81,9 +81,8 @@ describe('ProgressTrackerView', () => {
   it('shows Stop Session button when session is active', async () => {
     mockState = makeMockState({ activeSession: mockSessionActive });
     const { useAppSelector } = await import('../../app/hooks');
-    vi.mocked(useAppSelector).mockImplementation(
-      // biome-ignore lint/suspicious/noExplicitAny: test mock
-      (selector: (s: any) => unknown) => selector(mockState as any),
+    vi.mocked(useAppSelector).mockImplementation((selector: (s: RootState) => unknown) =>
+      selector(mockState),
     );
     render(<ProgressTrackerView />);
     expect(screen.getByRole('button', { name: 'progress.session.stop' })).toBeDefined();
@@ -92,9 +91,8 @@ describe('ProgressTrackerView', () => {
   it('dispatches endSession when Stop Session clicked', async () => {
     mockState = makeMockState({ activeSession: mockSessionActive });
     const { useAppSelector } = await import('../../app/hooks');
-    vi.mocked(useAppSelector).mockImplementation(
-      // biome-ignore lint/suspicious/noExplicitAny: test mock
-      (selector: (s: any) => unknown) => selector(mockState as any),
+    vi.mocked(useAppSelector).mockImplementation((selector: (s: RootState) => unknown) =>
+      selector(mockState),
     );
     render(<ProgressTrackerView />);
     fireEvent.click(screen.getByRole('button', { name: 'progress.session.stop' }));
@@ -111,11 +109,10 @@ describe('ProgressTrackerView', () => {
     mockState = {
       ...makeMockState(),
       project: { present: { data: { manuscript: [], writingHistory: [] } } },
-    };
+    } as unknown as RootState;
     const { useAppSelector } = await import('../../app/hooks');
-    vi.mocked(useAppSelector).mockImplementation(
-      // biome-ignore lint/suspicious/noExplicitAny: test mock
-      (selector: (s: any) => unknown) => selector(mockState as any),
+    vi.mocked(useAppSelector).mockImplementation((selector: (s: RootState) => unknown) =>
+      selector(mockState),
     );
     render(<ProgressTrackerView />);
     expect(screen.getByText('progress.chart.noData')).toBeDefined();
@@ -148,9 +145,8 @@ describe('ProgressTrackerView', () => {
   it('session timer displays timer element when session active', async () => {
     mockState = makeMockState({ activeSession: mockSessionActive });
     const { useAppSelector } = await import('../../app/hooks');
-    vi.mocked(useAppSelector).mockImplementation(
-      // biome-ignore lint/suspicious/noExplicitAny: test mock
-      (selector: (s: any) => unknown) => selector(mockState as any),
+    vi.mocked(useAppSelector).mockImplementation((selector: (s: RootState) => unknown) =>
+      selector(mockState),
     );
     render(<ProgressTrackerView />);
     expect(screen.getByRole('timer')).toBeDefined();

--- a/tests/unit/SubplotPanel.test.tsx
+++ b/tests/unit/SubplotPanel.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { RootState } from '../../app/store';
 import type { Subplot } from '../../types';
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────
@@ -10,39 +11,39 @@ const mockDispatch = vi.fn();
 const makeMockState = (overrides?: {
   plotSubplots?: Subplot[];
   activeSubplotFilter?: string | null;
-}) => ({
-  project: {
-    present: {
-      data: {
-        manuscript: [],
-        plotSubplots: overrides?.plotSubplots ?? [],
-        plotConnections: [],
-        plotTensionOverrides: {},
-        characters: { ids: [], entities: {} },
-        worlds: { ids: [], entities: {} },
-        outline: [],
-        logline: '',
-        title: '',
+}) =>
+  ({
+    project: {
+      present: {
+        data: {
+          manuscript: [],
+          plotSubplots: overrides?.plotSubplots ?? [],
+          plotConnections: [],
+          plotTensionOverrides: {},
+          characters: { ids: [], entities: {} },
+          worlds: { ids: [], entities: {} },
+          outline: [],
+          logline: '',
+          title: '',
+        },
       },
     },
-  },
-  plotBoard: {
-    activeSubplotFilter: overrides?.activeSubplotFilter ?? null,
-    selectedConnectionId: null,
-    isDrawingConnection: false,
-    drawFromSectionId: null,
-    activeMode: 'canvas',
-    zoom: 1,
-    panX: 0,
-    panY: 0,
-    snapToGrid: false,
-  },
-});
+    plotBoard: {
+      activeSubplotFilter: overrides?.activeSubplotFilter ?? null,
+      selectedConnectionId: null,
+      isDrawingConnection: false,
+      drawFromSectionId: null,
+      activeMode: 'canvas',
+      zoom: 1,
+      panX: 0,
+      panY: 0,
+      snapToGrid: false,
+    },
+  }) as unknown as RootState;
 
 vi.mock('../../app/hooks', () => ({
   useAppDispatch: () => mockDispatch,
-  // biome-ignore lint/suspicious/noExplicitAny: test mock — required for selector mock assignability
-  useAppSelectorShallow: vi.fn((selector: (s: any) => unknown) => selector(makeMockState())),
+  useAppSelectorShallow: vi.fn((selector: (s: RootState) => unknown) => selector(makeMockState())),
 }));
 
 import { SubplotPanel } from '../../components/scene-board/SubplotPanel';
@@ -74,8 +75,7 @@ describe('SubplotPanel', () => {
 
   it('renders subplot rows when subplots exist', async () => {
     const { useAppSelectorShallow } = await import('../../app/hooks');
-    // biome-ignore lint/suspicious/noExplicitAny: test mock — required for selector mock assignability
-    vi.mocked(useAppSelectorShallow).mockImplementation((selector: (s: any) => unknown) =>
+    vi.mocked(useAppSelectorShallow).mockImplementation((selector: (s: RootState) => unknown) =>
       selector(makeMockState({ plotSubplots: [mockSubplot] })),
     );
 
@@ -101,8 +101,7 @@ describe('SubplotPanel', () => {
 
   it('dispatches setActiveSubplotFilter when filter button clicked', async () => {
     const { useAppSelectorShallow } = await import('../../app/hooks');
-    // biome-ignore lint/suspicious/noExplicitAny: test mock — required for selector mock assignability
-    vi.mocked(useAppSelectorShallow).mockImplementation((selector: (s: any) => unknown) =>
+    vi.mocked(useAppSelectorShallow).mockImplementation((selector: (s: RootState) => unknown) =>
       selector(makeMockState({ plotSubplots: [mockSubplot] })),
     );
 
@@ -115,8 +114,7 @@ describe('SubplotPanel', () => {
 
   it('dispatches deletePlotSubplot when delete button clicked', async () => {
     const { useAppSelectorShallow } = await import('../../app/hooks');
-    // biome-ignore lint/suspicious/noExplicitAny: test mock — required for selector mock assignability
-    vi.mocked(useAppSelectorShallow).mockImplementation((selector: (s: any) => unknown) =>
+    vi.mocked(useAppSelectorShallow).mockImplementation((selector: (s: RootState) => unknown) =>
       selector(makeMockState({ plotSubplots: [mockSubplot] })),
     );
 

--- a/tests/unit/csp.test.ts
+++ b/tests/unit/csp.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment node
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// QNBS-v3: Regression guard for ADR-0004 (audit finding F-2). The web PWA connect-src keeps a
+// `https:` scheme-source ON PURPOSE — it is required by the shipped BYOK `openAiCompatibleBaseUrl`
+// feature (arbitrary user-configured HTTPS proxies that cannot be enumerated in a meta CSP). The
+// per-provider HTTPS entries were removed as dead allowlist entries (redundant under `https:`).
+// The native Tauri CSP must stay strict (NO `https:` blanket). These assertions lock that contract.
+
+const webHtml = readFileSync(fileURLToPath(new URL('../../index.html', import.meta.url)), 'utf8');
+const tauriConf = readFileSync(
+  fileURLToPath(new URL('../../src-tauri/tauri.conf.json', import.meta.url)),
+  'utf8',
+);
+
+/** Extract capture group 1 with a narrowing guard (noUncheckedIndexedAccess-safe). */
+function group1(m: RegExpMatchArray | null, msg: string): string {
+  if (!m || m[1] === undefined) throw new Error(msg);
+  return m[1];
+}
+
+/** Pull the `connect-src …;` directive value out of a CSP string, normalized to whitespace tokens. */
+function connectSrcTokens(csp: string): string[] {
+  return group1(csp.match(/connect-src([^;]*);/), 'connect-src directive must exist')
+    .split(/\s+/)
+    .map((t) => t.trim())
+    .filter(Boolean);
+}
+
+/** The web CSP lives in a multi-line <meta http-equiv="Content-Security-Policy" content="…">. */
+function webCsp(): string {
+  return group1(
+    webHtml.match(/Content-Security-Policy"\s*\n?\s*content="([\s\S]*?)"/),
+    'web CSP meta must exist in index.html',
+  );
+}
+
+/** Tauri v2 keeps the CSP at app.security.csp. */
+function tauriCsp(): string {
+  const conf = JSON.parse(tauriConf) as { app?: { security?: { csp?: string } } };
+  const csp = conf.app?.security?.csp;
+  expect(typeof csp, 'Tauri csp must be a string at app.security.csp').toBe('string');
+  return csp as string;
+}
+
+describe('CSP connect-src — ADR-0004 BYOK tradeoff', () => {
+  describe('web PWA (index.html)', () => {
+    const tokens = connectSrcTokens(webCsp());
+
+    it('keeps the intentional `https:` scheme-source (required by BYOK openAiCompatibleBaseUrl)', () => {
+      expect(tokens).toContain('https:');
+    });
+
+    it('has no `http:` or `ws:` scheme-wildcards (cleartext exfiltration stays blocked)', () => {
+      // `http://localhost:11434` and `wss://…` are explicit origins and allowed;
+      // bare scheme tokens `http:` / `ws:` would be wildcards and are not.
+      expect(tokens).not.toContain('http:');
+      expect(tokens).not.toContain('ws:');
+    });
+
+    it('removed the redundant explicit cloud-provider endpoints (covered by `https:`)', () => {
+      for (const dead of [
+        'https://generativelanguage.googleapis.com',
+        'https://api.openai.com',
+        'https://api.x.ai',
+        'https://api.groq.com',
+        'https://openrouter.ai',
+        'https://api.openrouter.ai',
+      ]) {
+        expect(tokens).not.toContain(dead);
+      }
+    });
+
+    it('keeps the local-inference origins `https:` does not cover', () => {
+      expect(tokens).toContain('http://localhost:11434'); // Ollama
+      expect(tokens).toContain('http://localhost:1234'); // LM Studio
+      expect(tokens).toContain('http://localhost:8000'); // local AI
+    });
+  });
+
+  describe('native Tauri (tauri.conf.json)', () => {
+    const tokens = connectSrcTokens(tauriCsp());
+
+    it('does NOT contain a `https:` scheme-source blanket (strict egress)', () => {
+      // Explicit `https://api.openai.com` tokens are fine; a bare `https:` token is not.
+      expect(tokens).not.toContain('https:');
+    });
+
+    it('enumerates cloud providers explicitly (allowlist is meaningful here)', () => {
+      expect(tokens).toContain('https://api.openai.com');
+    });
+  });
+});

--- a/types.ts
+++ b/types.ts
@@ -857,6 +857,9 @@ declare global {
   interface Window {
     SpeechRecognition: ISpeechRecognitionConstructor;
     webkitSpeechRecognition: ISpeechRecognitionConstructor;
+    // QNBS-v3: cross-service gate set by listenerMiddleware (adaptive-AI ON/OFF) and read by
+    // localAiFacade — typed here so call sites avoid `(window as any)` casts (F-4 abatement).
+    __storycraft_adaptive_ai__?: boolean;
   }
 }
 


### PR DESCRIPTION
Integrity & Hardening cycle from the deep audit (2026-06-09, findings **F-1…F-9**). Closes documentation/CSP/dependency/governance gaps **without shipping a release** (tagging is a separate manual step).

## Workstreams — all complete

| WS | Findings | Commit | Summary |
|----|----------|--------|---------|
| **WS-1** Doc integrity | F-1, F-3, F-5 | `bc53bbc` | README badge `v1.21.0`→`v1.20.0` + verified metrics (433 files / 2 357 keys); 28 misfiled CHANGELOG entries → `[1.19.0]`; TODO rollover |
| **WS-2** CSP Option B | F-2 | `5e7e49e` | Removed redundant `connect-src` endpoints (no-ops under `https:`); kept `https:` for shipped BYOK; ADR-0004; `csp.test.ts` (6); Tauri stays strict |
| **WS-3** transformers v4 | F-6 | `6ce236f` | 3.8.1→4.2.0 verified: APIs unchanged, typecheck clean, 63 ai-core/voice tests green; no source change |
| **WS-4** Suppression debt | F-4 | `f3cc74f`, `6cc3e7d` | Ratchet gate (`check-suppressions.mjs`, CI) at baseline 181 + abatement of **22** `noExplicitAny` (3 prod + 19 test mocks) → baseline **159** |
| **WS-5** Bundle budget | F-8 | `8e5bd4a` | Single source of truth: `--max-kb 6500 --max-entry-kb 4000`, script defaults aligned; corrected the false "~4000 KB entry" claim (real entry ≈496 KB) |
| **WS-6** Governance docs | F-7, F-9 | `3e0aa82` | `VENDOR-FORKS.md` CVE/OSV-coverage section (vendored y-webrtc invisible to OSV → manual process); new `docs/COVERAGE-POLICY.md` ratchet rule |

### Key decisions
- **F-2 → Option B** (user-confirmed): `https:` is required by the shipped `openAiCompatibleBaseUrl` BYOK feature, so strict allowlisting was rejected. Web PWA accepts `https:` by design; native Tauri CSP stays strict. Residual risk + mitigations in ADR-0004.
- **WS-4 re-scope** (user-confirmed): `services/` had **0** suppressions (the plan's premise); the 162 `noExplicitAny` were 159 test mocks + 3 production. Abated the 3 production (`window` augmentation → typed `Window`) + 19 selector mocks (`(s: any)`→`(s: RootState)`).

### Deviations (🟡)
- Verified metrics differ from the audit (433 not 445 test files; 2 357 not 2 351 keys) — used the locally-verified numbers.
- Kept the v1.20.0 TODO block inline (file convention) instead of moving to `docs/history/`.
- Extended `VENDOR-FORKS.md` instead of creating a parallel `docs/VENDORED-DEPS.md`.

## Local gate (final HEAD `3e0aa82`)
`pnpm lint` 0 diagnostics (1230 files) · `pnpm typecheck` clean · `check-suppressions` 159 = baseline · `pnpm i18n:check` 11 locales × 2 357 keys · `csp.test.ts` 6/6 · 63 ai-core/voice tests green. Coverage/E2E/Lighthouse/Stryker run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)