### PR TITLE
chore(release): v1.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-> Post-v1.20.0 work toward **v1.21.0 (in development)** — not yet released/tagged.
+_Nothing yet._
+
+## [1.21.0] — 2026-06-10
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <img src="https://img.shields.io/badge/TypeScript-7.x_(tsgo)-3178C6?logo=typescript&logoColor=white" alt="TypeScript 7 (tsgo)">
   <img src="https://img.shields.io/badge/AI-Gemini_%7C_OpenAI_%7C_Ollama_%7C_WebLLM-4285F4?logo=google" alt="Gemini · OpenAI · Ollama · WebLLM">
   <img src="https://img.shields.io/badge/Local_AI-WebGPU_%7C_ONNX_%7C_Transformers.js-8B5CF6" alt="WebGPU · ONNX · Transformers.js">
-  <img src="https://img.shields.io/badge/Version-v1.20.0-6366F1" alt="v1.20.0">
+  <img src="https://img.shields.io/badge/Version-v1.21.0-6366F1" alt="v1.21.0">
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-11_locales-2357_keys-0EA5E9" alt="i18n 11 locales — 2357 keys">
@@ -232,9 +232,9 @@ See [`docs/PROFORGE-PIPELINE.md`](docs/PROFORGE-PIPELINE.md) for full architectu
 
 A single-keystroke toggle that collapses all sidebars and chrome, leaving only the manuscript editor. Exit with `Escape` or the same toggle key. State is stored in the Zustand `transientUiStore` (`flowMode` flag) so it resets on page load.
 
-### 🗣️ Voice Dictation & WASM Voice Engines _(v1.17 foundation + v1.19.0 WASM scaffold + v1.21 model download UI — in development)_
+### 🗣️ Voice Dictation & WASM Voice Engines _(v1.17 foundation + v1.19.0 WASM scaffold + v1.21 model download UI)_
 
-Built-in speech-to-text via the browser's Web Speech API. Dictate scenes hands-free directly into the manuscript editor or into the Command Palette search field. **v1.19.0** adds WASM STT/VAD engine scaffolds; **v1.21 (in development)** ships the full model download flow:
+Built-in speech-to-text via the browser's Web Speech API. Dictate scenes hands-free directly into the manuscript editor or into the Command Palette search field. **v1.19.0** adds WASM STT/VAD engine scaffolds; **v1.21** ships the full model download flow:
 
 - **`WasmSttEngine`** (`services/voice/wasmSttEngine.ts`) — Whisper.cpp WASM interface scaffold (model download, chunked inference, 99+ language detection).
 - **`SileroVadEngine`** (`services/voice/sileroVadEngine.ts`) — Silero VAD v4 via ONNX Runtime Web (~2 MB model, lazy-loaded, replaces energy-threshold VAD).

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "storycraft-studio",
   "private": true,
-  "version": "1.20.0",
+  "version": "1.21.0",
   "type": "module",
   "packageManager": "pnpm@11.5.2",
   "engines": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4636,7 +4636,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "storycraft-studio"
-version = "1.20.0"
+version = "1.21.0"
 dependencies = [
  "base64 0.22.1",
  "candle-core",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "storycraft-studio"
-version = "1.20.0"
+version = "1.21.0"
 description = "AI-powered creative writing application"
 authors = ["QNBS"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "StoryCraft Studio",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "identifier": "com.storycraft.studio",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Release prep for **v1.21.0** — version bump (package.json / tauri.conf.json / Cargo.toml / Cargo.lock) + CHANGELOG cut (`[Unreleased]` → `[1.21.0] — 2026-06-10`) + README badge.

Release contents = the Integrity & Hardening cycle (#104, F-1…F-9) + post-v1.20.0 feature work already on main. Tag `v1.21.0` will be pushed after merge, triggering `tauri-build.yml` (desktop bundles + `latest.json` updater manifest + GitHub Release) and `docker.yml` (ghcr image).

Local gate: lint 0 diagnostics · all four version refs = 1.21.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)