### PR TITLE
fix(copilot): dismiss the assistant panel on outside click

### DIFF
--- a/components/copilot/CopilotPanel.tsx
+++ b/components/copilot/CopilotPanel.tsx
@@ -26,6 +26,20 @@ export const CopilotPanel: FC<CopilotPanelProps> = ({ copilot, contextLabel }) =
     return () => document.removeEventListener('keydown', onKey);
   }, [close]);
 
+  // QNBS-v3: clicking/tapping outside the panel dismisses it ("click away to close"). No blocking
+  // backdrop — the assistant is non-blocking, so the rest of the app stays interactive. The listener
+  // is attached after mount, so the pointerdown that opened the panel has already fired (no instant close).
+  useEffect(() => {
+    const onPointerDown = (e: PointerEvent) => {
+      const el = panelRef.current;
+      if (el && e.target instanceof Node && !el.contains(e.target)) {
+        close();
+      }
+    };
+    document.addEventListener('pointerdown', onPointerDown);
+    return () => document.removeEventListener('pointerdown', onPointerDown);
+  }, [close]);
+
   return (
     <div
       ref={panelRef}


### PR DESCRIPTION
## **User description**
## What
The Global AI Copilot panel could only be closed via the X button or Escape. Users expect clicking/tapping **anywhere outside** the panel to dismiss it too ("weg-klicken").

## Change
Add a `pointerdown` listener in `CopilotPanel` that calls `close()` when the click lands outside the panel. No backdrop is added — the assistant stays non-blocking and the rest of the app remains interactive. The listener attaches after mount, so the pointer-down that opened the panel doesn't instantly close it.

## Scope
One-file change; X button and Escape behaviour unchanged; the copilot-flags E2E (all interactions inside the dialog) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Dismiss the copilot panel when clicking outside it**

### What Changed
- The copilot panel now closes when the user clicks or taps anywhere outside it
- Clicking inside the panel still keeps it open, and the Escape key behavior is unchanged
- The panel stays non-blocking, so the rest of the app remains usable while it is open

### Impact
`✅ Easier panel dismissal`
`✅ Fewer extra clicks to close the assistant`
`✅ Less interruption while using the app`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
