### PR TITLE
v1.22.1 — Plugin sandbox fix, OpenRouter tests, Copilot apply-flow tests, Stryker expansion

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1538,10 +1538,14 @@ StoryCraft Studio was assessed as a strong, modern React/TypeScript application 
 | Status | Item |
 |--------|------|
 | ✅ | Replaced unsafe Worker global eval with function-scope sandbox in `workers/plugin.worker.ts` |
+| ✅ | Added runtime guards for `Function.prototype.constructor`, `eval`, `WebAssembly`, async/generator constructors |
+| ✅ | Normalized ESM `export function run` syntax for `new Function` execution |
+| ✅ | Converted denied async APIs to synchronous throwers so misuse always propagates |
+| ✅ | Made worker handler throw on plugin failures instead of returning `{ success: false }` |
 | ✅ | Added read-only project snapshot + side-effect bridge in `services/pluginRegistry.ts` |
 | ✅ | Added `plugin.sandbox` capability to WorkerBus v2 schema |
 | ✅ | Added telemetry logging to `pluginRegistry.ts` (loadPlugin method) |
-| ✅ | Created/extended `tests/unit/workers/plugin.worker.test.ts` (13 tests) |
+| ✅ | Created/extended `tests/unit/workers/plugin.worker.test.ts` (18 tests) |
 | ✅ | Created/extended `tests/unit/plugins/pluginRegistryLoad.test.ts` (8 tests) |
 | ✅ | Updated `docs/PLUGINS-BETA.md` with accurate sandbox/limitations description |
 | ⬜ | Full timeout/abort coupling for dynamic `import()` and sync loops (P0-2) |
@@ -1601,6 +1605,14 @@ StoryCraft Studio was assessed as a strong, modern React/TypeScript application 
 | ✅ | Plugin execution errors logged via structured logger |
 | ✅ | Voice error paths set `setVoiceError` in Redux |
 | ✅ | Storage encryption errors throw descriptive messages |
+
+### Tauri Build Pipeline (updated)
+
+| Status | Item |
+|--------|------|
+| ✅ | `tauri-build.yml` references `secrets.TAURI_SIGNING_PRIVATE_KEY` and password correctly |
+| ✅ | Workflow unsets signing keys and disables updater artifacts for `workflow_dispatch` test builds |
+| 🔄 | Full end-to-end signing verification pending next tag or manual workflow dispatch with secrets |
 
 ---
 

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1537,9 +1537,14 @@ StoryCraft Studio was assessed as a strong, modern React/TypeScript application 
 
 | Status | Item |
 |--------|------|
+| ✅ | Replaced unsafe Worker global eval with function-scope sandbox in `workers/plugin.worker.ts` |
+| ✅ | Added read-only project snapshot + side-effect bridge in `services/pluginRegistry.ts` |
+| ✅ | Added `plugin.sandbox` capability to WorkerBus v2 schema |
 | ✅ | Added telemetry logging to `pluginRegistry.ts` (loadPlugin method) |
-| ✅ | Created `tests/unit/plugins/pluginRegistryLoad.test.ts` (8 tests for timeout/fetch/error handling) |
-| ✅ | Created `docs/PLUGINS-BETA.md` documenting Beta/opt-in status |
+| ✅ | Created/extended `tests/unit/workers/plugin.worker.test.ts` (13 tests) |
+| ✅ | Created/extended `tests/unit/plugins/pluginRegistryLoad.test.ts` (8 tests) |
+| ✅ | Updated `docs/PLUGINS-BETA.md` with accurate sandbox/limitations description |
+| ⬜ | Full timeout/abort coupling for dynamic `import()` and sync loops (P0-2) |
 
 ### Supply-Chain Hardening (P1)
 
@@ -1550,6 +1555,19 @@ StoryCraft Studio was assessed as a strong, modern React/TypeScript application 
 | ✅ | Added `minimum-release-age=10080` (7 days) to `.npmrc` |
 | ✅ | Added security justification comments to `pnpm-workspace.yaml` overrides |
 
+### OpenRouter Provider Hardening (P1)
+
+| Status | Item |
+|--------|------|
+| ✅ | Expanded `tests/unit/ai/openrouterProvider.test.ts` to 19 tests covering streaming, 429 retry, Retry-After, circuit breaker, non-OK errors, AbortSignal, malformed SSE, RPM tracking |
+| ✅ | Added test-only delay provider hook to keep retry tests fast and deterministic |
+
+### Copilot Apply-Flow Hardening (P1)
+
+| Status | Item |
+|--------|------|
+| ✅ | Extended `tests/unit/copilot/useGlobalCopilot.test.ts` with 7 `applyLastSuggestion` tests (70% gate, empty section, missing section, status lifecycle, dispatch verification) |
+
 ### Mutation Testing Expansion (P1)
 
 | Status | Item |
@@ -1557,6 +1575,8 @@ StoryCraft Studio was assessed as a strong, modern React/TypeScript application 
 | ✅ | Added `services/ai/aiRetry.ts` to mutation targets |
 | ✅ | Added `services/ai/fetchAdapter.ts` to mutation targets |
 | ✅ | Added `services/ai/routingLogger.ts` to mutation targets |
+| ✅ | Added `services/copilot/heuristicEngine.ts`, `insightGenerator.ts`, `actionApplier.ts`, `copilotContextService.ts` to mutation targets |
+| ✅ | Added `services/ai/aiModeService.ts`, `services/ai/providers/openrouterProvider.ts`, `services/pluginRegistry.ts` to mutation targets |
 
 ### Voice Pipeline Status
 

--- a/docs/PLUGINS-BETA.md
+++ b/docs/PLUGINS-BETA.md
@@ -13,7 +13,7 @@ The StoryCraft Studio Plugin System allows extending the application with custom
 - All plugin code executes in `workers/plugin.worker.ts` (Web Worker)
 - Plugins cannot access the main thread directly
 - No direct access to Redux store, DOM, or browser APIs
-- Plugin code runs inside a function-scope sandbox: dangerous globals (`fetch`, `indexedDB`, `WebSocket`, `self`, `globalThis`, etc.) are shadowed with `undefined`. This closes the most common sandbox-escape vectors while keeping the architecture lightweight. It is **not** the same as process-level isolation; future releases may add iframe or ShadowRealm isolation (Phase 3).
+- Plugin code runs inside a function-scope sandbox: dangerous globals (`fetch`, `indexedDB`, `WebSocket`, `self`, `globalThis`, `Function`, `eval`, `WebAssembly`, etc.) are shadowed or neutered. Runtime guards also override `Function.prototype.constructor` (and async/generator variants) so a plugin cannot recover the real global object via `(function(){}).constructor`. This closes the most common sandbox-escape vectors while keeping the architecture lightweight. It is **not** the same as process-level isolation; future releases may add iframe or ShadowRealm isolation (Phase 3).
 - The worker does **not** receive live API objects. It gets a read-only project snapshot and returns serializable side effects (`appendToCurrentScene`, `log`) that the main thread applies after verifying permissions.
 
 ### Permission Gating

--- a/docs/PLUGINS-BETA.md
+++ b/docs/PLUGINS-BETA.md
@@ -13,6 +13,8 @@ The StoryCraft Studio Plugin System allows extending the application with custom
 - All plugin code executes in `workers/plugin.worker.ts` (Web Worker)
 - Plugins cannot access the main thread directly
 - No direct access to Redux store, DOM, or browser APIs
+- Plugin code runs inside a function-scope sandbox: dangerous globals (`fetch`, `indexedDB`, `WebSocket`, `self`, `globalThis`, etc.) are shadowed with `undefined`. This closes the most common sandbox-escape vectors while keeping the architecture lightweight. It is **not** the same as process-level isolation; future releases may add iframe or ShadowRealm isolation (Phase 3).
+- The worker does **not** receive live API objects. It gets a read-only project snapshot and returns serializable side effects (`appendToCurrentScene`, `log`) that the main thread applies after verifying permissions.
 
 ### Permission Gating
 Plugins declare required permissions in their manifest. The registry enforces these at runtime:
@@ -28,14 +30,14 @@ Plugins declare required permissions in their manifest. The registry enforces th
 
 ### Execution Timeout
 - Default timeout: 30 seconds
-- Plugins exceeding timeout are terminated
-- Timeout is enforced in the worker context
+- A timeout `AbortSignal` is propagated into the worker task, but `import()` of dynamic URLs and long-running synchronous plugin loops are only partially abortable today. Endless synchronous loops can still block the worker until the task is forcibly cancelled by the WorkerBus timeout/circuit breaker.
 
 ### Telemetry
 All plugin executions are logged to the structured logger:
 - Plugin ID and execution duration
 - Success/failure status
 - Error messages (sanitized)
+- No plugin data is sent to the cloud; telemetry is on-device only.
 
 ## API Reference
 
@@ -118,6 +120,10 @@ Two reference plugins are included in `services/plugins/`:
 ## Known Limitations
 
 - Plugin system must be explicitly enabled via feature flag
+- Worker sandbox uses function-scope shadowing, not process or iframe isolation
+- Async APIs (`generateText`, `storageRead`, `storageWrite`) inside the worker sandbox currently throw; asynchronous plugin features require a future proxy-to-main design
+- Timeout/abort covers the WorkerBus task boundary but does not yet forcibly interrupt in-flight dynamic `import()` or synchronous infinite loops
+- Side effects are limited to `appendToCurrentScene` and `log`; other mutations must be added explicitly on the main thread
 - No plugin discovery mechanism (manual registration only)
 - No plugin update mechanism
 - Storage access is namespaced but not project-scoped

--- a/docs/adr/0007-plugin-sandbox-model.md
+++ b/docs/adr/0007-plugin-sandbox-model.md
@@ -1,0 +1,52 @@
+# ADR 0007 — Plugin Sandbox Model
+
+## Status
+
+Accepted — implemented in v1.22.1
+
+## Context
+
+The Plugin System Beta (feature flag `enablePluginSystem`) executes third-party plugin code inside a Web Worker (`workers/plugin.worker.ts`). The initial implementation serialized the API object with `JSON.stringify`, turning every function into `null`, and evaluated the plugin code in the Worker's global scope. This allowed sandbox escape via `fetch`, `indexedDB`, `WebSocket`, `self`, `globalThis`, etc.
+
+We needed a pragmatic fix that:
+
+1. Closes the most common sandbox-escape vectors immediately.
+2. Keeps the Beta architecture lightweight and testable in Vitest.
+3. Preserves a path to stronger isolation (iframe, ShadowRealm) in Phase 3.
+
+## Decision
+
+Adopt **Option A: Function-Scope Sandbox in the Worker**.
+
+- Plugin code is passed as a string and wrapped in `new Function(...)`.
+- All dangerous globals (`fetch`, `XMLHttpRequest`, `WebSocket`, `indexedDB`, `IDBFactory`, `navigator`, `location`, `self`, `globalThis`, `window`, `top`, `parent`) are shadowed parameters set to `undefined`.
+- The worker receives a read-only serializable project snapshot (`projectTitle`, `sceneTitles`) and the plugin's declared `permissions`.
+- The plugin's `run(api)` callback can only collect serializable side effects (`appendToCurrentScene`, `log`), which the main thread applies after verifying permissions.
+- Async APIs (`generateText`, `storageRead`, `storageWrite`) inside the worker sandbox intentionally throw until a proxy-to-main design is implemented.
+
+## Consequences
+
+### Positive
+
+- Sandbox escape via shadowed globals is blocked.
+- Plugin code can no longer access the network, storage, or Worker global scope directly.
+- Side-effect model keeps Redux state mutation on the main thread.
+- Fully unit-testable; 13 worker tests cover escape attempts, payload validation, permission gating, and abort handling.
+
+### Negative / Trade-offs
+
+- This is **not** process-level or iframe isolation. A determined plugin can still perform CPU exhaustion or memory bombs inside the worker.
+- Async plugin features require a future proxy-to-main design.
+- Timeout/abort does not yet forcibly interrupt in-flight dynamic `import()` or synchronous infinite loops.
+
+## Alternatives Considered
+
+- **Option B: iframe with `sandbox="allow-scripts"`** — higher isolation, but requires a `postMessage` bridge between iframe, Worker, and main thread. Rejected for v1.22.1 to limit architectural churn; kept as Phase 3 candidate.
+
+## Related Files
+
+- `workers/plugin.worker.ts`
+- `services/pluginRegistry.ts`
+- `packages/worker-bus/src/schemas.ts`
+- `tests/unit/workers/plugin.worker.test.ts`
+- `tests/unit/plugins/pluginRegistryLoad.test.ts`

--- a/scripts/check-suppressions.mjs
+++ b/scripts/check-suppressions.mjs
@@ -9,8 +9,10 @@
  *
  * Run:    node scripts/check-suppressions.mjs            # gate (exit 1 if total > baseline)
  *         node scripts/check-suppressions.mjs --update   # rewrite baseline to current (after abatement)
+ *         node scripts/check-suppressions.mjs --details  # gate + per-file breakdown
  *
  * Writes a full per-rule breakdown to `reports/suppressions.json`.
+ * With --details, also writes a per-file breakdown to `reports/suppressions-details.json`.
  */
 import fs from 'node:fs';
 import path from 'node:path';
@@ -54,6 +56,8 @@ function collect(dir, out) {
 const files = collect(root, []);
 /** @type {Record<string, number>} */
 const byRule = {};
+/** @type {Record<string, Record<string, number>>} */
+const byFile = {};
 let total = 0;
 for (const file of files) {
   const text = fs.readFileSync(file, 'utf8');
@@ -63,6 +67,8 @@ for (const file of files) {
     const rule = m ? m[1] : 'unknown';
     byRule[rule] = (byRule[rule] ?? 0) + 1;
     total++;
+    if (!byFile[file]) byFile[file] = {};
+    byFile[file][rule] = (byFile[file][rule] ?? 0) + 1;
   }
 }
 
@@ -79,6 +85,35 @@ fs.writeFileSync(
   path.join(reportsDir, 'suppressions.json'),
   `${JSON.stringify(report, null, 2)}\n`,
 );
+
+const showDetails = process.argv.includes('--details');
+if (showDetails) {
+  const details = Object.entries(byFile)
+    .filter(([, rules]) => Object.keys(rules).length > 0)
+    .sort((a, b) => {
+      const countA = Object.values(a[1]).reduce((sum, n) => sum + n, 0);
+      const countB = Object.values(b[1]).reduce((sum, n) => sum + n, 0);
+      return countB - countA;
+    })
+    .map(([file, rules]) => ({ file, rules }));
+  fs.writeFileSync(
+    path.join(reportsDir, 'suppressions-details.json'),
+    `${JSON.stringify({ total, files: details.length, details, generatedAt: new Date().toISOString() }, null, 2)}\n`,
+  );
+  console.log('\n[suppressions] per-file breakdown:');
+  for (const { file, rules } of details.slice(0, 20)) {
+    const fileTotal = Object.values(rules).reduce((sum, n) => sum + n, 0);
+    console.log(`  ${fileTotal}  ${path.relative(root, file)}`);
+    for (const [rule, n] of Object.entries(rules).sort((a, b) => b[1] - a[1])) {
+      console.log(`       ${n}  ${rule}`);
+    }
+  }
+  if (details.length > 20) {
+    console.log(
+      `  ... and ${details.length - 20} more files (see reports/suppressions-details.json)`,
+    );
+  }
+}
 
 const baselinePath = path.join(root, 'suppressions-baseline.json');
 
@@ -106,6 +141,9 @@ if (total > baseline.total) {
   console.error(
     `\n[suppressions] FAIL — ${total} > baseline ${baseline.total} (+${total - baseline.total}). ` +
       'Remove a suppression or fix the root cause; do not raise the baseline (ratchet-only).',
+  );
+  console.error(
+    'Tip: run `node scripts/check-suppressions.mjs --details` for a per-file breakdown.',
   );
   process.exit(1);
 }

--- a/services/ai/providers/openrouterProvider.ts
+++ b/services/ai/providers/openrouterProvider.ts
@@ -122,8 +122,21 @@ function computeBackoffMs(attempt: number, retryAfterHeader?: string | null): nu
   return Math.min(BASE_DELAY_MS * 2 ** attempt, MAX_DELAY_MS);
 }
 
+let _delayProvider: (ms: number) => Promise<void> = (ms) =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
 function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+  return _delayProvider(ms);
+}
+
+/** Test-only hook to swap the retry delay provider (e.g. fake timers). */
+export function __setTestDelayProvider(provider: (ms: number) => Promise<void>): void {
+  _delayProvider = provider;
+}
+
+/** Reset the retry delay provider to the default setTimeout implementation. */
+export function __resetTestDelayProvider(): void {
+  _delayProvider = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 // ─── Request builder ─────────────────────────────────────────────────────────

--- a/services/pluginRegistry.ts
+++ b/services/pluginRegistry.ts
@@ -31,7 +31,6 @@ export type PluginPermission =
   | 'storage.write'
   | 'ai.invoke'
   | 'project.read'
-  | 'project.write'
   | 'scene.read'
   | 'scene.write';
 
@@ -45,7 +44,7 @@ export interface PluginDescriptor {
   /** Declared permission scopes the plugin requires (capability manifest). */
   permissions: PluginPermission[];
   /** Human-readable description shown in the Plugin Registry UI. */
-  description?: string;
+  description?: string | undefined;
 }
 
 /**
@@ -80,7 +79,6 @@ const PLUGIN_PERMISSIONS = [
   'storage.write',
   'ai.invoke',
   'project.read',
-  'project.write',
   'scene.read',
   'scene.write',
 ] as const;
@@ -211,7 +209,7 @@ export class PluginRegistry {
   /** Register with Zod schema validation — throws ZodError on invalid descriptor. */
   registerWithValidation(raw: unknown): void {
     const descriptor = PluginDescriptorSchema.parse(raw);
-    this.plugins.set(descriptor.id, descriptor as PluginDescriptor);
+    this.plugins.set(descriptor.id, descriptor);
   }
 
   unregister(id: string): boolean {
@@ -247,35 +245,39 @@ export class PluginRegistry {
       throw new Error(`Permission denied: ${perm}`);
     };
 
-    // Silence PERMISSION_API_MAP from dead-code elimination — documents the mapping.
-    void PERMISSION_API_MAP;
+    // QNBS-v3: Helper that reads the single source-of-truth permission map and throws
+    // when the plugin descriptor does not declare the required permission.
+    const guard = (method: keyof PluginSandboxedApi): void => {
+      const perm = PERMISSION_API_MAP[method];
+      if (perm && !granted.has(perm)) deny(perm);
+    };
 
     return {
       getProjectTitle: () => {
-        if (!granted.has('project.read')) deny('project.read');
+        guard('getProjectTitle');
         return rawApi.getProjectTitle();
       },
       getSceneTitles: () => {
-        if (!granted.has('scene.read')) deny('scene.read');
+        guard('getSceneTitles');
         return rawApi.getSceneTitles();
       },
       appendToCurrentScene: (text) => {
-        if (!granted.has('scene.write')) deny('scene.write');
+        guard('appendToCurrentScene');
         rawApi.appendToCurrentScene(text);
       },
       log: rawApi.log,
       generateText: (prompt, opts) => {
-        if (!granted.has('ai.invoke')) deny('ai.invoke');
+        guard('generateText');
         return rawApi.generateText(prompt, opts);
       },
       storageRead: (key) => {
-        if (!granted.has('storage.read')) deny('storage.read');
+        guard('storageRead');
         // QNBS-v3: Enforce plugin storage key namespacing to prevent cross-plugin data access.
         validatePluginStorageKey(key, descriptor.id);
         return rawApi.storageRead(key);
       },
       storageWrite: (key, value) => {
-        if (!granted.has('storage.write')) deny('storage.write');
+        guard('storageWrite');
         // QNBS-v3: Enforce plugin storage key namespacing and value size limits to prevent
         // cross-plugin data access and storage DoS.
         validatePluginStorageKey(key, descriptor.id);
@@ -337,12 +339,16 @@ export class PluginRegistry {
 
   /**
    * Dynamically load a plugin by entrypoint URL and execute its run() export.
-   * QNBS-v3: P0-2 — Routes to plugin.worker.ts for isolated execution.
+   * QNBS-v3: P0-1..P0-3 — Routes to plugin.worker.ts for isolated execution.
    * The entrypoint module must export `run(api: PluginSandboxedApi): Promise<void>`.
+   * Read-only API data is passed as a snapshot; side effects (appendToCurrentScene, log)
+   * are collected by the worker and applied back on the main thread after successful run.
+   * Async APIs that need main-thread state (generateText, storage) are unavailable inside
+   * the worker sandbox; use executeAsync() for those permissions instead.
    */
   async loadPlugin(
     descriptor: PluginDescriptor,
-    _rawApi: PluginSandboxedApi,
+    rawApi: PluginSandboxedApi,
   ): Promise<PluginExecuteResult> {
     const startTime = Date.now();
     if (!this._enabled) {
@@ -362,12 +368,22 @@ export class PluginRegistry {
       }
       const code = await response.text();
 
+      // QNBS-v3: Pass a read-only snapshot of the sandboxed API into the worker.
+      // The worker cannot receive function references over postMessage, so we serialize
+      // only the data and let the worker collect side effects to apply back here.
+      const readApiSnapshot = {
+        projectTitle: rawApi.getProjectTitle(),
+        sceneTitles: rawApi.getSceneTitles(),
+      };
+
       // Route to worker for isolated execution
       const { routeTask } = await import('./hybridRouter');
       const handle = await routeTask('plugin.execute', {
         pluginId: descriptor.id,
         code,
         timeoutMs: 30000,
+        grantedPermissions: descriptor.permissions,
+        readApiSnapshot,
       });
 
       if (!handle) {
@@ -378,9 +394,27 @@ export class PluginRegistry {
       }
 
       try {
-        await handle.result;
+        const result = (await handle.result) as {
+          pluginId: string;
+          sideEffects?: Array<{ kind: 'append' | 'log'; payload: unknown }>;
+          logs?: string[];
+        };
+        const sideEffects = result?.sideEffects ?? [];
+        for (const effect of sideEffects) {
+          if (effect.kind === 'append' && typeof effect.payload === 'string') {
+            rawApi.appendToCurrentScene(effect.payload);
+          }
+          // QNBS-v3: 'log' side effects are intentionally not replayed through rawApi.log
+          // to avoid log loops; they are included in the telemetry entry below.
+        }
+
         const duration = Date.now() - startTime;
-        log.info('Plugin executed successfully', { pluginId: descriptor.id, durationMs: duration });
+        log.info('Plugin executed successfully', {
+          pluginId: descriptor.id,
+          durationMs: duration,
+          sideEffects: sideEffects.length,
+          logs: result?.logs?.length ?? 0,
+        });
         return { ok: true };
       } catch (e) {
         const duration = Date.now() - startTime;

--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -30,7 +30,14 @@
     "features/settings/accessibilitySchema.ts",
     "features/progressTracker/progressTrackerSlice.ts",
     "features/featureFlags/featureFlagsSlice.ts",
-    "features/proForge/proForgeSlice.ts"
+    "features/proForge/proForgeSlice.ts",
+    "services/copilot/heuristicEngine.ts",
+    "services/copilot/insightGenerator.ts",
+    "services/copilot/actionApplier.ts",
+    "services/copilot/copilotContextService.ts",
+    "services/ai/aiModeService.ts",
+    "services/ai/providers/openrouterProvider.ts",
+    "services/pluginRegistry.ts"
   ],
   "thresholds": {
     "high": 85,

--- a/tests/unit/ai/openrouterProvider.test.ts
+++ b/tests/unit/ai/openrouterProvider.test.ts
@@ -1,20 +1,71 @@
 /**
  * Tests for services/ai/providers/openrouterProvider.ts
- * QNBS-v3: Circuit breaker state, isOpenRouterFreeModel(), and isCircuitOpen() resets.
+ * QNBS-v3: Utility functions, streaming/non-streaming completion, retry/backoff,
+ *          circuit breaker, AbortSignal, and RPM tracking.
  */
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  __resetTestDelayProvider,
+  __setTestDelayProvider,
+  generateOpenRouterText,
   getApproxRpm,
   isCircuitOpen,
   isOpenRouterFreeModel,
   OPENROUTER_FREE_MODELS,
   resetOpenRouterCircuit,
+  streamOpenRouter,
 } from '../../../services/ai/providers/openrouterProvider';
+import type { AIRequestOptions, AIStreamCallbacks } from '../../../services/aiProviderService';
 
-afterEach(() => {
-  resetOpenRouterCircuit();
-});
+const baseOpts: AIRequestOptions = {
+  model: 'deepseek/deepseek-r1:free' as AIRequestOptions['model'],
+  provider: 'openrouter',
+  temperature: 0.7,
+  maxTokens: 128,
+};
+
+function makeStreamResponse(
+  lines: string[],
+  opts: { status?: number; retryAfter?: string } = {},
+): Response {
+  const encoder = new TextEncoder();
+  const chunks = lines.map((line) => encoder.encode(`${line}\n`));
+  let index = 0;
+  return {
+    ok: opts.status === undefined ? true : opts.status >= 200 && opts.status < 300,
+    status: opts.status ?? 200,
+    statusText: opts.status === 429 ? 'Too Many Requests' : 'OK',
+    headers: new Headers(opts.retryAfter ? { 'retry-after': opts.retryAfter } : {}),
+    body: {
+      getReader: () => ({
+        read: async () => {
+          if (index >= chunks.length) return { done: true, value: undefined };
+          const value = chunks[index];
+          index++;
+          return { done: false, value };
+        },
+      }),
+    },
+  } as unknown as Response;
+}
+
+function sseLine(delta: string): string {
+  return `data: ${JSON.stringify({ choices: [{ delta: { content: delta } }] })}`;
+}
+
+function makeJsonResponse(
+  body: unknown,
+  opts: { status?: number; retryAfter?: string } = {},
+): Response {
+  return {
+    ok: opts.status === undefined ? true : opts.status >= 200 && opts.status < 300,
+    status: opts.status ?? 200,
+    statusText: opts.status === 429 ? 'Too Many Requests' : 'OK',
+    headers: new Headers(opts.retryAfter ? { 'retry-after': opts.retryAfter } : {}),
+    json: async () => body,
+  } as unknown as Response;
+}
 
 describe('isOpenRouterFreeModel()', () => {
   it('returns true for :free suffix models', () => {
@@ -48,5 +99,192 @@ describe('isCircuitOpen()', () => {
 describe('getApproxRpm()', () => {
   it('returns a number ≥ 0', () => {
     expect(getApproxRpm()).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('streamOpenRouter()', () => {
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    resetOpenRouterCircuit();
+    __setTestDelayProvider(() => Promise.resolve());
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    __resetTestDelayProvider();
+  });
+
+  it('streams chunks through callbacks', async () => {
+    const chunks: string[] = [];
+    const callbacks: AIStreamCallbacks = {
+      onChunk: (text) => chunks.push(text),
+      onDone: vi.fn(),
+    };
+
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(
+        makeStreamResponse([sseLine('Hello'), sseLine(' world'), 'data: [DONE]']),
+      ) as unknown as typeof fetch;
+
+    await streamOpenRouter('Say hi', baseOpts, callbacks, 'key');
+    expect(chunks).toEqual(['Hello', ' world']);
+    expect(callbacks.onDone).toHaveBeenCalled();
+  });
+
+  it('throws circuit-open error without calling fetch', async () => {
+    // Force circuit open by simulating 4 consecutive 429s first
+    global.fetch = vi.fn().mockResolvedValue(makeStreamResponse([], { status: 429 }));
+    const callbacks: AIStreamCallbacks = { onChunk: vi.fn() };
+
+    for (let i = 0; i < 4; i++) {
+      await expect(streamOpenRouter('x', baseOpts, callbacks, 'key')).rejects.toThrow(/OPENROUTER/);
+    }
+
+    expect(isCircuitOpen()).toBe(true);
+
+    global.fetch = vi.fn().mockResolvedValue(makeStreamResponse([sseLine('no')])); // should not be called
+    await expect(streamOpenRouter('x', baseOpts, callbacks, 'key')).rejects.toThrow(
+      /OPENROUTER_CIRCUIT_OPEN/,
+    );
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('retries on 429 and eventually succeeds', async () => {
+    const callbacks: AIStreamCallbacks = { onChunk: vi.fn(), onDone: vi.fn() };
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(makeStreamResponse([], { status: 429 }))
+      .mockResolvedValueOnce(makeStreamResponse([sseLine('ok')]));
+
+    await streamOpenRouter('x', baseOpts, callbacks, 'key');
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(callbacks.onChunk).toHaveBeenCalledWith('ok');
+  });
+
+  it('throws rate-limited after max retries', async () => {
+    const callbacks: AIStreamCallbacks = { onChunk: vi.fn() };
+    global.fetch = vi.fn().mockResolvedValue(makeStreamResponse([], { status: 429 }));
+
+    await expect(streamOpenRouter('x', baseOpts, callbacks, 'key')).rejects.toThrow(
+      /OPENROUTER_RATE_LIMITED/,
+    );
+    expect(global.fetch).toHaveBeenCalledTimes(4); // initial + 3 retries
+  });
+
+  it('respects Retry-After header', async () => {
+    const callbacks: AIStreamCallbacks = { onChunk: vi.fn() };
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(makeStreamResponse([], { status: 429, retryAfter: '2' }))
+      .mockResolvedValueOnce(makeStreamResponse([sseLine('delayed')]));
+
+    await streamOpenRouter('x', baseOpts, callbacks, 'key');
+    expect(callbacks.onChunk).toHaveBeenCalledWith('delayed');
+  });
+
+  it('throws on non-OK status', async () => {
+    const callbacks: AIStreamCallbacks = { onChunk: vi.fn() };
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(makeJsonResponse({ error: { message: 'Bad key' } }, { status: 401 }));
+
+    await expect(streamOpenRouter('x', baseOpts, callbacks, 'key')).rejects.toThrow(
+      /OpenRouter API Error 401/,
+    );
+  });
+
+  it('stops reading when signal is aborted', async () => {
+    const callbacks: AIStreamCallbacks = { onChunk: vi.fn() };
+    global.fetch = vi.fn().mockResolvedValue(makeStreamResponse([sseLine('a'), sseLine('b')]));
+
+    const controller = new AbortController();
+    const opts: AIRequestOptions = { ...baseOpts, signal: controller.signal };
+
+    // Abort before reading starts
+    controller.abort();
+    await streamOpenRouter('x', opts, callbacks, 'key');
+    expect(callbacks.onChunk).not.toHaveBeenCalled();
+  });
+
+  it('skips malformed SSE chunks', async () => {
+    const chunks: string[] = [];
+    const callbacks: AIStreamCallbacks = { onChunk: (text) => chunks.push(text) };
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(makeStreamResponse([sseLine('good'), 'data: not-json', sseLine('end')]));
+
+    await streamOpenRouter('x', baseOpts, callbacks, 'key');
+    expect(chunks).toEqual(['good', 'end']);
+  });
+});
+
+describe('generateOpenRouterText()', () => {
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    resetOpenRouterCircuit();
+    __setTestDelayProvider(() => Promise.resolve());
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    __resetTestDelayProvider();
+  });
+
+  it('returns generated text', async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(
+        makeJsonResponse({ choices: [{ message: { content: 'Generated text' } }] }),
+      );
+
+    const text = await generateOpenRouterText('prompt', baseOpts, 'key');
+    expect(text).toBe('Generated text');
+  });
+
+  it('throws on empty response', async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(makeJsonResponse({ choices: [{ message: { content: '' } }] }));
+
+    await expect(generateOpenRouterText('prompt', baseOpts, 'key')).rejects.toThrow(
+      /Empty response/,
+    );
+  });
+
+  it('retries on 429 and uses fallback after persistent rate limits', async () => {
+    global.fetch = vi.fn().mockResolvedValue(makeJsonResponse({}, { status: 429 }));
+
+    await expect(generateOpenRouterText('prompt', baseOpts, 'key')).rejects.toThrow(
+      /OPENROUTER_RATE_LIMITED/,
+    );
+    expect(global.fetch).toHaveBeenCalledTimes(4);
+  });
+
+  it('throws circuit-open error when circuit is open', async () => {
+    global.fetch = vi.fn().mockResolvedValue(makeJsonResponse({}, { status: 429 }));
+    for (let i = 0; i < 4; i++) {
+      await expect(generateOpenRouterText('x', baseOpts, 'key')).rejects.toThrow(/OPENROUTER/);
+    }
+
+    global.fetch = vi.fn();
+    await expect(generateOpenRouterText('x', baseOpts, 'key')).rejects.toThrow(
+      /OPENROUTER_CIRCUIT_OPEN/,
+    );
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('tracks approximate RPM', async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(makeJsonResponse({ choices: [{ message: { content: 'ok' } }] }));
+
+    const before = getApproxRpm();
+    await generateOpenRouterText('x', baseOpts, 'key');
+    expect(getApproxRpm()).toBe(before + 1);
   });
 });

--- a/tests/unit/copilot/useGlobalCopilot.test.ts
+++ b/tests/unit/copilot/useGlobalCopilot.test.ts
@@ -15,6 +15,12 @@ const { mockDispatch, mockStop, state } = vi.hoisted(() => ({
         { id: 'a1', role: 'assistant', content: 'partial…', pending: true, createdAt: '' },
       ],
     },
+    activeSectionId: null as string | null,
+    project: null as {
+      id: string;
+      title: string;
+      manuscript: Array<{ id: string; title?: string; content?: string }>;
+    } | null,
   },
 }));
 
@@ -33,7 +39,7 @@ vi.mock('../../../app/transientUiStore', () => ({
       setCopilotHeuristicsOnly: vi.fn(),
       setCopilotInsightStatus: vi.fn(),
       // QNBS-v3: Phase 2 additions
-      activeSectionId: null,
+      activeSectionId: state.activeSectionId,
       setActiveSectionId: vi.fn(),
       // QNBS-v3: CodeAnt fix — badge-to-insights-expand bridge
       copilotInsightExpanded: false,
@@ -49,7 +55,9 @@ vi.mock('../../../hooks/useTranslation', () => ({
 vi.mock('../../../contexts/CommandExecutorContext', () => ({
   useCommandExecutor: () => vi.fn(),
 }));
-vi.mock('../../../features/project/projectSelectors', () => ({ selectProjectData: () => null }));
+vi.mock('../../../features/project/projectSelectors', () => ({
+  selectProjectData: () => state.project,
+}));
 vi.mock('../../../features/featureFlags/featureFlagsSlice', () => ({
   selectEnableProForge: () => false,
 }));
@@ -82,6 +90,9 @@ beforeEach(() => {
   mockDispatch.mockClear();
   mockStop.mockClear();
   state.copilot.status = 'streaming';
+  state.project = null;
+  state.activeSectionId = null;
+  vi.useRealTimers();
 });
 
 describe('useGlobalCopilot.close (CodeAnt #7)', () => {
@@ -112,5 +123,99 @@ describe('useGlobalCopilot.close (CodeAnt #7)', () => {
     expect(mockDispatch).not.toHaveBeenCalledWith(
       expect.objectContaining({ type: 'copilot/setStatus' }),
     );
+  });
+});
+
+describe('useGlobalCopilot.applyLastSuggestion', () => {
+  function setupProject(content: string, activeId: string | null = 's1') {
+    state.project = {
+      id: 'p1',
+      title: 'Test Project',
+      manuscript: [
+        { id: 's1', title: 'Chapter 1', content },
+        { id: 's2', title: 'Chapter 2', content: 'Other chapter content.' },
+      ],
+    };
+    state.activeSectionId = activeId;
+  }
+
+  it('does nothing when there is no active section id', () => {
+    setupProject('Existing content', null);
+    const { result } = renderHook(() => useGlobalCopilot('writer' as never));
+    act(() => result.current.applyLastSuggestion('replacement'));
+    expect(mockDispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'project/updateManuscriptSection' }),
+    );
+  });
+
+  it('does nothing when the active section is not found', () => {
+    setupProject('Existing content', 'missing');
+    const { result } = renderHook(() => useGlobalCopilot('writer' as never));
+    act(() => result.current.applyLastSuggestion('replacement'));
+    expect(mockDispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'project/updateManuscriptSection' }),
+    );
+  });
+
+  it('rejects a block shorter than 70% of the existing content', () => {
+    setupProject('This is a fairly long piece of existing chapter content.');
+    const { result } = renderHook(() => useGlobalCopilot('writer' as never));
+    act(() => result.current.applyLastSuggestion('short'));
+    expect(result.current.applyStatus).toBe('error');
+    expect(mockDispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'project/updateManuscriptSection' }),
+    );
+  });
+
+  it('accepts a rewrite of an empty section regardless of length', () => {
+    setupProject('');
+    const { result } = renderHook(() => useGlobalCopilot('writer' as never));
+    act(() => result.current.applyLastSuggestion('New scene text'));
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'project/updateManuscriptSection',
+        payload: expect.objectContaining({ id: 's1', changes: { content: 'New scene text' } }),
+      }),
+    );
+  });
+
+  it('accepts a block that is at least 70% of the existing content and dispatches an update', () => {
+    const existing =
+      'This is the original chapter text that we want to replace with a full rewrite.';
+    setupProject(existing);
+    const replacement =
+      'This is the rewritten chapter text that is clearly a full rewrite of the scene.';
+    const { result } = renderHook(() => useGlobalCopilot('writer' as never));
+    act(() => result.current.applyLastSuggestion(replacement));
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'project/updateManuscriptSection',
+        payload: expect.objectContaining({ id: 's1', changes: { content: replacement } }),
+      }),
+    );
+  });
+
+  it('cycles applyStatus through applying -> success -> idle', async () => {
+    vi.useFakeTimers();
+    setupProject('Old content');
+    const { result } = renderHook(() => useGlobalCopilot('writer' as never));
+    act(() =>
+      result.current.applyLastSuggestion(
+        'Completely rewritten chapter content that is much longer than the original text so it passes the gate.',
+      ),
+    );
+    expect(result.current.applyStatus).toBe('success');
+    act(() => vi.advanceTimersByTime(3000));
+    await vi.waitFor(() => expect(result.current.applyStatus).toBe('idle'));
+  });
+
+  it('cycles applyStatus through applying -> error -> idle when the block is too short', async () => {
+    vi.useFakeTimers();
+    setupProject('This is a fairly long piece of existing chapter content.');
+    const { result } = renderHook(() => useGlobalCopilot('writer' as never));
+    act(() => result.current.applyLastSuggestion('short'));
+    expect(result.current.applyStatus).toBe('error');
+    act(() => vi.advanceTimersByTime(3000));
+    await vi.waitFor(() => expect(result.current.applyStatus).toBe('idle'));
   });
 });

--- a/tests/unit/plugins/pluginRegistryLoad.test.ts
+++ b/tests/unit/plugins/pluginRegistryLoad.test.ts
@@ -1,6 +1,7 @@
 /**
  * Tests for PluginRegistry.loadPlugin() — dynamic plugin loading via WorkerBus.
- * QNBS-v3: P0 — Tests timeout enforcement, fetch failures, and invalid manifest handling.
+ * QNBS-v3: P0 — Tests timeout enforcement, fetch failures, invalid manifest handling,
+ * and side-effect application back to the main-thread sandboxed API.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -20,13 +21,29 @@ function makePlugin(overrides: Partial<PluginDescriptor> = {}): PluginDescriptor
     name: 'Dynamic Plugin',
     type: 'command',
     entrypoint: 'https://example.com/plugin.js',
-    permissions: ['project.read'],
+    permissions: ['project.read', 'scene.write'],
     ...overrides,
   };
 }
 
-// Minimal mock API for loadPlugin tests (the API is not used in these tests)
-const mockApi = {} as unknown as PluginSandboxedApi;
+// Minimal mock API for loadPlugin tests
+const mockApi: PluginSandboxedApi = {
+  getProjectTitle: vi.fn().mockReturnValue('Test Project'),
+  getSceneTitles: vi.fn().mockReturnValue(['Scene 1', 'Scene 2']),
+  appendToCurrentScene: vi.fn(),
+  log: vi.fn(),
+  generateText: vi.fn().mockResolvedValue(''),
+  storageRead: vi.fn().mockResolvedValue(undefined),
+  storageWrite: vi.fn().mockResolvedValue(undefined),
+};
+
+function makeHandle(result: Promise<unknown>): ReturnType<typeof mockRouteTask> {
+  return {
+    result,
+    progress: (async function* () {})(),
+    cancel: vi.fn(),
+  };
+}
 
 describe('PluginRegistry.loadPlugin()', () => {
   let registry: PluginRegistry;
@@ -38,6 +55,11 @@ describe('PluginRegistry.loadPlugin()', () => {
     registry.setEnabled(true);
     mockRouteTask.mockReset();
     originalFetch = global.fetch;
+
+    vi.mocked(mockApi.getProjectTitle).mockClear();
+    vi.mocked(mockApi.getSceneTitles).mockClear();
+    vi.mocked(mockApi.appendToCurrentScene).mockClear();
+    vi.mocked(mockApi.log).mockClear();
   });
 
   afterEach(() => {
@@ -86,15 +108,36 @@ describe('PluginRegistry.loadPlugin()', () => {
       text: () => Promise.resolve('export async function run(api) { api.log("hello"); }'),
     }) as unknown as typeof fetch;
 
-    const mockHandle = {
-      result: Promise.resolve({ pluginId: 'test-dynamic-plugin' }),
-      progress: (async function* () {})(),
-      cancel: vi.fn(),
-    };
-    mockRouteTask.mockResolvedValue(mockHandle);
+    mockRouteTask.mockResolvedValue(
+      makeHandle(
+        Promise.resolve({ pluginId: 'test-dynamic-plugin', sideEffects: [], logs: ['hello'] }),
+      ),
+    );
 
     const result = await registry.loadPlugin(makePlugin(), mockApi);
     expect(result.ok).toBe(true);
+  });
+
+  it('applies appendToCurrentScene side effects returned by the worker', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      text: () =>
+        Promise.resolve('export async function run(api) { api.appendToCurrentScene("\\n---"); }'),
+    }) as unknown as typeof fetch;
+
+    mockRouteTask.mockResolvedValue(
+      makeHandle(
+        Promise.resolve({
+          pluginId: 'test-dynamic-plugin',
+          sideEffects: [{ kind: 'append' as const, payload: '\n---' }],
+          logs: [],
+        }),
+      ),
+    );
+
+    const result = await registry.loadPlugin(makePlugin(), mockApi);
+    expect(result.ok).toBe(true);
+    expect(mockApi.appendToCurrentScene).toHaveBeenCalledWith('\n---');
   });
 
   it('returns error when plugin execution throws', async () => {
@@ -104,35 +147,30 @@ describe('PluginRegistry.loadPlugin()', () => {
         Promise.resolve('export async function run(api) { throw new Error("plugin crash"); }'),
     }) as unknown as typeof fetch;
 
-    const mockHandle = {
-      result: Promise.reject(new Error('plugin crash')),
-      progress: (async function* () {})(),
-      cancel: vi.fn(),
-    };
-    mockRouteTask.mockResolvedValue(mockHandle);
+    mockRouteTask.mockResolvedValue(makeHandle(Promise.reject(new Error('plugin crash'))));
 
     const result = await registry.loadPlugin(makePlugin(), mockApi);
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.error).toMatch(/plugin crash/);
   });
 
-  it('passes timeoutMs to routeTask', async () => {
+  it('passes timeoutMs, permissions and read snapshot to routeTask', async () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
       text: () => Promise.resolve('export async function run(api) {}'),
     }) as unknown as typeof fetch;
 
-    mockRouteTask.mockResolvedValue({
-      result: Promise.resolve({}),
-      progress: (async function* () {})(),
-      cancel: vi.fn(),
-    });
+    mockRouteTask.mockResolvedValue(
+      makeHandle(Promise.resolve({ pluginId: 'test-dynamic-plugin' })),
+    );
 
     await registry.loadPlugin(makePlugin(), mockApi);
     expect(mockRouteTask).toHaveBeenCalledWith(
       'plugin.execute',
       expect.objectContaining({
         timeoutMs: 30000,
+        grantedPermissions: ['project.read', 'scene.write'],
+        readApiSnapshot: { projectTitle: 'Test Project', sceneTitles: ['Scene 1', 'Scene 2'] },
       }),
     );
   });

--- a/tests/unit/workers/plugin.worker.test.ts
+++ b/tests/unit/workers/plugin.worker.test.ts
@@ -43,6 +43,14 @@ async function importWorker(): Promise<void> {
   await import('../../../workers/plugin.worker', { with: { type: 'script' } });
 }
 
+async function expectRejects(
+  handler: (ctx: unknown) => Promise<unknown>,
+  ctx: ReturnType<typeof makeContext>,
+  pattern: RegExp,
+): Promise<void> {
+  await expect(handler(ctx)).rejects.toThrow(pattern);
+}
+
 describe('plugin.worker', () => {
   beforeEach(async () => {
     mockRegisterTaskHandler.mockClear();
@@ -71,9 +79,9 @@ describe('plugin.worker', () => {
         },
       });
 
-      const result = (await handler(ctx)) as { success: boolean; error: string };
-      expect(result.success).toBe(false);
-      expect(result.error).toMatch(
+      await expectRejects(
+        handler,
+        ctx,
         /fetch is not defined|undefined is not a function|is not a function/,
       );
     });
@@ -91,9 +99,11 @@ describe('plugin.worker', () => {
         },
       });
 
-      const result = (await handler(ctx)) as { success: boolean; error: string };
-      expect(result.success).toBe(false);
-      expect(result.error).toMatch(/indexedDB is not defined|Cannot read properties of undefined/);
+      await expectRejects(
+        handler,
+        ctx,
+        /indexedDB is not defined|Cannot read properties of undefined/,
+      );
     });
 
     it('denies access to self/globalThis inside plugin code', async () => {
@@ -109,27 +119,53 @@ describe('plugin.worker', () => {
         },
       });
 
-      const result = (await handler(ctx)) as {
-        success: boolean;
-        payload: { sideEffects: unknown[] };
-      };
-      expect(result.success).toBe(true);
-      expect(result.payload.sideEffects).toHaveLength(0);
+      const result = (await handler(ctx)) as { sideEffects: unknown[] };
+      expect(result.sideEffects).toHaveLength(0);
+    });
+
+    it('blocks Function constructor escape via (function(){}).constructor', async () => {
+      const handler = registeredHandlers.get('plugin.execute');
+      if (!handler) throw new Error('plugin.execute handler not registered');
+
+      const ctx = makeContext({
+        payload: {
+          pluginId: 'function-escape',
+          code: 'run = () => { (function(){}).constructor("return globalThis")(); };',
+          grantedPermissions: [],
+          readApiSnapshot: { projectTitle: '', sceneTitles: [] },
+        },
+      });
+
+      await expectRejects(handler, ctx, /Function constructor is disabled/);
+    });
+
+    it('blocks AsyncFunction constructor escape', async () => {
+      const handler = registeredHandlers.get('plugin.execute');
+      if (!handler) throw new Error('plugin.execute handler not registered');
+
+      const ctx = makeContext({
+        payload: {
+          pluginId: 'async-function-escape',
+          code: 'run = () => { (async function(){}).constructor("return globalThis")(); };',
+          grantedPermissions: [],
+          readApiSnapshot: { projectTitle: '', sceneTitles: [] },
+        },
+      });
+
+      await expectRejects(handler, ctx, /AsyncFunction constructor is disabled/);
     });
   });
 
   describe('plugin execution', () => {
-    it('returns error when payload is invalid', async () => {
+    it('throws when payload is invalid', async () => {
       const handler = registeredHandlers.get('plugin.execute');
       if (!handler) throw new Error('plugin.execute handler not registered');
 
       const ctx = makeContext({ payload: { pluginId: 'x' } });
-      const result = (await handler(ctx)) as { success: boolean; error: string };
-      expect(result.success).toBe(false);
-      expect(result.error).toMatch(/Invalid plugin.execute payload/);
+      await expectRejects(handler, ctx, /Invalid plugin.execute payload/);
     });
 
-    it('returns error when plugin has no run export', async () => {
+    it('throws when plugin has no run export', async () => {
       const handler = registeredHandlers.get('plugin.execute');
       if (!handler) throw new Error('plugin.execute handler not registered');
 
@@ -141,9 +177,39 @@ describe('plugin.worker', () => {
           readApiSnapshot: { projectTitle: '', sceneTitles: [] },
         },
       });
-      const result = (await handler(ctx)) as { success: boolean; error: string };
-      expect(result.success).toBe(false);
-      expect(result.error).toMatch(/has no exported run\(\) function/);
+      await expectRejects(handler, ctx, /has no exported run\(\) function/);
+    });
+
+    it('normalizes ESM export async function run syntax', async () => {
+      const handler = registeredHandlers.get('plugin.execute');
+      if (!handler) throw new Error('plugin.execute handler not registered');
+
+      const ctx = makeContext({
+        payload: {
+          pluginId: 'esm-plugin',
+          code: 'export async function run(api) { api.log("esm ok"); }',
+          grantedPermissions: [],
+          readApiSnapshot: { projectTitle: '', sceneTitles: [] },
+        },
+      });
+      const result = (await handler(ctx)) as { logs: string[] };
+      expect(result.logs).toEqual(['esm ok']);
+    });
+
+    it('normalizes ESM export function run syntax', async () => {
+      const handler = registeredHandlers.get('plugin.execute');
+      if (!handler) throw new Error('plugin.execute handler not registered');
+
+      const ctx = makeContext({
+        payload: {
+          pluginId: 'esm-plugin',
+          code: 'export function run(api) { api.log("esm sync ok"); }',
+          grantedPermissions: [],
+          readApiSnapshot: { projectTitle: '', sceneTitles: [] },
+        },
+      });
+      const result = (await handler(ctx)) as { logs: string[] };
+      expect(result.logs).toEqual(['esm sync ok']);
     });
 
     it('collects appendToCurrentScene side effects when permission is granted', async () => {
@@ -159,11 +225,9 @@ describe('plugin.worker', () => {
         },
       });
       const result = (await handler(ctx)) as {
-        success: boolean;
-        payload: { sideEffects: Array<{ kind: string; payload: string }> };
+        sideEffects: Array<{ kind: string; payload: string }>;
       };
-      expect(result.success).toBe(true);
-      expect(result.payload.sideEffects).toEqual([{ kind: 'append', payload: 'extra' }]);
+      expect(result.sideEffects).toEqual([{ kind: 'append', payload: 'extra' }]);
     });
 
     it('throws permission denied when appendToCurrentScene is called without scene.write', async () => {
@@ -178,9 +242,7 @@ describe('plugin.worker', () => {
           readApiSnapshot: { projectTitle: '', sceneTitles: [] },
         },
       });
-      const result = (await handler(ctx)) as { success: boolean; error: string };
-      expect(result.success).toBe(false);
-      expect(result.error).toMatch(/Permission denied: scene.write/);
+      await expectRejects(handler, ctx, /Permission denied: scene.write/);
     });
 
     it('collects logs', async () => {
@@ -195,12 +257,8 @@ describe('plugin.worker', () => {
           readApiSnapshot: { projectTitle: '', sceneTitles: [] },
         },
       });
-      const result = (await handler(ctx)) as {
-        success: boolean;
-        payload: { logs: string[] };
-      };
-      expect(result.success).toBe(true);
-      expect(result.payload.logs).toEqual(['hello', '123']);
+      const result = (await handler(ctx)) as { logs: string[] };
+      expect(result.logs).toEqual(['hello', '123']);
     });
 
     it('reads project title and scene titles from snapshot', async () => {
@@ -215,34 +273,47 @@ describe('plugin.worker', () => {
           readApiSnapshot: { projectTitle: 'My Novel', sceneTitles: ['Opening', 'Twist'] },
         },
       });
-      const result = (await handler(ctx)) as {
-        success: boolean;
-        payload: { logs: string[] };
-      };
-      expect(result.success).toBe(true);
-      expect(result.payload.logs[0]).toBe('{"title":"My Novel","scenes":["Opening","Twist"]}');
+      const result = (await handler(ctx)) as { logs: string[] };
+      expect(result.logs[0]).toBe('{"title":"My Novel","scenes":["Opening","Twist"]}');
     });
 
-    it('async APIs are unavailable in worker sandbox', async () => {
+    it('async APIs are unavailable in worker sandbox even without await', async () => {
       const handler = registeredHandlers.get('plugin.execute');
       if (!handler) throw new Error('plugin.execute handler not registered');
 
       const ctx = makeContext({
         payload: {
           pluginId: 'async-api',
-          code: 'run = async (api) => { await api.generateText("x"); };',
+          code: 'run = (api) => { api.generateText("x"); };',
           grantedPermissions: ['ai.invoke'],
           readApiSnapshot: { projectTitle: '', sceneTitles: [] },
         },
       });
-      const result = (await handler(ctx)) as { success: boolean; error: string };
-      expect(result.success).toBe(false);
-      expect(result.error).toMatch(/generateText\(\) is not available inside the worker sandbox/);
+      await expectRejects(
+        handler,
+        ctx,
+        /generateText\(\) is not available inside the worker sandbox/,
+      );
+    });
+
+    it('propagates plugin errors instead of returning success', async () => {
+      const handler = registeredHandlers.get('plugin.execute');
+      if (!handler) throw new Error('plugin.execute handler not registered');
+
+      const ctx = makeContext({
+        payload: {
+          pluginId: 'crash',
+          code: 'run = () => { throw new Error("plugin crash"); };',
+          grantedPermissions: [],
+          readApiSnapshot: { projectTitle: '', sceneTitles: [] },
+        },
+      });
+      await expectRejects(handler, ctx, /plugin crash/);
     });
   });
 
   describe('abort/timeout', () => {
-    it('returns aborted error when signal is already aborted', async () => {
+    it('throws aborted error when signal is already aborted', async () => {
       const handler = registeredHandlers.get('plugin.execute');
       if (!handler) throw new Error('plugin.execute handler not registered');
 
@@ -255,9 +326,7 @@ describe('plugin.worker', () => {
         },
         signalAborted: true,
       });
-      const result = (await handler(ctx)) as { success: boolean; error: string };
-      expect(result.success).toBe(false);
-      expect(result.error).toMatch(/aborted before start/);
+      await expectRejects(handler, ctx, /aborted before start/);
     });
   });
 
@@ -266,12 +335,8 @@ describe('plugin.worker', () => {
       const handler = registeredHandlers.get('plugin.ping');
       if (!handler) throw new Error('plugin.ping handler not registered');
 
-      const result = (await handler(makeContext())) as {
-        success: boolean;
-        payload: { status: string };
-      };
-      expect(result.success).toBe(true);
-      expect(result.payload.status).toBe('ok');
+      const result = (await handler(makeContext())) as { status: string };
+      expect(result.status).toBe('ok');
     });
   });
 });

--- a/tests/unit/workers/plugin.worker.test.ts
+++ b/tests/unit/workers/plugin.worker.test.ts
@@ -1,29 +1,277 @@
 /**
  * Tests for plugin.worker.ts — Worker isolation for plugin execution.
- * QNBS-v3: P1 tests for P0-2 plugin worker isolation.
+ * QNBS-v3: P0 — Verifies Function-scope sandbox: dangerous globals are shadowed,
+ *          side effects are collected, and AbortSignal is respected.
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Mock the worker-bus module
-const mockRegisterTaskHandler = vi.fn();
+// Capture registered handlers so we can invoke them directly.
+const registeredHandlers = new Map<string, (ctx: unknown) => Promise<unknown>>();
+const mockRegisterTaskHandler = vi.fn(
+  (taskType: string, handler: (ctx: unknown) => Promise<unknown>) => {
+    registeredHandlers.set(taskType, handler);
+  },
+);
+
 vi.mock('@domain/worker-bus', () => ({
   registerTaskHandler: mockRegisterTaskHandler,
 }));
 
+function makeContext(overrides: { payload?: unknown; signalAborted?: boolean } = {}): {
+  taskId: string;
+  taskType: string;
+  payload: unknown;
+  signal: AbortSignal;
+  emitProgress: ReturnType<typeof vi.fn>;
+} {
+  const controller = new AbortController();
+  if (overrides.signalAborted) controller.abort();
+  return {
+    taskId: 'task-1',
+    taskType: 'plugin.execute',
+    payload: overrides.payload,
+    signal: controller.signal,
+    emitProgress: vi.fn(),
+  };
+}
+
+async function importWorker(): Promise<void> {
+  registeredHandlers.clear();
+  // QNBS-v3: Force re-evaluation of the worker module so registerTaskHandler runs again.
+  vi.resetModules();
+  await import('../../../workers/plugin.worker', { with: { type: 'script' } });
+}
+
 describe('plugin.worker', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     mockRegisterTaskHandler.mockClear();
+    await importWorker();
   });
 
   describe('task registration', () => {
-    it('registers plugin.execute and plugin.ping task handlers on module load', async () => {
-      // Import the worker module to trigger registration
-      await import('../../../workers/plugin.worker', { with: { type: 'script' } });
-      // Should have registered both handlers
+    it('registers plugin.execute and plugin.ping task handlers on module load', () => {
       expect(mockRegisterTaskHandler).toHaveBeenCalledTimes(2);
       expect(mockRegisterTaskHandler).toHaveBeenCalledWith('plugin.execute', expect.any(Function));
       expect(mockRegisterTaskHandler).toHaveBeenCalledWith('plugin.ping', expect.any(Function));
+    });
+  });
+
+  describe('sandbox security', () => {
+    it('denies access to fetch inside plugin code', async () => {
+      const handler = registeredHandlers.get('plugin.execute');
+      if (!handler) throw new Error('plugin.execute handler not registered');
+
+      const ctx = makeContext({
+        payload: {
+          pluginId: 'escape-test',
+          code: 'run = async () => { await fetch("https://evil.test"); };',
+          grantedPermissions: [],
+          readApiSnapshot: { projectTitle: '', sceneTitles: [] },
+        },
+      });
+
+      const result = (await handler(ctx)) as { success: boolean; error: string };
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(
+        /fetch is not defined|undefined is not a function|is not a function/,
+      );
+    });
+
+    it('denies access to indexedDB inside plugin code', async () => {
+      const handler = registeredHandlers.get('plugin.execute');
+      if (!handler) throw new Error('plugin.execute handler not registered');
+
+      const ctx = makeContext({
+        payload: {
+          pluginId: 'escape-test',
+          code: 'run = async () => { indexedDB.open("x"); };',
+          grantedPermissions: [],
+          readApiSnapshot: { projectTitle: '', sceneTitles: [] },
+        },
+      });
+
+      const result = (await handler(ctx)) as { success: boolean; error: string };
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/indexedDB is not defined|Cannot read properties of undefined/);
+    });
+
+    it('denies access to self/globalThis inside plugin code', async () => {
+      const handler = registeredHandlers.get('plugin.execute');
+      if (!handler) throw new Error('plugin.execute handler not registered');
+
+      const ctx = makeContext({
+        payload: {
+          pluginId: 'escape-test',
+          code: 'run = () => { return typeof self !== "undefined" || typeof globalThis !== "undefined"; };',
+          grantedPermissions: [],
+          readApiSnapshot: { projectTitle: '', sceneTitles: [] },
+        },
+      });
+
+      const result = (await handler(ctx)) as {
+        success: boolean;
+        payload: { sideEffects: unknown[] };
+      };
+      expect(result.success).toBe(true);
+      expect(result.payload.sideEffects).toHaveLength(0);
+    });
+  });
+
+  describe('plugin execution', () => {
+    it('returns error when payload is invalid', async () => {
+      const handler = registeredHandlers.get('plugin.execute');
+      if (!handler) throw new Error('plugin.execute handler not registered');
+
+      const ctx = makeContext({ payload: { pluginId: 'x' } });
+      const result = (await handler(ctx)) as { success: boolean; error: string };
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/Invalid plugin.execute payload/);
+    });
+
+    it('returns error when plugin has no run export', async () => {
+      const handler = registeredHandlers.get('plugin.execute');
+      if (!handler) throw new Error('plugin.execute handler not registered');
+
+      const ctx = makeContext({
+        payload: {
+          pluginId: 'no-run',
+          code: 'const x = 1;',
+          grantedPermissions: [],
+          readApiSnapshot: { projectTitle: '', sceneTitles: [] },
+        },
+      });
+      const result = (await handler(ctx)) as { success: boolean; error: string };
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/has no exported run\(\) function/);
+    });
+
+    it('collects appendToCurrentScene side effects when permission is granted', async () => {
+      const handler = registeredHandlers.get('plugin.execute');
+      if (!handler) throw new Error('plugin.execute handler not registered');
+
+      const ctx = makeContext({
+        payload: {
+          pluginId: 'side-effect',
+          code: 'run = (api) => { api.appendToCurrentScene("extra"); };',
+          grantedPermissions: ['scene.write'],
+          readApiSnapshot: { projectTitle: '', sceneTitles: [] },
+        },
+      });
+      const result = (await handler(ctx)) as {
+        success: boolean;
+        payload: { sideEffects: Array<{ kind: string; payload: string }> };
+      };
+      expect(result.success).toBe(true);
+      expect(result.payload.sideEffects).toEqual([{ kind: 'append', payload: 'extra' }]);
+    });
+
+    it('throws permission denied when appendToCurrentScene is called without scene.write', async () => {
+      const handler = registeredHandlers.get('plugin.execute');
+      if (!handler) throw new Error('plugin.execute handler not registered');
+
+      const ctx = makeContext({
+        payload: {
+          pluginId: 'no-perm',
+          code: 'run = (api) => { api.appendToCurrentScene("extra"); };',
+          grantedPermissions: [],
+          readApiSnapshot: { projectTitle: '', sceneTitles: [] },
+        },
+      });
+      const result = (await handler(ctx)) as { success: boolean; error: string };
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/Permission denied: scene.write/);
+    });
+
+    it('collects logs', async () => {
+      const handler = registeredHandlers.get('plugin.execute');
+      if (!handler) throw new Error('plugin.execute handler not registered');
+
+      const ctx = makeContext({
+        payload: {
+          pluginId: 'logger',
+          code: 'run = (api) => { api.log("hello"); api.log(123); };',
+          grantedPermissions: [],
+          readApiSnapshot: { projectTitle: '', sceneTitles: [] },
+        },
+      });
+      const result = (await handler(ctx)) as {
+        success: boolean;
+        payload: { logs: string[] };
+      };
+      expect(result.success).toBe(true);
+      expect(result.payload.logs).toEqual(['hello', '123']);
+    });
+
+    it('reads project title and scene titles from snapshot', async () => {
+      const handler = registeredHandlers.get('plugin.execute');
+      if (!handler) throw new Error('plugin.execute handler not registered');
+
+      const ctx = makeContext({
+        payload: {
+          pluginId: 'reader',
+          code: 'let captured; run = (api) => { captured = { title: api.getProjectTitle(), scenes: api.getSceneTitles() }; api.log(JSON.stringify(captured)); };',
+          grantedPermissions: ['project.read', 'scene.read'],
+          readApiSnapshot: { projectTitle: 'My Novel', sceneTitles: ['Opening', 'Twist'] },
+        },
+      });
+      const result = (await handler(ctx)) as {
+        success: boolean;
+        payload: { logs: string[] };
+      };
+      expect(result.success).toBe(true);
+      expect(result.payload.logs[0]).toBe('{"title":"My Novel","scenes":["Opening","Twist"]}');
+    });
+
+    it('async APIs are unavailable in worker sandbox', async () => {
+      const handler = registeredHandlers.get('plugin.execute');
+      if (!handler) throw new Error('plugin.execute handler not registered');
+
+      const ctx = makeContext({
+        payload: {
+          pluginId: 'async-api',
+          code: 'run = async (api) => { await api.generateText("x"); };',
+          grantedPermissions: ['ai.invoke'],
+          readApiSnapshot: { projectTitle: '', sceneTitles: [] },
+        },
+      });
+      const result = (await handler(ctx)) as { success: boolean; error: string };
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/generateText\(\) is not available inside the worker sandbox/);
+    });
+  });
+
+  describe('abort/timeout', () => {
+    it('returns aborted error when signal is already aborted', async () => {
+      const handler = registeredHandlers.get('plugin.execute');
+      if (!handler) throw new Error('plugin.execute handler not registered');
+
+      const ctx = makeContext({
+        payload: {
+          pluginId: 'aborted',
+          code: 'run = () => {};',
+          grantedPermissions: [],
+          readApiSnapshot: { projectTitle: '', sceneTitles: [] },
+        },
+        signalAborted: true,
+      });
+      const result = (await handler(ctx)) as { success: boolean; error: string };
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/aborted before start/);
+    });
+  });
+
+  describe('plugin.ping', () => {
+    it('responds with ok status', async () => {
+      const handler = registeredHandlers.get('plugin.ping');
+      if (!handler) throw new Error('plugin.ping handler not registered');
+
+      const result = (await handler(makeContext())) as {
+        success: boolean;
+        payload: { status: string };
+      };
+      expect(result.success).toBe(true);
+      expect(result.payload.status).toBe('ok');
     });
   });
 });

--- a/workers/plugin.worker.ts
+++ b/workers/plugin.worker.ts
@@ -39,6 +39,119 @@ interface PluginExecuteResult {
 }
 
 // ---------------------------------------------------------------------------
+// Runtime guard setup
+// ---------------------------------------------------------------------------
+
+// QNBS-v3: Capture the original Function constructor before we install runtime guards.
+// The worker uses this reference to build sandboxed runners; plugin code sees only the
+// guarded (throwing) global Function.
+const GlobalFunction = Function;
+
+const AsyncFunction = (async () => {
+  /** no-op */
+}).constructor as typeof Function;
+const GeneratorFunction = function* () {
+  /** no-op */
+}.constructor as typeof Function;
+const AsyncGeneratorFunction = async function* () {
+  /** no-op */
+}.constructor as typeof Function;
+
+function createDeniedConstructor(name: string): (...args: unknown[]) => never {
+  return function deniedConstructor() {
+    throw new Error(`${name} constructor is disabled inside the plugin sandbox`);
+  };
+}
+
+interface GuardSnapshot {
+  functionConstructor: (typeof Function)['prototype']['constructor'];
+  asyncFunctionConstructor: (typeof Function)['prototype']['constructor'];
+  generatorFunctionConstructor: (typeof Function)['prototype']['constructor'];
+  asyncGeneratorFunctionConstructor: (typeof Function)['prototype']['constructor'];
+  selfFunction: unknown;
+  selfEval: unknown;
+  selfWebAssembly: unknown;
+}
+
+/**
+ * Install runtime guards that close common sandbox-escape paths.
+ *
+ * QNBS-v3: Shadowing dangerous globals as parameters is not enough — a plugin can still
+ * reach the real Function constructor via `(function(){}).constructor`. We therefore
+ * also override `Function.prototype.constructor` (and the async/generator variants) and
+ * the global `Function`/`eval` bindings while the plugin runs, then restore them so the
+ * dedicated worker stays healthy for subsequent tasks and tests.
+ */
+function installRuntimeGuards(): GuardSnapshot {
+  const denied = createDeniedConstructor('Function');
+  const deniedEval = function deniedEval() {
+    throw new Error('eval is disabled inside the plugin sandbox');
+  };
+
+  // Snapshot originals before mutation.
+  const snapshot: GuardSnapshot = {
+    functionConstructor: Function.prototype.constructor,
+    asyncFunctionConstructor: AsyncFunction.prototype.constructor,
+    generatorFunctionConstructor: GeneratorFunction.prototype.constructor,
+    asyncGeneratorFunctionConstructor: AsyncGeneratorFunction.prototype.constructor,
+    selfFunction: (self as unknown as Record<string, unknown>)['Function'],
+    selfEval: (self as unknown as Record<string, unknown>)['eval'],
+    selfWebAssembly: (self as unknown as Record<string, unknown>)['WebAssembly'],
+  };
+
+  // Override the constructors plugin-defined functions would use to build new functions.
+  // QNBS-v3: Some of these prototypes have non-writable but configurable constructors,
+  // so Object.defineProperty is required instead of direct assignment.
+  function defineDenied(proto: typeof Function.prototype, name: string): void {
+    Object.defineProperty(proto, 'constructor', {
+      value: createDeniedConstructor(name),
+      writable: false,
+      configurable: true,
+      enumerable: false,
+    });
+  }
+
+  Function.prototype.constructor = denied;
+  defineDenied(AsyncFunction.prototype, 'AsyncFunction');
+  defineDenied(GeneratorFunction.prototype, 'GeneratorFunction');
+  defineDenied(AsyncGeneratorFunction.prototype, 'AsyncGeneratorFunction');
+
+  // Override global bindings so direct `Function(...)` / `eval(...)` calls fail.
+  // QNBS-v3: `eval` cannot be shadowed as a parameter or var in strict mode, so we neuter
+  // the global binding instead. Plugin code referencing `eval` resolves to this override.
+  (self as unknown as Record<string, unknown>)['Function'] = denied;
+  (self as unknown as Record<string, unknown>)['eval'] = deniedEval;
+  (self as unknown as Record<string, unknown>)['WebAssembly'] = undefined;
+
+  return snapshot;
+}
+
+function restoreRuntimeGuards(snapshot: GuardSnapshot): void {
+  Function.prototype.constructor = snapshot.functionConstructor;
+  Object.defineProperty(AsyncFunction.prototype, 'constructor', {
+    value: snapshot.asyncFunctionConstructor,
+    writable: false,
+    configurable: true,
+    enumerable: false,
+  });
+  Object.defineProperty(GeneratorFunction.prototype, 'constructor', {
+    value: snapshot.generatorFunctionConstructor,
+    writable: false,
+    configurable: true,
+    enumerable: false,
+  });
+  Object.defineProperty(AsyncGeneratorFunction.prototype, 'constructor', {
+    value: snapshot.asyncGeneratorFunctionConstructor,
+    writable: false,
+    configurable: true,
+    enumerable: false,
+  });
+  (self as unknown as Record<string, unknown>)['Function'] = snapshot.selfFunction;
+  (self as unknown as Record<string, unknown>)['eval'] = snapshot.selfEval;
+  (self as unknown as Record<string, unknown>)['WebAssembly'] = snapshot.selfWebAssembly;
+}
+
+// ---------------------------------------------------------------------------
 // Sandbox implementation
 // ---------------------------------------------------------------------------
 
@@ -64,7 +177,33 @@ const DENIED_GLOBALS = new Set<string>([
   'Worker',
   'SharedArrayBuffer',
   'Atomics',
+  'WebAssembly',
+  'Intl',
+  'Function',
+  'constructor',
 ]);
+
+/**
+ * Normalize plugin source so ESM-style entrypoints compile inside a `Function` body.
+ * QNBS-v3: Plugin entrypoints are fetched as text and must not rely on module loaders
+ * inside the worker. We strip import/export statements and convert the common `run`
+ * export forms into a plain script binding.
+ */
+function normalizePluginSource(code: string): string {
+  // Remove full-line import/export declarations.
+  let normalized = code
+    .replace(/^import\s+[^;]+;?\s*$/gm, '')
+    .replace(/^export\s+\{[^}]*\};?\s*$/gm, '');
+
+  // Convert the supported `run` export forms to plain declarations.
+  normalized = normalized
+    .replace(/\bexport\s+async\s+function\s+run\b/g, 'async function run')
+    .replace(/\bexport\s+function\s+run\b/g, 'function run')
+    .replace(/\bexport\s+const\s+run\b/g, 'const run')
+    .replace(/\bexport\s+default\s+[^;]+;?/g, '');
+
+  return normalized.trim();
+}
 
 /**
  * Build a sandboxed runner for plugin code.
@@ -76,6 +215,7 @@ function createSandboxedRunner(
   code: string,
   sandbox: Record<string, unknown>,
 ): () => ((api: Record<string, unknown>) => Promise<void> | void) | undefined {
+  const normalized = normalizePluginSource(code);
   const sandboxKeys = Object.keys(sandbox);
   const sandboxValues = Object.values(sandbox);
 
@@ -92,17 +232,15 @@ function createSandboxedRunner(
   const wrapped = `
 "use strict";
 ${shadowDeclarations}
-var run = undefined;
-${code}
+var run;
+${normalized}
 return typeof run === 'function' ? run : undefined;
 `;
 
   try {
-    // QNBS-v3: `new Function` creates a function in the global scope but with the
-    // parameter list controlling what identifiers are injectable. By not including any
-    // dangerous globals in the parameter list and shadowing them with `var`, the plugin
-    // cannot reach them.
-    const fn = new Function(...sandboxKeys, wrapped);
+    // QNBS-v3: Use the captured original Function constructor so runtime guards do not
+    // prevent us from creating subsequent runners in this dedicated worker.
+    const fn = new GlobalFunction(...sandboxKeys, wrapped);
     return () =>
       fn(...sandboxValues) as ((api: Record<string, unknown>) => Promise<void> | void) | undefined;
   } catch (err) {
@@ -123,7 +261,7 @@ function buildSandboxApi(
   logs: string[],
 ) {
   const granted = new Set(payload.grantedPermissions);
-  const denyAsync = (name: string): never => {
+  const deny = (name: string): never => {
     throw new Error(
       `${name}() is not available inside the worker sandbox. Use pluginRegistry.executeAsync() for plugins that need ${name}.`,
     );
@@ -149,9 +287,11 @@ function buildSandboxApi(
       const entry = typeof message === 'string' ? message : String(message);
       logs.push(entry);
     },
-    generateText: async () => denyAsync('generateText'),
-    storageRead: async () => denyAsync('storageRead'),
-    storageWrite: async () => denyAsync('storageWrite'),
+    // QNBS-v3: These APIs are synchronous throwers. Async throwers would return a rejected
+    // Promise that a plugin could ignore; synchronous throw always propagates to run().
+    generateText: () => deny('generateText'),
+    storageRead: () => deny('storageRead'),
+    storageWrite: () => deny('storageWrite'),
   };
 }
 
@@ -172,12 +312,7 @@ function isPluginExecutePayload(value: unknown): value is PluginExecutePayload {
 
 registerTaskHandler('plugin.execute', async (ctx: WorkerHandlerContext) => {
   if (!isPluginExecutePayload(ctx.payload)) {
-    return {
-      success: false,
-      payload: null,
-      error: 'Invalid plugin.execute payload',
-      latencyMs: 0,
-    };
+    throw new Error('Invalid plugin.execute payload');
   }
 
   const payload = ctx.payload;
@@ -190,23 +325,15 @@ registerTaskHandler('plugin.execute', async (ctx: WorkerHandlerContext) => {
   const runner = createSandboxedRunner(payload.code, { api: sandboxApi });
 
   if (ctx.signal.aborted) {
-    return {
-      success: false,
-      payload: null,
-      error: 'Plugin execution aborted before start',
-      latencyMs: 0,
-    };
+    throw new Error('Plugin execution aborted before start');
   }
+
+  const guardSnapshot = installRuntimeGuards();
 
   try {
     const runFn = runner();
     if (typeof runFn !== 'function') {
-      return {
-        success: false,
-        payload: null,
-        error: `Plugin '${payload.pluginId}' has no exported run() function`,
-        latencyMs: 0,
-      };
+      throw new Error(`Plugin '${payload.pluginId}' has no exported run() function`);
     }
 
     ctx.emitProgress('running', 0.5);
@@ -235,29 +362,15 @@ registerTaskHandler('plugin.execute', async (ctx: WorkerHandlerContext) => {
       logs,
     };
 
-    return {
-      success: true,
-      payload: executeResult,
-      error: null,
-      latencyMs: 0,
-    };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    return {
-      success: false,
-      payload: null,
-      error: message,
-      latencyMs: 0,
-    };
+    // QNBS-v3: Return the payload directly. The WorkerBus bootstrap wraps it; throwing here
+    // on failure keeps the worker-bus contract consistent.
+    return executeResult;
+  } finally {
+    restoreRuntimeGuards(guardSnapshot);
   }
 });
 
 // Handle unknown task types gracefully
 registerTaskHandler('plugin.ping', async () => {
-  return {
-    success: true,
-    payload: { status: 'ok', version: '1.0.0' },
-    error: null,
-    latencyMs: 0,
-  };
+  return { status: 'ok', version: '1.0.0' };
 });

--- a/workers/plugin.worker.ts
+++ b/workers/plugin.worker.ts
@@ -1,105 +1,246 @@
 /// <reference lib="webworker" />
 /**
  * Plugin Worker — Isolated execution context for StoryCraft plugins.
- * QNBS-v3: P0-2 — Worker isolation prevents plugins from accessing main-thread state.
- *           Enforces timeout, resource limits, and sandboxed API surface.
+ * QNBS-v3: P0-1 — Plugins run inside a Function-scope sandbox with shadowed globals.
+ *          P0-2 — Execution respects the AbortSignal supplied by WorkerBus v2.
+ *          P0-3 — Read-only API snapshots are passed in the task payload; side effects
+ *          (appendToCurrentScene, log) are collected and returned to the main thread for
+ *          application. Async APIs that require main-thread state (generateText, storage)
+ *          are explicitly unsupported inside the worker sandbox.
  */
 
 import { registerTaskHandler, type WorkerHandlerContext } from '@domain/worker-bus';
-import type { PluginSandboxedApi } from '../services/pluginRegistry';
+import type { PluginPermission } from '../services/pluginRegistry';
 
-// Minimal sandboxed API available to plugins in worker context
-const sandboxApi: PluginSandboxedApi = {
-  getProjectTitle: () => '',
-  getSceneTitles: () => [],
-  appendToCurrentScene: () => {},
-  log: () => {
-    // Worker-safe logging - no structured logger in worker
-  },
-  generateText: async () => {
-    throw new Error('generateText not available in plugin worker');
-  },
-  storageRead: async () => {
-    throw new Error('storageRead not available in plugin worker');
-  },
-  storageWrite: async () => {
-    throw new Error('storageWrite not available in plugin worker');
-  },
-};
+// ---------------------------------------------------------------------------
+// Task payload types
+// ---------------------------------------------------------------------------
 
-registerTaskHandler('plugin.execute', async (ctx: WorkerHandlerContext) => {
-  const {
-    pluginId,
-    code,
-    timeoutMs = 30000,
-  } = ctx.payload as {
-    pluginId: string;
-    code: string;
-    timeoutMs?: number;
+interface PluginExecutePayload {
+  readonly pluginId: string;
+  readonly code: string;
+  readonly timeoutMs?: number;
+  readonly grantedPermissions: readonly PluginPermission[];
+  readonly readApiSnapshot: {
+    readonly projectTitle: string;
+    readonly sceneTitles: readonly string[];
   };
+}
 
-  // Create timeout controller
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+interface PluginSideEffect {
+  readonly kind: 'append' | 'log';
+  readonly payload: unknown;
+}
+
+interface PluginExecuteResult {
+  readonly pluginId: string;
+  readonly sideEffects: readonly PluginSideEffect[];
+  readonly logs: readonly string[];
+}
+
+// ---------------------------------------------------------------------------
+// Sandbox implementation
+// ---------------------------------------------------------------------------
+
+const DENIED_GLOBALS = new Set<string>([
+  'self',
+  'globalThis',
+  'window',
+  'top',
+  'parent',
+  'opener',
+  'fetch',
+  'XMLHttpRequest',
+  'WebSocket',
+  'EventSource',
+  'indexedDB',
+  'caches',
+  'navigator',
+  'location',
+  'document',
+  'localStorage',
+  'sessionStorage',
+  'importScripts',
+  'Worker',
+  'SharedArrayBuffer',
+  'Atomics',
+]);
+
+/**
+ * Build a sandboxed runner for plugin code.
+ * QNBS-v3: Uses `new Function` with explicit parameter names so every identifier the
+ * plugin references must be resolved from the supplied sandbox object. Dangerous globals
+ * are intentionally absent. The plugin must export a `run(api)` function.
+ */
+function createSandboxedRunner(
+  code: string,
+  sandbox: Record<string, unknown>,
+): () => ((api: Record<string, unknown>) => Promise<void> | void) | undefined {
+  const sandboxKeys = Object.keys(sandbox);
+  const sandboxValues = Object.values(sandbox);
+
+  // QNBS-v3: Prepend a shadow-declaration for every denied global so that even if the
+  // plugin tries to access them they are undefined in this scope. Also shadow
+  // `globalThis`/`self` with undefined to break escape paths.
+  const shadowDeclarations = Array.from(DENIED_GLOBALS)
+    .map((name) => `var ${name} = undefined;`)
+    .join('\n');
+
+  // QNBS-v3: Wrap the plugin code so it can declare `run` (or `export const run`) in a
+  // way that survives the Function body. We collect the declared `run` binding and
+  // return it. `const`/`let` declared inside the user code stay in the function scope.
+  const wrapped = `
+"use strict";
+${shadowDeclarations}
+var run = undefined;
+${code}
+return typeof run === 'function' ? run : undefined;
+`;
 
   try {
-    // Create sandboxed scope with limited globals
-    const sandboxGlobals = {
-      console: {
-        log: () => {},
-        error: () => {},
-        warn: () => {},
-        info: () => {},
-        debug: () => {},
-      },
-      setTimeout,
-      clearTimeout,
-      AbortController,
-      AbortSignal,
-    };
+    // QNBS-v3: `new Function` creates a function in the global scope but with the
+    // parameter list controlling what identifiers are injectable. By not including any
+    // dangerous globals in the parameter list and shadowing them with `var`, the plugin
+    // cannot reach them.
+    const fn = new Function(...sandboxKeys, wrapped);
+    return () =>
+      fn(...sandboxValues) as ((api: Record<string, unknown>) => Promise<void> | void) | undefined;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Plugin code failed to compile: ${message}`);
+  }
+}
 
-    // Create blob URL for dynamic import
-    const blob = new Blob(
-      [
-        `const sandbox = ${JSON.stringify(sandboxGlobals)};`,
-        `const api = ${JSON.stringify(sandboxApi)};`,
-        `(${code})`,
-      ],
-      { type: 'application/javascript' },
+function assertPermission(granted: ReadonlySet<PluginPermission>, perm: PluginPermission): void {
+  if (!granted.has(perm)) {
+    throw new Error(`Permission denied: ${perm}`);
+  }
+}
+
+function buildSandboxApi(
+  payload: PluginExecutePayload,
+  sideEffects: PluginSideEffect[],
+  logs: string[],
+) {
+  const granted = new Set(payload.grantedPermissions);
+  const denyAsync = (name: string): never => {
+    throw new Error(
+      `${name}() is not available inside the worker sandbox. Use pluginRegistry.executeAsync() for plugins that need ${name}.`,
     );
-    const url = URL.createObjectURL(blob);
+  };
 
-    try {
-      // Dynamic import in worker context
-      const module = (await import(/* @vite-ignore */ url)) as {
-        run?: (api: PluginSandboxedApi) => Promise<void>;
-      };
-
-      if (typeof module['run'] !== 'function') {
-        return {
-          success: false,
-          payload: null,
-          error: `Plugin '${pluginId}' has no exported run() function`,
-          latencyMs: 0,
-        };
+  return {
+    getProjectTitle: () => {
+      assertPermission(granted, 'project.read');
+      return payload.readApiSnapshot.projectTitle;
+    },
+    getSceneTitles: () => {
+      assertPermission(granted, 'scene.read');
+      return payload.readApiSnapshot.sceneTitles.slice();
+    },
+    appendToCurrentScene: (text: string) => {
+      assertPermission(granted, 'scene.write');
+      if (typeof text !== 'string') {
+        throw new Error('appendToCurrentScene requires a string argument');
       }
+      sideEffects.push({ kind: 'append', payload: text });
+    },
+    log: (message: string) => {
+      const entry = typeof message === 'string' ? message : String(message);
+      logs.push(entry);
+    },
+    generateText: async () => denyAsync('generateText'),
+    storageRead: async () => denyAsync('storageRead'),
+    storageWrite: async () => denyAsync('storageWrite'),
+  };
+}
 
-      ctx.emitProgress('running', 0.5);
+function isPluginExecutePayload(value: unknown): value is PluginExecutePayload {
+  const p = value as Record<string, unknown> | undefined;
+  if (!p || typeof p !== 'object') return false;
+  if (typeof p['pluginId'] !== 'string' || typeof p['code'] !== 'string') return false;
+  if (!Array.isArray(p['grantedPermissions'])) return false;
+  const snap = p['readApiSnapshot'] as Record<string, unknown> | undefined;
+  if (!snap || typeof snap !== 'object') return false;
+  if (typeof snap['projectTitle'] !== 'string' || !Array.isArray(snap['sceneTitles'])) return false;
+  return true;
+}
 
-      // Execute plugin with timeout
-      await module['run'](sandboxApi);
+// ---------------------------------------------------------------------------
+// Task handler
+// ---------------------------------------------------------------------------
 
-      ctx.emitProgress('completed', 1);
+registerTaskHandler('plugin.execute', async (ctx: WorkerHandlerContext) => {
+  if (!isPluginExecutePayload(ctx.payload)) {
+    return {
+      success: false,
+      payload: null,
+      error: 'Invalid plugin.execute payload',
+      latencyMs: 0,
+    };
+  }
 
+  const payload = ctx.payload;
+  const sideEffects: PluginSideEffect[] = [];
+  const logs: string[] = [];
+  const sandboxApi = buildSandboxApi(payload, sideEffects, logs);
+
+  // QNBS-v3: The sandbox runner receives only the API object. We deliberately do NOT
+  // pass any browser globals. The plugin's `run` function is extracted and invoked.
+  const runner = createSandboxedRunner(payload.code, { api: sandboxApi });
+
+  if (ctx.signal.aborted) {
+    return {
+      success: false,
+      payload: null,
+      error: 'Plugin execution aborted before start',
+      latencyMs: 0,
+    };
+  }
+
+  try {
+    const runFn = runner();
+    if (typeof runFn !== 'function') {
       return {
-        success: true,
-        payload: { pluginId },
-        error: null,
+        success: false,
+        payload: null,
+        error: `Plugin '${payload.pluginId}' has no exported run() function`,
         latencyMs: 0,
       };
-    } finally {
-      URL.revokeObjectURL(url);
     }
+
+    ctx.emitProgress('running', 0.5);
+
+    // QNBS-v3: Poll the AbortSignal before and after the plugin run. Long-running
+    // synchronous plugin code cannot be pre-empted, but the timeout gates subsequent
+    // side-effect application and async plugins cooperate via the signal.
+    if (ctx.signal.aborted) {
+      throw new Error('Plugin execution aborted');
+    }
+
+    const result = runFn(sandboxApi);
+    if (result && typeof (result as Promise<void>).then === 'function') {
+      await result;
+    }
+
+    if (ctx.signal.aborted) {
+      throw new Error('Plugin execution aborted');
+    }
+
+    ctx.emitProgress('completed', 1);
+
+    const executeResult: PluginExecuteResult = {
+      pluginId: payload.pluginId,
+      sideEffects,
+      logs,
+    };
+
+    return {
+      success: true,
+      payload: executeResult,
+      error: null,
+      latencyMs: 0,
+    };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return {
@@ -108,8 +249,6 @@ registerTaskHandler('plugin.execute', async (ctx: WorkerHandlerContext) => {
       error: message,
       latencyMs: 0,
     };
-  } finally {
-    clearTimeout(timeoutId);
   }
 });
 


### PR DESCRIPTION
## **User description**
## Summary

Completes Phase 1 of the v1.22.0 perfection plan:

- **P0-1** Plugin worker sandbox (Option A: function-scope shadowing)
- **P0-3** Plugin `rawApi` bridge via serializable snapshot + side effects
- **P1-1** Expanded OpenRouter provider tests
- **P1-3** Copilot `applyLastSuggestion` tests (70% gate, status lifecycle)
- **P1-4** Stryker mutation targets expanded to v1.22.0 modules
- **P2-1** Plugin beta docs and ADR updated

## Changes

| Area | Files |
|------|-------|
| Plugin sandbox | `workers/plugin.worker.ts`, `services/pluginRegistry.ts` |
| Plugin tests | `tests/unit/workers/plugin.worker.test.ts`, `tests/unit/plugins/pluginRegistryLoad.test.ts` |
| OpenRouter tests | `services/ai/providers/openrouterProvider.ts`, `tests/unit/ai/openrouterProvider.test.ts` |
| Copilot tests | `tests/unit/copilot/useGlobalCopilot.test.ts` |
| Mutation testing | `stryker.conf.json` |
| Docs | `docs/PLUGINS-BETA.md`, `docs/adr/0007-plugin-sandbox-model.md`, `AUDIT.md` |

## Verification

Local quick tier passed:

```bash
pnpm run lint && pnpm run typecheck && pnpm run i18n:check
pnpm exec vitest run tests/unit/ai/openrouterProvider.test.ts tests/unit/copilot/useGlobalCopilot.test.ts tests/unit/workers/plugin.worker.test.ts tests/unit/plugins/pluginRegistryLoad.test.ts tests/unit/pluginRegistry.test.ts
```

- **88/88** targeted tests pass
- Lint, typecheck, and i18n checks green

## Remaining

- **P0-2** Explicit `signal.aborted` checks inside plugin `import()` / `run()` (partially mitigated by WorkerBus timeout).
- **P2-6** Tauri updater signing is a maintainer-secret issue outside code.

## Cloud CI

Please run the full quality/build/e2e/mutation pipeline on this branch.


___

## **CodeAnt-AI Description**
**Harden plugin execution and add coverage for Copilot and OpenRouter flows**

### What Changed
- Plugin code now runs in a tighter sandbox that blocks access to browser globals like network, storage, and shared page objects
- Plugins receive read-only project data and can only return limited side effects such as appending to the current scene or writing logs
- Plugin runs now keep permission checks on the main thread and report what side effects were applied
- Copilot apply-last-suggestion now enforces the 70% content gate, handles empty sections, and resets its status after success or error
- OpenRouter tests now cover streaming, retries, retry-after handling, aborted requests, malformed SSE, and circuit-breaker behavior
- Plugin sandbox, beta docs, and ADR were updated to reflect the new behavior and limits

### Impact
`✅ Fewer plugin sandbox escapes`
`✅ Safer plugin edits`
`✅ Clearer Copilot apply feedback`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
