### PR TITLE
feat(design-system): Phase 3 — Copilot view token & icon cleanup

### DIFF
--- a/components/CharacterGraphView.tsx
+++ b/components/CharacterGraphView.tsx
@@ -46,15 +46,21 @@ const CharacterForceGraph: FC = () => {
   const [dimensions, setDimensions] = useState({ width: 800, height: 500 });
   // QNBS-v3: initial paint colors resolved from design-system CSS variables so the first canvas frame
   //          already matches the active theme; SSR falls back to hard-coded indigo equivalents.
-  function resolvePaintColors(): { fill: string; stroke: string; label: string } {
+  function resolvePaintColors(): {
+    fill: string;
+    stroke: string;
+    label: string;
+    textOnAccent: string;
+  } {
     if (typeof document === 'undefined') {
-      return { fill: '#6366f1', stroke: '#a5b4fc', label: '#e2e8f0' };
+      return { fill: '#6366f1', stroke: '#a5b4fc', label: '#e2e8f0', textOnAccent: '#fff' };
     }
     const body = document.body;
     return {
       fill: getComputedStyle(body).getPropertyValue('--sc-accent').trim() || '#6366f1',
       stroke: getComputedStyle(body).getPropertyValue('--sc-text-secondary').trim() || '#a5b4fc',
       label: getComputedStyle(body).getPropertyValue('--sc-text-secondary').trim() || '#e2e8f0',
+      textOnAccent: getComputedStyle(body).getPropertyValue('--sc-text-on-accent').trim() || '#fff',
     };
   }
 
@@ -70,6 +76,8 @@ const CharacterForceGraph: FC = () => {
         fill: getComputedStyle(body).getPropertyValue('--sc-accent').trim() || '#6366f1',
         stroke: getComputedStyle(body).getPropertyValue('--sc-text-secondary').trim() || '#a5b4fc',
         label: getComputedStyle(body).getPropertyValue('--sc-text-secondary').trim() || '#e2e8f0',
+        textOnAccent:
+          getComputedStyle(body).getPropertyValue('--sc-text-on-accent').trim() || '#fff',
       });
     });
     return () => cancelAnimationFrame(id);
@@ -121,9 +129,8 @@ const CharacterForceGraph: FC = () => {
       ctx.stroke();
 
       const initials = n.name.slice(0, 2).toUpperCase();
-      // QNBS-v3: initials use the on-accent token so they remain readable across themes.
-      ctx.fillStyle =
-        getComputedStyle(document.body).getPropertyValue('--sc-text-on-accent').trim() || '#fff';
+      // QNBS-v3: initials use the cached on-accent token; avoids getComputedStyle in the hot draw loop.
+      ctx.fillStyle = paintColors.textOnAccent;
       ctx.font = `bold ${Math.max(8, 13 / globalScale)}px sans-serif`;
       ctx.textAlign = 'center';
       ctx.textBaseline = 'middle';
@@ -164,7 +171,10 @@ const CharacterForceGraph: FC = () => {
           nodeCanvasObjectMode={() => 'replace'}
           nodeRelSize={18}
           nodeLabel={(node) => (node as GraphNode).name}
-          linkColor={(link) => `${getRelationshipColor((link as GraphLink).type)}cc`}
+          // QNBS-v3: relationship colors are CSS variables now; use color-mix for the 80% alpha link tint.
+          linkColor={(link) =>
+            `color-mix(in srgb, ${getRelationshipColor((link as GraphLink).type)} 80%, transparent)`
+          }
           linkWidth={(link) => Math.max(0.5, ((link as GraphLink).strength ?? 5) / 2.5)}
           linkDirectionalArrowLength={5}
           linkDirectionalArrowRelPos={1}

--- a/components/CharacterGraphView.tsx
+++ b/components/CharacterGraphView.tsx
@@ -44,11 +44,21 @@ const CharacterForceGraph: FC = () => {
   const appearancePreset = useAppSelector((s) => s.settings?.appearancePreset ?? 'default');
   const containerRef = useRef<HTMLDivElement>(null);
   const [dimensions, setDimensions] = useState({ width: 800, height: 500 });
-  const [paintColors, setPaintColors] = useState({
-    fill: '#6366f1',
-    stroke: '#a5b4fc',
-    label: '#e2e8f0',
-  });
+  // QNBS-v3: initial paint colors resolved from design-system CSS variables so the first canvas frame
+  //          already matches the active theme; SSR falls back to hard-coded indigo equivalents.
+  function resolvePaintColors(): { fill: string; stroke: string; label: string } {
+    if (typeof document === 'undefined') {
+      return { fill: '#6366f1', stroke: '#a5b4fc', label: '#e2e8f0' };
+    }
+    const body = document.body;
+    return {
+      fill: getComputedStyle(body).getPropertyValue('--sc-accent').trim() || '#6366f1',
+      stroke: getComputedStyle(body).getPropertyValue('--sc-text-secondary').trim() || '#a5b4fc',
+      label: getComputedStyle(body).getPropertyValue('--sc-text-secondary').trim() || '#e2e8f0',
+    };
+  }
+
+  const [paintColors, setPaintColors] = useState(resolvePaintColors);
 
   // QNBS-v3: Canvas nodes follow DS accent — refresh after body theme/preset classes update.
   // biome-ignore lint/correctness/useExhaustiveDependencies: theme/preset are intentional triggers; effect reads computed CSS after App updates body.
@@ -111,7 +121,9 @@ const CharacterForceGraph: FC = () => {
       ctx.stroke();
 
       const initials = n.name.slice(0, 2).toUpperCase();
-      ctx.fillStyle = '#fff';
+      // QNBS-v3: initials use the on-accent token so they remain readable across themes.
+      ctx.fillStyle =
+        getComputedStyle(document.body).getPropertyValue('--sc-text-on-accent').trim() || '#fff';
       ctx.font = `bold ${Math.max(8, 13 / globalScale)}px sans-serif`;
       ctx.textAlign = 'center';
       ctx.textBaseline = 'middle';
@@ -356,7 +368,7 @@ const CharacterGraphUI: FC = () => {
                                       strength: parseInt(e.target.value, 10),
                                     })
                                   }
-                                  className="w-full accent-indigo-500"
+                                  className="w-full accent-[var(--sc-accent)]"
                                 />
                               </td>
                             </tr>
@@ -435,7 +447,7 @@ const CharacterGraphUI: FC = () => {
                           onChange={(e) =>
                             onUpdateRelationship(rel.id, { strength: parseInt(e.target.value, 10) })
                           }
-                          className="flex-1 h-1 accent-indigo-500"
+                          className="flex-1 h-1 accent-[var(--sc-accent)]"
                         />
                         <span className="text-[var(--sc-text-muted)] w-4 text-right">
                           {rel.strength || 5}

--- a/components/CharacterInterviewsView.tsx
+++ b/components/CharacterInterviewsView.tsx
@@ -7,6 +7,7 @@ import { useCharacterInterviewsView } from '../hooks/useCharacterInterviewsView'
 import { useTranslation } from '../hooks/useTranslation';
 import { ArchetypeSelector } from './character-interviews/ArchetypeSelector';
 import { InterviewPanel } from './character-interviews/InterviewPanel';
+import { Icon } from './ui/Icon';
 import { Select } from './ui/Select';
 
 function CharacterInterviewsViewContent() {
@@ -100,7 +101,7 @@ function CharacterInterviewsViewContent() {
                           setNewTitle('');
                           setShowNewForm(false);
                         }}
-                        className="flex-1 rounded-sc-md bg-[var(--sc-accent)] py-1 text-sm text-white hover:bg-[var(--sc-accent-hover)]"
+                        className="flex-1 rounded-sc-md bg-[var(--sc-accent)] py-1 text-sm text-[var(--sc-text-on-accent)] hover:bg-[var(--sc-accent-hover)]"
                       >
                         {t('characterInterviews.startInterview')}
                       </button>
@@ -182,7 +183,7 @@ function CharacterInterviewsViewContent() {
                       }}
                       className="absolute right-2 top-1/2 -translate-y-1/2 rounded-sc-sm p-2 text-[var(--sc-text-muted)] hover:text-[var(--sc-danger-fg)] md:opacity-0 md:group-hover:opacity-100 transition-opacity"
                     >
-                      ×
+                      <Icon name="close" size="sm" aria-hidden="true" />
                     </button>
                   )}
                 </div>

--- a/components/CharacterView.tsx
+++ b/components/CharacterView.tsx
@@ -64,7 +64,7 @@ const TabButton: FC<{
     aria-selected={active}
     aria-controls={controls}
     onClick={onClick}
-    className={`px-4 py-2 text-sm font-medium rounded-t-lg border-b-2 transition-colors ${active ? 'border-indigo-500 text-[var(--sc-text-primary)]' : 'border-transparent text-[var(--sc-text-muted)] hover:border-[var(--sc-border-subtle)] hover:text-[var(--sc-text-secondary)]'}`}
+    className={`px-4 py-2 text-sm font-medium rounded-t-lg border-b-2 transition-colors ${active ? 'border-[var(--sc-accent)] text-[var(--sc-text-primary)]' : 'border-transparent text-[var(--sc-text-muted)] hover:border-[var(--sc-border-subtle)] hover:text-[var(--sc-text-secondary)]'}`}
   >
     {children}
   </button>

--- a/components/CollaborationPanel.tsx
+++ b/components/CollaborationPanel.tsx
@@ -7,22 +7,23 @@ import { collaborationService } from '../services/collaborationService';
 import type { CollaborationUser } from '../types';
 import { Button } from './ui/Button';
 import { EmptyState } from './ui/EmptyState';
+import { Icon } from './ui/Icon';
 import { Input } from './ui/Input';
 
-// Preset user colors for avatar display
+// QNBS-v3: preset user colors use the design-system data-viz palette so avatars adapt to theme/sepia.
 const USER_COLORS = [
-  '#6366f1',
-  '#14b8a6',
-  '#f59e0b',
-  '#ec4899',
-  '#10b981',
-  '#3b82f6',
-  '#f97316',
-  '#84cc16',
+  'var(--sc-data-2)',
+  'var(--sc-data-7)',
+  'var(--sc-data-4)',
+  'var(--sc-data-5)',
+  'var(--sc-data-3)',
+  'var(--sc-data-2)',
+  'var(--sc-data-4)',
+  'var(--sc-data-3)',
 ];
 
 const getRandomColor = () =>
-  USER_COLORS[Math.floor(Math.random() * USER_COLORS.length)] ?? '#6366f1';
+  USER_COLORS[Math.floor(Math.random() * USER_COLORS.length)] ?? 'var(--sc-data-2)';
 
 // Persistent user identity for the session
 function getLocalUser(): CollaborationUser {
@@ -57,7 +58,7 @@ const UserAvatar: FC<{ user: CollaborationUser; size?: 'sm' | 'md' }> = ({ user,
   const dim = size === 'sm' ? 'w-6 h-6 text-xs' : 'w-8 h-8 text-sm';
   return (
     <div
-      className={`${dim} rounded-full flex items-center justify-center text-white font-bold flex-shrink-0`}
+      className={`${dim} rounded-full flex items-center justify-center text-[var(--sc-text-on-accent)] font-bold flex-shrink-0`}
       style={{ backgroundColor: user.color }}
       title={user.name}
       role="img"
@@ -277,7 +278,7 @@ export const CollaborationPanel: FC<CollaborationPanelProps> = ({ isOpen, onClos
               className="p-2 rounded-md hover:bg-[var(--sc-surface-raised)] text-[var(--sc-text-secondary)] transition-colors"
               aria-label={t('collab.close')}
             >
-              <span aria-hidden="true">✕</span>
+              <Icon name="close" size="sm" aria-hidden="true" />
             </button>
           </div>
         </div>
@@ -403,7 +404,7 @@ export const CollaborationPanel: FC<CollaborationPanelProps> = ({ isOpen, onClos
             <div
               role="alert"
               aria-live="polite"
-              className="p-3 rounded-sc-md bg-[var(--sc-warning-bg)] border border-amber-500/30 text-sm text-[var(--sc-warning-fg)] space-y-1"
+              className="p-3 rounded-sc-md bg-[var(--sc-warning-bg)] border border-[var(--sc-warning-border)] text-sm text-[var(--sc-warning-fg)] space-y-1"
             >
               <p className="font-semibold">{t('collab.securityWarning')}</p>
               <p>{t('collab.securityWarningDetail')}</p>
@@ -411,7 +412,7 @@ export const CollaborationPanel: FC<CollaborationPanelProps> = ({ isOpen, onClos
                 href="https://github.com/yjs/y-webrtc#signaling"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="underline focus-visible:ring-2 focus-visible:ring-amber-400 rounded"
+                className="underline focus-visible:ring-2 focus-visible:ring-[var(--sc-warning-fg)] rounded"
               >
                 {t('collab.selfHostLinkLabel')}
               </a>

--- a/components/CommandPalette.tsx
+++ b/components/CommandPalette.tsx
@@ -27,6 +27,7 @@ import {
 } from '../services/commands/palettePreferences';
 import { approximateManuscriptWordCount } from '../services/commands/wordCountApprox';
 import type { View } from '../types';
+import { Icon } from './ui/Icon';
 
 const CATEGORY_SORT: CommandCategory[] = [
   'navigation',
@@ -374,20 +375,12 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({
           {paletteLiveStatus}
         </div>
         <div className="flex items-center px-4 py-4 border-b border-[var(--sc-border-subtle)]/50">
-          <svg
-            className="w-5 h-5 text-[var(--sc-text-muted)] me-3 shrink-0"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth={2}
-            stroke="currentColor"
-            aria-hidden
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 001.061 1.061z"
-            />
-          </svg>
+          <Icon
+            name="search"
+            size="md"
+            className="text-[var(--sc-text-muted)] me-3 shrink-0"
+            aria-hidden="true"
+          />
           <input
             ref={inputRef}
             type="search"
@@ -422,27 +415,23 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({
             aria-label={isListening ? t('palette.voice.stop') : t('palette.voice.start')}
             aria-pressed={isListening}
           >
-            <svg
-              className="w-5 h-5"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={1.5}
-              stroke="currentColor"
-            >
-              {isListening ? (
+            {isListening ? (
+              <svg
+                className="w-5 h-5"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+                stroke="currentColor"
+              >
                 <path
                   strokeLinecap="round"
                   strokeLinejoin="round"
                   d="M5.25 7.5A2.25 2.25 0 017.5 5.25h9a2.25 2.25 0 012.25 2.25v9a2.25 2.25 0 01-2.25 2.25h-9a2.25 2.25 0 01-2.25-2.25v-9z"
                 />
-              ) : (
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M12 18.75a6 6 0 006-6v-1.5m-6 7.5a6 6 0 01-6-6v-1.5m6 7.5v3.75m-3.75 0h7.5M12 15.75a3 3 0 01-3-3V4.5a3 3 0 116 0v8.25a3 3 0 01-3 3z"
-                />
-              )}
-            </svg>
+              </svg>
+            ) : (
+              <Icon name="microphone" size="md" />
+            )}
           </button>
           <div className="hidden sm:flex items-center gap-1">
             <kbd className="px-2 py-1 text-xs font-semibold text-[var(--sc-text-muted)] bg-[var(--sc-surface-overlay)] rounded border border-[var(--sc-border-subtle)]">
@@ -537,7 +526,7 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({
                       <div className="flex items-center gap-2 shrink-0">
                         {prefs.pinnedIds.includes(cmd.id) ? (
                           <span
-                            // QNBS-v3: text-white/70 fails WCAG AA contrast on --sc-accent background; use full-opacity white.
+                            // QNBS-v3: text-[var(--sc-text-on-accent)]/70 fails WCAG AA contrast on --sc-accent background; use full-opacity white.
                             className={`text-[10px] uppercase tracking-wide ${isActive ? 'text-[var(--sc-text-on-accent)]' : 'text-[var(--sc-text-muted)]'}`}
                           >
                             {t('palette.pin.badge')}

--- a/components/ManuscriptView.tsx
+++ b/components/ManuscriptView.tsx
@@ -176,7 +176,7 @@ const ManuscriptViewUI: FC = () => {
                     aria-selected={leftNavTab === 'chapters'}
                     className={`flex-1 rounded-md px-2 py-1.5 text-xs font-semibold uppercase tracking-wide transition-colors ${
                       leftNavTab === 'chapters'
-                        ? 'bg-[var(--sc-accent)] text-white'
+                        ? 'bg-[var(--sc-accent)] text-[var(--sc-text-on-accent)]'
                         : 'text-[var(--sc-text-muted)] hover:bg-[var(--sc-surface-overlay)]'
                     }`}
                     onClick={() => setLeftNavTab('chapters')}
@@ -189,7 +189,7 @@ const ManuscriptViewUI: FC = () => {
                     aria-selected={leftNavTab === 'binder'}
                     className={`flex-1 rounded-md px-2 py-1.5 text-xs font-semibold uppercase tracking-wide transition-colors ${
                       leftNavTab === 'binder'
-                        ? 'bg-[var(--sc-accent)] text-white'
+                        ? 'bg-[var(--sc-accent)] text-[var(--sc-text-on-accent)]'
                         : 'text-[var(--sc-text-muted)] hover:bg-[var(--sc-surface-overlay)]'
                     }`}
                     onClick={() => setLeftNavTab('binder')}

--- a/components/ObjectsView.tsx
+++ b/components/ObjectsView.tsx
@@ -302,7 +302,11 @@ const ObjectCard: FC<{ obj: StoryObject }> = ({ obj }) => {
             <span
               key={g.id}
               className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs"
-              style={{ backgroundColor: `${g.color}22`, color: g.color }}
+              // QNBS-v3: color-mix keeps CSS variable group colors valid (hex-alpha suffix only worked for literal hex).
+              style={{
+                backgroundColor: `color-mix(in srgb, ${g.color} 13%, transparent)`,
+                color: g.color,
+              }}
             >
               <span
                 className="w-1.5 h-1.5 rounded-full flex-shrink-0"
@@ -358,7 +362,8 @@ const GroupCard: FC<{ group: ObjectGroup }> = ({ group }) => {
   return (
     <div
       className="bg-[var(--sc-surface-raised)] border rounded-xl p-4 flex flex-col gap-2"
-      style={{ borderColor: `${group.color}66` }}
+      // QNBS-v3: color-mix keeps CSS variable group colors valid (hex-alpha suffix only worked for literal hex).
+      style={{ borderColor: `color-mix(in srgb, ${group.color} 40%, transparent)` }}
     >
       <div className="flex items-center gap-2">
         <span

--- a/components/ObjectsView.tsx
+++ b/components/ObjectsView.tsx
@@ -4,19 +4,20 @@ import { ObjectsViewContext, useObjectsViewContext } from '../contexts/ObjectsVi
 import { useObjectsView } from '../hooks/useObjectsView';
 import type { ObjectGroup, StoryObject, StoryObjectType } from '../types';
 import { EmptyState } from './ui/EmptyState';
+import { Icon } from './ui/Icon';
 import { SectionIcon } from './ui/SectionIcon';
 import { Select } from './ui/Select';
 
 // ── Object Type Badge ─────────────────────────────────────────────────────────
 
-// QNBS-v3: Replaced dark: Tailwind prefixes with alpha-bg pattern — works on all appearance presets.
+// QNBS-v3: type badge colors use the design-system data-viz palette so they adapt to theme/sepia.
 const TYPE_COLORS: Record<StoryObjectType, string> = {
-  prop: 'bg-blue-500/15 text-blue-600',
-  weapon: 'bg-red-500/15 text-red-600',
-  vehicle: 'bg-orange-500/15 text-orange-600',
-  artifact: 'bg-purple-500/15 text-purple-600',
-  document: 'bg-yellow-500/15 text-yellow-600',
-  'place-item': 'bg-green-500/15 text-green-600',
+  prop: 'bg-[var(--sc-data-2)]/15 text-[var(--sc-data-2)]',
+  weapon: 'bg-[var(--sc-data-1)]/15 text-[var(--sc-data-1)]',
+  vehicle: 'bg-[var(--sc-data-4)]/15 text-[var(--sc-data-4)]',
+  artifact: 'bg-[var(--sc-data-6)]/15 text-[var(--sc-data-6)]',
+  document: 'bg-[var(--sc-data-4)]/15 text-[var(--sc-data-4)]',
+  'place-item': 'bg-[var(--sc-data-3)]/15 text-[var(--sc-data-3)]',
   other: 'bg-[var(--sc-surface-overlay)] text-[var(--sc-text-muted)]',
 };
 
@@ -150,7 +151,7 @@ const ObjectForm: FC = () => {
         <button
           type="submit"
           disabled={!name.trim()}
-          className="px-4 py-2 text-sm rounded-lg bg-stone-600 text-white hover:bg-stone-700 disabled:opacity-40 focus-visible:ring-2 focus-visible:ring-[var(--sc-ring-focus)]"
+          className="px-4 py-2 text-sm rounded-lg bg-[var(--sc-accent)] text-[var(--sc-text-on-accent)] hover:bg-[var(--sc-accent-hover)] disabled:opacity-40 focus-visible:ring-2 focus-visible:ring-[var(--sc-ring-focus)]"
         >
           {t('objects.save')}
         </button>
@@ -161,15 +162,16 @@ const ObjectForm: FC = () => {
 
 // ── Group Form ────────────────────────────────────────────────────────────────
 
+// QNBS-v3: group color presets use the design-system data-viz palette so they adapt to theme/sepia.
 const GROUP_COLORS = [
-  '#78716c',
-  '#6366f1',
-  '#10b981',
-  '#f59e0b',
-  '#ef4444',
-  '#8b5cf6',
-  '#ec4899',
-  '#14b8a6',
+  'var(--sc-text-muted)',
+  'var(--sc-data-2)',
+  'var(--sc-data-3)',
+  'var(--sc-data-4)',
+  'var(--sc-data-1)',
+  'var(--sc-data-6)',
+  'var(--sc-data-5)',
+  'var(--sc-data-7)',
 ];
 
 const GroupForm: FC = () => {
@@ -256,7 +258,7 @@ const GroupForm: FC = () => {
         <button
           type="submit"
           disabled={!name.trim()}
-          className="px-4 py-2 text-sm rounded-lg bg-stone-600 text-white hover:bg-stone-700 disabled:opacity-40 focus-visible:ring-2 focus-visible:ring-[var(--sc-ring-focus)]"
+          className="px-4 py-2 text-sm rounded-lg bg-[var(--sc-accent)] text-[var(--sc-text-on-accent)] hover:bg-[var(--sc-accent-hover)] disabled:opacity-40 focus-visible:ring-2 focus-visible:ring-[var(--sc-ring-focus)]"
         >
           {t('objects.save')}
         </button>
@@ -434,22 +436,9 @@ const ObjectsViewContent: FC = () => {
         <button
           type="button"
           onClick={activeTab === 'objects' ? handleAddObject : handleAddGroup}
-          className="flex items-center gap-1.5 px-3 py-2 bg-stone-600 hover:bg-stone-700 text-white text-sm font-medium rounded-lg focus-visible:ring-2 focus-visible:ring-[var(--sc-ring-focus)] transition-colors"
+          className="flex items-center gap-1.5 px-3 py-2 bg-[var(--sc-accent)] hover:bg-[var(--sc-accent-hover)] text-[var(--sc-text-on-accent)] text-sm font-medium rounded-lg focus-visible:ring-2 focus-visible:ring-[var(--sc-ring-focus)] transition-colors"
         >
-          <svg
-            className="w-4 h-4"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-            aria-hidden="true"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M12 4.5v15m7.5-7.5h-15"
-            />
-          </svg>
+          <Icon name="plus" size="sm" aria-hidden="true" />
           {activeTab === 'objects' ? t('objects.addObject') : t('objects.addGroup')}
         </button>
       </div>

--- a/components/OutlineGeneratorView.tsx
+++ b/components/OutlineGeneratorView.tsx
@@ -10,6 +10,7 @@ import type { View } from '../types';
 import { Button } from './ui/Button';
 import { Card, CardContent, CardHeader } from './ui/Card';
 import { Checkbox } from './ui/Checkbox';
+import { Icon } from './ui/Icon';
 import { Input } from './ui/Input';
 import { Modal } from './ui/Modal';
 import { SectionIcon } from './ui/SectionIcon';
@@ -171,17 +172,7 @@ const IdeaForm: FC = () => {
           {isLoading ? (
             <Spinner />
           ) : (
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={1.5}
-              stroke="currentColor"
-              className="w-5 h-5 mr-2"
-              aria-hidden="true"
-            >
-              {ICONS.SPARKLES}
-            </svg>
+            <Icon name="sparkles" size="md" className="me-2" aria-hidden="true" />
           )}
           {t('outline.idea.generateButton')}
         </Button>
@@ -275,7 +266,7 @@ const OutlineResult: FC = () => {
                 onDragOver={(e) => e.preventDefault()}
               >
                 <div
-                  className={`relative overflow-hidden rounded-xl border transition-all duration-300 ${section.isTwist ? 'bg-[var(--accent-1-background)]/20 border-[var(--accent-1-border)]' : 'bg-transparent border-[var(--sc-border-subtle)] hover:bg-[var(--sc-surface-raised)]/30'} ${draggingIndex === index ? 'opacity-60 scale-[1.02] shadow-2xl shadow-indigo-500/50' : ''}`}
+                  className={`relative overflow-hidden rounded-xl border transition-all duration-300 ${section.isTwist ? 'bg-[var(--accent-1-background)]/20 border-[var(--accent-1-border)]' : 'bg-transparent border-[var(--sc-border-subtle)] hover:bg-[var(--sc-surface-raised)]/30'} ${draggingIndex === index ? 'opacity-60 scale-[1.02] shadow-2xl shadow-[var(--sc-accent)]/50' : ''}`}
                 >
                   <div className="p-4 border-b border-[var(--sc-border-subtle)]/50 flex justify-between items-start gap-2 bg-white/[0.01]">
                     <div className="flex-grow flex items-center gap-2">
@@ -325,18 +316,7 @@ const OutlineResult: FC = () => {
                         title={t('common.moveUp')}
                         aria-label={t('common.moveUp')}
                       >
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          className="h-5 w-5"
-                          viewBox="0 0 20 20"
-                          fill="currentColor"
-                        >
-                          <path
-                            fillRule="evenodd"
-                            d="M14.707 12.707a1 1 0 01-1.414 0L10 9.414l-3.293 3.293a1 1 0 01-1.414-1.414l4-4a1 1 0 011.414 0l4 4a1 1 0 010 1.414z"
-                            clipRule="evenodd"
-                          />
-                        </svg>
+                        <Icon name="chevron-up" size="md" />
                       </button>
                       <button
                         type="button"
@@ -346,18 +326,7 @@ const OutlineResult: FC = () => {
                         title={t('common.moveDown')}
                         aria-label={t('common.moveDown')}
                       >
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          className="h-5 w-5"
-                          viewBox="0 0 20 20"
-                          fill="currentColor"
-                        >
-                          <path
-                            fillRule="evenodd"
-                            d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
-                            clipRule="evenodd"
-                          />
-                        </svg>
+                        <Icon name="chevron-down" size="md" />
                       </button>
                       <Button
                         variant="ghost"
@@ -389,16 +358,7 @@ const OutlineResult: FC = () => {
                         title={t('outline.result.addTooltip')}
                         aria-label={t('outline.result.addTooltip')}
                       >
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          strokeWidth={1.5}
-                          stroke="currentColor"
-                          className="w-5 h-5"
-                        >
-                          {ICONS.ADD}
-                        </svg>
+                        <Icon name="plus" size="md" />
                       </Button>
                       <Button
                         variant="ghost"
@@ -408,16 +368,7 @@ const OutlineResult: FC = () => {
                         aria-label={t('outline.result.deleteTooltip')}
                         className="text-[var(--sc-danger-fg)] hover:bg-[var(--sc-danger-bg)]"
                       >
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          strokeWidth={1.5}
-                          stroke="currentColor"
-                          className="w-5 h-5"
-                        >
-                          {ICONS.TRASH}
-                        </svg>
+                        <Icon name="trash" size="md" />
                       </Button>
                     </div>
                   </div>

--- a/components/ProgressTrackerView.tsx
+++ b/components/ProgressTrackerView.tsx
@@ -224,7 +224,7 @@ const WeeklyBars: FC<{ history: { date: string; words: number }[]; goalPerDay: n
             className="w-full rounded-t"
             style={{
               height: `${Math.round((d.words / max) * 40)}px`,
-              background: d.words >= goalPerDay ? '#4ade80' : 'var(--sc-accent)',
+              background: d.words >= goalPerDay ? 'var(--sc-success-fg)' : 'var(--sc-accent)',
               minHeight: d.words > 0 ? 2 : 0,
             }}
           />

--- a/components/SceneTimelinePanel.tsx
+++ b/components/SceneTimelinePanel.tsx
@@ -125,7 +125,7 @@ export const SceneTimelinePanel: FC<SceneTimelinePanelProps> = ({ sections, t })
                   </span>
                   <div className="flex-1 h-6 rounded-md bg-[var(--sc-surface-overlay)] overflow-hidden flex">
                     <div
-                      className="h-full bg-violet-500/45 border-r border-violet-400/30"
+                      className="h-full bg-[var(--sc-data-6)]/45 border-r border-[var(--sc-data-6)]/30"
                       style={{ width: `${pct}%` }}
                       title={`${words} ${t('sceneboard.words')}`}
                     />

--- a/components/TemplateView.tsx
+++ b/components/TemplateView.tsx
@@ -159,7 +159,7 @@ const PreviewModal: FC = () => {
                     viewBox="0 0 24 24"
                     strokeWidth={1.5}
                     stroke="currentColor"
-                    className="w-5 h-5 text-gray-500 flex-shrink-0 mt-1.5"
+                    className="w-5 h-5 text-[var(--sc-text-muted)] flex-shrink-0 mt-1.5"
                   >
                     {ICONS.GRIP_VERTICAL}
                   </svg>
@@ -349,7 +349,7 @@ const CommunityTemplateCard: FC<{
         <div className="flex items-start justify-between gap-2">
           <h3 className="text-xl font-bold text-[var(--sc-text-primary)]">{template.name}</h3>
           {template.stars != null && (
-            <span className="flex items-center gap-1 text-xs text-amber-400 flex-shrink-0">
+            <span className="flex items-center gap-1 text-xs text-[var(--sc-warning-fg)] flex-shrink-0">
               ★ {template.stars}
             </span>
           )}
@@ -478,7 +478,7 @@ const CommunityTab: FC = () => {
   return (
     <div>
       {isFallback && (
-        <div className="mb-6 p-3 rounded-lg bg-amber-500/10 border border-amber-500/30 text-sm text-amber-400">
+        <div className="mb-6 p-3 rounded-lg bg-[var(--sc-warning-bg)] border border-[var(--sc-warning-border)] text-sm text-[var(--sc-warning-fg)]">
           {_t('templates.offlineFallback')}
         </div>
       )}

--- a/components/VersionControlPanel.tsx
+++ b/components/VersionControlPanel.tsx
@@ -26,6 +26,7 @@ const MAX_DIFF_VIEW_LINES = 450;
 
 import { Button } from './ui/Button';
 import { EmptyState } from './ui/EmptyState';
+import { Icon } from './ui/Icon';
 import { Input } from './ui/Input';
 import { Modal } from './ui/Modal';
 
@@ -109,7 +110,7 @@ const BranchBadge: FC<{ branch: VersionBranch; isActive?: boolean }> = ({ branch
   <span
     className={`inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs font-semibold ${
       isActive
-        ? 'bg-[var(--sc-accent)] text-white'
+        ? 'bg-[var(--sc-accent)] text-[var(--sc-text-on-accent)]'
         : 'bg-[var(--sc-surface-overlay)] text-[var(--sc-text-secondary)]'
     }`}
   >
@@ -146,7 +147,7 @@ const SnapshotCard: FC<{
               {snapshot.label}
             </span>
             {isHead && (
-              <span className="px-1.5 py-0.5 text-xs bg-[var(--sc-accent)] text-white rounded">
+              <span className="px-1.5 py-0.5 text-xs bg-[var(--sc-accent)] text-[var(--sc-text-on-accent)] rounded">
                 HEAD
               </span>
             )}
@@ -190,7 +191,7 @@ const SnapshotCard: FC<{
             aria-label={t('vc.deleteSnapshot', { label: snapshot.label })}
             className="text-[var(--sc-danger-fg)] hover:bg-[var(--sc-danger-bg)]"
           >
-            ✕
+            <Icon name="close" size="sm" aria-hidden="true" />
           </Button>
         </div>
       </div>
@@ -397,7 +398,7 @@ export const VersionControlPanel: FC = () => {
             className="p-2 rounded-md hover:bg-[var(--sc-surface-raised)] text-[var(--sc-text-secondary)] transition-colors"
             aria-label={t('vc.close')}
           >
-            <span aria-hidden="true">✕</span>
+            <Icon name="close" size="sm" aria-hidden="true" />
           </button>
         </div>
 
@@ -533,7 +534,7 @@ export const VersionControlPanel: FC = () => {
                         className="text-[var(--sc-danger-fg)] hover:bg-[var(--sc-danger-bg)]"
                         aria-label={t('vc.deleteBranch', { name: branch.name })}
                       >
-                        ✕
+                        <Icon name="close" size="sm" aria-hidden="true" />
                       </Button>
                     )}
                   </div>
@@ -621,7 +622,10 @@ export const VersionControlPanel: FC = () => {
             <strong className="text-[var(--sc-text-primary)]">„{pendingRestore?.label}“</strong> (
             {pendingRestore && new Date(pendingRestore.timestamp).toLocaleString()})
           </p>
-          <p className="text-sm text-amber-400">⚠️ {t('vc.restoreWarning')}</p>
+          <p className="text-sm text-[var(--sc-warning-fg)] flex items-center gap-1">
+            <Icon name="warning" size="sm" aria-hidden="true" />
+            {t('vc.restoreWarning')}
+          </p>
           <div className="flex gap-3 justify-end">
             <Button
               variant="secondary"

--- a/components/WelcomePortal.tsx
+++ b/components/WelcomePortal.tsx
@@ -29,7 +29,7 @@ const NewProjectOption: React.FC<{
     <button
       type="button"
       onClick={onClick}
-      className="bg-[var(--sc-surface-raised)]/80 p-6 rounded-lg border border-[var(--sc-border-subtle)] hover:border-indigo-500 hover:bg-[var(--sc-surface-raised)] transition-all cursor-pointer flex items-start space-x-4 w-full text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+      className="bg-[var(--sc-surface-raised)]/80 p-6 rounded-lg border border-[var(--sc-border-subtle)] hover:border-[var(--sc-accent)] hover:bg-[var(--sc-surface-raised)] transition-all cursor-pointer flex items-start space-x-4 w-full text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--sc-ring-focus)]"
     >
       <div className="flex-shrink-0 bg-[var(--sc-surface-overlay)] p-3 rounded-lg">
         <svg

--- a/components/WorldView.tsx
+++ b/components/WorldView.tsx
@@ -64,7 +64,7 @@ const TabButton: FC<{
     aria-selected={active}
     aria-controls={controls}
     onClick={onClick}
-    className={`px-4 py-2 text-sm font-medium rounded-t-lg border-b-2 transition-colors ${active ? 'border-indigo-500 text-[var(--sc-text-primary)]' : 'border-transparent text-[var(--sc-text-muted)] hover:border-[var(--sc-border-subtle)] hover:text-[var(--sc-text-secondary)]'}`}
+    className={`px-4 py-2 text-sm font-medium rounded-t-lg border-b-2 transition-colors ${active ? 'border-[var(--sc-accent)] text-[var(--sc-text-primary)]' : 'border-transparent text-[var(--sc-text-muted)] hover:border-[var(--sc-border-subtle)] hover:text-[var(--sc-text-secondary)]'}`}
   >
     {children}
   </button>

--- a/components/character-interviews/InterviewPanel.tsx
+++ b/components/character-interviews/InterviewPanel.tsx
@@ -21,12 +21,12 @@ function MessageBubble({
       <div
         className={`max-w-[80%] rounded-sc-xl px-4 py-3 ${
           isUser
-            ? 'bg-[var(--sc-accent)] text-white'
+            ? 'bg-[var(--sc-accent)] text-[var(--sc-text-on-accent)]'
             : 'bg-[var(--sc-surface-overlay)] text-[var(--sc-text-primary)]'
         }`}
       >
         <p
-          className={`mb-1 text-xs font-medium ${isUser ? 'text-white/70' : 'text-[var(--sc-text-muted)]'}`}
+          className={`mb-1 text-xs font-medium ${isUser ? 'text-[var(--sc-text-on-accent)]/70' : 'text-[var(--sc-text-muted)]'}`}
         >
           {label}
         </p>

--- a/components/character-interviews/InterviewQuestionBar.tsx
+++ b/components/character-interviews/InterviewQuestionBar.tsx
@@ -64,7 +64,7 @@ export function InterviewQuestionBar() {
           type="button"
           onClick={handleSend}
           disabled={isStreaming || !customQuestion.trim()}
-          className="rounded-sc-md bg-[var(--sc-accent)] px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[var(--sc-accent-hover)] disabled:opacity-50"
+          className="rounded-sc-md bg-[var(--sc-accent)] px-4 py-2 text-sm font-medium text-[var(--sc-text-on-accent)] transition-colors hover:bg-[var(--sc-accent-hover)] disabled:opacity-50"
         >
           {t('characterInterviews.sendQuestion')}
         </button>

--- a/components/copilot/CopilotComposer.tsx
+++ b/components/copilot/CopilotComposer.tsx
@@ -1,6 +1,7 @@
 import type { FC, FormEvent, KeyboardEvent } from 'react';
 import { useEffect, useState } from 'react';
 import { useTransientUiStore } from '../../app/transientUiStore';
+import { Icon } from '../ui/Icon';
 
 interface CopilotComposerProps {
   placeholder: string;
@@ -59,23 +60,15 @@ export const CopilotComposer: FC<CopilotComposerProps> = ({
         placeholder={placeholder}
         aria-label={placeholder}
         rows={1}
-        className="flex-1 resize-none rounded-sc-lg bg-[var(--sc-surface-raised)] text-[var(--sc-text-primary)] text-sm px-3 py-2 max-h-28 overflow-y-auto focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--sc-border-focus)]"
+        className="flex-1 resize-none rounded-sc-lg bg-[var(--sc-surface-raised)] text-[var(--sc-text-primary)] text-sm px-3 py-2 max-h-28 overflow-y-auto focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--sc-ring-focus)]"
       />
       <button
         type="submit"
         disabled={isStreaming || !value.trim()}
         aria-label={sendLabel}
-        className="shrink-0 rounded-sc-lg bg-[var(--sc-accent)] text-white p-2 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--sc-border-focus)]"
+        className="shrink-0 rounded-sc-lg bg-[var(--sc-accent)] text-[var(--sc-text-on-accent)] p-2 disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--sc-ring-focus)]"
       >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          fill="currentColor"
-          className="w-icon-sc-sm h-icon-sc-sm"
-          aria-hidden="true"
-        >
-          <path d="M3.4 20.4 21 12 3.4 3.6 3.4 10l12.6 2-12.6 2z" />
-        </svg>
+        <Icon name="send" size="sm" aria-hidden />
       </button>
     </form>
   );

--- a/components/copilot/CopilotLauncher.tsx
+++ b/components/copilot/CopilotLauncher.tsx
@@ -4,6 +4,7 @@ import { useAnnounce } from '../../contexts/LiveRegionContext';
 import { useGlobalCopilot } from '../../hooks/useGlobalCopilot';
 import { viewNavigationLabelKey } from '../../services/viewNavigationLabels';
 import type { View } from '../../types';
+import { Icon } from '../ui/Icon';
 import { CopilotPanel } from './CopilotPanel';
 
 interface CopilotLauncherProps {
@@ -44,17 +45,9 @@ export const CopilotLauncher: FC<CopilotLauncherProps> = ({ currentView, onNavig
           // QNBS-v3: on <md the mobile bottom-nav (Sidebar `data-tour="nav-mobile"`, fixed bottom-0)
           // occupies the same corner; bottom-4 put this z-90 FAB on top of the "More" tab and ate its
           // taps (broke all mobile clickNavItem E2E). Raise it clear of the bar on mobile, normal on md+.
-          className="fixed bottom-20 right-4 z-[90] flex h-14 w-14 items-center justify-center rounded-full bg-[var(--sc-accent)] text-white shadow-lg transition-transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--sc-border-focus)] focus-visible:ring-offset-2 md:bottom-4"
+          className="fixed bottom-20 right-4 z-[90] flex h-14 w-14 items-center justify-center rounded-full bg-[var(--sc-accent)] text-[var(--sc-text-on-accent)] shadow-lg transition-transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--sc-ring-focus)] focus-visible:ring-offset-2 md:bottom-4"
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            fill="currentColor"
-            className="w-icon-sc-lg h-icon-sc-lg"
-            aria-hidden="true"
-          >
-            <path d="M12 2a1 1 0 0 1 .92.61l1.2 2.87 2.87 1.2a1 1 0 0 1 0 1.84l-2.87 1.2-1.2 2.87a1 1 0 0 1-1.84 0l-1.2-2.87-2.87-1.2a1 1 0 0 1 0-1.84l2.87-1.2 1.2-2.87A1 1 0 0 1 12 2zM5 14a1 1 0 0 1 .92.61l.63 1.5 1.5.63a1 1 0 0 1 0 1.84l-1.5.63-.63 1.5a1 1 0 0 1-1.84 0l-.63-1.5-1.5-.63a1 1 0 0 1 0-1.84l1.5-.63.63-1.5A1 1 0 0 1 5 14z" />
-          </svg>
+          <Icon name="sparkles" size="lg" aria-hidden />
         </button>
       )}
       {isOpen && (

--- a/components/copilot/CopilotMessageList.tsx
+++ b/components/copilot/CopilotMessageList.tsx
@@ -215,7 +215,7 @@ export const CopilotMessageList: FC<CopilotMessageListProps> = ({
             <div
               className={`max-w-[85%] rounded-sc-lg px-3 py-2 text-sm ${
                 isUser
-                  ? 'bg-[var(--sc-accent)] text-white'
+                  ? 'bg-[var(--sc-accent)] text-[var(--sc-text-on-accent)]'
                   : 'bg-[var(--sc-surface-raised)] text-[var(--sc-text-primary)]'
               }`}
             >
@@ -235,7 +235,7 @@ export const CopilotMessageList: FC<CopilotMessageListProps> = ({
                   const block = extractCodeBlock(msg.content);
                   if (block) onApply(block);
                 }}
-                className="mt-1 rounded-sc-md border border-[var(--sc-border-subtle)] bg-[var(--sc-surface-base)] px-2.5 py-1 text-xs text-[var(--sc-text-secondary)] hover:bg-[var(--sc-surface-raised)] disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--sc-border-focus)]"
+                className="mt-1 rounded-sc-md border border-[var(--sc-border-subtle)] bg-[var(--sc-surface-base)] px-2.5 py-1 text-xs text-[var(--sc-text-secondary)] hover:bg-[var(--sc-surface-raised)] disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--sc-ring-focus)]"
               >
                 {applyStatus === 'applying' ? applyingLabel : applyLabel}
               </button>

--- a/components/copilot/CopilotPanel.tsx
+++ b/components/copilot/CopilotPanel.tsx
@@ -10,6 +10,7 @@ import { useTransientUiStore } from '../../app/transientUiStore';
 import { useFocusTrap } from '../../hooks/useFocusTrap';
 import type { UseGlobalCopilotReturn } from '../../hooks/useGlobalCopilot';
 import type { View } from '../../types';
+import { Icon } from '../ui/Icon';
 import { AiModeIndicator } from './AiModeIndicator';
 import { CopilotComposer } from './CopilotComposer';
 import { CopilotMessageList } from './CopilotMessageList';
@@ -134,34 +135,7 @@ export const CopilotPanel: FC<CopilotPanelProps> = ({ copilot, contextLabel, onN
             title={isSidebar ? t('copilot.dialogMode') : t('copilot.sidebarMode')}
             className="hidden rounded-sc-lg p-1.5 text-[var(--sc-text-muted)] hover:bg-[var(--sc-surface-raised)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--sc-border-focus)] md:flex"
           >
-            {isSidebar ? (
-              /* dock→dialog icon */
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                className="h-icon-sc-sm w-icon-sc-sm"
-                aria-hidden="true"
-              >
-                <rect x="3" y="3" width="18" height="18" rx="2" />
-                <path d="M15 3v18" />
-              </svg>
-            ) : (
-              /* float icon */
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                className="h-icon-sc-sm w-icon-sc-sm"
-                aria-hidden="true"
-              >
-                <path d="M8 3H5a2 2 0 00-2 2v14a2 2 0 002 2h3M16 3h3a2 2 0 012 2v14a2 2 0 01-2 2h-3" />
-              </svg>
-            )}
+            <Icon name={isSidebar ? 'panel-dock' : 'panel-float'} size="sm" aria-hidden />
           </button>
           <button
             type="button"
@@ -169,17 +143,7 @@ export const CopilotPanel: FC<CopilotPanelProps> = ({ copilot, contextLabel, onN
             aria-label={t('copilot.clear')}
             className="rounded-sc-lg p-1.5 text-[var(--sc-text-muted)] hover:bg-[var(--sc-surface-raised)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--sc-border-focus)]"
           >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              className="h-icon-sc-sm w-icon-sc-sm"
-              aria-hidden="true"
-            >
-              <path d="M3 6h18M8 6V4h8v2m-9 0v14a2 2 0 002 2h6a2 2 0 002-2V6" />
-            </svg>
+            <Icon name="trash" size="sm" aria-hidden />
           </button>
           <button
             type="button"
@@ -187,17 +151,7 @@ export const CopilotPanel: FC<CopilotPanelProps> = ({ copilot, contextLabel, onN
             aria-label={t('copilot.closeLabel')}
             className="rounded-sc-lg p-1.5 text-[var(--sc-text-muted)] hover:bg-[var(--sc-surface-raised)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--sc-border-focus)]"
           >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              className="h-icon-sc-sm w-icon-sc-sm"
-              aria-hidden="true"
-            >
-              <path d="M6 6l12 12M18 6L6 18" />
-            </svg>
+            <Icon name="close" size="sm" aria-hidden />
           </button>
         </div>
       </header>

--- a/components/copilot/HeuristicsModeToggle.tsx
+++ b/components/copilot/HeuristicsModeToggle.tsx
@@ -6,6 +6,7 @@
 
 import type { FC } from 'react';
 import type { UseGlobalCopilotReturn } from '../../hooks/useGlobalCopilot';
+import { Icon } from '../ui/Icon';
 
 interface HeuristicsModeToggleProps {
   heuristicsOnly: boolean;
@@ -26,24 +27,13 @@ export const HeuristicsModeToggle: FC<HeuristicsModeToggleProps> = ({
       aria-label={t('copilot.heuristicsOnlyLabel')}
       onClick={onToggle}
       title={t('copilot.heuristicsOnlyLabel')}
-      className={`flex items-center gap-1 rounded-sc-md px-2 py-1 text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--sc-border-focus)] ${
+      className={`flex items-center gap-1 rounded-sc-md px-2 py-1 text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--sc-ring-focus)] ${
         heuristicsOnly
           ? 'bg-[var(--sc-info-bg)] text-[var(--sc-info-fg)]'
           : 'text-[var(--sc-text-muted)] hover:bg-[var(--sc-surface-raised)]'
       }`}
     >
-      {/* Offline/shield icon */}
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        className="h-3 w-3"
-        aria-hidden="true"
-      >
-        <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
-      </svg>
+      <Icon name="shield" size="sm" className="h-3 w-3" aria-hidden />
       <span>{t('copilot.heuristicsOnly')}</span>
     </button>
   );

--- a/components/copilot/InlineAnnotationLayer.tsx
+++ b/components/copilot/InlineAnnotationLayer.tsx
@@ -12,6 +12,7 @@ import { copilotActions } from '../../features/copilot/copilotSlice';
 import { selectEnableGlobalCopilot } from '../../features/featureFlags/featureFlagsSlice';
 import { useTranslation } from '../../hooks/useTranslation';
 import type { HeuristicFinding } from '../../services/copilot/heuristicEngine';
+import { Icon } from '../ui/Icon';
 
 interface InlineAnnotationLayerProps {
   sectionTitle: string;
@@ -72,21 +73,9 @@ export const InlineAnnotationLayer: FC<InlineAnnotationLayerProps> = ({ sectionT
       type="button"
       onClick={handleClick}
       aria-label={t('copilot.annotationCount', { count: relevant.length })}
-      className={`absolute bottom-2 end-2 z-10 flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-medium shadow-sm backdrop-blur-sm transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--sc-border-focus)] ${severityColor(topSeverity)}`}
+      className={`absolute bottom-2 end-2 z-10 flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-medium shadow-sm backdrop-blur-sm transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--sc-ring-focus)] ${severityColor(topSeverity)}`}
     >
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        className="h-3 w-3"
-        aria-hidden="true"
-      >
-        <circle cx="12" cy="12" r="10" />
-        <line x1="12" y1="8" x2="12" y2="12" />
-        <line x1="12" y1="16" x2="12.01" y2="16" />
-      </svg>
+      <Icon name="info" size="sm" className="h-3 w-3" aria-hidden />
       {t('copilot.annotationCount', { count: relevant.length })}
     </button>
   );

--- a/components/copilot/InsightCard.tsx
+++ b/components/copilot/InsightCard.tsx
@@ -76,7 +76,7 @@ export const InsightCard: FC<InsightCardProps> = ({ finding, copilot, onNavigate
               <button
                 type="button"
                 onClick={handleTellMore}
-                className="rounded-sc-md border border-[var(--sc-border-subtle)] bg-[var(--sc-surface-base)] px-2 py-0.5 text-[var(--sc-text-secondary)] hover:bg-[var(--sc-surface-raised)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--sc-border-focus)]"
+                className="rounded-sc-md border border-[var(--sc-border-subtle)] bg-[var(--sc-surface-base)] px-2 py-0.5 text-[var(--sc-text-secondary)] hover:bg-[var(--sc-surface-raised)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--sc-ring-focus)]"
               >
                 {t('copilot.insightTellMore')}
               </button>
@@ -85,7 +85,7 @@ export const InsightCard: FC<InsightCardProps> = ({ finding, copilot, onNavigate
               <button
                 type="button"
                 onClick={handleOpenView}
-                className="rounded-sc-md border border-[var(--sc-border-subtle)] bg-[var(--sc-surface-base)] px-2 py-0.5 text-[var(--sc-text-secondary)] hover:bg-[var(--sc-surface-raised)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--sc-border-focus)]"
+                className="rounded-sc-md border border-[var(--sc-border-subtle)] bg-[var(--sc-surface-base)] px-2 py-0.5 text-[var(--sc-text-secondary)] hover:bg-[var(--sc-surface-raised)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--sc-ring-focus)]"
               >
                 {t('copilot.insightOpenView', { view: finding.targetView })}
               </button>

--- a/components/copilot/InsightSection.tsx
+++ b/components/copilot/InsightSection.tsx
@@ -10,6 +10,7 @@ import { useAnnounce } from '../../contexts/LiveRegionContext';
 import type { UseGlobalCopilotReturn } from '../../hooks/useGlobalCopilot';
 import type { HeuristicFinding } from '../../services/copilot/heuristicEngine';
 import type { View } from '../../types';
+import { Icon } from '../ui/Icon';
 import { InsightCard } from './InsightCard';
 
 interface InsightSectionProps {
@@ -58,20 +59,15 @@ export const InsightSection: FC<InsightSectionProps> = ({ insights, copilot, onN
         onClick={() => setExpanded((v) => !v)}
         aria-expanded={expanded}
         aria-controls={sectionId}
-        className="flex w-full items-center justify-between gap-1 text-xs font-medium text-[var(--sc-text-secondary)] hover:text-[var(--sc-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--sc-border-focus)]"
+        className="flex w-full items-center justify-between gap-1 text-xs font-medium text-[var(--sc-text-secondary)] hover:text-[var(--sc-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--sc-ring-focus)]"
       >
         <span>{t('copilot.insightSection', { count: insights.length })}</span>
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
+        <Icon
+          name="chevron-down"
+          size="sm"
           className={`h-3 w-3 transition-transform ${expanded ? 'rotate-180' : ''}`}
-          aria-hidden="true"
-        >
-          <path d="M6 9l6 6 6-6" />
-        </svg>
+          aria-hidden
+        />
       </button>
 
       {expanded && (

--- a/components/dashboard/ManuscriptCompositionCard.tsx
+++ b/components/dashboard/ManuscriptCompositionCard.tsx
@@ -3,18 +3,29 @@ import { useDashboardContext } from '../../contexts/DashboardContext';
 import { Card, CardContent, CardHeader } from '../ui/Card';
 import { BookOpenIcon } from './dashboardIcons';
 
-// QNBS-v3: Scene status taxonomy mirrors StorySection['status'] + an "untracked" bucket for
-// scenes that never had a status set. Order = narrative maturity (outline → final).
+// QNBS-v3: status colors use the design-system data-viz palette so they adapt to theme/sepia.
 const STATUS_META: { key: string; labelKey: string; color: string }[] = [
-  { key: 'outline', labelKey: 'dashboard.composition.status.outline', color: 'bg-slate-400' },
-  { key: 'draft', labelKey: 'dashboard.composition.status.draft', color: 'bg-amber-500' },
+  {
+    key: 'outline',
+    labelKey: 'dashboard.composition.status.outline',
+    color: 'bg-[var(--sc-data-4)]',
+  },
+  {
+    key: 'draft',
+    labelKey: 'dashboard.composition.status.draft',
+    color: 'bg-[var(--sc-text-muted)]',
+  },
   {
     key: 'first-draft',
     labelKey: 'dashboard.composition.status.firstDraft',
-    color: 'bg-blue-500',
+    color: 'bg-[var(--sc-data-2)]',
   },
-  { key: 'revised', labelKey: 'dashboard.composition.status.revised', color: 'bg-violet-500' },
-  { key: 'final', labelKey: 'dashboard.composition.status.final', color: 'bg-emerald-500' },
+  {
+    key: 'revised',
+    labelKey: 'dashboard.composition.status.revised',
+    color: 'bg-[var(--sc-data-6)]',
+  },
+  { key: 'final', labelKey: 'dashboard.composition.status.final', color: 'bg-[var(--sc-data-3)]' },
   {
     key: 'untracked',
     labelKey: 'dashboard.composition.status.untracked',

--- a/components/dashboard/WritingMomentumCard.tsx
+++ b/components/dashboard/WritingMomentumCard.tsx
@@ -101,7 +101,7 @@ export const WritingMomentumCard: FC = () => {
           <div
             className={`flex h-16 w-16 shrink-0 items-center justify-center rounded-2xl border ${
               streakDays > 0
-                ? 'border-orange-500/30 bg-orange-500/10 text-orange-500'
+                ? 'border-[var(--sc-data-4)]/30 bg-[var(--sc-data-4)]/10 text-[var(--sc-data-4)]'
                 : 'border-[var(--sc-border-subtle)] bg-[var(--sc-surface-overlay)] text-[var(--sc-text-muted)]'
             }`}
           >

--- a/components/lora/LoraAdapterLibrary.tsx
+++ b/components/lora/LoraAdapterLibrary.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import { useLoraViewContext } from '../../contexts/LoraViewContext';
 import type { LoraAdapter } from '../../features/lora/types';
 import { useTranslation } from '../../hooks/useTranslation';
+import { Icon } from '../ui/Icon';
 
 function formatBytes(bytes: number): string {
   if (bytes === 0) return '—';
@@ -54,7 +55,7 @@ function AdapterCard({ adapter }: { adapter: LoraAdapter }) {
           <div className="flex items-center gap-2">
             <h3 className="truncate font-medium text-[var(--sc-text-primary)]">{adapter.name}</h3>
             {adapter.isActive && (
-              <span className="shrink-0 rounded-full bg-[var(--sc-interactive-primary)] px-2 py-0.5 text-xs text-white">
+              <span className="shrink-0 rounded-full bg-[var(--sc-interactive-primary)] px-2 py-0.5 text-xs text-[var(--sc-text-on-accent)]">
                 {t('lora.adapter.active')}
               </span>
             )}
@@ -86,9 +87,7 @@ function AdapterCard({ adapter }: { adapter: LoraAdapter }) {
             className="rounded-sc-md p-1.5 text-[var(--sc-text-secondary)] hover:text-[var(--sc-status-error)] focus-visible:ring-2 focus-visible:ring-[var(--sc-border-focus)]"
             aria-label={t('lora.adapter.delete')}
           >
-            <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-              <path d="M6 2h4a1 1 0 0 1 1 1v1H5V3a1 1 0 0 1 1-1zM3 5h10l-1 9H4L3 5zm3 2v5h1V7H6zm3 0v5h1V7H9z" />
-            </svg>
+            <Icon name="trash" size="sm" />
           </button>
         </div>
       </div>
@@ -113,7 +112,7 @@ export default React.memo(function LoraAdapterLibrary() {
           type="button"
           onClick={openWizard}
           disabled={isTraining}
-          className="rounded-sc-md bg-[var(--sc-interactive-primary)] px-4 py-2 text-sm font-medium text-white hover:bg-[var(--sc-interactive-primary-hover)] focus-visible:ring-2 focus-visible:ring-[var(--sc-border-focus)] disabled:opacity-50"
+          className="rounded-sc-md bg-[var(--sc-interactive-primary)] px-4 py-2 text-sm font-medium text-[var(--sc-text-on-accent)] hover:bg-[var(--sc-interactive-primary-hover)] focus-visible:ring-2 focus-visible:ring-[var(--sc-border-focus)] disabled:opacity-50"
         >
           {t('lora.wizard.startFirstTraining')}
         </button>
@@ -131,7 +130,7 @@ export default React.memo(function LoraAdapterLibrary() {
           type="button"
           onClick={openWizard}
           disabled={isTraining}
-          className="rounded-sc-md bg-[var(--sc-interactive-primary)] px-3 py-1.5 text-sm font-medium text-white hover:bg-[var(--sc-interactive-primary-hover)] focus-visible:ring-2 focus-visible:ring-[var(--sc-border-focus)] disabled:opacity-50"
+          className="rounded-sc-md bg-[var(--sc-interactive-primary)] px-3 py-1.5 text-sm font-medium text-[var(--sc-text-on-accent)] hover:bg-[var(--sc-interactive-primary-hover)] focus-visible:ring-2 focus-visible:ring-[var(--sc-border-focus)] disabled:opacity-50"
         >
           {t('lora.wizard.trainNew')}
         </button>

--- a/components/lora/LoraDatasetBuilder.tsx
+++ b/components/lora/LoraDatasetBuilder.tsx
@@ -84,7 +84,7 @@ export default React.memo(function LoraDatasetBuilder() {
             type="button"
             onClick={() => buildDataset()}
             disabled={isBuilding}
-            className="rounded-sc-md bg-[var(--sc-interactive-primary)] px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50 hover:bg-[var(--sc-interactive-primary-hover)] focus-visible:ring-2 focus-visible:ring-[var(--sc-border-focus)]"
+            className="rounded-sc-md bg-[var(--sc-interactive-primary)] px-3 py-1.5 text-sm font-medium text-[var(--sc-text-on-accent)] disabled:opacity-50 hover:bg-[var(--sc-interactive-primary-hover)] focus-visible:ring-2 focus-visible:ring-[var(--sc-border-focus)]"
           >
             {isBuilding ? t('lora.dataset.extracting') : t('lora.dataset.extract')}
           </button>

--- a/components/lora/LoraEvaluationPanel.tsx
+++ b/components/lora/LoraEvaluationPanel.tsx
@@ -112,7 +112,7 @@ export default React.memo(function LoraEvaluationPanel() {
           type="button"
           onClick={handleEvaluate}
           disabled={isEvaluating}
-          className="rounded-sc-md bg-[var(--sc-interactive-primary)] px-4 py-2 text-sm font-medium text-white disabled:opacity-50 hover:bg-[var(--sc-interactive-primary-hover)] focus-visible:ring-2 focus-visible:ring-[var(--sc-border-focus)]"
+          className="rounded-sc-md bg-[var(--sc-interactive-primary)] px-4 py-2 text-sm font-medium text-[var(--sc-text-on-accent)] disabled:opacity-50 hover:bg-[var(--sc-interactive-primary-hover)] focus-visible:ring-2 focus-visible:ring-[var(--sc-border-focus)]"
         >
           {isEvaluating ? t('lora.evaluation.evaluating') : t('lora.evaluation.run')}
         </button>

--- a/components/lora/LoraOnboarding.tsx
+++ b/components/lora/LoraOnboarding.tsx
@@ -5,6 +5,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from '../../hooks/useTranslation';
+import { Icon } from '../ui/Icon';
 
 interface EnvStatus {
   loaded: boolean;
@@ -35,7 +36,7 @@ function StatusRow({ label, ok, detail }: { label: string; ok: boolean; detail?:
         className={ok ? 'text-[var(--sc-success-fg)]' : 'text-[var(--sc-danger-fg)]'}
         aria-hidden="true"
       >
-        {ok ? '✓' : '✗'}
+        <Icon name={ok ? 'check' : 'error'} size="sm" />
       </span>
       <span className="text-[var(--sc-text-primary)]">{label}</span>
       {detail && <span className="text-xs text-[var(--sc-text-secondary)]">({detail})</span>}
@@ -122,7 +123,7 @@ export default React.memo(function LoraOnboarding({ onDismiss }: { onDismiss: ()
       <button
         type="button"
         onClick={onDismiss}
-        className="self-end rounded-sc-md bg-[var(--sc-interactive-primary)] px-5 py-2 text-sm font-medium text-white hover:bg-[var(--sc-interactive-primary-hover)] focus-visible:ring-2 focus-visible:ring-[var(--sc-border-focus)]"
+        className="self-end rounded-sc-md bg-[var(--sc-interactive-primary)] px-5 py-2 text-sm font-medium text-[var(--sc-text-on-accent)] hover:bg-[var(--sc-interactive-primary-hover)] focus-visible:ring-2 focus-visible:ring-[var(--sc-border-focus)]"
       >
         {t('lora.onboarding.getStarted')}
       </button>

--- a/components/lora/LoraTrainingWizard.tsx
+++ b/components/lora/LoraTrainingWizard.tsx
@@ -9,6 +9,7 @@ import { useLoraViewContext } from '../../contexts/LoraViewContext';
 import type { LoraWizardStep, PresetId } from '../../features/lora/types';
 import { HYPERPARAM_PRESETS } from '../../features/lora/types';
 import { useTranslation } from '../../hooks/useTranslation';
+import { Icon } from '../ui/Icon';
 
 // ---------------------------------------------------------------------------
 // Step indicator
@@ -30,14 +31,14 @@ function StepIndicator({ current }: { current: LoraWizardStep }) {
               <span
                 className={`flex h-7 w-7 items-center justify-center rounded-full text-xs font-semibold ${
                   active
-                    ? 'bg-[var(--sc-interactive-primary)] text-white'
+                    ? 'bg-[var(--sc-interactive-primary)] text-[var(--sc-text-on-accent)]'
                     : done
-                      ? 'bg-[var(--sc-success-fg)] text-white'
+                      ? 'bg-[var(--sc-success-fg)] text-[var(--sc-text-on-accent)]'
                       : 'bg-[var(--sc-surface-raised)] text-[var(--sc-text-secondary)]'
                 }`}
                 aria-current={active ? 'step' : undefined}
               >
-                {done ? '✓' : i + 1}
+                {done ? <Icon name="check" size="sm" aria-hidden="true" /> : i + 1}
               </span>
               <span className="ml-1.5 hidden text-xs sm:inline text-[var(--sc-text-secondary)]">
                 {t(`lora.wizard.steps.${step}`)}
@@ -252,7 +253,7 @@ export default React.memo(function LoraTrainingWizard() {
             type="button"
             onClick={next}
             disabled={!canProceed || isTraining}
-            className="rounded-sc-md bg-[var(--sc-interactive-primary)] px-4 py-2 text-sm font-medium text-white hover:bg-[var(--sc-interactive-primary-hover)] focus-visible:ring-2 focus-visible:ring-[var(--sc-border-focus)] disabled:opacity-50"
+            className="rounded-sc-md bg-[var(--sc-interactive-primary)] px-4 py-2 text-sm font-medium text-[var(--sc-text-on-accent)] hover:bg-[var(--sc-interactive-primary-hover)] focus-visible:ring-2 focus-visible:ring-[var(--sc-border-focus)] disabled:opacity-50"
           >
             {t('common.next')}
           </button>

--- a/components/manuscript/CommentsPanel.tsx
+++ b/components/manuscript/CommentsPanel.tsx
@@ -178,7 +178,7 @@ export const CommentsPanel: FC<{ sectionId: string }> = ({ sectionId }) => {
           {t('comments.title')}
         </span>
         {unresolvedCount > 0 && (
-          <span className="text-xs px-2 py-0.5 rounded-full bg-amber-100 text-amber-700">
+          <span className="text-xs px-2 py-0.5 rounded-full bg-[var(--sc-warning-bg)] text-[var(--sc-warning-fg)]">
             {t('comments.unresolved', { n: String(unresolvedCount) })}
           </span>
         )}

--- a/components/manuscript/ManuscriptEditor.tsx
+++ b/components/manuscript/ManuscriptEditor.tsx
@@ -334,7 +334,7 @@ export const ManuscriptEditor: FC<{ isFocusMode: boolean }> = React.memo(({ isFo
                     e.preventDefault();
                     handleMentionSelect(item);
                   }}
-                  className={`px-3 py-3 rounded-md text-sm cursor-pointer flex items-center space-x-3 transition-colors ${index === selectedMentionIndex ? 'bg-[var(--sc-accent)] text-white' : 'text-[var(--sc-text-primary)] hover:bg-[var(--sc-accent)] hover:text-white'}`}
+                  className={`px-3 py-3 rounded-md text-sm cursor-pointer flex items-center space-x-3 transition-colors ${index === selectedMentionIndex ? 'bg-[var(--sc-accent)] text-[var(--sc-text-on-accent)]' : 'text-[var(--sc-text-primary)] hover:bg-[var(--sc-accent)] hover:text-[var(--sc-text-on-accent)]'}`}
                 >
                   {item.type === 'character' ? (
                     <div
@@ -344,7 +344,9 @@ export const ManuscriptEditor: FC<{ isFocusMode: boolean }> = React.memo(({ isFo
                         name="characters"
                         size="sm"
                         className={
-                          index === selectedMentionIndex ? 'text-white' : 'text-[var(--sc-info-fg)]'
+                          index === selectedMentionIndex
+                            ? 'text-[var(--sc-text-on-accent)]'
+                            : 'text-[var(--sc-info-fg)]'
                         }
                       />
                     </div>
@@ -357,7 +359,7 @@ export const ManuscriptEditor: FC<{ isFocusMode: boolean }> = React.memo(({ isFo
                         size="sm"
                         className={
                           index === selectedMentionIndex
-                            ? 'text-white'
+                            ? 'text-[var(--sc-text-on-accent)]'
                             : 'text-[var(--sc-success-fg)]'
                         }
                       />
@@ -388,7 +390,7 @@ export const ManuscriptEditor: FC<{ isFocusMode: boolean }> = React.memo(({ isFo
           <button
             type="button"
             onClick={applyCorrection}
-            className="block w-full text-left px-3 py-2 min-h-[44px] rounded hover:bg-[var(--sc-accent)] hover:text-white text-[var(--sc-text-primary)] font-medium flex items-center"
+            className="block w-full text-left px-3 py-2 min-h-[44px] rounded hover:bg-[var(--sc-accent)] hover:text-[var(--sc-text-on-accent)] text-[var(--sc-text-primary)] font-medium flex items-center"
           >
             {spellCheckPopover.suggestion}
           </button>

--- a/components/manuscript/NavigatorPanel.tsx
+++ b/components/manuscript/NavigatorPanel.tsx
@@ -70,7 +70,7 @@ const NavigatorItem: FC<NavigatorItemProps> = React.memo(
               onMoveUp(index);
             }}
             disabled={isFirst}
-            className="p-2 md:p-1 rounded-md hover:bg-[var(--sc-surface-raised)] disabled:opacity-20 focus-visible:ring-2 focus-visible:ring-indigo-500"
+            className="p-2 md:p-1 rounded-md hover:bg-[var(--sc-surface-raised)] disabled:opacity-20 focus-visible:ring-2 focus-visible:ring-[var(--sc-ring-focus)]"
             title={t('common.moveUp')}
             aria-label={t('outline.moveUp', { title: section.title })}
           >
@@ -83,7 +83,7 @@ const NavigatorItem: FC<NavigatorItemProps> = React.memo(
               onMoveDown(index);
             }}
             disabled={isLast}
-            className="p-2 md:p-1 rounded-md hover:bg-[var(--sc-surface-raised)] disabled:opacity-20 focus-visible:ring-2 focus-visible:ring-indigo-500"
+            className="p-2 md:p-1 rounded-md hover:bg-[var(--sc-surface-raised)] disabled:opacity-20 focus-visible:ring-2 focus-visible:ring-[var(--sc-ring-focus)]"
             title={t('common.moveDown')}
             aria-label={t('outline.moveDown', { title: section.title })}
           >
@@ -105,7 +105,7 @@ const NavigatorItem: FC<NavigatorItemProps> = React.memo(
           )}
           <div
             aria-hidden="true"
-            className={`cursor-move p-1 ${isActive ? 'text-[var(--sc-accent)] group-hover:text-white' : 'text-[var(--sc-text-muted)] group-hover:text-[var(--sc-text-primary)]'}`}
+            className={`cursor-move p-1 ${isActive ? 'text-[var(--sc-accent)] group-hover:text-[var(--sc-text-primary)]' : 'text-[var(--sc-text-muted)] group-hover:text-[var(--sc-text-primary)]'}`}
           >
             <Icon name="grip-horizontal" size="sm" />
           </div>
@@ -200,7 +200,7 @@ export const StoryNavigator: FC<{ onSectionSelect?: () => void }> = React.memo(
               aria-label={t('manuscript.navigator.largeManuscriptDismiss')}
               className="shrink-0 hover:text-[var(--sc-text-primary)] transition-colors"
             >
-              ×
+              <Icon name="close" size="sm" aria-hidden="true" />
             </button>
           </div>
         )}

--- a/components/manuscript/ReferencePanelView.tsx
+++ b/components/manuscript/ReferencePanelView.tsx
@@ -12,6 +12,7 @@ import { statusActions } from '../../features/status/statusSlice';
 import { useTranslation } from '../../hooks/useTranslation';
 import { rebuildHybridRagIndex } from '../../services/localRagService';
 import type { StorySection } from '../../types';
+import { Icon } from '../ui/Icon';
 import { CommentsPanel } from './CommentsPanel';
 import { SceneRevisionPanel } from './SceneRevisionPanel';
 
@@ -43,7 +44,7 @@ const CharactersTab: FC<{ section: StorySection }> = ({ section }) => {
         >
           {c.hasAvatar ? (
             <div
-              className="w-10 h-10 rounded-full flex-shrink-0 flex items-center justify-center bg-[var(--sc-accent)] text-white text-sm font-bold"
+              className="w-10 h-10 rounded-full flex-shrink-0 flex items-center justify-center bg-[var(--sc-accent)] text-[var(--sc-text-on-accent)] text-sm font-bold"
               aria-hidden="true"
             >
               {c.name.slice(0, 1).toUpperCase()}
@@ -53,7 +54,7 @@ const CharactersTab: FC<{ section: StorySection }> = ({ section }) => {
               className="w-10 h-10 rounded-full flex-shrink-0 flex items-center justify-center bg-[var(--sc-surface-overlay)] text-lg"
               aria-hidden="true"
             >
-              👤
+              <Icon name="characters" size="md" className="text-[var(--sc-text-muted)]" />
             </div>
           )}
           <div className="min-w-0">

--- a/components/manuscript/SceneRevisionPanel.tsx
+++ b/components/manuscript/SceneRevisionPanel.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from '../../hooks/useTranslation';
 import { deleteRevision, listRevisions, saveRevision } from '../../services/sceneRevisionService';
 import { diffTokensToOps, tokenizeWordsAndSpaces } from '../../services/wordDiff';
 import type { SceneRevision, StorySection } from '../../types';
+import { Icon } from '../ui/Icon';
 
 // ── Word-level diff view ──────────────────────────────────────────────────────
 
@@ -101,7 +102,7 @@ const RevisionItem: FC<{
               <button
                 type="button"
                 onClick={handleRestore}
-                className="text-xs px-2 py-1 rounded bg-amber-500 text-white hover:bg-amber-600"
+                className="text-xs px-2 py-1 rounded bg-[var(--sc-warning-fg)] text-[var(--sc-text-on-accent)] hover:opacity-80"
               >
                 {t('revisions.confirmRestore')}
               </button>
@@ -117,7 +118,7 @@ const RevisionItem: FC<{
             <button
               type="button"
               onClick={() => setConfirmRestore(true)}
-              className="text-xs px-2 py-1 rounded bg-[var(--sc-accent)] text-[white] hover:opacity-90"
+              className="text-xs px-2 py-1 rounded bg-[var(--sc-accent)] text-[var(--sc-text-on-accent)] hover:opacity-90"
             >
               {t('revisions.restore')}
             </button>
@@ -128,7 +129,7 @@ const RevisionItem: FC<{
             className="text-xs px-2 py-1 rounded text-[var(--sc-danger-fg)] hover:text-[var(--sc-danger-fg)]/80"
             aria-label={t('revisions.delete')}
           >
-            ✕
+            <Icon name="close" size="sm" aria-hidden="true" />
           </button>
         </div>
       </div>
@@ -192,7 +193,7 @@ export const SceneRevisionPanel: FC<{ section: StorySection }> = ({ section }) =
           type="button"
           onClick={() => void handleSaveNamed()}
           disabled={isSaving}
-          className="px-2 py-1 rounded bg-[var(--sc-accent)] text-[white] text-xs disabled:opacity-50"
+          className="px-2 py-1 rounded bg-[var(--sc-accent)] text-[var(--sc-text-on-accent)] text-xs disabled:opacity-50"
         >
           {isSaving ? '…' : t('revisions.saveNamed')}
         </button>

--- a/components/mind-map/MindMapEdgeLayer.tsx
+++ b/components/mind-map/MindMapEdgeLayer.tsx
@@ -39,7 +39,8 @@ export function MindMapEdgeLayer({ nodes, edges, selectedEdgeId, onSelectEdge }:
         const isDotted = edge.style === 'dotted';
         const isBi = edge.direction === 'bi';
         const d = cubicPath(src.x, src.y, tgt.x, tgt.y);
-        const stroke = isSelected ? '#818cf8' : edge.color;
+        // QNBS-v3: selected edge uses the design-system accent token so it adapts to theme/sepia.
+        const stroke = isSelected ? 'var(--sc-accent)' : edge.color;
 
         return (
           // QNBS-v3: the <g> is the interactive element; role=button with keyboard support for a11y

--- a/components/mind-map/MindMapListPanel.tsx
+++ b/components/mind-map/MindMapListPanel.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useMindMapViewContext } from '../../contexts/MindMapViewContext';
 import type { NewMindMapDraft } from '../../hooks/useMindMapView';
 import { useTranslation } from '../../hooks/useTranslation';
+import { Icon } from '../ui/Icon';
 
 // QNBS-v3: All dark: stone/violet prefixes replaced with --sc-* tokens — appearance presets now work.
 const inputClass =
@@ -76,7 +77,7 @@ function MapForm({
         </button>
         <button
           type="submit"
-          className="text-xs px-3 py-1.5 rounded-sc-sm bg-[var(--sc-accent)] hover:bg-[var(--sc-accent-hover)] text-white"
+          className="text-xs px-3 py-1.5 rounded-sc-sm bg-[var(--sc-accent)] hover:bg-[var(--sc-accent-hover)] text-[var(--sc-text-on-accent)]"
         >
           {t('mindmap.save')}
         </button>
@@ -122,18 +123,7 @@ export function MindMapListPanel() {
           title={t('mindmap.addMap')}
           className="p-1 rounded-sc-sm hover:bg-[var(--sc-surface-overlay)] text-[var(--sc-text-muted)]"
         >
-          <svg
-            width="14"
-            height="14"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth={2.5}
-            aria-hidden="true"
-          >
-            <line x1="12" y1="5" x2="12" y2="19" />
-            <line x1="5" y1="12" x2="19" y2="12" />
-          </svg>
+          <Icon name="plus" size="sm" aria-hidden="true" />
         </button>
       </div>
 
@@ -211,18 +201,7 @@ export function MindMapListPanel() {
                     aria-label={t('mindmap.editMap')}
                     className="opacity-100 md:opacity-0 md:group-hover:opacity-100 p-1.5 rounded-sc-sm hover:bg-[var(--sc-surface-overlay)] text-[var(--sc-text-muted)] transition-opacity"
                   >
-                    <svg
-                      width="11"
-                      height="11"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth={2}
-                      aria-hidden="true"
-                    >
-                      <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
-                      <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
-                    </svg>
+                    <Icon name="settings" size="sm" aria-hidden="true" />
                   </button>
                   <button
                     type="button"
@@ -230,19 +209,7 @@ export function MindMapListPanel() {
                     aria-label={t('mindmap.deleteMap')}
                     className="opacity-100 md:opacity-0 md:group-hover:opacity-100 p-1.5 rounded-sc-sm hover:bg-[var(--sc-danger-bg)] text-[var(--sc-text-muted)] hover:text-[var(--sc-danger-fg)] transition-opacity"
                   >
-                    <svg
-                      width="11"
-                      height="11"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth={2}
-                      aria-hidden="true"
-                    >
-                      <polyline points="3 6 5 6 21 6" />
-                      <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
-                      <path d="M10 11v6M14 11v6" />
-                    </svg>
+                    <Icon name="trash" size="sm" aria-hidden="true" />
                   </button>
                 </div>
               )}
@@ -261,10 +228,10 @@ export function MindMapListPanel() {
                 position: { x: 300 + Math.random() * 100, y: 200 + Math.random() * 100 },
                 type: 'free',
                 shape: 'rectangle',
-                color: '#6366f1',
+                color: 'var(--sc-data-2)',
               })
             }
-            className="w-full text-xs py-1.5 rounded-sc-sm bg-[var(--sc-accent)] hover:bg-[var(--sc-accent-hover)] text-white"
+            className="w-full text-xs py-1.5 rounded-sc-sm bg-[var(--sc-accent)] hover:bg-[var(--sc-accent-hover)] text-[var(--sc-text-on-accent)]"
           >
             {t('mindmap.addNode')}
           </button>

--- a/components/mind-map/MindMapNodeEditor.tsx
+++ b/components/mind-map/MindMapNodeEditor.tsx
@@ -2,10 +2,20 @@ import { useCallback, useEffect, useState } from 'react';
 import { useMindMapViewContext } from '../../contexts/MindMapViewContext';
 import { useTranslation } from '../../hooks/useTranslation';
 import type { MindMapLinkedEntityType, MindMapNodeShape, MindMapNodeType } from '../../types';
+import { Icon } from '../ui/Icon';
 import { Select } from '../ui/Select';
 
 const SHAPES: MindMapNodeShape[] = ['circle', 'rectangle', 'diamond', 'ellipse', 'hexagon'];
-const COLORS = ['#6366f1', '#ec4899', '#f59e0b', '#10b981', '#3b82f6', '#8b5cf6', '#ef4444'];
+// QNBS-v3: node color presets use the design-system data-viz palette so they adapt to theme/sepia.
+const COLORS = [
+  'var(--sc-data-2)',
+  'var(--sc-data-5)',
+  'var(--sc-data-4)',
+  'var(--sc-data-3)',
+  'var(--sc-data-6)',
+  'var(--sc-data-1)',
+  'var(--sc-data-8)',
+];
 const LINKED_TYPES: MindMapLinkedEntityType[] = ['character', 'world', 'object', 'group', 'scene'];
 
 const SHAPE_KEY: Record<MindMapNodeShape, string> = {
@@ -34,7 +44,7 @@ export function MindMapNodeEditor() {
   const [textNotes, setTextNotes] = useState('');
   const [type, setType] = useState<MindMapNodeType>('free');
   const [shape, setShape] = useState<MindMapNodeShape>('rectangle');
-  const [color, setColor] = useState('#6366f1');
+  const [color, setColor] = useState('var(--sc-data-2)');
   const [linkedEntityType, setLinkedEntityType] = useState<MindMapLinkedEntityType | ''>('');
 
   useEffect(() => {
@@ -102,18 +112,7 @@ export function MindMapNodeEditor() {
           aria-label={t('mindmap.cancel')}
           className="p-1 rounded-sc-sm hover:bg-[var(--sc-surface-overlay)] text-[var(--sc-text-muted)]"
         >
-          <svg
-            width="14"
-            height="14"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth={2}
-            aria-hidden="true"
-          >
-            <line x1="18" y1="6" x2="6" y2="18" />
-            <line x1="6" y1="6" x2="18" y2="18" />
-          </svg>
+          <Icon name="close" size="sm" aria-hidden="true" />
         </button>
       </div>
 
@@ -260,7 +259,7 @@ export function MindMapNodeEditor() {
           <button
             type="button"
             onClick={handleSave}
-            className="text-xs px-3 py-1.5 rounded-sc-sm bg-[var(--sc-accent)] hover:bg-[var(--sc-accent-hover)] text-white"
+            className="text-xs px-3 py-1.5 rounded-sc-sm bg-[var(--sc-accent)] hover:bg-[var(--sc-accent-hover)] text-[var(--sc-text-on-accent)]"
           >
             {t('mindmap.save')}
           </button>

--- a/components/mind-map/MindMapNodeShape.tsx
+++ b/components/mind-map/MindMapNodeShape.tsx
@@ -22,9 +22,10 @@ function ShapeBody({
   isSelected: boolean;
 }) {
   // QNBS-v3: selection stroke uses the design-system accent token so it adapts to theme/sepia.
+  // Fill opacity replaces the old hex-alpha suffix so CSS variables (var(--sc-data-*)) remain valid.
   const stroke = isSelected ? 'var(--sc-accent)' : color;
   const strokeW = isSelected ? 2.5 : 1.5;
-  const fill = `${color}22`;
+  const fillOpacity = 0.13;
 
   switch (shape) {
     case 'circle':
@@ -34,7 +35,8 @@ function ShapeBody({
           cy={H / 2}
           rx={R}
           ry={R}
-          fill={fill}
+          fill={color}
+          fillOpacity={fillOpacity}
           stroke={stroke}
           strokeWidth={strokeW}
         />
@@ -47,7 +49,8 @@ function ShapeBody({
           width={W - 4}
           height={H - 4}
           rx={4}
-          fill={fill}
+          fill={color}
+          fillOpacity={fillOpacity}
           stroke={stroke}
           strokeWidth={strokeW}
         />
@@ -58,7 +61,15 @@ function ShapeBody({
       const dx = W / 2 - 4;
       const dy = H / 2 - 2;
       const pts = `${cx},${cy - dy} ${cx + dx},${cy} ${cx},${cy + dy} ${cx - dx},${cy}`;
-      return <polygon points={pts} fill={fill} stroke={stroke} strokeWidth={strokeW} />;
+      return (
+        <polygon
+          points={pts}
+          fill={color}
+          fillOpacity={fillOpacity}
+          stroke={stroke}
+          strokeWidth={strokeW}
+        />
+      );
     }
     case 'ellipse':
       return (
@@ -67,7 +78,8 @@ function ShapeBody({
           cy={H / 2}
           rx={W / 2 - 4}
           ry={H / 2 - 4}
-          fill={fill}
+          fill={color}
+          fillOpacity={fillOpacity}
           stroke={stroke}
           strokeWidth={strokeW}
         />
@@ -87,7 +99,15 @@ function ShapeBody({
       ]
         .map((p) => p.join(','))
         .join(' ');
-      return <polygon points={pts} fill={fill} stroke={stroke} strokeWidth={strokeW} />;
+      return (
+        <polygon
+          points={pts}
+          fill={color}
+          fillOpacity={fillOpacity}
+          stroke={stroke}
+          strokeWidth={strokeW}
+        />
+      );
     }
     default:
       return (
@@ -97,7 +117,8 @@ function ShapeBody({
           width={W - 4}
           height={H - 4}
           rx={4}
-          fill={fill}
+          fill={color}
+          fillOpacity={fillOpacity}
           stroke={stroke}
           strokeWidth={strokeW}
         />

--- a/components/mind-map/MindMapNodeShape.tsx
+++ b/components/mind-map/MindMapNodeShape.tsx
@@ -21,7 +21,8 @@ function ShapeBody({
   color: string;
   isSelected: boolean;
 }) {
-  const stroke = isSelected ? '#6366f1' : color;
+  // QNBS-v3: selection stroke uses the design-system accent token so it adapts to theme/sepia.
+  const stroke = isSelected ? 'var(--sc-accent)' : color;
   const strokeW = isSelected ? 2.5 : 1.5;
   const fill = `${color}22`;
 

--- a/components/proForge/PipelineReviewPanel.tsx
+++ b/components/proForge/PipelineReviewPanel.tsx
@@ -18,9 +18,9 @@ import { useTranslation } from '../../hooks/useTranslation';
 import { Icon } from '../ui/Icon';
 
 const SEVERITY_ICONS: Record<string, React.ReactNode> = {
-  critical: <Icon name="error" size="sm" aria-hidden="true" />,
-  warning: <Icon name="warning" size="sm" aria-hidden="true" />,
-  info: <Icon name="info" size="sm" aria-hidden="true" />,
+  critical: <Icon name="error" size="sm" aria-hidden="true" data-testid="severity-icon-critical" />,
+  warning: <Icon name="warning" size="sm" aria-hidden="true" data-testid="severity-icon-warning" />,
+  info: <Icon name="info" size="sm" aria-hidden="true" data-testid="severity-icon-info" />,
 };
 
 const SEVERITY_GROUPS = [

--- a/components/proForge/PipelineReviewPanel.tsx
+++ b/components/proForge/PipelineReviewPanel.tsx
@@ -15,11 +15,12 @@ import { selectEnableGlobalCopilot } from '../../features/featureFlags/featureFl
 import { proForgeActions } from '../../features/proForge/proForgeSlice';
 import type { ReviewItem, ReviewItemStatus } from '../../features/proForge/types';
 import { useTranslation } from '../../hooks/useTranslation';
+import { Icon } from '../ui/Icon';
 
-const SEVERITY_ICONS: Record<string, string> = {
-  critical: '🔴',
-  warning: '🟡',
-  info: '🔵',
+const SEVERITY_ICONS: Record<string, React.ReactNode> = {
+  critical: <Icon name="error" size="sm" aria-hidden="true" />,
+  warning: <Icon name="warning" size="sm" aria-hidden="true" />,
+  info: <Icon name="info" size="sm" aria-hidden="true" />,
 };
 
 const SEVERITY_GROUPS = [
@@ -203,8 +204,8 @@ export const PipelineReviewPanel: React.FC = () => {
       {criticalPending.length > 0 && (
         <div className="mx-4 mt-3 p-3 rounded-sc-md border border-[var(--sc-error-muted)] bg-[var(--sc-error-muted)]">
           <div className="flex items-center justify-between mb-2">
-            <span className="text-xs font-semibold text-[var(--sc-error)]">
-              <span aria-hidden="true">🔴 </span>
+            <span className="text-xs font-semibold text-[var(--sc-error)] flex items-center gap-1">
+              <Icon name="error" size="sm" aria-hidden="true" />
               {t(
                 criticalPending.length === 1
                   ? 'proforge.review.criticalHeadingOne'
@@ -215,7 +216,7 @@ export const PipelineReviewPanel: React.FC = () => {
             <button
               type="button"
               onClick={handleAcceptAllCritical}
-              className="px-2 py-0.5 text-xs rounded-sc-sm bg-[var(--sc-error)] text-white hover:opacity-80 transition-opacity"
+              className="px-2 py-0.5 text-xs rounded-sc-sm bg-[var(--sc-error)] text-[var(--sc-text-on-accent)] hover:opacity-80 transition-opacity"
             >
               {t('proforge.review.acceptAllCritical')}
             </button>
@@ -248,7 +249,7 @@ export const PipelineReviewPanel: React.FC = () => {
               aria-pressed={filter === f}
               className={`px-2.5 py-1 text-xs rounded-sc-md transition-colors ${
                 filter === f
-                  ? 'bg-[var(--sc-accent)] text-white'
+                  ? 'bg-[var(--sc-accent)] text-[var(--sc-text-on-accent)]'
                   : 'bg-[var(--sc-surface-base)] text-[var(--sc-text-secondary)] hover:text-[var(--sc-text-primary)]'
               }`}
             >
@@ -305,7 +306,7 @@ export const PipelineReviewPanel: React.FC = () => {
           type="button"
           onClick={() => void handleSubmit()}
           disabled={pendingCount > 0}
-          className="px-4 py-1.5 text-xs font-medium rounded-sc-md text-white disabled:opacity-50 transition-opacity"
+          className="px-4 py-1.5 text-xs font-medium rounded-sc-md text-[var(--sc-text-on-accent)] disabled:opacity-50 transition-opacity"
           style={{ backgroundColor: 'var(--sc-accent)' }}
         >
           {pendingCount > 0
@@ -402,7 +403,7 @@ function ReviewItemCard({
                 aria-pressed={item.status === btn.status}
                 className={`px-2 py-0.5 text-xs rounded-sc-sm border transition-all ${
                   item.status === btn.status
-                    ? 'text-white'
+                    ? 'text-[var(--sc-text-on-accent)]'
                     : 'bg-[var(--sc-surface-elevated)] text-[var(--sc-text-secondary)] border-[var(--sc-border-subtle)] hover:text-[var(--sc-text-primary)]'
                 }`}
                 style={

--- a/components/proForge/ProForgeDashboard.tsx
+++ b/components/proForge/ProForgeDashboard.tsx
@@ -222,10 +222,11 @@ export const ProForgeDashboard: React.FC = () => {
                         active ? 'ring-2 ring-[var(--sc-ring-focus)]' : ''
                       }`}
                       style={{
+                        // QNBS-v3: color-mix keeps CSS variable stage colors valid (hex-alpha suffix only worked for literal hex).
                         backgroundColor:
                           status === 'pending'
                             ? 'var(--sc-surface-base)'
-                            : `${STAGE_COLORS[status]}15`,
+                            : `color-mix(in srgb, ${STAGE_COLORS[status]} 8%, transparent)`,
                         borderColor: STAGE_COLORS[status],
                         color: STAGE_COLORS[status],
                       }}

--- a/components/proForge/ProForgeDashboard.tsx
+++ b/components/proForge/ProForgeDashboard.tsx
@@ -82,7 +82,7 @@ export const ProForgeDashboard: React.FC = () => {
             className="w-8 h-8 rounded-sc-md flex items-center justify-center"
             style={{ backgroundColor: 'var(--sc-accent)' }}
           >
-            <span className="text-white font-bold text-sm">P</span>
+            <span className="text-[var(--sc-text-on-accent)] font-bold text-sm">P</span>
           </div>
           <div>
             <h2 className="text-base font-semibold">{t('proforge.pipeline.title')}</h2>
@@ -96,7 +96,7 @@ export const ProForgeDashboard: React.FC = () => {
             <button
               type="button"
               onClick={handleAbort}
-              className="px-3 py-1.5 text-sm rounded-sc-md bg-[var(--sc-error)] text-white hover:opacity-90 transition-opacity"
+              className="px-3 py-1.5 text-sm rounded-sc-md bg-[var(--sc-error)] text-[var(--sc-text-on-accent)] hover:opacity-90 transition-opacity"
               aria-label={t('proforge.dashboard.abortAria')}
             >
               {t('common.abort')}
@@ -148,7 +148,7 @@ export const ProForgeDashboard: React.FC = () => {
                 type="button"
                 onClick={handleStart}
                 disabled={isLoading}
-                className="w-full px-4 py-2.5 text-sm font-medium rounded-sc-md text-white transition-opacity disabled:opacity-50"
+                className="w-full px-4 py-2.5 text-sm font-medium rounded-sc-md text-[var(--sc-text-on-accent)] transition-opacity disabled:opacity-50"
                 style={{ backgroundColor: 'var(--sc-accent)' }}
               >
                 {isLoading ? t('proforge.dashboard.starting') : t('proforge.dashboard.start')}

--- a/components/scene-board/ConnectionLayer.tsx
+++ b/components/scene-board/ConnectionLayer.tsx
@@ -17,12 +17,13 @@ const CARD_H = 130;
 
 // ── Connection type visual metadata ───────────────────────────────────────────
 
+// QNBS-v3: connection type colors use the design-system data-viz palette so they adapt to theme/sepia.
 const TYPE_COLORS: Record<PlotConnectionType, string> = {
-  'cause-effect': '#ef4444',
-  parallel: '#3b82f6',
-  subplot: '#8b5cf6',
-  temporal: '#f59e0b',
-  'character-arc': '#10b981',
+  'cause-effect': 'var(--sc-data-1)',
+  parallel: 'var(--sc-data-2)',
+  subplot: 'var(--sc-data-6)',
+  temporal: 'var(--sc-data-4)',
+  'character-arc': 'var(--sc-data-3)',
 };
 
 const CONNECTION_TYPES: PlotConnectionType[] = [
@@ -87,7 +88,7 @@ const ArrowMarkers: FC = () => (
       markerHeight="6"
       orient="auto-start-reverse"
     >
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--sc-accent-primary,#6366f1)" />
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--sc-accent)" />
     </marker>
     <marker
       id="pb-arrow-preview"
@@ -98,7 +99,7 @@ const ArrowMarkers: FC = () => (
       markerHeight="6"
       orient="auto-start-reverse"
     >
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--sc-text-muted,#9ca3af)" />
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--sc-text-muted)" />
     </marker>
   </defs>
 );
@@ -182,7 +183,7 @@ export const ConnectionLayer: FC<ConnectionLayerProps> = ({
         const isHovered = conn.id === hoveredId;
         const typeColor = TYPE_COLORS[conn.type];
         const strokeColor = isSelected
-          ? 'var(--sc-accent-primary,#6366f1)'
+          ? 'var(--sc-accent)'
           : conn.subplotId
             ? (subplotColorMap.get(conn.subplotId) ?? typeColor)
             : typeColor;
@@ -246,7 +247,7 @@ export const ConnectionLayer: FC<ConnectionLayerProps> = ({
         <path
           d={`M ${drawFromCenter.x},${drawFromCenter.y} L ${cursorCanvasPos.x},${cursorCanvasPos.y}`}
           fill="none"
-          stroke="var(--sc-text-muted,#9ca3af)"
+          stroke="var(--sc-text-muted)"
           strokeWidth={2}
           strokeDasharray="8,4"
           markerEnd="url(#pb-arrow-preview)"

--- a/components/scene-board/ConnectionToolbar.tsx
+++ b/components/scene-board/ConnectionToolbar.tsx
@@ -10,6 +10,7 @@ import {
 import { selectPlotConnections } from '../../features/project/projectSelectors';
 import { projectActions } from '../../features/project/projectSlice';
 import type { PlotConnectionType } from '../../types';
+import { Icon } from '../ui/Icon';
 
 const CONNECTION_TYPE_OPTIONS: { value: PlotConnectionType; icon: string }[] = [
   { value: 'cause-effect', icon: '→' },
@@ -88,7 +89,7 @@ export const ConnectionToolbar: FC<ConnectionToolbarProps> = ({ t }) => {
             onClick={() => handleTypeChange(value)}
             className={`w-7 h-7 rounded text-sm transition-colors ${
               selected.type === value
-                ? 'bg-[var(--sc-accent-primary,#6366f1)] text-white'
+                ? 'bg-[var(--sc-accent)] text-[var(--sc-text-on-accent)]'
                 : 'text-[var(--sc-text-muted)] hover:bg-[var(--sc-surface-overlay)]'
             }`}
             title={t(`sceneboard.connectionType.${value}`)}
@@ -116,7 +117,7 @@ export const ConnectionToolbar: FC<ConnectionToolbarProps> = ({ t }) => {
           }
         }}
         placeholder={t('sceneboard.connectionToolbar.labelPlaceholder')}
-        className="w-28 text-xs px-2 py-0.5 bg-[var(--sc-surface-base)] border border-[var(--sc-border-subtle)] rounded text-[var(--sc-text-primary)] outline-none focus-visible:ring-1 focus-visible:ring-[var(--sc-accent-primary,#6366f1)]"
+        className="w-28 text-xs px-2 py-0.5 bg-[var(--sc-surface-base)] border border-[var(--sc-border-subtle)] rounded text-[var(--sc-text-primary)] outline-none focus-visible:ring-1 focus-visible:ring-[var(--sc-accent)]"
         aria-label={t('sceneboard.connectionToolbar.labelInput')}
       />
 
@@ -130,7 +131,7 @@ export const ConnectionToolbar: FC<ConnectionToolbarProps> = ({ t }) => {
         aria-label={t('sceneboard.connectionToolbar.delete')}
         title={t('sceneboard.connectionToolbar.delete')}
       >
-        🗑
+        <Icon name="trash" size="sm" aria-hidden="true" />
       </button>
 
       {/* Deselect */}
@@ -140,7 +141,7 @@ export const ConnectionToolbar: FC<ConnectionToolbarProps> = ({ t }) => {
         className="text-xs text-[var(--sc-text-muted)] hover:text-[var(--sc-text-primary)] px-1"
         aria-label={t('sceneboard.connectionToolbar.close')}
       >
-        ×
+        <Icon name="close" size="sm" aria-hidden="true" />
       </button>
     </div>
   );

--- a/components/scene-board/PlotCanvas.tsx
+++ b/components/scene-board/PlotCanvas.tsx
@@ -36,14 +36,15 @@ interface CanvasCardProps {
 const CanvasCard: FC<CanvasCardProps> = React.memo(
   ({ section, x, y, t, isDrawing, onPointerDown, onCardClick, onCardLongPress }) => {
     const longPress = useLongPress(() => onCardLongPress(section.id), 550);
+    // QNBS-v3: status colors use the design-system data-viz palette so they adapt to theme/sepia.
     const statusColors: Record<string, string> = {
-      draft: '#6b7280',
-      outline: '#f59e0b',
-      'first-draft': '#3b82f6',
-      revised: '#8b5cf6',
-      final: '#10b981',
+      draft: 'var(--sc-text-muted)',
+      outline: 'var(--sc-data-4)',
+      'first-draft': 'var(--sc-data-2)',
+      revised: 'var(--sc-data-6)',
+      final: 'var(--sc-data-3)',
     };
-    const statusColor = statusColors[section.status || 'draft'] || '#6b7280';
+    const statusColor = statusColors[section.status || 'draft'] || 'var(--sc-text-muted)';
 
     return (
       <div
@@ -76,7 +77,7 @@ const CanvasCard: FC<CanvasCardProps> = React.memo(
         <div className="flex items-center gap-1.5 mb-1">
           <div
             className="w-2 h-2 rounded-full flex-shrink-0"
-            style={{ backgroundColor: section.color || '#3b82f6' }}
+            style={{ backgroundColor: section.color || 'var(--sc-data-2)' }}
           />
           {/* QNBS-v3: RTL beta — board wrapper is .rtl-keep-ltr for pointer geometry, but user
               text must read per its own script; dir="auto" restores RTL/BiDi for Arabic/Hebrew. */}

--- a/components/scene-board/PlotMinimap.tsx
+++ b/components/scene-board/PlotMinimap.tsx
@@ -72,7 +72,7 @@ export const PlotMinimap: FC<PlotMinimapProps> = ({
             width={CARD_W * scaleX}
             height={CARD_H * scaleY}
             rx={2}
-            fill={s.color || '#3b82f6'}
+            fill={s.color || 'var(--sc-data-2)'}
             opacity={0.7}
           />
         );
@@ -83,7 +83,7 @@ export const PlotMinimap: FC<PlotMinimapProps> = ({
         width={Math.max(vpW, 4)}
         height={Math.max(vpH, 4)}
         fill="none"
-        stroke="var(--sc-ring-focus, #6366f1)"
+        stroke="var(--sc-ring-focus)"
         strokeWidth={1}
         opacity={0.8}
       />

--- a/components/scene-board/SceneCard.tsx
+++ b/components/scene-board/SceneCard.tsx
@@ -4,16 +4,18 @@ import type { FC } from 'react';
 import React, { useState } from 'react';
 import type { Character, StorySection } from '../../types';
 import { Button } from '../ui/Button';
+import { Icon } from '../ui/Icon';
 import { Input } from '../ui/Input';
 import { Select } from '../ui/Select';
 import { Textarea } from '../ui/Textarea';
 
+// QNBS-v3: status colors use the design-system data-viz palette so they adapt to theme/sepia.
 const STATUS_COLORS: Record<string, string> = {
-  draft: '#6b7280',
-  outline: '#f59e0b',
-  'first-draft': '#3b82f6',
-  revised: '#8b5cf6',
-  final: '#10b981',
+  draft: 'var(--sc-text-muted)',
+  outline: 'var(--sc-data-4)',
+  'first-draft': 'var(--sc-data-2)',
+  revised: 'var(--sc-data-6)',
+  final: 'var(--sc-data-3)',
 };
 
 interface SceneCardProps {
@@ -47,7 +49,7 @@ export const SceneCard: FC<SceneCardProps> = React.memo(
     const [editData, setEditData] = useState({
       title: section.title,
       summary: section.summary || '',
-      color: section.color || '#3b82f6',
+      color: section.color || 'var(--sc-data-2)',
       status: section.status || 'draft',
       act: section.act || 1,
       sceneStart: section.sceneStart ?? '',
@@ -83,7 +85,7 @@ export const SceneCard: FC<SceneCardProps> = React.memo(
     };
 
     const linkedChars = (characters || []).filter((c) => section.characterIds?.includes(c.id));
-    const statusColor = STATUS_COLORS[section.status || 'draft'] || '#6b7280';
+    const statusColor = STATUS_COLORS[section.status || 'draft'] || 'var(--sc-text-muted)';
 
     return (
       <div
@@ -208,7 +210,7 @@ export const SceneCard: FC<SceneCardProps> = React.memo(
               <div className="flex items-center gap-1.5">
                 <div
                   className="w-2 h-2 rounded-full flex-shrink-0"
-                  style={{ backgroundColor: section.color || '#3b82f6' }}
+                  style={{ backgroundColor: section.color || 'var(--sc-data-2)' }}
                 />
                 <h4 className="text-sm font-semibold text-[var(--sc-text-primary)] line-clamp-1">
                   {section.title}
@@ -222,7 +224,7 @@ export const SceneCard: FC<SceneCardProps> = React.memo(
                   setEditData({
                     title: section.title,
                     summary: section.summary || '',
-                    color: section.color || '#3b82f6',
+                    color: section.color || 'var(--sc-data-2)',
                     status: section.status || 'draft',
                     act: section.act || 1,
                     sceneStart: section.sceneStart ?? '',
@@ -303,7 +305,7 @@ export const SceneCard: FC<SceneCardProps> = React.memo(
                   onReorderInAct(section.id, 'up');
                 }}
               >
-                ↑
+                <Icon name="chevron-up" size="sm" aria-hidden="true" />
               </Button>
               <Button
                 type="button"
@@ -317,7 +319,7 @@ export const SceneCard: FC<SceneCardProps> = React.memo(
                   onReorderInAct(section.id, 'down');
                 }}
               >
-                ↓
+                <Icon name="chevron-down" size="sm" aria-hidden="true" />
               </Button>
             </div>
           </div>

--- a/components/scene-board/SubplotPanel.tsx
+++ b/components/scene-board/SubplotPanel.tsx
@@ -10,6 +10,7 @@ import {
 import { selectPlotSubplots } from '../../features/project/projectSelectors';
 import { projectActions } from '../../features/project/projectSlice';
 import type { StorySection, Subplot } from '../../types';
+import { Icon } from '../ui/Icon';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -75,7 +76,7 @@ const AssignPopover: FC<AssignPopoverProps> = ({ subplot, sections, onClose, t }
                     type="checkbox"
                     checked={checked}
                     onChange={() => toggle(s.id)}
-                    className="accent-[var(--sc-accent-primary,#6366f1)]"
+                    className="accent-[var(--sc-accent)]"
                     aria-label={s.title}
                   />
                   <span className="truncate text-[var(--sc-text-primary)]">{s.title}</span>
@@ -138,7 +139,7 @@ const SubplotRow: FC<SubplotRowProps> = ({
         {/* Color swatch */}
         <button
           type="button"
-          className="w-3 h-3 rounded-full flex-shrink-0 focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-[var(--sc-accent-primary,#6366f1)]"
+          className="w-3 h-3 rounded-full flex-shrink-0 focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:ring-[var(--sc-accent)]"
           style={{ backgroundColor: subplot.color }}
           aria-label={t('sceneboard.subplot.changeColor')}
           onClick={onFilterToggle}
@@ -187,7 +188,7 @@ const SubplotRow: FC<SubplotRowProps> = ({
           aria-label={t('sceneboard.subplot.assignScenes')}
           aria-expanded={showAssign}
         >
-          ⊕
+          <Icon name="plus" size="sm" aria-hidden="true" />
         </button>
 
         {/* Delete button */}
@@ -197,7 +198,7 @@ const SubplotRow: FC<SubplotRowProps> = ({
           className="opacity-0 group-hover:opacity-100 text-[var(--sc-text-muted)] hover:text-[var(--sc-danger-fg)] text-xs px-0.5"
           aria-label={`${t('sceneboard.subplot.delete')} ${subplot.name}`}
         >
-          ×
+          <Icon name="close" size="sm" aria-hidden="true" />
         </button>
       </div>
 
@@ -227,7 +228,7 @@ export const SubplotPanel: FC<SubplotPanelProps> = ({ sections, t }) => {
   const [collapsed, setCollapsed] = useState(false);
   const [adding, setAdding] = useState(false);
   const [newName, setNewName] = useState('');
-  const [newColor, setNewColor] = useState(PRESET_COLORS[0] ?? '#6366f1');
+  const [newColor, setNewColor] = useState(PRESET_COLORS[0]!);
   const colorInputRef = useRef<HTMLInputElement>(null);
 
   const handleAddSubplot = useCallback(() => {
@@ -270,7 +271,7 @@ export const SubplotPanel: FC<SubplotPanelProps> = ({ sections, t }) => {
           aria-label={t('sceneboard.subplot.expandPanel')}
           title={t('sceneboard.subplot.expandPanel')}
         >
-          ▶
+          <Icon name="chevron-right" size="sm" aria-hidden="true" />
         </button>
         {subplots.map((sp) => (
           <div
@@ -300,7 +301,7 @@ export const SubplotPanel: FC<SubplotPanelProps> = ({ sections, t }) => {
           className="text-[var(--sc-text-muted)] hover:text-[var(--sc-text-primary)] text-xs"
           aria-label={t('sceneboard.subplot.collapsePanel')}
         >
-          ◀
+          <Icon name="chevron-left" size="sm" aria-hidden="true" />
         </button>
       </div>
 
@@ -337,7 +338,7 @@ export const SubplotPanel: FC<SubplotPanelProps> = ({ sections, t }) => {
                 if (e.key === 'Enter') handleAddSubplot();
                 if (e.key === 'Escape') setAdding(false);
               }}
-              className="w-full text-xs px-2 py-1 bg-[var(--sc-surface-base)] border border-[var(--sc-border-subtle)] rounded text-[var(--sc-text-primary)] outline-none focus-visible:ring-1 focus-visible:ring-[var(--sc-accent-primary,#6366f1)]"
+              className="w-full text-xs px-2 py-1 bg-[var(--sc-surface-base)] border border-[var(--sc-border-subtle)] rounded text-[var(--sc-text-primary)] outline-none focus-visible:ring-1 focus-visible:ring-[var(--sc-accent)]"
               aria-label={t('sceneboard.subplot.editName')}
             />
             {/* Preset color swatches */}
@@ -349,7 +350,7 @@ export const SubplotPanel: FC<SubplotPanelProps> = ({ sections, t }) => {
                   className="w-4 h-4 rounded-full border-2 transition-transform hover:scale-110"
                   style={{
                     backgroundColor: c,
-                    borderColor: newColor === c ? 'white' : 'transparent',
+                    borderColor: newColor === c ? 'var(--sc-surface-inverse)' : 'transparent',
                   }}
                   onClick={() => setNewColor(c)}
                   aria-label={c}
@@ -377,7 +378,7 @@ export const SubplotPanel: FC<SubplotPanelProps> = ({ sections, t }) => {
               <button
                 type="button"
                 onClick={handleAddSubplot}
-                className="flex-1 text-xs py-0.5 rounded bg-[var(--sc-accent-primary,#6366f1)] text-white"
+                className="flex-1 text-xs py-0.5 rounded bg-[var(--sc-accent)] text-[var(--sc-text-on-accent)]"
               >
                 {t('common.add')}
               </button>
@@ -397,7 +398,7 @@ export const SubplotPanel: FC<SubplotPanelProps> = ({ sections, t }) => {
             className="w-full text-xs text-[var(--sc-text-muted)] hover:text-[var(--sc-text-primary)] flex items-center gap-1 px-1 py-0.5 rounded hover:bg-[var(--sc-surface-overlay)] transition-colors"
             aria-label={t('sceneboard.subplot.addSubplot')}
           >
-            <span aria-hidden="true">+</span>
+            <Icon name="plus" size="sm" aria-hidden="true" />
             {t('sceneboard.subplot.addSubplot')}
           </button>
         )}

--- a/components/scene-board/TensionCurvePanel.tsx
+++ b/components/scene-board/TensionCurvePanel.tsx
@@ -7,6 +7,7 @@ import { selectPlotTensionOverrides } from '../../features/project/projectSelect
 import { projectActions } from '../../features/project/projectSlice';
 import { computeTensionCurve } from '../../services/plotBoardService';
 import type { StorySection } from '../../types';
+import { Icon } from '../ui/Icon';
 import { Select } from '../ui/Select';
 
 // ── Beat sheet presets ────────────────────────────────────────────────────────
@@ -17,42 +18,43 @@ interface Beat {
   color: string;
 }
 
+// QNBS-v3: beat colors use the design-system data-viz palette so they adapt to theme/sepia.
 const BEAT_SHEETS: Record<string, Beat[]> = {
   'three-act': [
-    { label: 'Act 1 End', pct: 0.25, color: '#6366f1' },
-    { label: 'Midpoint', pct: 0.5, color: '#a855f7' },
-    { label: 'Act 2 End', pct: 0.75, color: '#6366f1' },
+    { label: 'Act 1 End', pct: 0.25, color: 'var(--sc-data-2)' },
+    { label: 'Midpoint', pct: 0.5, color: 'var(--sc-data-6)' },
+    { label: 'Act 2 End', pct: 0.75, color: 'var(--sc-data-2)' },
   ],
   'save-the-cat': [
-    { label: 'Opening Image', pct: 0.01, color: '#8b5cf6' },
-    { label: 'Theme Stated', pct: 0.05, color: '#8b5cf6' },
-    { label: 'Set-Up', pct: 0.1, color: '#8b5cf6' },
-    { label: 'Catalyst', pct: 0.12, color: '#ec4899' },
-    { label: 'Debate', pct: 0.2, color: '#8b5cf6' },
-    { label: 'Break into 2', pct: 0.25, color: '#6366f1' },
-    { label: 'B Story', pct: 0.3, color: '#8b5cf6' },
-    { label: 'Fun & Games', pct: 0.4, color: '#8b5cf6' },
-    { label: 'Midpoint', pct: 0.5, color: '#a855f7' },
-    { label: 'Bad Guys Close In', pct: 0.6, color: '#ef4444' },
-    { label: 'All Is Lost', pct: 0.75, color: '#ef4444' },
-    { label: 'Dark Night of Soul', pct: 0.8, color: '#ef4444' },
-    { label: 'Break into 3', pct: 0.85, color: '#6366f1' },
-    { label: 'Finale', pct: 0.9, color: '#10b981' },
-    { label: 'Final Image', pct: 0.99, color: '#10b981' },
+    { label: 'Opening Image', pct: 0.01, color: 'var(--sc-data-6)' },
+    { label: 'Theme Stated', pct: 0.05, color: 'var(--sc-data-6)' },
+    { label: 'Set-Up', pct: 0.1, color: 'var(--sc-data-6)' },
+    { label: 'Catalyst', pct: 0.12, color: 'var(--sc-data-5)' },
+    { label: 'Debate', pct: 0.2, color: 'var(--sc-data-6)' },
+    { label: 'Break into 2', pct: 0.25, color: 'var(--sc-data-2)' },
+    { label: 'B Story', pct: 0.3, color: 'var(--sc-data-6)' },
+    { label: 'Fun & Games', pct: 0.4, color: 'var(--sc-data-6)' },
+    { label: 'Midpoint', pct: 0.5, color: 'var(--sc-data-6)' },
+    { label: 'Bad Guys Close In', pct: 0.6, color: 'var(--sc-data-1)' },
+    { label: 'All Is Lost', pct: 0.75, color: 'var(--sc-data-1)' },
+    { label: 'Dark Night of Soul', pct: 0.8, color: 'var(--sc-data-1)' },
+    { label: 'Break into 3', pct: 0.85, color: 'var(--sc-data-2)' },
+    { label: 'Finale', pct: 0.9, color: 'var(--sc-data-3)' },
+    { label: 'Final Image', pct: 0.99, color: 'var(--sc-data-3)' },
   ],
   "hero's-journey": [
-    { label: 'Ordinary World', pct: 0.04, color: '#6366f1' },
-    { label: 'Call to Adventure', pct: 0.12, color: '#f59e0b' },
-    { label: 'Refusal', pct: 0.18, color: '#ef4444' },
-    { label: 'Mentor', pct: 0.25, color: '#10b981' },
-    { label: 'Crossing Threshold', pct: 0.33, color: '#6366f1' },
-    { label: 'Tests & Allies', pct: 0.42, color: '#8b5cf6' },
-    { label: 'Approach', pct: 0.5, color: '#a855f7' },
-    { label: 'Ordeal', pct: 0.62, color: '#ef4444' },
-    { label: 'Reward', pct: 0.7, color: '#10b981' },
-    { label: 'Road Back', pct: 0.8, color: '#6366f1' },
-    { label: 'Resurrection', pct: 0.9, color: '#a855f7' },
-    { label: 'Return', pct: 0.97, color: '#10b981' },
+    { label: 'Ordinary World', pct: 0.04, color: 'var(--sc-data-2)' },
+    { label: 'Call to Adventure', pct: 0.12, color: 'var(--sc-data-4)' },
+    { label: 'Refusal', pct: 0.18, color: 'var(--sc-data-1)' },
+    { label: 'Mentor', pct: 0.25, color: 'var(--sc-data-3)' },
+    { label: 'Crossing Threshold', pct: 0.33, color: 'var(--sc-data-2)' },
+    { label: 'Tests & Allies', pct: 0.42, color: 'var(--sc-data-6)' },
+    { label: 'Approach', pct: 0.5, color: 'var(--sc-data-6)' },
+    { label: 'Ordeal', pct: 0.62, color: 'var(--sc-data-1)' },
+    { label: 'Reward', pct: 0.7, color: 'var(--sc-data-3)' },
+    { label: 'Road Back', pct: 0.8, color: 'var(--sc-data-2)' },
+    { label: 'Resurrection', pct: 0.9, color: 'var(--sc-data-6)' },
+    { label: 'Return', pct: 0.97, color: 'var(--sc-data-3)' },
   ],
 };
 
@@ -141,7 +143,7 @@ const TensionDot: FC<TensionDotProps> = ({
       cx={cx}
       cy={cy}
       r={5}
-      fill={isOverridden ? 'var(--sc-accent-primary,#6366f1)' : 'var(--sc-text-muted,#9ca3af)'}
+      fill={isOverridden ? 'var(--sc-accent)' : 'var(--sc-text-muted)'}
       stroke="var(--sc-surface-raised)"
       strokeWidth={2}
       style={{ cursor: 'ns-resize', touchAction: 'none' }}
@@ -209,7 +211,12 @@ export const TensionCurvePanel: FC<TensionCurvePanelProps> = ({ sections, t }) =
         aria-controls="tension-curve-panel"
       >
         <span>{t('sceneboard.tension.title')}</span>
-        <span aria-hidden="true">{collapsed ? '▲' : '▼'}</span>
+        <Icon
+          name={collapsed ? 'chevron-up' : 'chevron-down'}
+          size="sm"
+          className="text-[var(--sc-text-muted)]"
+          aria-hidden="true"
+        />
       </button>
 
       {!collapsed && (
@@ -222,7 +229,7 @@ export const TensionCurvePanel: FC<TensionCurvePanelProps> = ({ sections, t }) =
                 type="checkbox"
                 checked={showBeats}
                 onChange={(e) => setShowBeats(e.target.checked)}
-                className="accent-[var(--sc-accent-primary,#6366f1)]"
+                className="accent-[var(--sc-accent)]"
               />
               {t('sceneboard.tension.showBeatSheet')}
             </label>
@@ -270,7 +277,7 @@ export const TensionCurvePanel: FC<TensionCurvePanelProps> = ({ sections, t }) =
                   y={yForScore(v) + 4}
                   textAnchor="end"
                   fontSize={9}
-                  fill="var(--sc-text-muted,#9ca3af)"
+                  fill="var(--sc-text-muted)"
                 >
                   {v}
                 </text>
@@ -321,7 +328,7 @@ export const TensionCurvePanel: FC<TensionCurvePanelProps> = ({ sections, t }) =
               <polyline
                 points={pointsToPolyline(autoPoints)}
                 fill="none"
-                stroke="var(--sc-text-muted,#9ca3af)"
+                stroke="var(--sc-text-muted)"
                 strokeWidth={1.5}
                 strokeDasharray="4,3"
                 opacity={0.5}
@@ -331,7 +338,7 @@ export const TensionCurvePanel: FC<TensionCurvePanelProps> = ({ sections, t }) =
               <polyline
                 points={pointsToPolyline(overriddenPoints)}
                 fill="none"
-                stroke="var(--sc-accent-primary,#6366f1)"
+                stroke="var(--sc-accent)"
                 strokeWidth={2}
                 opacity={0.9}
               />
@@ -358,7 +365,7 @@ export const TensionCurvePanel: FC<TensionCurvePanelProps> = ({ sections, t }) =
                       y={cy - 8}
                       textAnchor="middle"
                       fontSize={8}
-                      fill="var(--sc-text-muted,#9ca3af)"
+                      fill="var(--sc-text-muted)"
                       pointerEvents="none"
                     >
                       {p.score.toFixed(0)}
@@ -369,7 +376,7 @@ export const TensionCurvePanel: FC<TensionCurvePanelProps> = ({ sections, t }) =
                       y={PADDING_T + CHART_H + 18}
                       textAnchor="middle"
                       fontSize={8}
-                      fill="var(--sc-text-muted,#9ca3af)"
+                      fill="var(--sc-text-muted)"
                       pointerEvents="none"
                     >
                       {label}

--- a/components/settings/AiProviderCard.tsx
+++ b/components/settings/AiProviderCard.tsx
@@ -14,6 +14,7 @@ import { storageService } from '../../services/storageService';
 import type { AdvancedAiSettings, AIProvider, LocalBackendPreset } from '../../types';
 import { Button } from '../ui/Button';
 import { Card, CardContent, CardHeader } from '../ui/Card';
+import { Icon } from '../ui/Icon';
 import { Input } from '../ui/Input';
 import { Select } from '../ui/Select';
 import { Spinner } from '../ui/Spinner';
@@ -160,7 +161,7 @@ export const AiProviderCard: FC<AiProviderCardProps> = ({
                 onProviderChange(p.id);
                 setTestStatus('idle');
               }}
-              className={`px-3 py-2 rounded-lg text-sm font-medium border transition-colors ${provider === p.id ? 'bg-[var(--sc-accent)] border-[var(--sc-accent)] text-white' : 'border-[var(--sc-border-subtle)] text-[var(--sc-text-secondary)] hover:border-[var(--border-interactive)]'}`}
+              className={`px-3 py-2 rounded-lg text-sm font-medium border transition-colors ${provider === p.id ? 'bg-[var(--sc-accent)] border-[var(--sc-accent)] text-[var(--sc-text-on-accent)]' : 'border-[var(--sc-border-subtle)] text-[var(--sc-text-secondary)] hover:border-[var(--border-interactive)]'}`}
             >
               {p.label}
             </button>
@@ -268,8 +269,11 @@ export const AiProviderCard: FC<AiProviderCardProps> = ({
         {provider === 'ollama' && (
           <div className="space-y-3">
             {!isDesktop && (
-              <div className="p-3 rounded-lg bg-amber-500/10 border border-amber-500/30 text-sm text-amber-400">
-                <p className="font-semibold mb-1">⚠️ {t('settings.ai.corsRestriction')}</p>
+              <div className="p-3 rounded-lg bg-[var(--sc-warning-bg)] border border-[var(--sc-warning-border)] text-sm text-[var(--sc-warning-fg)]">
+                <p className="font-semibold mb-1 flex items-center gap-1">
+                  <Icon name="warning" size="sm" aria-hidden="true" />
+                  {t('settings.ai.corsRestriction')}
+                </p>
                 <p>{t('settings.ai.ollamaBrowserNote')}</p>
               </div>
             )}
@@ -366,7 +370,7 @@ export const AiProviderCard: FC<AiProviderCardProps> = ({
                       type="button"
                       key={m}
                       onClick={() => onModelSelect?.(`ollama/${m}`)}
-                      className="px-2 py-1 text-xs rounded-full bg-[var(--sc-surface-overlay)] text-[var(--sc-text-secondary)] hover:bg-[var(--sc-accent)] hover:text-white transition-colors"
+                      className="px-2 py-1 text-xs rounded-full bg-[var(--sc-surface-overlay)] text-[var(--sc-text-secondary)] hover:bg-[var(--sc-accent)] hover:text-[var(--sc-text-on-accent)] transition-colors"
                     >
                       {m}
                     </button>
@@ -495,8 +499,11 @@ export const AiProviderCard: FC<AiProviderCardProps> = ({
         )}
 
         {provider === 'anthropic' && (
-          <div className="p-3 rounded-lg bg-amber-500/10 border border-amber-500/30 text-sm text-amber-400">
-            <p className="font-semibold mb-1">⚠️ {t('settings.ai.corsRestriction')}</p>
+          <div className="p-3 rounded-lg bg-[var(--sc-warning-bg)] border border-[var(--sc-warning-border)] text-sm text-[var(--sc-warning-fg)]">
+            <p className="font-semibold mb-1 flex items-center gap-1">
+              <Icon name="warning" size="sm" aria-hidden="true" />
+              {t('settings.ai.corsRestriction')}
+            </p>
             <p>{t('settings.ai.anthropicCorsNote')}</p>
           </div>
         )}
@@ -511,12 +518,16 @@ export const AiProviderCard: FC<AiProviderCardProps> = ({
               )}
             </Button>
             {testStatus === 'ok' && (
-              <span className="text-sm text-[var(--sc-success-fg)]">
-                ✓ {t('settings.ai.connectionSuccess')}
+              <span className="text-sm text-[var(--sc-success-fg)] flex items-center gap-1">
+                <Icon name="success" size="sm" aria-hidden="true" />
+                {t('settings.ai.connectionSuccess')}
               </span>
             )}
             {testStatus === 'error' && (
-              <span className="text-sm text-[var(--sc-danger-fg)]">✗ {testError}</span>
+              <span className="text-sm text-[var(--sc-danger-fg)] flex items-center gap-1">
+                <Icon name="error" size="sm" aria-hidden="true" />
+                {testError}
+              </span>
             )}
           </div>
         )}

--- a/components/settings/AiSections.tsx
+++ b/components/settings/AiSections.tsx
@@ -504,7 +504,7 @@ export const AdvancedAiSection: FC = () => {
                 <button
                   type="button"
                   onClick={applyCustomModel}
-                  className="px-3 py-2 rounded-md text-sm font-medium bg-[var(--sc-accent)] text-white hover:opacity-90 transition-opacity"
+                  className="px-3 py-2 rounded-md text-sm font-medium bg-[var(--sc-accent)] text-[var(--sc-text-on-accent)] hover:opacity-90 transition-opacity"
                 >
                   {t('settings.ai.save')}
                 </button>
@@ -518,7 +518,7 @@ export const AdvancedAiSection: FC = () => {
                   type="button"
                   onClick={() => void handleWebllmDownload()}
                   disabled={webllmProgress !== null}
-                  className="px-3 py-2 rounded-md text-sm font-medium bg-[var(--sc-accent)] text-white hover:opacity-90 transition-opacity disabled:opacity-50"
+                  className="px-3 py-2 rounded-md text-sm font-medium bg-[var(--sc-accent)] text-[var(--sc-text-on-accent)] hover:opacity-90 transition-opacity disabled:opacity-50"
                   aria-label={t('settings.ai.webllm.downloading')}
                 >
                   {webllmProgress !== null

--- a/components/settings/CollaborationSection.tsx
+++ b/components/settings/CollaborationSection.tsx
@@ -20,7 +20,7 @@ export const CollaborationSection: FC = () => {
           <div
             role="alert"
             aria-live="polite"
-            className="p-3 rounded-sc-md bg-[var(--sc-warning-bg)] border border-amber-500/30 text-sm text-[var(--sc-warning-fg)] space-y-1"
+            className="p-3 rounded-sc-md bg-[var(--sc-warning-bg)] border border-[var(--sc-warning-border)] text-sm text-[var(--sc-warning-fg)] space-y-1"
           >
             <p className="font-semibold">{t('collab.securityWarning')}</p>
             <p>{t('collab.securityWarningDetail')}</p>

--- a/components/settings/OpenRouterSection.tsx
+++ b/components/settings/OpenRouterSection.tsx
@@ -203,7 +203,7 @@ export const OpenRouterSection: FC = () => {
             >
               <span
                 aria-hidden="true"
-                className={`pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow-lg ring-0 transition-transform duration-200 ${
+                className={`pointer-events-none inline-block h-5 w-5 rounded-full bg-[var(--sc-surface-inverse)] shadow-lg ring-0 transition-transform duration-200 ${
                   enabled ? 'translate-x-5' : 'translate-x-0'
                 }`}
               />

--- a/components/settings/ProjectAiPresetSection.tsx
+++ b/components/settings/ProjectAiPresetSection.tsx
@@ -189,7 +189,7 @@ export const ProjectAiPresetSection: FC = () => {
               >
                 {t('settings.projectAi.temperature')}
                 {preset?.temperature !== undefined && (
-                  <span className="ml-2 font-mono text-xs text-gray-500">
+                  <span className="ml-2 font-mono text-xs text-[var(--sc-text-muted)]">
                     {preset.temperature.toFixed(2)}
                   </span>
                 )}
@@ -204,7 +204,7 @@ export const ProjectAiPresetSection: FC = () => {
                 onChange={(e) => patch({ temperature: Number.parseFloat(e.target.value) })}
                 className="w-full accent-[var(--sc-accent)]"
               />
-              <div className="flex justify-between text-xs text-gray-400">
+              <div className="flex justify-between text-xs text-[var(--sc-text-muted)]">
                 <span>0 — precise</span>
                 <span>2 — creative</span>
               </div>
@@ -263,7 +263,7 @@ export const ProjectAiPresetSection: FC = () => {
 
             {/* LoRA section — preparatory, only for local inference providers */}
             {showLoraFields && (
-              <div className="space-y-4 rounded-sc-md border border-dashed border-amber-500/40 bg-[var(--sc-warning-bg)] p-4">
+              <div className="space-y-4 rounded-sc-md border border-dashed border-[var(--sc-warning-border)] bg-[var(--sc-warning-bg)] p-4">
                 <p className="text-xs font-semibold uppercase tracking-wider text-[var(--sc-warning-fg)]">
                   {t('settings.projectAi.loraSection')}
                 </p>
@@ -291,7 +291,7 @@ export const ProjectAiPresetSection: FC = () => {
                     className="block text-sm font-medium text-[var(--sc-text-primary)]"
                   >
                     {t('settings.projectAi.loraScale')}
-                    <span className="ml-2 font-mono text-xs text-gray-500">
+                    <span className="ml-2 font-mono text-xs text-[var(--sc-text-muted)]">
                       {(preset?.loraScale ?? 1.0).toFixed(2)}
                     </span>
                   </label>
@@ -303,7 +303,7 @@ export const ProjectAiPresetSection: FC = () => {
                     step="0.05"
                     value={preset?.loraScale ?? 1.0}
                     onChange={(e) => patch({ loraScale: Number.parseFloat(e.target.value) })}
-                    className="w-full accent-amber-500"
+                    className="w-full accent-[var(--sc-warning-fg)]"
                   />
                   <p className="text-xs text-[var(--sc-text-muted)]">
                     {t('settings.projectAi.loraScaleHint')}

--- a/components/settings/ShortcutsSection.tsx
+++ b/components/settings/ShortcutsSection.tsx
@@ -124,7 +124,7 @@ export const ShortcutsSection: FC = () => {
           {conflicts.length > 0 ? (
             <div
               role="alert"
-              className="rounded-sc-md border border-amber-500/40 bg-[var(--sc-warning-bg)] px-3 py-2 text-sm text-[var(--sc-warning-fg)]"
+              className="rounded-sc-md border border-[var(--sc-warning-border)] bg-[var(--sc-warning-bg)] px-3 py-2 text-sm text-[var(--sc-warning-fg)]"
             >
               {t('settings.shortcuts.conflictWarning')}
               <ul className="list-disc ml-5 mt-1">
@@ -146,7 +146,7 @@ export const ShortcutsSection: FC = () => {
                   key={def.action}
                   className={`flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 rounded-lg border px-3 py-3 ${
                     hasConflict
-                      ? 'border-amber-500/50 bg-amber-500/5'
+                      ? 'border-[var(--sc-warning-border)] bg-[var(--sc-warning-bg)]'
                       : 'border-[var(--sc-border-subtle)] bg-[var(--glass-bg)]'
                   }`}
                 >
@@ -160,7 +160,9 @@ export const ShortcutsSection: FC = () => {
                     type="button"
                     variant={isRecording ? 'secondary' : 'ghost'}
                     size="sm"
-                    className={isRecording ? 'ring-2 ring-indigo-500 animate-pulse' : ''}
+                    className={
+                      isRecording ? 'ring-2 ring-[var(--sc-ring-focus)] animate-pulse' : ''
+                    }
                     onClick={() => setRecordingAction(isRecording ? null : def.action)}
                   >
                     {isRecording

--- a/components/settings/VoiceSettingsSection.tsx
+++ b/components/settings/VoiceSettingsSection.tsx
@@ -369,7 +369,7 @@ export const VoiceSettingsSection: FC = () => {
                     setDownloadModelType('stt');
                     setDownloadModalOpen(true);
                   }}
-                  className="rounded-md bg-[var(--sc-accent)] px-3 py-1.5 text-sm font-medium text-white hover:bg-[var(--sc-accent-hover)] focus-visible:ring-2 focus-visible:ring-[var(--sc-border-focus)] focus-visible:outline-none"
+                  className="rounded-md bg-[var(--sc-accent)] px-3 py-1.5 text-sm font-medium text-[var(--sc-text-on-accent)] hover:bg-[var(--sc-accent-hover)] focus-visible:ring-2 focus-visible:ring-[var(--sc-border-focus)] focus-visible:outline-none"
                 >
                   {t('settings.voice.downloadSttModel')}
                 </button>

--- a/components/ui/AddNewCard.tsx
+++ b/components/ui/AddNewCard.tsx
@@ -29,7 +29,7 @@ export const AddNewCard: React.FC<AddNewCardProps> = ({
     default:
       'bg-[var(--sc-surface-overlay)] text-[var(--sc-text-secondary)] group-hover:scale-110 group-hover:bg-[var(--sc-surface-raised)] group-hover:text-[var(--sc-text-primary)] group-hover:shadow-md',
     primary:
-      'bg-[var(--sc-accent)]/10 text-[var(--sc-accent)] group-hover:scale-110 group-hover:bg-[var(--sc-accent)] group-hover:text-white shadow-sm group-hover:shadow-[0_0_15px_var(--sc-accent)]',
+      'bg-[var(--sc-accent)]/10 text-[var(--sc-accent)] group-hover:scale-110 group-hover:bg-[var(--sc-accent)] group-hover:text-[var(--sc-text-on-accent)] shadow-sm group-hover:shadow-[0_0_15px_var(--sc-accent)]',
   };
 
   const titleClasses = 'text-lg font-bold text-[var(--sc-text-primary)] mb-2 tracking-tight';
@@ -61,7 +61,7 @@ export const AddNewCard: React.FC<AddNewCardProps> = ({
       <p className={descriptionClasses[variant]}>{description}</p>
 
       {/* Subtle highlight overlay */}
-      <div className="absolute inset-0 bg-white/0 group-hover:bg-[var(--glass-bg)] transition-colors duration-sc-normal pointer-events-none" />
+      <div className="absolute inset-0 bg-[var(--sc-surface-base)]/0 group-hover:bg-[var(--glass-bg)] transition-colors duration-sc-normal pointer-events-none" />
     </button>
   );
 };

--- a/components/ui/Card.tsx
+++ b/components/ui/Card.tsx
@@ -21,22 +21,22 @@ export const Card: React.FC<CardProps> = ({
         relative group rounded-sc-xl
         bg-[var(--sc-surface-raised)]/60 backdrop-blur-3xl
         border border-[var(--glass-border)]
-        shadow-[0_8px_30px_rgb(0,0,0,0.04)]
+        shadow-[var(--sc-shadow-lg)]
         transition-all duration-sc-normal ease-out
-        ${isInteractive ? 'hover:-translate-y-1 hover:shadow-[0_20px_40px_rgba(0,0,0,0.1)] hover:bg-[var(--sc-surface-raised)]/80 cursor-pointer active:scale-[0.99]' : ''} 
+        ${isInteractive ? 'hover:-translate-y-1 hover:shadow-[var(--sc-shadow-xl)] hover:bg-[var(--sc-surface-raised)]/80 cursor-pointer active:scale-[0.99]' : ''} 
         ${className ?? ''}
       `}
       {...props}
     >
       {/* Inner Border Gradient - gives a subtle high-end look */}
       <div className="absolute inset-0 rounded-sc-xl border border-[var(--glass-border)] pointer-events-none" />
-      <div className="absolute inset-0 rounded-sc-xl border border-transparent group-hover:border-indigo-500/20 transition-colors duration-500 pointer-events-none" />
+      <div className="absolute inset-0 rounded-sc-xl border border-transparent group-hover:border-[var(--sc-accent)]/20 transition-colors duration-500 pointer-events-none" />
 
       {/* Specular Highlight - Simulates light hitting the top edge of glass */}
       <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-[var(--glass-highlight)] to-transparent opacity-50 pointer-events-none" />
 
       {/* Spotlight Effect */}
-      <div className="absolute inset-0 bg-gradient-to-r from-indigo-500/0 via-indigo-500/5 to-indigo-500/0 opacity-0 group-hover:opacity-100 transition-opacity duration-700 blur-lg pointer-events-none" />
+      <div className="absolute inset-0 bg-gradient-to-r from-[var(--sc-accent)]/0 via-[var(--sc-accent)]/5 to-[var(--sc-accent)]/0 opacity-0 group-hover:opacity-100 transition-opacity duration-700 blur-lg pointer-events-none" />
 
       <div className="relative z-10 h-full flex flex-col">{children}</div>
     </Component>
@@ -60,7 +60,7 @@ interface CardHeaderProps {
 export const CardHeader: React.FC<CardHeaderProps> = ({ children, className }) => {
   return (
     <div
-      className={`p-6 border-b border-[var(--sc-border-subtle)]/50 bg-white/[0.02] ${className ?? ''}`}
+      className={`p-6 border-b border-[var(--sc-border-subtle)]/50 bg-[var(--sc-surface-raised)]/[0.02] ${className ?? ''}`}
     >
       {children}
     </div>

--- a/components/ui/Checkbox.tsx
+++ b/components/ui/Checkbox.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Icon } from './Icon';
 
 interface CheckboxProps extends React.InputHTMLAttributes<HTMLInputElement> {
   label?: string;
@@ -25,19 +26,12 @@ export const Checkbox = React.memo(
             `}
             {...props}
           />
-          <svg
-            aria-hidden="true"
-            className="pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-3.5 h-3.5 text-white opacity-0 peer-checked:opacity-100 transition-opacity duration-sc-fast"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="3"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <polyline points="20 6 9 17 4 12"></polyline>
-          </svg>
+          <Icon
+            name="check"
+            size="sm"
+            className="pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-[var(--sc-text-on-accent)] opacity-0 peer-checked:opacity-100 transition-opacity duration-sc-fast"
+            aria-hidden
+          />
         </div>
         {label && (
           <label

--- a/components/ui/Drawer.tsx
+++ b/components/ui/Drawer.tsx
@@ -1,6 +1,7 @@
 import type React from 'react';
 import { useEffect, useRef } from 'react';
 import { useTranslation } from '../../hooks/useTranslation';
+import { Icon } from './Icon';
 
 interface DrawerProps {
   isOpen: boolean;
@@ -128,17 +129,7 @@ export const Drawer: React.FC<DrawerProps> = ({
             className="text-[var(--sc-text-muted)] hover:text-[var(--sc-text-primary)] transition-colors"
             aria-label={t('common.close')}
           >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={1.5}
-              stroke="currentColor"
-              className="w-6 h-6"
-              aria-hidden="true"
-            >
-              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-            </svg>
+            <Icon name="close" size="md" aria-hidden />
           </button>
         </div>
         <div className="flex-grow overflow-y-auto">{children}</div>

--- a/components/ui/DuckDbMigrationBanner.tsx
+++ b/components/ui/DuckDbMigrationBanner.tsx
@@ -5,6 +5,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useAppSelector } from '../../app/hooks';
 import { useTranslation } from '../../hooks/useTranslation';
+import { Icon } from './Icon';
 import { Progress } from './Progress';
 
 export function DuckDbMigrationBanner() {
@@ -97,13 +98,11 @@ export function DuckDbMigrationBanner() {
               hover:bg-[var(--sc-surface-raised)]
               hover:text-[var(--sc-text-primary)]
               focus-visible:ring-2
-              focus-visible:ring-[var(--sc-border-focus)]
+              focus-visible:ring-[var(--sc-ring-focus)]
               focus-visible:outline-none
             "
           >
-            <svg aria-hidden="true" width="14" height="14" viewBox="0 0 14 14" fill="currentColor">
-              <path d="M2.293 2.293a1 1 0 0 1 1.414 0L7 5.586l3.293-3.293a1 1 0 1 1 1.414 1.414L8.414 7l3.293 3.293a1 1 0 0 1-1.414 1.414L7 8.414l-3.293 3.293a1 1 0 0 1-1.414-1.414L5.586 7 2.293 3.707a1 1 0 0 1 0-1.414z" />
-            </svg>
+            <Icon name="close" size="sm" className="h-3.5 w-3.5" aria-hidden />
           </button>
         )}
       </div>
@@ -117,7 +116,7 @@ function IndeterminateProgress() {
   return (
     <div className="h-2 w-full overflow-hidden rounded-full bg-[var(--sc-surface-overlay)]">
       <div
-        className="h-full w-1/2 rounded-full bg-gradient-to-r from-indigo-500 to-purple-500"
+        className="h-full w-1/2 rounded-full bg-[var(--sc-accent)]"
         style={{ animation: 'duckdb-indeterminate 1.5s ease-in-out infinite' }}
       />
       <style>{`

--- a/components/ui/ErrorBoundary.tsx
+++ b/components/ui/ErrorBoundary.tsx
@@ -1,10 +1,10 @@
 import type { ErrorInfo, ReactNode } from 'react';
 import { Component } from 'react';
-import { ICONS } from '../../constants';
 import { useTranslation } from '../../hooks/useTranslation';
 import { logger } from '../../services/logger';
 import { Button } from './Button';
 import { Card, CardContent, CardHeader } from './Card';
+import { Icon } from './Icon';
 
 interface ErrorBoundaryProps {
   children?: ReactNode;
@@ -23,16 +23,7 @@ function ErrorFallback({ onReset }: { onReset?: () => void }) {
       <Card className="max-w-lg w-full text-center animate-in">
         <CardHeader className="flex items-center justify-center space-x-2">
           <div className="text-[var(--sc-danger-fg)]">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={1.5}
-              stroke="currentColor"
-              className="w-8 h-8"
-            >
-              {ICONS.LIGHTNING_BOLT}
-            </svg>
+            <Icon name="error" size="xl" aria-hidden />
           </div>
           <h1 className="text-xl font-bold text-[var(--sc-danger-fg)]">
             {t('error.boundary.title')}

--- a/components/ui/Icon.tsx
+++ b/components/ui/Icon.tsx
@@ -26,7 +26,11 @@ export type IconName =
   | 'photo'
   | 'characters'
   | 'world'
-  | 'grip-horizontal';
+  | 'grip-horizontal'
+  | 'send'
+  | 'shield'
+  | 'panel-dock'
+  | 'panel-float';
 
 interface IconProps extends React.SVGAttributes<SVGSVGElement> {
   name: IconName;
@@ -177,6 +181,17 @@ const PATHS: Record<IconName, React.ReactNode> = {
   ),
   'grip-horizontal': (
     <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 9h16.5m-16.5 6.25h16.5" />
+  ),
+  send: <path d="M3.4 20.4L21 12 3.4 3.6 3.4 10l12.6 2-12.6 2z" />,
+  shield: <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />,
+  'panel-dock': (
+    <>
+      <rect x="3" y="3" width="18" height="18" rx="2" />
+      <path d="M15 3v18" />
+    </>
+  ),
+  'panel-float': (
+    <path d="M8 3H5a2 2 0 00-2 2v14a2 2 0 002 2h3M16 3h3a2 2 0 012 2v14a2 2 0 01-2 2h-3" />
   ),
 };
 

--- a/components/ui/Icon.tsx
+++ b/components/ui/Icon.tsx
@@ -30,7 +30,9 @@ export type IconName =
   | 'send'
   | 'shield'
   | 'panel-dock'
-  | 'panel-float';
+  | 'panel-float'
+  | 'download'
+  | 'refresh';
 
 interface IconProps extends React.SVGAttributes<SVGSVGElement> {
   name: IconName;
@@ -192,6 +194,20 @@ const PATHS: Record<IconName, React.ReactNode> = {
   ),
   'panel-float': (
     <path d="M8 3H5a2 2 0 00-2 2v14a2 2 0 002 2h3M16 3h3a2 2 0 012 2v14a2 2 0 01-2 2h-3" />
+  ),
+  download: (
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
+    />
+  ),
+  refresh: (
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99"
+    />
   ),
 };
 

--- a/components/ui/LanguageSelector.tsx
+++ b/components/ui/LanguageSelector.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useSta
 import { createPortal } from 'react-dom';
 import type { Language } from '../../contexts/I18nContext';
 import { useTranslation } from '../../hooks/useTranslation';
+import { Icon } from './Icon';
 
 // QNBS-v3: Language metadata with flag emoji and native names for premium UX
 const LANGUAGE_METADATA: Record<
@@ -204,17 +205,7 @@ export const LanguageSelector = React.memo(
                     </span>
                   )}
                   {isActive && (
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      strokeWidth={2}
-                      stroke="currentColor"
-                      className="w-4 h-4 text-[var(--sc-accent)]"
-                      aria-hidden="true"
-                    >
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                    </svg>
+                    <Icon name="check" size="sm" className="text-[var(--sc-accent)]" aria-hidden />
                   )}
                 </button>
               </li>
@@ -245,17 +236,12 @@ export const LanguageSelector = React.memo(
                 β
               </sup>
             )}
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={2}
-              stroke="currentColor"
-              className={`w-3 h-3 text-[var(--sc-text-muted)] transition-transform duration-sc-fast ${isOpen ? 'rotate-180' : ''}`}
-              aria-hidden="true"
-            >
-              <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-            </svg>
+            <Icon
+              name="chevron-down"
+              size="sm"
+              className={`text-[var(--sc-text-muted)] transition-transform duration-sc-fast ${isOpen ? 'rotate-180' : ''}`}
+              aria-hidden
+            />
           </button>
 
           {isOpen && createPortal(dropdown, document.body)}
@@ -285,17 +271,12 @@ export const LanguageSelector = React.memo(
               </span>
             )}
           </div>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth={2}
-            stroke="currentColor"
-            className={`w-4 h-4 text-[var(--sc-text-muted)] transition-transform duration-sc-fast ${isOpen ? 'rotate-180' : ''}`}
-            aria-hidden="true"
-          >
-            <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-          </svg>
+          <Icon
+            name="chevron-down"
+            size="sm"
+            className={`text-[var(--sc-text-muted)] transition-transform duration-sc-fast ${isOpen ? 'rotate-180' : ''}`}
+            aria-hidden
+          />
         </button>
 
         {isOpen && createPortal(dropdown, document.body)}

--- a/components/ui/PWAComponents.tsx
+++ b/components/ui/PWAComponents.tsx
@@ -176,7 +176,7 @@ export const PWAUpdateToast: FC = () => {
               px-3 py-1.5
               rounded-lg
               bg-[var(--sc-accent)] hover:bg-[var(--sc-accent-hover)]
-              text-white text-xs font-semibold
+              text-[var(--sc-text-on-accent)] text-xs font-semibold
               transition-all active:scale-95
             "
           >

--- a/components/ui/PWAComponents.tsx
+++ b/components/ui/PWAComponents.tsx
@@ -9,6 +9,7 @@
 import type { FC } from 'react';
 import { usePWA } from '../../hooks/usePWA';
 import { useTranslation } from '../../hooks/useTranslation';
+import { Icon } from './Icon';
 
 // ────────────────────────────────────────────────────────────
 // OfflineIndicator
@@ -29,8 +30,8 @@ export const OfflineIndicator: FC = () => {
         flex flex-col gap-1
         px-4 py-3
         rounded-xl
-        bg-amber-500/20 border border-amber-500/40
-        text-amber-400 text-xs font-medium
+        bg-[var(--sc-warning-bg)] border border-[var(--sc-warning-border)]
+        text-[var(--sc-warning-fg)] text-xs font-medium
         shadow-lg backdrop-blur-sm
         animate-fade-in-up
         max-w-xs
@@ -38,12 +39,12 @@ export const OfflineIndicator: FC = () => {
     >
       <div className="flex items-center gap-2">
         <span className="relative flex h-2 w-2">
-          <span className="absolute inline-flex h-full w-full rounded-full bg-amber-400 opacity-75 animate-ping" />
-          <span className="relative inline-flex rounded-full h-2 w-2 bg-amber-500" />
+          <span className="absolute inline-flex h-full w-full rounded-full bg-[var(--sc-warning-fg)] opacity-75 animate-ping" />
+          <span className="relative inline-flex rounded-full h-2 w-2 bg-[var(--sc-warning-fg)]" />
         </span>
         <span className="font-semibold">{t('pwa.offlineBadgeTitle')}</span>
       </div>
-      <p className="text-amber-300/80 leading-tight">
+      <p className="text-[var(--sc-warning-fg)]/80 leading-tight">
         {t('pwa.offlineAiUnavailable')}
         <br />
         {t('pwa.offlineWorksContinue')}
@@ -79,20 +80,8 @@ export const PWAInstallBanner: FC = () => {
       "
       >
         {/* Icon */}
-        <div className="shrink-0 w-10 h-10 rounded-xl bg-gradient-to-br from-indigo-500 to-purple-600 flex items-center justify-center shadow-md">
-          <svg
-            className="w-5 h-5 text-white"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth={2}
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
-            />
-          </svg>
+        <div className="shrink-0 w-10 h-10 rounded-xl bg-[var(--sc-accent)] flex items-center justify-center shadow-md">
+          <Icon name="download" size="md" className="text-[var(--sc-text-on-accent)]" aria-hidden />
         </div>
 
         {/* Text */}
@@ -118,15 +107,7 @@ export const PWAInstallBanner: FC = () => {
             transition-colors
           "
           >
-            <svg
-              className="w-4 h-4"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={2}
-              stroke="currentColor"
-            >
-              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-            </svg>
+            <Icon name="close" size="sm" aria-hidden />
           </button>
           <button
             type="button"
@@ -135,10 +116,10 @@ export const PWAInstallBanner: FC = () => {
             px-3 py-1.5
             rounded-xl
             bg-[var(--sc-accent)] hover:bg-[var(--sc-accent-hover)]
-            text-white text-xs font-semibold
-            shadow-[0_4px_14px_0_rgba(99,102,241,0.35)]
-            hover:shadow-[0_6px_20px_rgba(99,102,241,0.25)]
-            border border-indigo-500/20
+            text-[var(--sc-text-on-accent)] text-xs font-semibold
+            shadow-[0_4px_14px_0_var(--sc-accent-subtle)]
+            hover:shadow-[0_6px_20px_var(--sc-accent-subtle)]
+            border border-[var(--sc-accent)]/20
             transition-all active:scale-95
           "
           >
@@ -176,19 +157,7 @@ export const PWAUpdateToast: FC = () => {
     >
       {/* Update icon */}
       <div className="shrink-0 w-9 h-9 rounded-xl bg-[var(--sc-accent)]/20 border border-[var(--sc-accent)]/30 flex items-center justify-center mt-0.5">
-        <svg
-          className="w-4 h-4 text-[var(--sc-accent)]"
-          fill="none"
-          viewBox="0 0 24 24"
-          strokeWidth={2}
-          stroke="currentColor"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99"
-          />
-        </svg>
+        <Icon name="refresh" size="sm" className="text-[var(--sc-accent)]" aria-hidden />
       </div>
 
       {/* Content */}
@@ -242,15 +211,7 @@ export const PWAUpdateToast: FC = () => {
           transition-colors
         "
       >
-        <svg
-          className="w-3.5 h-3.5"
-          fill="none"
-          viewBox="0 0 24 24"
-          strokeWidth={2.5}
-          stroke="currentColor"
-        >
-          <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-        </svg>
+        <Icon name="close" size="sm" aria-hidden />
       </button>
     </div>
   );

--- a/components/ui/Textarea.tsx
+++ b/components/ui/Textarea.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef } from 'react';
 import { useAppSelector } from '../../app/hooks';
 import { useSpeechRecognition } from '../../hooks/useSpeechRecognition';
 import { useTranslation } from '../../hooks/useTranslation';
+import { Icon } from './Icon';
 
 export const Textarea = React.memo(
   React.forwardRef<HTMLTextAreaElement, React.TextareaHTMLAttributes<HTMLTextAreaElement>>(
@@ -77,30 +78,9 @@ export const Textarea = React.memo(
             aria-label={isListening ? t('common.dictation.stop') : t('common.dictation.start')}
           >
             {isListening ? (
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-                className="w-5 h-5"
-              >
-                <path d="M8.25 4.5a3.75 3.75 0 117.5 0v8.25a3.75 3.75 0 11-7.5 0V4.5z" />
-                <path d="M6 10.5a.75.75 0 01.75.75v1.5a5.25 5.25 0 1010.5 0v-1.5a.75.75 0 011.5 0v1.5a6.751 6.751 0 01-6 6.709v2.291h3a.75.75 0 010 1.5h-7.5a.75.75 0 010-1.5h3v-2.291a6.751 6.751 0 01-6-6.709v-1.5A.75.75 0 016 10.5z" />
-              </svg>
+              <Icon name="microphone-solid" size="md" aria-hidden />
             ) : (
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                strokeWidth={1.5}
-                stroke="currentColor"
-                className="w-5 h-5"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M12 18.75a6 6 0 006-6v-1.5m-6 7.5a6 6 0 01-6-6v-1.5m6 7.5v3.75m-3.75 0h7.5M12 15.75a3 3 0 01-3-3V4.5a3 3 0 116 0v8.25a3 3 0 01-3 3z"
-                />
-              </svg>
+              <Icon name="microphone" size="md" aria-hidden />
             )}
           </button>
         </div>

--- a/components/voice/VoiceControlPanel.tsx
+++ b/components/voice/VoiceControlPanel.tsx
@@ -6,6 +6,7 @@
 import React, { useCallback } from 'react';
 import { useTranslation } from '../../hooks/useTranslation';
 import { useVoice } from '../../hooks/useVoice';
+import { Icon } from '../ui/Icon';
 
 export const VoiceControlPanel = React.memo(function VoiceControlPanel() {
   const { t } = useTranslation();
@@ -60,27 +61,14 @@ export const VoiceControlPanel = React.memo(function VoiceControlPanel() {
         onClick={handleToggleListening}
         className={`flex items-center justify-center w-10 h-10 rounded-full transition-colors ${
           isActive
-            ? 'bg-[var(--sc-accent)] text-white'
+            ? 'bg-[var(--sc-accent)] text-[var(--sc-text-on-accent)]'
             : 'bg-[var(--sc-surface-subtle)] text-[var(--sc-text-primary)] hover:bg-[var(--sc-surface-hover)]'
         }`}
         aria-pressed={isActive}
         aria-label={isListening ? t('voice.stopListening') : t('voice.startListening')}
         title={isListening ? t('voice.stopListening') : t('voice.startListening')}
       >
-        <svg
-          width="20"
-          height="20"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          aria-hidden="true"
-        >
-          <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z" />
-          <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
-          <line x1="12" y1="19" x2="12" y2="23" />
-          <line x1="8" y1="23" x2="16" y2="23" />
-        </svg>
+        <Icon name="microphone" size="md" aria-hidden="true" />
       </button>
 
       <button
@@ -88,7 +76,7 @@ export const VoiceControlPanel = React.memo(function VoiceControlPanel() {
         onClick={handleToggleDictation}
         className={`flex items-center justify-center w-10 h-10 rounded-full transition-colors ${
           dictationActive
-            ? 'bg-[var(--sc-success)] text-white'
+            ? 'bg-[var(--sc-success-fg)] text-[var(--sc-text-on-accent)]'
             : 'bg-[var(--sc-surface-subtle)] text-[var(--sc-text-primary)] hover:bg-[var(--sc-surface-hover)]'
         }`}
         aria-pressed={dictationActive}

--- a/components/writing/ToolsPanel.tsx
+++ b/components/writing/ToolsPanel.tsx
@@ -8,6 +8,7 @@ import { writerActions } from '../../features/writer/writerSlice';
 import { useTranslation } from '../../hooks/useTranslation';
 import { Button } from '../ui/Button';
 import { Card, CardContent, CardHeader } from '../ui/Card';
+import { Icon } from '../ui/Icon';
 import { Select } from '../ui/Select';
 import { ToolInputs } from './ToolInputs';
 
@@ -91,7 +92,7 @@ const ToolsPanel: FC = React.memo(() => {
                 onClick={() => dispatch(writerActions.setActiveTool(tool.id as WriterTool))}
                 className={`flex flex-col items-center justify-center p-2 rounded-lg transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--sc-ring-focus)] active:scale-95 touch-manipulation min-h-[44px] min-w-[44px] ${
                   activeTool === tool.id
-                    ? 'bg-[var(--sc-accent)] text-white shadow-md transform scale-[1.02]'
+                    ? 'bg-[var(--sc-accent)] text-[var(--sc-text-on-accent)] shadow-md transform scale-[1.02]'
                     : 'bg-[var(--glass-bg)] text-[var(--sc-text-secondary)] hover:bg-[var(--glass-bg-hover)] border border-[var(--sc-border-subtle)]'
                 }`}
                 aria-label={tool.title}
@@ -195,16 +196,7 @@ const ToolsPanel: FC = React.memo(() => {
                 disabled={isGenerateDisabled()}
                 className="w-full py-3 text-base shadow-lg"
               >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  strokeWidth={1.5}
-                  stroke="currentColor"
-                  className="w-5 h-5 mr-2"
-                >
-                  {ICONS.SPARKLES}
-                </svg>
+                <Icon name="sparkles" size="md" className="me-2" aria-hidden="true" />
                 {t('common.generate')}
               </Button>
             )}

--- a/index.css
+++ b/index.css
@@ -447,7 +447,7 @@ body.storycraft-screen-reader {
   line-height: 1.65;
 }
 
-/* Tailwind v4 theme bridge → utilities bg-sc-* / text-sc-* */
+/* Tailwind v4 theme bridge → utilities bg-sc-* / text-sc-* / icon-sc-* */
 @theme inline {
   --color-sc-bg: var(--sc-bg);
   --color-sc-fg: var(--sc-fg);
@@ -476,6 +476,32 @@ body.storycraft-screen-reader {
   --ease-sc-emphasized: var(--sc-ease-emphasized);
   --duration-sc-fast: var(--sc-duration-fast);
   --duration-sc-normal: var(--sc-duration-normal);
+  /* QNBS-v3: fluid type scale used by text-sc-* utilities */
+  --font-size-sc-xs: var(--text-sc-xs);
+  --font-size-sc-xs--line-height: 1.5;
+  --font-size-sc-sm: var(--text-sc-sm);
+  --font-size-sc-sm--line-height: 1.5;
+  --font-size-sc-base: var(--text-sc-base);
+  --font-size-sc-base--line-height: 1.6;
+  --font-size-sc-lg: var(--text-sc-lg);
+  --font-size-sc-lg--line-height: 1.5;
+  --font-size-sc-xl: var(--text-sc-xl);
+  --font-size-sc-xl--line-height: 1.4;
+  --font-size-sc-2xl: var(--text-sc-2xl);
+  --font-size-sc-2xl--line-height: 1.3;
+  --font-size-sc-3xl: var(--text-sc-3xl);
+  --font-size-sc-3xl--line-height: 1.25;
+  --font-size-sc-4xl: var(--text-sc-4xl);
+  --font-size-sc-4xl--line-height: 1.1;
+  /* QNBS-v3: icon size utilities used by the centralized <Icon /> component */
+  --width-icon-sc-sm: var(--icon-sc-sm);
+  --width-icon-sc-md: var(--icon-sc-md);
+  --width-icon-sc-lg: var(--icon-sc-lg);
+  --width-icon-sc-xl: var(--icon-sc-xl);
+  --height-icon-sc-sm: var(--icon-sc-sm);
+  --height-icon-sc-md: var(--icon-sc-md);
+  --height-icon-sc-lg: var(--icon-sc-lg);
+  --height-icon-sc-xl: var(--icon-sc-xl);
 }
 
 /* ── Base ──────────────────────────────────────────────── */

--- a/scripts/audit-tokens.mjs
+++ b/scripts/audit-tokens.mjs
@@ -39,6 +39,8 @@ const EXCLUDED_FILES = new Set([
   path.join(root, '.storybook', 'preview.tsx'),
   // The icon component is the central registry for SVG paths.
   path.join(root, 'components', 'ui', 'Icon.tsx'),
+  // SectionIcon renders icons from the APP_SECTIONS central config, not duplicated inline SVGs.
+  path.join(root, 'components', 'ui', 'SectionIcon.tsx'),
 ]);
 
 const SOURCE_EXTENSIONS = new Set(['.tsx', '.jsx', '.ts', '.js']);

--- a/tests/unit/TensionCurvePanel.test.tsx
+++ b/tests/unit/TensionCurvePanel.test.tsx
@@ -231,7 +231,7 @@ describe('TensionCurvePanel', () => {
     );
     fireEvent.click(screen.getByRole('button', { name: /sceneboard.tension.title/i }));
     // Overridden dot should use accent fill
-    const accentDot = container.querySelector('circle[fill*="--sc-accent-primary"]');
+    const accentDot = container.querySelector('circle[fill*="--sc-accent"]');
     expect(accentDot).toBeTruthy();
   });
 });

--- a/tests/unit/mind-map/MindMapNodeEditor.test.tsx
+++ b/tests/unit/mind-map/MindMapNodeEditor.test.tsx
@@ -21,7 +21,7 @@ const mockNode = {
   textNotes: 'Some notes',
   type: 'free' as const,
   shape: 'rectangle' as const,
-  color: '#6366f1',
+  color: 'var(--sc-data-2)',
   linkedEntityType: undefined,
 };
 
@@ -107,7 +107,7 @@ describe('MindMapNodeEditor', () => {
     mockNode.textNotes = 'Some notes';
     mockNode.type = 'free';
     mockNode.shape = 'rectangle';
-    mockNode.color = '#6366f1';
+    mockNode.color = 'var(--sc-data-2)';
     mockNode.linkedEntityType = undefined;
   });
 
@@ -164,7 +164,7 @@ describe('MindMapNodeEditor', () => {
   it('marks current color swatch as pressed', () => {
     render(<MindMapNodeEditor />);
     const colorGroup = screen.getByRole('group', { name: 'mindmap.nodeColor' });
-    const accentSwatch = within(colorGroup).getByLabelText('#6366f1');
+    const accentSwatch = within(colorGroup).getByLabelText('var(--sc-data-2)');
     expect(accentSwatch).toHaveAttribute('aria-pressed', 'true');
   });
 

--- a/tests/unit/proForge/components/PipelineReviewPanel.test.tsx
+++ b/tests/unit/proForge/components/PipelineReviewPanel.test.tsx
@@ -453,8 +453,8 @@ describe('PipelineReviewPanel', () => {
         currentStageReviewItems: [makeItem('item-1', 'pending', { severity: 'critical' })],
       });
       render(<PipelineReviewPanel />);
-      // 🔴 appears in the item card and (for critical items) the summary card; both are aria-hidden.
-      expect(screen.getAllByText('🔴').length).toBeGreaterThanOrEqual(1);
+      // QNBS-v3: critical items render the design-system error icon (decorative; testid is stable).
+      expect(screen.getByTestId('severity-icon-critical')).toBeInTheDocument();
     });
 
     it('shows sectionTitle when present', () => {


### PR DESCRIPTION
## Summary

Completes the Phase 3 view-by-view design-system cleanup across all views.

## Changes

- Migrated all remaining `--sc-accent-primary` and hard-coded Tailwind colors to `--sc-*` design tokens
- Replaced `text-white` on accent/primary/error/success backgrounds with `text-[var(--sc-text-on-accent)]`
- Replaced inline SVGs and Unicode symbols with the centralized `<Icon />` component where appropriate
- Updated affected unit tests to match new tokenized colors
- Views covered: Copilot, Scene Board, Mind Map, Character Graph, Objects, Collaboration, Settings, ProForge, Manuscript, Character/World Views, Dashboard, Welcome Portal, Template View, Version Control, Command Palette, Voice, Progress Tracker, Outline Generator

## Quality gates

- [x] pnpm run lint
- [x] pnpm run typecheck
- [x] pnpm run i18n:check
- [x] Unit tests (affected suites)

Part of the UI/UX, Design System & Experience Perfection program.