### PR TITLE
test(coverage): Batch 1 — RadioGroup, Tabs, factoryResetService

### DIFF
--- a/tests/unit/RadioGroup.test.tsx
+++ b/tests/unit/RadioGroup.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * Tests for components/ui/RadioGroup.tsx
+ * QNBS-v3: Accessible radiogroup atom — render, checked state, onChange, disabled, description, orientation.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { RadioGroup } from '../../components/ui/RadioGroup';
+
+const OPTIONS = [
+  { value: 'a', label: 'Option A', description: 'First choice' },
+  { value: 'b', label: 'Option B' },
+  { value: 'c', label: 'Option C', disabled: true },
+];
+
+describe('RadioGroup', () => {
+  it('renders a radiogroup with each option label and description', () => {
+    render(<RadioGroup options={OPTIONS} value="a" onChange={vi.fn()} name="choices" />);
+    expect(screen.getByRole('radiogroup', { name: 'choices' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Option A' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Option B' })).toBeInTheDocument();
+    expect(screen.getByText('First choice')).toBeInTheDocument();
+  });
+
+  it('marks the option matching value as checked', () => {
+    render(<RadioGroup options={OPTIONS} value="b" onChange={vi.fn()} name="choices" />);
+    expect(screen.getByRole('radio', { name: 'Option B' })).toBeChecked();
+    expect(screen.getByRole('radio', { name: 'Option A' })).not.toBeChecked();
+  });
+
+  it('calls onChange with the option value when an option is selected', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<RadioGroup options={OPTIONS} value="a" onChange={onChange} name="choices" />);
+    await user.click(screen.getByRole('radio', { name: 'Option B' }));
+    expect(onChange).toHaveBeenCalledWith('b');
+  });
+
+  it('renders disabled options as disabled and does not fire onChange', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<RadioGroup options={OPTIONS} value="a" onChange={onChange} name="choices" />);
+    const disabled = screen.getByRole('radio', { name: 'Option C' });
+    expect(disabled).toBeDisabled();
+    await user.click(disabled);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('applies horizontal orientation layout', () => {
+    render(
+      <RadioGroup
+        options={OPTIONS}
+        value="a"
+        onChange={vi.fn()}
+        name="choices"
+        orientation="horizontal"
+      />,
+    );
+    expect(screen.getByRole('radiogroup').className).toContain('flex-row');
+  });
+
+  it('defaults to vertical orientation', () => {
+    render(<RadioGroup options={OPTIONS} value="a" onChange={vi.fn()} name="choices" />);
+    expect(screen.getByRole('radiogroup').className).toContain('flex-col');
+  });
+});

--- a/tests/unit/Tabs.test.tsx
+++ b/tests/unit/Tabs.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * Tests for components/ui/Tabs.tsx (Tabs + TabPanel)
+ * QNBS-v3: WAI-ARIA tabs atom — tablist/tab roles, aria-selected, onChange, disabled, variants, panel visibility.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { TabPanel, Tabs } from '../../components/ui/Tabs';
+
+const TABS = [
+  { id: 'one', label: 'One' },
+  { id: 'two', label: 'Two' },
+  { id: 'three', label: 'Three', disabled: true },
+];
+
+describe('Tabs', () => {
+  it('renders a tablist with a tab per entry', () => {
+    render(<Tabs tabs={TABS} activeTab="one" onChange={vi.fn()} ariaLabel="Sections" />);
+    expect(screen.getByRole('tablist', { name: 'Sections' })).toBeInTheDocument();
+    expect(screen.getAllByRole('tab')).toHaveLength(3);
+  });
+
+  it('marks the active tab with aria-selected', () => {
+    render(<Tabs tabs={TABS} activeTab="two" onChange={vi.fn()} ariaLabel="Sections" />);
+    expect(screen.getByRole('tab', { name: 'Two' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tab', { name: 'One' })).toHaveAttribute('aria-selected', 'false');
+  });
+
+  it('calls onChange with the tab id when a tab is clicked', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Tabs tabs={TABS} activeTab="one" onChange={onChange} ariaLabel="Sections" />);
+    await user.click(screen.getByRole('tab', { name: 'Two' }));
+    expect(onChange).toHaveBeenCalledWith('two');
+  });
+
+  it('does not fire onChange for a disabled tab', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Tabs tabs={TABS} activeTab="one" onChange={onChange} ariaLabel="Sections" />);
+    const disabled = screen.getByRole('tab', { name: 'Three' });
+    expect(disabled).toBeDisabled();
+    await user.click(disabled);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('applies the pills variant class on tabs', () => {
+    render(<Tabs tabs={TABS} activeTab="one" onChange={vi.fn()} ariaLabel="S" variant="pills" />);
+    expect(screen.getByRole('tab', { name: 'One' }).className).toContain('rounded-full');
+  });
+
+  it('marks the active tab with data-state=active and inactive otherwise', () => {
+    render(
+      <Tabs tabs={TABS} activeTab="one" onChange={vi.fn()} ariaLabel="S" variant="underline" />,
+    );
+    expect(screen.getByRole('tab', { name: 'One' })).toHaveAttribute('data-state', 'active');
+    expect(screen.getByRole('tab', { name: 'Two' })).toHaveAttribute('data-state', 'inactive');
+  });
+});
+
+describe('TabPanel', () => {
+  it('shows content and exposes the tabpanel role when active', () => {
+    render(
+      <TabPanel tabId="one" activeTab="one" groupId="grp">
+        Panel One
+      </TabPanel>,
+    );
+    const panel = screen.getByRole('tabpanel');
+    expect(panel).not.toHaveAttribute('hidden');
+    expect(panel).toHaveTextContent('Panel One');
+    expect(panel).toHaveAttribute('aria-labelledby', 'grp-one');
+    expect(panel).toHaveAttribute('id', 'grp-one-panel');
+  });
+
+  it('hides the panel when not the active tab', () => {
+    render(
+      <TabPanel tabId="one" activeTab="two" groupId="grp">
+        Panel One
+      </TabPanel>,
+    );
+    // A hidden tabpanel is removed from the a11y tree, so query the section directly.
+    const section = screen.getByText('Panel One').closest('section');
+    expect(section).toHaveAttribute('hidden');
+    expect(section?.className).toContain('hidden');
+  });
+});

--- a/tests/unit/factoryResetService.test.ts
+++ b/tests/unit/factoryResetService.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests for services/factoryResetService.ts
+ * QNBS-v3: wipeAllAppData — clears IDB + web storage + SW caches, then reloads. Covers the
+ * native indexedDB.databases() path, the known-list fallback, and the Cache API branch.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { wipeAllAppData } from '../../services/factoryResetService';
+import { logger } from '../../services/logger';
+
+vi.mock('../../services/logger', () => ({
+  logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+}));
+
+function createDb(name: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(name, 1);
+    req.onupgradeneeded = () => req.result.createObjectStore('s');
+    req.onsuccess = () => {
+      req.result.close();
+      resolve();
+    };
+    req.onerror = () => reject(req.error);
+  });
+}
+
+let reloadMock: ReturnType<typeof vi.fn>;
+let originalLocation: Location;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  reloadMock = vi.fn();
+  originalLocation = window.location;
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: { ...originalLocation, reload: reloadMock },
+  });
+  localStorage.clear();
+  sessionStorage.clear();
+});
+
+afterEach(() => {
+  Object.defineProperty(window, 'location', { configurable: true, value: originalLocation });
+  vi.unstubAllGlobals();
+});
+
+describe('wipeAllAppData', () => {
+  it('clears web storage, deletes IDB databases, and reloads', async () => {
+    await createDb('storycraft-data-db');
+    localStorage.setItem('foo', 'bar');
+    sessionStorage.setItem('baz', 'qux');
+    const delSpy = vi.spyOn(indexedDB, 'deleteDatabase');
+
+    await wipeAllAppData();
+
+    expect(localStorage.getItem('foo')).toBeNull();
+    expect(sessionStorage.getItem('baz')).toBeNull();
+    expect(delSpy).toHaveBeenCalledWith('storycraft-data-db');
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    delSpy.mockRestore();
+  });
+
+  it('falls back to the known database list when indexedDB.databases() fails', async () => {
+    const dbSpy = vi.spyOn(indexedDB, 'databases').mockRejectedValueOnce(new Error('not allowed'));
+    const delSpy = vi.spyOn(indexedDB, 'deleteDatabase');
+
+    await wipeAllAppData();
+
+    // Fallback deletes every name in the known list (e.g. the logs DB).
+    expect(delSpy).toHaveBeenCalledWith('storycraft-logs-db');
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+    dbSpy.mockRestore();
+    delSpy.mockRestore();
+  });
+
+  it('clears service-worker caches when the Cache API is available', async () => {
+    const del = vi.fn().mockResolvedValue(true);
+    vi.stubGlobal('caches', {
+      keys: vi.fn().mockResolvedValue(['static-v1', 'dynamic-v1']),
+      delete: del,
+    });
+
+    await wipeAllAppData();
+
+    expect(del).toHaveBeenCalledWith('static-v1');
+    expect(del).toHaveBeenCalledWith('dynamic-v1');
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/factoryResetService.test.ts
+++ b/tests/unit/factoryResetService.test.ts
@@ -23,6 +23,20 @@ function createDb(name: string): Promise<void> {
   });
 }
 
+// QNBS-v3: production has a real 300ms settle delay before reload — drive it with fake timers so
+// the suite stays deterministic and fast (CodeAnt #132). runAllTimersAsync loops until every
+// pending timer is drained, which also flushes the fake-indexeddb deletion scheduling.
+async function runWipe(): Promise<void> {
+  vi.useFakeTimers();
+  try {
+    const done = wipeAllAppData();
+    await vi.runAllTimersAsync();
+    await done;
+  } finally {
+    vi.useRealTimers();
+  }
+}
+
 let reloadMock: ReturnType<typeof vi.fn>;
 let originalLocation: Location;
 
@@ -50,7 +64,7 @@ describe('wipeAllAppData', () => {
     sessionStorage.setItem('baz', 'qux');
     const delSpy = vi.spyOn(indexedDB, 'deleteDatabase');
 
-    await wipeAllAppData();
+    await runWipe();
 
     expect(localStorage.getItem('foo')).toBeNull();
     expect(sessionStorage.getItem('baz')).toBeNull();
@@ -64,7 +78,7 @@ describe('wipeAllAppData', () => {
     const dbSpy = vi.spyOn(indexedDB, 'databases').mockRejectedValueOnce(new Error('not allowed'));
     const delSpy = vi.spyOn(indexedDB, 'deleteDatabase');
 
-    await wipeAllAppData();
+    await runWipe();
 
     // Fallback deletes every name in the known list (e.g. the logs DB).
     expect(delSpy).toHaveBeenCalledWith('storycraft-logs-db');
@@ -80,7 +94,7 @@ describe('wipeAllAppData', () => {
       delete: del,
     });
 
-    await wipeAllAppData();
+    await runWipe();
 
     expect(del).toHaveBeenCalledWith('static-v1');
     expect(del).toHaveBeenCalledWith('dynamic-v1');


### PR DESCRIPTION
## **User description**
## Summary
Coverage lift **Batch 1** (plan #3 / TODO v1.23 P1). Three previously-**0%** modules now have deterministic unit tests. Targets were chosen from the **CI V8 per-file branch report** harvested from the #131 Quality Gate (baseline **B63.15**), not from a heuristic.

| Module | Was | Tests | Covers |
|--------|-----|-------|--------|
| `components/ui/RadioGroup.tsx` | 0% | 6 | radiogroup role + aria-label, checked state, `onChange(value)`, disabled option, vertical/horizontal orientation |
| `components/ui/Tabs.tsx` (Tabs + TabPanel) | 0% | 8 | tablist/tab roles, `aria-selected`, `onChange(id)`, disabled tab, pills/underline variant, `data-state`, panel show/hide + aria wiring |
| `services/factoryResetService.ts` | 0% | 3 | `wipeAllAppData`: web-storage clear, IDB deletion, **`databases()`-fails fallback branch**, **Cache API branch**, reload |

Also closes the long-standing "add unit tests for RadioGroup/Tabs" item from the v1.20 UI-Modernization list.

## Notes
- Pure test-only PR — no source changes.
- jsdom + `fake-indexeddb/auto`; `factoryResetService` uses real timers (300 ms settle) and a scoped `window.location.reload` stub.
- Storybook stories for the two atoms are intentionally **out of scope** here (kept to coverage) — tracked as a follow-up.

## Gates
- lint ✅ (1328 files) · typecheck ✅ · 17 new tests ✅ (full coverage delta verified by CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Add unit coverage for RadioGroup, Tabs, and app reset behavior

### What Changed
- Added tests for RadioGroup to verify labels and descriptions show up, the selected option is marked correctly, disabled options cannot be chosen, and vertical/horizontal layouts render as expected
- Added tests for Tabs and TabPanel to verify tab roles, active state, disabled tabs, tab switching, variant styling, and panel show/hide behavior
- Added tests for app reset behavior to verify local storage, session storage, browser databases, and service-worker caches are cleared before the page reloads, including the fallback path when database listing fails

### Impact
`✅ Fewer regressions in radio and tab controls`
`✅ Safer app reset flow`
`✅ Clearer coverage for storage and cache cleanup`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
