### PR TITLE
ci(lighthouse): fix recurring "Execution context destroyed" flake

### DIFF
--- a/.lighthouserc.cjs
+++ b/.lighthouserc.cjs
@@ -6,6 +6,12 @@ module.exports = {
       url: ['http://127.0.0.1:4173/StoryCraft-Studio/'],
       numberOfRuns: 3,
       settings: {
+        // QNBS-v3: harden Chrome launch on CI runners. `--disable-dev-shm-usage` is the fix for the
+        // intermittent "Protocol error (Runtime.evaluate): Execution context was destroyed" flake —
+        // GitHub runners have a tiny /dev/shm, so the renderer crashes mid-collect and aborts the
+        // whole `lhci autorun` (numberOfRuns can't recover a crashed run). --no-sandbox/--disable-gpu
+        // are standard headless-CI hygiene.
+        chromeFlags: '--no-sandbox --disable-dev-shm-usage --disable-gpu',
         emulatedFormFactor: 'mobile',
         throttlingMethod: 'simulate',
         screenEmulation: {

--- a/.lighthouserc.desktop.cjs
+++ b/.lighthouserc.desktop.cjs
@@ -9,6 +9,9 @@ module.exports = {
       url: ['http://127.0.0.1:4173/StoryCraft-Studio/'],
       numberOfRuns: 2,
       settings: {
+        // QNBS-v3: same /dev/shm crash hardening as the mobile config (.lighthouserc.cjs) —
+        // --disable-dev-shm-usage prevents the "Execution context was destroyed" CI flake.
+        chromeFlags: '--no-sandbox --disable-dev-shm-usage --disable-gpu',
         preset: 'desktop',
         throttlingMethod: 'simulate',
       },


### PR DESCRIPTION
## **User description**
## Problem
The Lighthouse CI job fails intermittently (most recently on #132, a test-only PR that cannot affect Lighthouse) with:

```
Runtime error encountered: Protocol error (Runtime.evaluate): Execution context was destroyed.
Run #1...failed! → Lighthouse failed with exit code 1
```

## Root cause
GitHub-hosted runners ship a very small `/dev/shm` (~64 MB). Chrome's renderer uses shared memory; under that constraint it intermittently crashes mid-collect, which surfaces as "Execution context was destroyed". A crashed collect run aborts the entire `lhci autorun` — `numberOfRuns: 3` does **not** help, because it averages *successful* runs and cannot recover a crashed one. This is the same flake noted as "just re-run" on #130; this PR fixes it at the source.

## Fix
Add `chromeFlags: '--no-sandbox --disable-dev-shm-usage --disable-gpu'` to `collect.settings` in **both** Lighthouse configs:
- `.lighthouserc.cjs` (mobile — the run that fails the gate)
- `.lighthouserc.desktop.cjs` (desktop — `continue-on-error`, hardened for consistency)

`--disable-dev-shm-usage` makes Chrome write shared memory to `/tmp` instead of `/dev/shm`, eliminating the crash. `--no-sandbox` / `--disable-gpu` are standard headless-CI hygiene.

Config key verified against the official LHCI docs (`collect.settings.chromeFlags`).

## Verification
- Both configs `require()` cleanly and expose the new `chromeFlags`.
- lint ✅. The real proof is CI stability over subsequent runs (no more "context destroyed").

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Stop Lighthouse CI from failing with "Execution context was destroyed"**

### What Changed
- Added Chrome launch settings that prevent the Lighthouse job from crashing on GitHub-hosted runners
- Applied the same protection to both the mobile and desktop Lighthouse checks so they behave consistently
- Kept the existing retry count, but made the run less likely to abort before it can finish

### Impact
`✅ Fewer Lighthouse CI failures`
`✅ More stable mobile and desktop audit runs`
`✅ Less rerunning flaky CI jobs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
