### PR TITLE
test(coverage): Batch 2 — Copilot UI (InsightCard, CopilotComposer, AiModeIndicator)

### DIFF
--- a/tests/unit/copilot/AiModeIndicator.test.tsx
+++ b/tests/unit/copilot/AiModeIndicator.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * Tests for components/copilot/AiModeIndicator.tsx
+ * QNBS-v3: mode chip label/dot logic — plain mode, OpenRouter active (free vs paid), circuit-open
+ * suffix + pulsing dot, and OpenRouter suppression in local mode.
+ */
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AiModeIndicator } from '../../../components/copilot/AiModeIndicator';
+
+// `mock`-prefixed so the hoisted vi.mock factories may reference them.
+let mockState: {
+  settings: { aiMode?: string; openRouter?: { enabled?: boolean; preferredModel?: string } };
+} = { settings: { aiMode: 'hybrid', openRouter: { enabled: false } } };
+const mockIsCircuitOpen = vi.fn(() => false);
+const mockGetApproxRpm = vi.fn(() => 0);
+const mockIsFreeModel = vi.fn((_model: string) => false);
+
+vi.mock('../../../app/hooks', () => ({
+  useAppSelector: (selector: (s: unknown) => unknown) => selector(mockState),
+}));
+vi.mock('../../../hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, unknown>) =>
+      params ? `${key}:${JSON.stringify(params)}` : key,
+  }),
+}));
+vi.mock('../../../services/ai', () => ({
+  isCircuitOpen: () => mockIsCircuitOpen(),
+  getApproxRpm: () => mockGetApproxRpm(),
+  isOpenRouterFreeModel: (m: string) => mockIsFreeModel(m),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsCircuitOpen.mockReturnValue(false);
+  mockGetApproxRpm.mockReturnValue(0);
+  mockIsFreeModel.mockReturnValue(false);
+  mockState = { settings: { aiMode: 'hybrid', openRouter: { enabled: false } } };
+});
+
+describe('AiModeIndicator', () => {
+  it('renders the plain mode label when OpenRouter is disabled', () => {
+    mockState = { settings: { aiMode: 'hybrid', openRouter: { enabled: false } } };
+    render(<AiModeIndicator />);
+    const chip = screen.getByRole('status');
+    expect(chip).toHaveTextContent('settings.aiMode.indicator.hybrid');
+    expect(chip).not.toHaveTextContent('·');
+  });
+
+  it('appends the OpenRouter label when OpenRouter is active (paid model)', () => {
+    mockState = { settings: { aiMode: 'cloud', openRouter: { enabled: true } } };
+    render(<AiModeIndicator />);
+    const chip = screen.getByRole('status');
+    expect(chip).toHaveTextContent('settings.aiMode.indicator.cloud');
+    expect(chip).toHaveTextContent('settings.aiMode.indicator.openRouter');
+  });
+
+  it('shows the free-tier OpenRouter label for a :free model', () => {
+    mockIsFreeModel.mockReturnValue(true);
+    mockState = {
+      settings: { aiMode: 'cloud', openRouter: { enabled: true, preferredModel: 'x/y:free' } },
+    };
+    render(<AiModeIndicator />);
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'settings.aiMode.indicator.openRouterFree',
+    );
+  });
+
+  it('shows the compact circuit-open suffix and a pulsing dot when the breaker is open', () => {
+    mockIsCircuitOpen.mockReturnValue(true);
+    mockState = { settings: { aiMode: 'cloud', openRouter: { enabled: true } } };
+    render(<AiModeIndicator />);
+    const chip = screen.getByRole('status');
+    expect(chip).toHaveTextContent('settings.aiMode.indicator.orShort');
+    expect(chip.querySelector('span[aria-hidden="true"]')?.className).toContain('animate-pulse');
+  });
+
+  it('suppresses OpenRouter status in local mode even when enabled', () => {
+    mockState = { settings: { aiMode: 'local', openRouter: { enabled: true } } };
+    render(<AiModeIndicator />);
+    const chip = screen.getByRole('status');
+    expect(chip).toHaveTextContent('settings.aiMode.indicator.local');
+    expect(chip).not.toHaveTextContent('openRouter');
+  });
+});

--- a/tests/unit/copilot/CopilotComposer.test.tsx
+++ b/tests/unit/copilot/CopilotComposer.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * Tests for components/copilot/CopilotComposer.tsx
+ * QNBS-v3: Enter sends / Shift+Enter newline; send gated on non-empty + not streaming;
+ * consumes a transient-store draft once then clears it.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CopilotComposer } from '../../../components/copilot/CopilotComposer';
+
+// `mock`-prefixed so the hoisted vi.mock factory may reference them.
+let mockDraft: string | null = null;
+const mockSetDraft = vi.fn((m: string | null) => {
+  mockDraft = m;
+});
+
+vi.mock('../../../app/transientUiStore', () => ({
+  useTransientUiStore: (selector: (s: unknown) => unknown) =>
+    selector({ copilotDraftMessage: mockDraft, setCopilotDraftMessage: mockSetDraft }),
+}));
+
+vi.mock('../../../components/ui/Icon', () => ({ Icon: () => null }));
+
+const baseProps = {
+  placeholder: 'Ask the Co-Pilot',
+  sendLabel: 'Send',
+  isStreaming: false,
+  onSend: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDraft = null;
+});
+
+describe('CopilotComposer', () => {
+  it('sends the trimmed value on Enter and clears the input', async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+    render(<CopilotComposer {...baseProps} onSend={onSend} />);
+    const textarea = screen.getByRole('textbox', { name: 'Ask the Co-Pilot' });
+    await user.type(textarea, '  hello world  {Enter}');
+    expect(onSend).toHaveBeenCalledWith('hello world');
+    expect(textarea).toHaveValue('');
+  });
+
+  it('inserts a newline (does not send) on Shift+Enter', async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+    render(<CopilotComposer {...baseProps} onSend={onSend} />);
+    const textarea = screen.getByRole('textbox');
+    await user.type(textarea, 'line one{Shift>}{Enter}{/Shift}line two');
+    expect(onSend).not.toHaveBeenCalled();
+    expect((textarea as HTMLTextAreaElement).value).toContain('\n');
+  });
+
+  it('disables the send button when empty and enables it once text is entered', async () => {
+    const user = userEvent.setup();
+    render(<CopilotComposer {...baseProps} />);
+    const button = screen.getByRole('button', { name: 'Send' });
+    expect(button).toBeDisabled();
+    await user.type(screen.getByRole('textbox'), 'hi');
+    expect(button).toBeEnabled();
+  });
+
+  it('does not send while streaming', async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+    render(<CopilotComposer {...baseProps} isStreaming onSend={onSend} />);
+    const textarea = screen.getByRole('textbox');
+    await user.type(textarea, 'hello{Enter}');
+    expect(onSend).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: 'Send' })).toBeDisabled();
+  });
+
+  it('prefills from a transient-store draft and clears it once consumed', () => {
+    mockDraft = 'drafted question';
+    render(<CopilotComposer {...baseProps} />);
+    expect(screen.getByRole('textbox')).toHaveValue('drafted question');
+    expect(mockSetDraft).toHaveBeenCalledWith(null);
+  });
+});

--- a/tests/unit/copilot/InsightCard.test.tsx
+++ b/tests/unit/copilot/InsightCard.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * Tests for components/copilot/InsightCard.tsx
+ * QNBS-v3: props-only presentational card — title/desc render, severity, Tell-me-more (gated by
+ * heuristicsOnly), Open-view (gated by actionable + onNavigate).
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { InsightCard } from '../../../components/copilot/InsightCard';
+import type { UseGlobalCopilotReturn } from '../../../hooks/useGlobalCopilot';
+import type { HeuristicFinding } from '../../../services/copilot/heuristicEngine';
+
+function makeFinding(overrides: Partial<HeuristicFinding> = {}): HeuristicFinding {
+  return {
+    id: 'f1',
+    ruleId: 'tension-drop',
+    severity: 'warning',
+    titleKey: 'copilot.rule.tension.title',
+    descriptionKey: 'copilot.rule.tension.desc',
+    params: {},
+    targetView: 'manuscript',
+    actionable: true,
+    ...overrides,
+  };
+}
+
+function makeCopilot(heuristicsOnly = false) {
+  return {
+    t: ((key: string) => key) as UseGlobalCopilotReturn['t'],
+    sendMessage: vi.fn(),
+    heuristicsOnly,
+  };
+}
+
+describe('InsightCard', () => {
+  it('renders the localized title and description', () => {
+    render(<InsightCard finding={makeFinding()} copilot={makeCopilot()} />);
+    expect(screen.getByText('copilot.rule.tension.title')).toBeInTheDocument();
+    expect(screen.getByText('copilot.rule.tension.desc')).toBeInTheDocument();
+  });
+
+  it('shows "Tell me more" and calls sendMessage with the finding context', async () => {
+    const user = userEvent.setup();
+    const copilot = makeCopilot(false);
+    render(<InsightCard finding={makeFinding()} copilot={copilot} />);
+    await user.click(screen.getByRole('button', { name: 'copilot.insightTellMore' }));
+    expect(copilot.sendMessage).toHaveBeenCalledTimes(1);
+    expect(copilot.sendMessage).toHaveBeenCalledWith(
+      expect.stringContaining('copilot.rule.tension.title'),
+    );
+  });
+
+  it('hides "Tell me more" in heuristics-only mode', () => {
+    render(<InsightCard finding={makeFinding()} copilot={makeCopilot(true)} />);
+    expect(screen.queryByRole('button', { name: 'copilot.insightTellMore' })).toBeNull();
+  });
+
+  it('shows "Open view" and calls onNavigate with the target view when actionable', async () => {
+    const user = userEvent.setup();
+    const onNavigate = vi.fn();
+    render(
+      <InsightCard
+        finding={makeFinding({ actionable: true, targetView: 'manuscript' })}
+        copilot={makeCopilot()}
+        onNavigate={onNavigate}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: 'copilot.insightOpenView' }));
+    expect(onNavigate).toHaveBeenCalledWith('manuscript');
+  });
+
+  it('hides "Open view" when the finding is not actionable', () => {
+    render(
+      <InsightCard
+        finding={makeFinding({ actionable: false })}
+        copilot={makeCopilot()}
+        onNavigate={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole('button', { name: 'copilot.insightOpenView' })).toBeNull();
+  });
+
+  it('hides "Open view" when no onNavigate handler is provided', () => {
+    render(<InsightCard finding={makeFinding({ actionable: true })} copilot={makeCopilot()} />);
+    expect(screen.queryByRole('button', { name: 'copilot.insightOpenView' })).toBeNull();
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary
Coverage lift **Batch 2** (plan #3). Three previously-**0%** Copilot UI components, targeted from the CI V8 per-file branch report.

| Component | Tests | Covers |
|-----------|-------|--------|
| `components/copilot/InsightCard.tsx` | 6 | title/desc render, "Tell me more" (gated by `heuristicsOnly` → calls `sendMessage`), "Open view" (gated by `actionable` + `onNavigate`) |
| `components/copilot/CopilotComposer.tsx` | 5 | Enter sends / Shift+Enter newline, send disabled when empty or streaming, transient-store draft consume-and-clear |
| `components/copilot/AiModeIndicator.tsx` | 5 | plain mode label, OpenRouter active (free vs paid), circuit-open suffix + pulsing dot, OpenRouter suppression in local mode |

Pure test-only PR. Deterministic — Zustand/redux/i18n/service deps mocked; no real timers.

## Gates
- lint ✅ (1331 files) · typecheck ✅ · 16 tests ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Add coverage for three Copilot UI components**

### What Changed
- Added tests for the AI mode indicator to verify the label shown for local, cloud, and OpenRouter modes, including the free-tier label and the circuit-open warning state.
- Added tests for the composer to confirm Enter sends a trimmed message, Shift+Enter inserts a new line, sending is disabled while empty or streaming, and saved draft text is loaded once then cleared.
- Added tests for the insight card to confirm it shows the title and description, reveals "Tell me more" only when allowed, and shows "Open view" only for actionable findings with a navigation handler.

### Impact
`✅ Fewer Copilot UI regressions`
`✅ Safer message sending behavior`
`✅ Clearer AI mode status labels`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
