### PR TITLE
test(coverage): Batch 3 — CopilotMessageList (markdown + sanitization + apply)

### DIFF
--- a/tests/unit/copilot/CopilotMessageList.test.tsx
+++ b/tests/unit/copilot/CopilotMessageList.test.tsx
@@ -73,6 +73,8 @@ describe('CopilotMessageList', () => {
     expect(html).toContain('<li>item one</li>');
     expect(html).toContain('<pre');
     expect(html).toContain('const x = 1;');
+    // heading '# Title' renders as a semibold paragraph (not plain text)
+    expect(html).toMatch(/font-semibold[^>]*>Title/);
     expect(screen.getByText('Co-Pilot')).toBeInTheDocument();
   });
 
@@ -85,6 +87,9 @@ describe('CopilotMessageList', () => {
     expect(html).not.toContain('<script');
     expect(html).not.toContain('onerror');
     expect(html).not.toContain('<img');
+    // safe surrounding text must survive sanitization (guards against over-stripping)
+    expect(html).toContain('before');
+    expect(html).toContain('after');
   });
 
   it('shows a spinner for a pending assistant message with no content', () => {
@@ -131,20 +136,25 @@ describe('CopilotMessageList', () => {
     expect(screen.queryByRole('button', { name: 'Apply to chapter' })).toBeNull();
   });
 
-  it('only shows the apply button on the LAST assistant message', () => {
+  it('shows one apply button, wired to the LAST assistant message', async () => {
+    const user = userEvent.setup();
+    const onApply = vi.fn();
     render(
       <CopilotMessageList
         {...baseProps}
         hasActiveSection
-        onApply={vi.fn()}
+        onApply={onApply}
         messages={[
           msg('assistant', 'first\n```\nold\n```'),
           msg('assistant', 'second\n```\nnew\n```'),
         ]}
       />,
     );
-    // Exactly one apply button — on the second (last) assistant message.
-    expect(screen.getAllByRole('button', { name: 'Apply to chapter' })).toHaveLength(1);
+    const buttons = screen.getAllByRole('button', { name: 'Apply to chapter' });
+    expect(buttons).toHaveLength(1);
+    // Clicking applies the LAST message's code ("new"), proving placement — not "old".
+    await user.click(buttons[0]!);
+    expect(onApply).toHaveBeenCalledWith('new');
   });
 
   it('disables the apply button and shows the applying label while applying', () => {

--- a/tests/unit/copilot/CopilotMessageList.test.tsx
+++ b/tests/unit/copilot/CopilotMessageList.test.tsx
@@ -5,7 +5,7 @@
  */
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { CopilotMessageList } from '../../../components/copilot/CopilotMessageList';
 import type { CopilotMessage } from '../../../features/copilot/copilotSlice';
 
@@ -13,9 +13,14 @@ vi.mock('../../../components/ui/Spinner', () => ({
   Spinner: () => <div data-testid="copilot-spinner" />,
 }));
 
+// jsdom does not implement scrollIntoView (called in the auto-scroll effect). Stub it, then restore
+// the original in afterAll so this prototype patch can't leak into other suites (CodeAnt #136).
+const originalScrollIntoView = Element.prototype.scrollIntoView;
 beforeAll(() => {
-  // jsdom does not implement scrollIntoView (called in the auto-scroll effect).
   Element.prototype.scrollIntoView = vi.fn();
+});
+afterAll(() => {
+  Element.prototype.scrollIntoView = originalScrollIntoView;
 });
 
 let idCounter = 0;

--- a/tests/unit/copilot/CopilotMessageList.test.tsx
+++ b/tests/unit/copilot/CopilotMessageList.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * Tests for components/copilot/CopilotMessageList.tsx
+ * QNBS-v3: empty state, user plain-text vs assistant markdown, DOMPurify sanitization, pending
+ * spinner, and the "Apply to chapter" button gating + code-block extraction.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CopilotMessageList } from '../../../components/copilot/CopilotMessageList';
+import type { CopilotMessage } from '../../../features/copilot/copilotSlice';
+
+vi.mock('../../../components/ui/Spinner', () => ({
+  Spinner: () => <div data-testid="copilot-spinner" />,
+}));
+
+beforeAll(() => {
+  // jsdom does not implement scrollIntoView (called in the auto-scroll effect).
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+let idCounter = 0;
+function msg(role: 'user' | 'assistant', content: string, pending = false): CopilotMessage {
+  idCounter += 1;
+  return { id: `m${idCounter}`, role, content, createdAt: '2026-01-01T00:00:00Z', pending };
+}
+
+const baseProps = {
+  emptyTitle: 'No messages yet',
+  emptyBody: 'Ask the Co-Pilot anything',
+  youLabel: 'You',
+  assistantLabel: 'Co-Pilot',
+  applyLabel: 'Apply to chapter',
+  applyingLabel: 'Applying…',
+  hasActiveSection: false,
+  applyStatus: 'idle' as const,
+};
+
+function md(container: HTMLElement): string {
+  return container.querySelector('.prose-copilot')?.innerHTML ?? '';
+}
+
+beforeEach(() => {
+  idCounter = 0;
+});
+
+describe('CopilotMessageList', () => {
+  it('renders the empty state when there are no messages', () => {
+    render(<CopilotMessageList {...baseProps} messages={[]} />);
+    expect(screen.getByText('No messages yet')).toBeInTheDocument();
+    expect(screen.getByText('Ask the Co-Pilot anything')).toBeInTheDocument();
+  });
+
+  it('renders a user message as plain text with the You label', () => {
+    render(<CopilotMessageList {...baseProps} messages={[msg('user', 'hello <b>there</b>')]} />);
+    expect(screen.getByText('You')).toBeInTheDocument();
+    // Angle brackets are shown literally, not parsed as HTML.
+    expect(screen.getByText('hello <b>there</b>')).toBeInTheDocument();
+  });
+
+  it('renders assistant markdown (bold, heading, list, inline code, code block) as HTML', () => {
+    const content = '# Title\n**bold** and `code`\n- item one\n```\nconst x = 1;\n```';
+    const { container } = render(
+      <CopilotMessageList {...baseProps} messages={[msg('assistant', content)]} />,
+    );
+    const html = md(container);
+    expect(html).toContain('<strong>bold</strong>');
+    expect(html).toContain('<code');
+    expect(html).toContain('<li>item one</li>');
+    expect(html).toContain('<pre');
+    expect(html).toContain('const x = 1;');
+    expect(screen.getByText('Co-Pilot')).toBeInTheDocument();
+  });
+
+  it('sanitizes dangerous HTML in assistant content (DOMPurify allowlist)', () => {
+    const content = 'before <script>alert(1)</script> <img src=x onerror=alert(2)> after';
+    const { container } = render(
+      <CopilotMessageList {...baseProps} messages={[msg('assistant', content)]} />,
+    );
+    const html = md(container);
+    expect(html).not.toContain('<script');
+    expect(html).not.toContain('onerror');
+    expect(html).not.toContain('<img');
+  });
+
+  it('shows a spinner for a pending assistant message with no content', () => {
+    render(<CopilotMessageList {...baseProps} messages={[msg('assistant', '', true)]} />);
+    expect(screen.getByTestId('copilot-spinner')).toBeInTheDocument();
+  });
+
+  it('shows "Apply to chapter" on the last assistant message with a code block when a section is active', async () => {
+    const user = userEvent.setup();
+    const onApply = vi.fn();
+    render(
+      <CopilotMessageList
+        {...baseProps}
+        hasActiveSection
+        onApply={onApply}
+        messages={[msg('assistant', 'Here:\n```\nrewritten text\n```')]}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: 'Apply to chapter' }));
+    expect(onApply).toHaveBeenCalledWith('rewritten text');
+  });
+
+  it('hides the apply button without an active section', () => {
+    render(
+      <CopilotMessageList
+        {...baseProps}
+        hasActiveSection={false}
+        onApply={vi.fn()}
+        messages={[msg('assistant', '```\ncode\n```')]}
+      />,
+    );
+    expect(screen.queryByRole('button', { name: 'Apply to chapter' })).toBeNull();
+  });
+
+  it('hides the apply button when the assistant message has no code block', () => {
+    render(
+      <CopilotMessageList
+        {...baseProps}
+        hasActiveSection
+        onApply={vi.fn()}
+        messages={[msg('assistant', 'just prose, no fence')]}
+      />,
+    );
+    expect(screen.queryByRole('button', { name: 'Apply to chapter' })).toBeNull();
+  });
+
+  it('only shows the apply button on the LAST assistant message', () => {
+    render(
+      <CopilotMessageList
+        {...baseProps}
+        hasActiveSection
+        onApply={vi.fn()}
+        messages={[
+          msg('assistant', 'first\n```\nold\n```'),
+          msg('assistant', 'second\n```\nnew\n```'),
+        ]}
+      />,
+    );
+    // Exactly one apply button — on the second (last) assistant message.
+    expect(screen.getAllByRole('button', { name: 'Apply to chapter' })).toHaveLength(1);
+  });
+
+  it('disables the apply button and shows the applying label while applying', () => {
+    render(
+      <CopilotMessageList
+        {...baseProps}
+        hasActiveSection
+        applyStatus="applying"
+        onApply={vi.fn()}
+        messages={[msg('assistant', '```\ncode\n```')]}
+      />,
+    );
+    const button = screen.getByRole('button', { name: 'Applying…' });
+    expect(button).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary
Coverage lift **Batch 3** (plan #3). `components/copilot/CopilotMessageList.tsx` (**249 LOC, previously 0%**) — a branch-heavy file (the micro-markdown renderer + DOMPurify sanitization + apply-button logic).

**10 tests covering:**
- Empty state (no messages).
- User message rendered as **plain text** (angle brackets shown literally).
- Assistant **markdown → HTML**: bold, heading, unordered list, inline code, fenced code block.
- **DOMPurify sanitization** — `<script>`, `<img onerror>` stripped (guards the PR #114 hardening).
- **Pending spinner** for a streaming assistant message with no content yet.
- **"Apply to chapter"** gating: shows only on the *last* assistant message **and** with an active section **and** a code block; extracts the fenced block and calls `onApply`; disabled + "Applying…" label while applying.

Pure test-only PR. Deterministic — `scrollIntoView` stubbed, `Spinner` mocked.

## Gates
- lint ✅ · typecheck ✅ · 10 tests ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Add coverage for Copilot message rendering and apply behavior

### What Changed
- Covers the empty state, plain user messages, and assistant messages rendered with markdown formatting
- Verifies unsafe HTML is removed from assistant content while normal text still shows
- Checks the pending spinner, when the “Apply to chapter” button appears, and that it applies the last assistant message’s code block only when a section is active
- Confirms the apply button is disabled and relabeled while an apply action is in progress

### Impact
`✅ Safer Copilot message display`
`✅ Fewer broken apply actions`
`✅ Clearer coverage for chat and apply flow`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
