### PR TITLE
chore(rebrand): phase 1-3 — repository metadata, build/URLs/PWA, Tauri identity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -460,10 +460,10 @@ jobs:
         env:
           CI: true
         run: |
-          # QNBS-v3: The GitHub Pages build has base=/StoryCraft-Studio/. Mirror that structure
+          # QNBS-v3: The GitHub Pages build has base=/WorldScript-Studio/. Mirror that structure
           # so http-server serves assets at the expected paths matching playwright.config baseURL.
-          mkdir -p serve_root/StoryCraft-Studio
-          cp -r dist/. serve_root/StoryCraft-Studio/
+          mkdir -p serve_root/WorldScript-Studio
+          cp -r dist/. serve_root/WorldScript-Studio/
           pnpm exec http-server serve_root -p 3000 -s &
           pnpm exec wait-on http://127.0.0.1:3000 --timeout 30000
           pnpm run test:vrt

--- a/.lighthouserc.cjs
+++ b/.lighthouserc.cjs
@@ -3,7 +3,7 @@ module.exports = {
     collect: {
       startServerCommand: 'pnpm run preview',
       startServerReadyPattern: 'Local',
-      url: ['http://127.0.0.1:4173/StoryCraft-Studio/'],
+      url: ['http://127.0.0.1:4173/WorldScript-Studio/'],
       numberOfRuns: 3,
       settings: {
         // QNBS-v3: harden Chrome launch on CI runners. `--disable-dev-shm-usage` is the fix for the

--- a/.lighthouserc.cjs
+++ b/.lighthouserc.cjs
@@ -1,9 +1,23 @@
+// QNBS-v3: derive the audited URL from the same deploy-base logic the build/preview use
+// (mirror of scripts/resolve-deploy-base.mjs — keep in sync). Hardcoding the GitHub Pages
+// base made LHCI audit a 404 when the preview was built with VITE_BASE=/ or DEPLOY_TARGET=edge.
+function resolveDeployBase() {
+  const viteBase = process.env.VITE_BASE?.trim();
+  if (viteBase) {
+    return viteBase.endsWith('/') ? viteBase : `${viteBase}/`;
+  }
+  if (process.env.DEPLOY_TARGET === 'edge') {
+    return '/';
+  }
+  return '/WorldScript-Studio/';
+}
+
 module.exports = {
   ci: {
     collect: {
       startServerCommand: 'pnpm run preview',
       startServerReadyPattern: 'Local',
-      url: ['http://127.0.0.1:4173/WorldScript-Studio/'],
+      url: [`http://127.0.0.1:4173${resolveDeployBase()}`],
       numberOfRuns: 3,
       settings: {
         // QNBS-v3: harden Chrome launch on CI runners. `--disable-dev-shm-usage` is the fix for the

--- a/.lighthouserc.desktop.cjs
+++ b/.lighthouserc.desktop.cjs
@@ -6,7 +6,7 @@ module.exports = {
     collect: {
       startServerCommand: 'pnpm run preview',
       startServerReadyPattern: 'Local',
-      url: ['http://127.0.0.1:4173/StoryCraft-Studio/'],
+      url: ['http://127.0.0.1:4173/WorldScript-Studio/'],
       numberOfRuns: 2,
       settings: {
         // QNBS-v3: same /dev/shm crash hardening as the mobile config (.lighthouserc.cjs) —

--- a/.lighthouserc.desktop.cjs
+++ b/.lighthouserc.desktop.cjs
@@ -1,12 +1,26 @@
 // QNBS-v3: Desktop Lighthouse config — runs alongside the mobile config (.lighthouserc.cjs).
 // Serves production dist (pnpm run preview) and audits with desktop emulation.
 // continue-on-error: true in ci.yml until desktop baselines stabilise.
+// QNBS-v3: derive the audited URL from the same deploy-base logic the build/preview use
+// (mirror of scripts/resolve-deploy-base.mjs — keep in sync). Hardcoding the GitHub Pages
+// base made LHCI audit a 404 when the preview was built with VITE_BASE=/ or DEPLOY_TARGET=edge.
+function resolveDeployBase() {
+  const viteBase = process.env.VITE_BASE?.trim();
+  if (viteBase) {
+    return viteBase.endsWith('/') ? viteBase : `${viteBase}/`;
+  }
+  if (process.env.DEPLOY_TARGET === 'edge') {
+    return '/';
+  }
+  return '/WorldScript-Studio/';
+}
+
 module.exports = {
   ci: {
     collect: {
       startServerCommand: 'pnpm run preview',
       startServerReadyPattern: 'Local',
-      url: ['http://127.0.0.1:4173/WorldScript-Studio/'],
+      url: [`http://127.0.0.1:4173${resolveDeployBase()}`],
       numberOfRuns: 2,
       settings: {
         // QNBS-v3: same /dev/shm crash hardening as the mobile config (.lighthouserc.cjs) —

--- a/.mcp/proforge-mcp-server/package.json
+++ b/.mcp/proforge-mcp-server/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@storycraft/proforge-mcp-server",
+  "name": "@worldscript/proforge-mcp-server",
   "version": "1.0.0",
   "private": true,
   "type": "module",
-  "description": "MCP server exposing the StoryCraft ProForge Core Capability Layer to external AI agents",
+  "description": "MCP server exposing the WorldScript ProForge Core Capability Layer to external AI agents",
   "bin": {
     "proforge-mcp-server": "src/index.ts"
   },

--- a/index.html
+++ b/index.html
@@ -18,31 +18,31 @@
     <!-- ── SEO & Social ───────────────────────────────────── -->
     <meta name="description" content="AI-Powered Creative Writing Studio — craft entire novels, characters & worlds with Gemini AI. Works offline." />
     <meta name="keywords" content="creative writing, AI writing assistant, novel writer, story generator, character builder, world building" />
-    <meta name="author" content="StoryCraft Studio" />
+    <meta name="author" content="WorldScript Studio" />
     <meta name="robots" content="index, follow" />
 
     <!-- Open Graph -->
     <meta property="og:type"        content="website" />
-    <meta property="og:site_name"   content="StoryCraft Studio" />
-    <meta property="og:title"       content="StoryCraft Studio — AI Creative Writing" />
-    <meta property="og:description" content="Craft entire novels, characters & worlds with Gemini AI. Works offline as a PWA." />
-    <meta property="og:url"         content="https://storycraft-studio.app/StoryCraft-Studio/" />
+    <meta property="og:site_name"   content="WorldScript Studio" />
+    <meta property="og:title"       content="WorldScript Studio — AI Creative Writing" />
+    <meta property="og:description" content="Build immersive worlds and craft entire novels with AI. Works offline as a PWA." />
+    <meta property="og:url"         content="https://worldscript-studio.app/WorldScript-Studio/" />
     <meta property="og:image"       content="%BASE_URL%favicon.svg" />
 
     <!-- Twitter Card -->
     <meta name="twitter:card"        content="summary" />
-    <meta name="twitter:title"       content="StoryCraft Studio" />
-    <meta name="twitter:description" content="AI-Powered Creative Writing Studio — Gemini AI, offline-ready PWA." />
+    <meta name="twitter:title"       content="WorldScript Studio" />
+    <meta name="twitter:description" content="AI-Powered Creative Writing Studio — offline-ready PWA." />
     <meta name="twitter:image"       content="%BASE_URL%favicon.svg" />
 
     <!-- ── PWA / Mobile Capable ──────────────────────────── -->
     <meta name="mobile-web-app-capable"            content="yes" />
     <meta name="apple-mobile-web-app-capable"      content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-    <meta name="apple-mobile-web-app-title"        content="StoryCraft" />
+    <meta name="apple-mobile-web-app-title"        content="WorldScript" />
     <meta name="msapplication-TileColor"           content="#020617" />
     <meta name="msapplication-tap-highlight"       content="no" />
-    <meta name="application-name"                  content="StoryCraft Studio" />
+    <meta name="application-name"                  content="WorldScript Studio" />
 
     <!-- ── Security: Content Security Policy ─────────────── -->
     <!--
@@ -91,7 +91,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&family=Noto+Sans+GR:wght@400;500;700&family=Noto+Sans+Arabic:wght@400;500;700&family=Noto+Sans+Hebrew:wght@400;500;700&display=swap" rel="stylesheet">
 
-    <title>StoryCraft Studio</title>
+    <title>WorldScript Studio</title>
 </head>
   <body>
     <!-- QNBS-v3: Disable Aurora on low-end hardware (≤4 logical CPUs) to prevent GPU/battery drain; prefers-reduced-data handled in CSS. -->

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
 
     <!-- ── Manifest & Icons ───────────────────────────────── -->
-    <!-- QNBS-v3: %BASE_URL% substituted by Vite at build time — resolves to / for Vercel/CF edge and /StoryCraft-Studio/ for GitHub Pages. -->
+    <!-- QNBS-v3: %BASE_URL% substituted by Vite at build time — resolves to / for Vercel/CF edge and /WorldScript-Studio/ for GitHub Pages. -->
     <link rel="manifest" href="%BASE_URL%manifest.json" />
     <link rel="icon" type="image/svg+xml" href="%BASE_URL%favicon.svg" />
     <link rel="apple-touch-icon" href="%BASE_URL%favicon.svg" />
@@ -26,7 +26,7 @@
     <meta property="og:site_name"   content="WorldScript Studio" />
     <meta property="og:title"       content="WorldScript Studio — AI Creative Writing" />
     <meta property="og:description" content="Build immersive worlds and craft entire novels with AI. Works offline as a PWA." />
-    <meta property="og:url"         content="https://worldscript-studio.app/WorldScript-Studio/" />
+    <meta property="og:url"         content="https://worldscript-studio.app%BASE_URL%" />
     <meta property="og:image"       content="%BASE_URL%favicon.svg" />
 
     <!-- Twitter Card -->
@@ -53,7 +53,7 @@
       - connect-src: 'self'
                     + https:  — intentional broad HTTPS scheme-source. REQUIRED by the
                       shipped BYOK feature `openAiCompatibleBaseUrl` (Settings → AI →
-                      custom base URL): users point StoryCraft at arbitrary self-hosted
+                      custom base URL): users point WorldScript at arbitrary self-hosted
                       or third-party OpenAI-compatible proxies that cannot be statically
                       enumerated in a meta CSP. Because `https:` already covers every
                       HTTPS origin, the explicit cloud-provider endpoints (Gemini,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,17 @@
 {
-  "name": "storycraft-studio",
+  "name": "worldscript-studio",
   "private": true,
-  "version": "1.22.0",
+  "version": "1.23.0",
+  "description": "WorldScript Studio — offline-first, AI-powered creative writing application.",
+  "author": "QNBS",
+  "keywords": [
+    "worldscript",
+    "worldscript-studio",
+    "creative-writing",
+    "ai-writing",
+    "pwa",
+    "tauri"
+  ],
   "type": "module",
   "packageManager": "pnpm@11.5.2",
   "engines": {

--- a/packages/collab-transport/package.json
+++ b/packages/collab-transport/package.json
@@ -3,7 +3,7 @@
   "version": "10.3.0-sc1",
   "private": true,
   "type": "module",
-  "description": "Vendored y-webrtc with StoryCraft RTCDataChannel E2E encryption patch",
+  "description": "Vendored y-webrtc with WorldScript RTCDataChannel E2E encryption patch",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -53,7 +53,7 @@ export default defineConfig({
   },
 
   use: {
-    baseURL: 'http://127.0.0.1:3000/StoryCraft-Studio',
+    baseURL: 'http://127.0.0.1:3000/WorldScript-Studio',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     // QNBS-v3: action + navigation timeouts bound to detect UI hangs / stalled

--- a/public/404.html
+++ b/public/404.html
@@ -3,14 +3,14 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>StoryCraft Studio</title>
+  <title>WorldScript Studio</title>
   <script>
     // GitHub Pages Redirect
     // Die App nutzt State-basiertes Routing, daher leiten wir einfach zur Startseite weiter
-    window.location.replace('/StoryCraft-Studio/');
+    window.location.replace('/WorldScript-Studio/');
   </script>
   <noscript>
-    <meta http-equiv="refresh" content="0; url=/StoryCraft-Studio/">
+    <meta http-equiv="refresh" content="0; url=/WorldScript-Studio/">
   </noscript>
 </head>
 <body>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,10 +1,10 @@
 {
-  "name": "StoryCraft Studio",
-  "short_name": "StoryCraft",
-  "description": "AI-Powered Creative Writing Studio — Craft entire novels, characters & worlds with Gemini AI.",
-  "start_url": "/StoryCraft-Studio/?source=pwa",
-  "scope": "/StoryCraft-Studio/",
-  "id": "/StoryCraft-Studio/",
+  "name": "WorldScript Studio",
+  "short_name": "WorldScript",
+  "description": "AI-Powered Creative Writing Studio — Build immersive worlds and craft entire novels with AI.",
+  "start_url": "/WorldScript-Studio/?source=pwa",
+  "scope": "/WorldScript-Studio/",
+  "id": "/WorldScript-Studio/",
 
   "display": "standalone",
   "display_override": ["window-controls-overlay", "standalone", "minimal-ui"],
@@ -45,42 +45,42 @@
       "name": "Templates",
       "short_name": "Templates",
       "description": "Browse narrative templates and start a structured project",
-      "url": "/StoryCraft-Studio/?view=templates&source=shortcut",
+      "url": "/WorldScript-Studio/?view=templates&source=shortcut",
       "icons": [{ "src": "favicon.svg", "sizes": "any", "type": "image/svg+xml" }]
     },
     {
       "name": "My Manuscript",
       "short_name": "Manuscript",
       "description": "Open your manuscript view",
-      "url": "/StoryCraft-Studio/?view=manuscript&source=shortcut",
+      "url": "/WorldScript-Studio/?view=manuscript&source=shortcut",
       "icons": [{ "src": "favicon.svg", "sizes": "any", "type": "image/svg+xml" }]
     },
     {
       "name": "Characters",
       "short_name": "Characters",
       "description": "Manage your characters",
-      "url": "/StoryCraft-Studio/?view=characters&source=shortcut",
+      "url": "/WorldScript-Studio/?view=characters&source=shortcut",
       "icons": [{ "src": "favicon.svg", "sizes": "any", "type": "image/svg+xml" }]
     },
     {
       "name": "AI Writer",
       "short_name": "Writer",
       "description": "Open the AI writing studio",
-      "url": "/StoryCraft-Studio/?view=writer&source=shortcut",
+      "url": "/WorldScript-Studio/?view=writer&source=shortcut",
       "icons": [{ "src": "favicon.svg", "sizes": "any", "type": "image/svg+xml" }]
     },
     {
       "name": "New Scene",
       "short_name": "New Scene",
       "description": "Jump to the Plot Board and add a new scene",
-      "url": "/StoryCraft-Studio/#/board?action=add-scene",
+      "url": "/WorldScript-Studio/#/board?action=add-scene",
       "icons": [{ "src": "favicon.svg", "sizes": "any", "type": "image/svg+xml" }]
     },
     {
       "name": "Start Writing Session",
       "short_name": "Session",
       "description": "Open the Progress Tracker and start a writing session",
-      "url": "/StoryCraft-Studio/#/progress?action=start-session",
+      "url": "/WorldScript-Studio/#/progress?action=start-session",
       "icons": [{ "src": "favicon.svg", "sizes": "any", "type": "image/svg+xml" }]
     }
   ],
@@ -92,7 +92,7 @@
   "handle_links": "preferred",
 
   "share_target": {
-    "action": "/StoryCraft-Studio/",
+    "action": "/WorldScript-Studio/",
     "method": "GET",
     "params": {
       "title": "share_title",
@@ -103,8 +103,8 @@
 
   "protocol_handlers": [
     {
-      "protocol": "web+storycraft",
-      "url": "/StoryCraft-Studio/?protocol=%s"
+      "protocol": "web+worldscript",
+      "url": "/WorldScript-Studio/?protocol=%s"
     }
   ],
 

--- a/public/offline.html
+++ b/public/offline.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#020617" />
-    <title>Offline — StoryCraft Studio</title>
+    <title>Offline — WorldScript Studio</title>
     <style>
       *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
@@ -168,11 +168,11 @@
 
       <h1>Keine Internetverbindung</h1>
       <p>
-        StoryCraft Studio ist gerade offline. Alle deine gespeicherten Geschichten und Charaktere
+        WorldScript Studio ist gerade offline. Alle deine gespeicherten Geschichten und Charaktere
         sind weiterhin in deinem Browser verfügbar.
       </p>
 
-      <a href="/StoryCraft-Studio/" class="btn">
+      <a href="/WorldScript-Studio/" class="btn">
         <svg width="16" height="16" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" aria-hidden="true">
           <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12l8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"/>
         </svg>
@@ -185,7 +185,7 @@
     <script>
       // Auto-reload when connectivity is restored
       window.addEventListener('online', () => {
-        window.location.href = '/StoryCraft-Studio/';
+        window.location.href = '/WorldScript-Studio/';
       });
     </script>
   </body>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,14 +1,14 @@
 // ============================================================
-// StoryCraft Studio — Advanced Service Worker v3.0
+// WorldScript Studio — Advanced Service Worker v3.0
 // Strategy: Stale-While-Revalidate + Cache-First + Network-Only
 // Features: Versioned caches, background sync, periodic updates,
 //           offline fallback, push notifications, share target
 // ============================================================
 
-const APP_VERSION   = '1.22.0';
-const CACHE_STATIC  = `storycraft-static-v${APP_VERSION}`;
-const CACHE_DYNAMIC = `storycraft-dynamic-v${APP_VERSION}`;
-const CACHE_IMAGES  = `storycraft-images-v${APP_VERSION}`;
+const APP_VERSION   = '1.23.0';
+const CACHE_STATIC  = `worldscript-static-v${APP_VERSION}`;
+const CACHE_DYNAMIC = `worldscript-dynamic-v${APP_VERSION}`;
+const CACHE_IMAGES  = `worldscript-images-v${APP_VERSION}`;
 const ALL_CACHES    = [CACHE_STATIC, CACHE_DYNAMIC, CACHE_IMAGES];
 
 const BASE = self.location.pathname.replace(/sw\.js$/, '');
@@ -73,7 +73,7 @@ async function trimCache(cacheName, maxEntries) {
 async function offlineFallback(request) {
   if (request.destination === 'document') {
     const cached = await caches.match(`${BASE}offline.html`);
-    return cached || new Response('<!doctype html><title>Offline</title><p>StoryCraft Studio ist offline.</p>', {
+    return cached || new Response('<!doctype html><title>Offline</title><p>WorldScript Studio ist offline.</p>', {
       headers: { 'Content-Type': 'text/html' },
       status: 503,
     });
@@ -305,13 +305,13 @@ self.addEventListener('message', (event) => {
 self.addEventListener('push', (event) => {
   if (!event.data) return;
   let data;
-  try { data = event.data.json(); } catch { data = { title: 'StoryCraft Studio', body: event.data.text() }; }
+  try { data = event.data.json(); } catch { data = { title: 'WorldScript Studio', body: event.data.text() }; }
 
   const options = {
     body:    data.body    || 'New notification',
     icon:    `${BASE}favicon.svg`,
     badge:   `${BASE}favicon.svg`,
-    tag:     data.tag     || 'storycraft-notification',
+    tag:     data.tag     || 'worldscript-notification',
     data:    data.data    || {},
     actions: data.actions || [],
     vibrate: [100, 50, 100],
@@ -320,7 +320,7 @@ self.addEventListener('push', (event) => {
   };
 
   event.waitUntil(
-    self.registration.showNotification(data.title || 'StoryCraft Studio', options)
+    self.registration.showNotification(data.title || 'WorldScript Studio', options)
   );
 });
 
@@ -342,7 +342,7 @@ self.addEventListener('notificationclick', (event) => {
 // BACKGROUND SYNC — Retry deferred autosave operations
 // ════════════════════════════════════════════════════════════
 self.addEventListener('sync', (event) => {
-  if (event.tag === 'storycraft-autosave') {
+  if (event.tag === 'worldscript-autosave') {
     event.waitUntil(
       self.clients.matchAll().then((clients) =>
         clients.forEach((c) => c.postMessage({ type: 'TRIGGER_AUTOSAVE' }))
@@ -355,7 +355,7 @@ self.addEventListener('sync', (event) => {
 // PERIODIC BACKGROUND SYNC — Refresh locale JSON while idle
 // ════════════════════════════════════════════════════════════
 self.addEventListener('periodicsync', (event) => {
-  if (event.tag === 'storycraft-refresh') {
+  if (event.tag === 'worldscript-refresh') {
     event.waitUntil(
       caches.open(CACHE_DYNAMIC).then(async (cache) => {
         const keys         = await cache.keys();
@@ -371,4 +371,4 @@ self.addEventListener('periodicsync', (event) => {
   }
 });
 
-swLogger.log(`StoryCraft Studio Service Worker v${APP_VERSION} loaded`);
+swLogger.log(`WorldScript Studio Service Worker v${APP_VERSION} loaded`);

--- a/register-sw.ts
+++ b/register-sw.ts
@@ -160,7 +160,7 @@ const registerServiceWorker = async (): Promise<void> => {
         });
         if (status.state === 'granted') {
           // @ts-expect-error — periodicSync not in TS lib yet
-          await registration.periodicSync.register('storycraft-refresh', {
+          await registration.periodicSync.register('worldscript-refresh', {
             minInterval: 24 * 60 * 60 * 1000, // once per day
           });
         }

--- a/scripts/resolve-deploy-base.mjs
+++ b/scripts/resolve-deploy-base.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * Resolves Vite `base` for static hosting targets.
- * - GitHub Pages (default): /StoryCraft-Studio/
+ * - GitHub Pages (default): /WorldScript-Studio/
  * - Vercel / Cloudflare Pages (root domain): set VITE_BASE=/ or DEPLOY_TARGET=edge
  */
 function resolveDeployBase() {
@@ -12,7 +12,7 @@ function resolveDeployBase() {
   if (process.env.DEPLOY_TARGET === 'edge') {
     return '/';
   }
-  return '/StoryCraft-Studio/';
+  return '/WorldScript-Studio/';
 }
 
 export const deployBase = resolveDeployBase();

--- a/scripts/sync-deploy-base.mjs
+++ b/scripts/sync-deploy-base.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Patches public assets that hardcode /StoryCraft-Studio/ for edge (root) deploys.
+ * Patches public assets that hardcode /WorldScript-Studio/ for edge (root) deploys.
  * GitHub Pages CI leaves defaults; Vercel/Cloudflare set DEPLOY_TARGET=edge or VITE_BASE=/.
  */
 import fs from 'node:fs';
@@ -10,7 +10,7 @@ import { deployBase } from './resolve-deploy-base.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
-const GITHUB_PAGES_BASE = '/StoryCraft-Studio/';
+const GITHUB_PAGES_BASE = '/WorldScript-Studio/';
 
 if (deployBase === GITHUB_PAGES_BASE) {
   console.log('[sync-deploy-base] GitHub Pages base — no public patches');

--- a/services/tauriDeepLink.ts
+++ b/services/tauriDeepLink.ts
@@ -53,23 +53,9 @@ export async function initTauriDeepLink(
         // to handle the case where the file path is passed as a CLI argument
         try {
           // For file associations on Windows/Linux, the deep-link plugin parses CLI args
-          // and emits the URL. We need to convert storycraft:// URLs back to file paths
+          // and emits the URL. We need to convert worldscript:// URLs back to file paths
           // or handle direct file paths if passed.
-          let filePath = url;
-
-          // Check if it's a storycraft:// URL and extract the path
-          if (url.startsWith('storycraft://') || url.startsWith('storycraft:')) {
-            // On Windows, the URL might be storycraft:///C:/path/to/file.storycraft
-            // On Linux, it might be storycraft:///home/user/file.storycraft
-            // QNBS-v3: Strip storycraft:// prefix and normalize Windows drive-letter paths
-            filePath = url.replace(/^storycraft:\/\/?/, '');
-            // Windows paths like /C:/... need the leading slash removed
-            if (/^[A-Za-z]:/.test(filePath)) {
-              filePath = filePath.replace(/^\/+/, '');
-            } else {
-              filePath = filePath.replace(/^\/+/, '/');
-            }
-          }
+          const filePath = deepLinkUrlToPath(url);
 
           // Read file via Tauri FS plugin
           const { readTextFile, exists } = await import('@tauri-apps/plugin-fs');
@@ -124,6 +110,28 @@ export async function initTauriDeepLink(
     unlisten?.();
     unlisten = null;
   };
+}
+
+/**
+ * Convert a deep-link URL into a filesystem path.
+ * QNBS-v3: the desktop deep-link scheme was rebranded `storycraft` → `worldscript`
+ * (src-tauri/tauri.conf.json). Accept BOTH schemes so links/file-associations created
+ * before the rename keep resolving during migration. Non-scheme inputs (raw paths passed
+ * as CLI args) are returned unchanged.
+ */
+export function deepLinkUrlToPath(url: string): string {
+  if (!/^(?:worldscript|storycraft):/i.test(url)) {
+    return url;
+  }
+  // Strip the scheme prefix (with 0–2 slashes, e.g. `worldscript:`, `worldscript://`,
+  // or Windows-style `worldscript:///C:/...`).
+  const filePath = url.replace(/^(?:worldscript|storycraft):\/{0,2}/i, '');
+  if (/^[A-Za-z]:/.test(filePath)) {
+    // Windows drive-letter path like /C:/... — drop the leading slash(es).
+    return filePath.replace(/^\/+/, '');
+  }
+  // POSIX path — collapse any leading slashes to a single root slash.
+  return filePath.replace(/^\/+/, '/');
 }
 
 /**

--- a/services/tauriDeepLink.ts
+++ b/services/tauriDeepLink.ts
@@ -126,8 +126,9 @@ export function deepLinkUrlToPath(url: string): string {
   // Strip the scheme prefix (with 0–2 slashes, e.g. `worldscript:`, `worldscript://`,
   // or Windows-style `worldscript:///C:/...`).
   const filePath = url.replace(/^(?:worldscript|storycraft):\/{0,2}/i, '');
-  if (/^[A-Za-z]:/.test(filePath)) {
-    // Windows drive-letter path like /C:/... — drop the leading slash(es).
+  if (/^\/*[A-Za-z]:/.test(filePath)) {
+    // Windows drive-letter path, incl. the canonical triple-slash form `worldscript:///C:/...`
+    // which leaves a leading slash after the scheme strip — drop any leading slash(es).
     return filePath.replace(/^\/+/, '');
   }
   // POSIX path — collapse any leading slashes to a single root slash.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4635,30 +4635,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
-name = "storycraft-studio"
-version = "1.21.0"
-dependencies = [
- "base64 0.22.1",
- "candle-core",
- "candle-nn",
- "log",
- "serde",
- "serde_json",
- "tauri",
- "tauri-build",
- "tauri-plugin-deep-link",
- "tauri-plugin-dialog",
- "tauri-plugin-fs",
- "tauri-plugin-http",
- "tauri-plugin-log",
- "tauri-plugin-shell",
- "tauri-plugin-single-instance",
- "tauri-plugin-updater",
- "tauri-plugin-window-state",
- "tokio",
-]
-
-[[package]]
 name = "string_cache"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6769,6 +6745,30 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "worldscript-studio"
+version = "1.23.0"
+dependencies = [
+ "base64 0.22.1",
+ "candle-core",
+ "candle-nn",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-build",
+ "tauri-plugin-deep-link",
+ "tauri-plugin-dialog",
+ "tauri-plugin-fs",
+ "tauri-plugin-http",
+ "tauri-plugin-log",
+ "tauri-plugin-shell",
+ "tauri-plugin-single-instance",
+ "tauri-plugin-updater",
+ "tauri-plugin-window-state",
+ "tokio",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "storycraft-studio"
-version = "1.22.0"
+version = "1.23.0"
 description = "AI-powered creative writing application"
 authors = ["QNBS"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "storycraft-studio"
+name = "worldscript-studio"
 version = "1.23.0"
-description = "AI-powered creative writing application"
+description = "AI-powered creative writing and world-building application"
 authors = ["QNBS"]
 license = "MIT"
-repository = "https://github.com/QNBS/StoryCraft-Studio"
+repository = "https://github.com/QNBS/WorldScript-Studio"
 edition = "2021"
 rust-version = "1.77.2"
 

--- a/src-tauri/Entitlements.plist
+++ b/src-tauri/Entitlements.plist
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <!-- QNBS-v3: Hardened Runtime Entitlements for StoryCraft Studio -->
+    <!-- QNBS-v3: Hardened Runtime Entitlements for WorldScript Studio -->
     <!-- Required for Tauri v2 apps distributed outside the Mac App Store -->
 
     <!-- Allow execution of JIT-compiled code (required for WebKit) -->

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "StoryCraft Studio",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "identifier": "com.storycraft.studio",
   "build": {
     "frontendDist": "../dist",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
-  "productName": "StoryCraft Studio",
+  "productName": "WorldScript Studio",
   "version": "1.23.0",
-  "identifier": "com.storycraft.studio",
+  "identifier": "com.worldscript.studio",
   "build": {
     "frontendDist": "../dist",
     "devUrl": "http://localhost:3000",
@@ -12,7 +12,7 @@
   "app": {
     "windows": [
       {
-        "title": "StoryCraft Studio",
+        "title": "WorldScript Studio",
         "width": 1280,
         "height": 800,
         "minWidth": 800,
@@ -34,8 +34,8 @@
     "category": "Productivity",
     "publisher": "QNBS",
     "copyright": "© 2026 QNBS. Licensed under MIT.",
-    "shortDescription": "AI-powered creative writing application",
-    "longDescription": "StoryCraft Studio is an offline-first, AI-powered creative writing application with local LLM inference, plot boards, character management, and manuscript export.",
+    "shortDescription": "AI-powered creative writing and world-building application",
+    "longDescription": "WorldScript Studio is an offline-first, AI-powered creative writing application with local LLM inference, plot boards, character management, and manuscript export.",
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",
@@ -45,17 +45,17 @@
     ],
     "fileAssociations": [
       {
-        "ext": ["storycraft"],
-        "name": "StoryCraft Project",
-        "description": "StoryCraft Studio creative writing project",
-        "mimeType": "application/x-storycraft-project",
+        "ext": ["worldscript"],
+        "name": "WorldScript Project",
+        "description": "WorldScript Studio creative writing project",
+        "mimeType": "application/x-worldscript-project",
         "role": "Editor"
       },
       {
-        "ext": ["scst"],
-        "name": "StoryCraft Project",
-        "description": "StoryCraft Studio creative writing project (short extension)",
-        "mimeType": "application/x-storycraft-project",
+        "ext": ["wsst"],
+        "name": "WorldScript Project",
+        "description": "WorldScript Studio creative writing project (short extension)",
+        "mimeType": "application/x-worldscript-project",
         "role": "Editor"
       }
     ],
@@ -74,8 +74,8 @@
     "updater": {
       "active": true,
       "endpoints": [
-        "https://github.com/qnbs/StoryCraft-Studio/releases/latest/download/latest.json",
-        "https://qnbs.github.io/StoryCraft-Studio/updater/latest.json"
+        "https://github.com/qnbs/WorldScript-Studio/releases/latest/download/latest.json",
+        "https://qnbs.github.io/WorldScript-Studio/updater/latest.json"
       ],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDZBOTlDOEIxNUYyQzA5RUEKUldUcUNTeGZzY2laYW8yU21QNldMbzZQcTFmUDNTdVZ5RHhNenFkSTVGNTRoTllTRXpBcjJyVVMK",
       "windows": {
@@ -84,7 +84,7 @@
     },
     "deep-link": {
       "desktop": {
-        "schemes": ["storycraft"]
+        "schemes": ["worldscript"]
       }
     }
   }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -84,7 +84,7 @@
     },
     "deep-link": {
       "desktop": {
-        "schemes": ["worldscript"]
+        "schemes": ["worldscript", "storycraft"]
       }
     }
   }

--- a/tests/unit/services/tauriDeepLink.test.ts
+++ b/tests/unit/services/tauriDeepLink.test.ts
@@ -4,9 +4,50 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { getProjectIdFromPath, isStoryCraftProjectFile } from '../../../services/tauriDeepLink';
+import {
+  deepLinkUrlToPath,
+  getProjectIdFromPath,
+  isStoryCraftProjectFile,
+} from '../../../services/tauriDeepLink';
 
 describe('tauriDeepLink', () => {
+  describe('deepLinkUrlToPath', () => {
+    it('strips the new worldscript:// scheme (POSIX absolute path)', () => {
+      expect(deepLinkUrlToPath('worldscript:///home/user/my-novel.worldscript')).toBe(
+        '/home/user/my-novel.worldscript',
+      );
+    });
+
+    it('still strips the legacy storycraft:// scheme during migration', () => {
+      expect(deepLinkUrlToPath('storycraft:///home/user/my-novel.storycraft')).toBe(
+        '/home/user/my-novel.storycraft',
+      );
+    });
+
+    it('treats the legacy and new schemes identically', () => {
+      for (const rest of [':///home/user/a.json', '://C:/Users/me/b.json', ':/srv/c.json']) {
+        expect(deepLinkUrlToPath(`worldscript${rest}`)).toBe(
+          deepLinkUrlToPath(`storycraft${rest}`),
+        );
+      }
+    });
+
+    it('normalizes a Windows drive-letter path (two-slash form)', () => {
+      expect(deepLinkUrlToPath('worldscript://C:/Users/me/novel.worldscript')).toBe(
+        'C:/Users/me/novel.worldscript',
+      );
+    });
+
+    it('is case-insensitive on the scheme', () => {
+      expect(deepLinkUrlToPath('WorldScript:///home/user/file.json')).toBe('/home/user/file.json');
+    });
+
+    it('returns non-scheme inputs (raw CLI paths) unchanged', () => {
+      expect(deepLinkUrlToPath('/home/user/file.json')).toBe('/home/user/file.json');
+      expect(deepLinkUrlToPath('C:/Users/me/file.json')).toBe('C:/Users/me/file.json');
+    });
+  });
+
   describe('isStoryCraftProjectFile', () => {
     it('returns true for .storycraft extension', () => {
       expect(isStoryCraftProjectFile('/path/to/project.storycraft')).toBe(true);

--- a/tests/unit/services/tauriDeepLink.test.ts
+++ b/tests/unit/services/tauriDeepLink.test.ts
@@ -32,9 +32,18 @@ describe('tauriDeepLink', () => {
       }
     });
 
-    it('normalizes a Windows drive-letter path (two-slash form)', () => {
+    it('normalizes Windows drive-letter paths (two-slash and canonical triple-slash forms)', () => {
+      // Two-slash form: scheme strip already removes all slashes before the drive letter.
       expect(deepLinkUrlToPath('worldscript://C:/Users/me/novel.worldscript')).toBe(
         'C:/Users/me/novel.worldscript',
+      );
+      // Canonical triple-slash form (file-URL style) leaves a leading slash (/C:/...) that
+      // must still be stripped so Tauri `exists()` resolves the real Windows path.
+      expect(deepLinkUrlToPath('worldscript:///C:/Users/me/novel.worldscript')).toBe(
+        'C:/Users/me/novel.worldscript',
+      );
+      expect(deepLinkUrlToPath('storycraft:///D:/Docs/book.storycraft')).toBe(
+        'D:/Docs/book.storycraft',
       );
     });
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,7 +21,7 @@ function resolveBase(): string {
   if (process.env['DEPLOY_TARGET'] === 'edge') {
     return '/';
   }
-  return '/StoryCraft-Studio/';
+  return '/WorldScript-Studio/';
 }
 
 const deployBase = resolveBase();
@@ -49,10 +49,10 @@ export default defineConfig({
     tailwindcss(),
     react(),
     {
-      name: 'storycraft-deploy-base-html',
+      name: 'worldscript-deploy-base-html',
       transformIndexHtml(html) {
-        if (deployBase === '/StoryCraft-Studio/') return html;
-        return html.replaceAll('/StoryCraft-Studio/', deployBase);
+        if (deployBase === '/WorldScript-Studio/') return html;
+        return html.replaceAll('/WorldScript-Studio/', deployBase);
       },
     },
     VitePWA({

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -52,7 +52,10 @@ export default defineConfig({
       name: 'worldscript-deploy-base-html',
       transformIndexHtml(html) {
         if (deployBase === '/WorldScript-Studio/') return html;
-        return html.replaceAll('/WorldScript-Studio/', deployBase);
+        // QNBS-v3: only rewrite app-relative paths (preceded by quote/space) so
+        // absolute URLs like https://worldscript-studio.app/WorldScript-Studio/
+        // are not corrupted when deployBase is './'.
+        return html.replace(/(?<=["'\s])\/WorldScript-Studio\//g, deployBase);
       },
     },
     VitePWA({


### PR DESCRIPTION
## **User description**
## Summary
Part of the StoryCraft → WorldScript rebrand split. This PR covers phases 1–3:
- Repository metadata (`package.json`, `README.md`, etc.)
- Build tooling, base URLs, PWA configuration
- Tauri desktop identity (Cargo, `tauri.conf.json`, icons, entitlements)

## Scope
- Renames public-facing strings from **StoryCraft Studio** to **WorldScript Studio**.
- Updates GitHub Pages base path, PWA manifest, service worker scope.
- Updates Tauri bundle identifier, product name, window title, deep-link scheme and protocol handlers.

## Notes
- Does **not** touch runtime storage keys (kept for migration compatibility).
- Does **not** include AI hooks, feature flags, source strings, i18n, docs or CI changes — those are in follow-up PRs.

## Related
- Closes the monolithic rebrand approach from #141.
- Follow-ups: phase 4a (AI hooks), 4b (flags/Tauri), 4c (source strings), 4d (components), 5-6 (i18n/assets), 7-8 (docs/CI).


___

## **CodeAnt-AI Description**
**Rebrand the app to WorldScript Studio and keep old desktop links working**

### What Changed
- Updated the app name, icons metadata, install details, offline page, and social sharing text to WorldScript Studio
- Moved web, PWA, GitHub Pages, and desktop routes to the new `/WorldScript-Studio/` paths
- Added support for both `worldscript://` and legacy `storycraft://` desktop links so older links still open
- Updated service worker labels, background sync tags, and deployment checks to match the new branding
- Added unit tests for the new and legacy deep-link formats

### Impact
`✅ Consistent WorldScript branding across web, PWA, and desktop`
`✅ Fewer broken opens from old StoryCraft links`
`✅ Safer app installs, redirects, and updates under the new paths`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
