### PR TITLE
docs(adr): ADR-0009 XState hybrid orchestration + machine catalogue

### DIFF
--- a/docs/XSTATE-MACHINES.md
+++ b/docs/XSTATE-MACHINES.md
@@ -1,0 +1,99 @@
+# XState machines
+
+Workflow orchestration in StoryCraft Studio runs on XState v5 — the third state layer alongside
+Redux (persistent domain state) and RTK Query (async AI). The decision and layering rules are in
+[ADR 0009](adr/0009-xstate-workflow-orchestration.md). This doc catalogues the machines.
+
+**Conventions**
+- Machine definition: `features/<domain>/machine/<domain>Machine.ts` (+ `.types.ts`).
+- React integration: `hooks/use<Domain>Machine.ts`.
+- Side effects live only in **actors** (`fromPromise`) that wrap `services/*`. The machine definition
+  is pure control flow → unit-tested headless with `createActor` + `.provide({ actors })`, no React,
+  no live store.
+- Machines **dispatch existing Redux slice actions**; they never become a second source of truth for
+  domain data.
+
+---
+
+## 1. ProForge pipeline — **implemented** (additive; live wiring behind `enableProForgeXState`)
+
+`features/proForge/machine/proForgeMachine.ts` formalizes the 8-stage human-in-the-loop pipeline that
+`services/proForge/proForgeOrchestrator.ts` implements imperatively.
+
+**States:** `idle → preparing → running.{preStageSnapshot → executingStage → supervising → gate →
+(retrying | awaitingReview)} → running.{applyingEdits → advancing} → (completed | failed) ` plus
+`aborting → aborted`. `ABORT` is handled on the `running` parent (cancels the active actor).
+
+**Gate order (parity with the orchestrator):** `canRetry` → `intakeHardFail` (intake quality < 30,
+no retry left) → human `awaitingReview`. Editing stages route review through `applyingEdits`; advisory
+stages (production/publishing/analytics) skip straight to `advancing`.
+
+**Actors (injected):** `snapshot`, `runStage` (loads the stage agent via `pipelineAgents/agentRegistry`),
+`supervise` (`SupervisorAgent.evaluate`, heuristic — no AI), `applyEdits`
+(`applyReviewEdits.planAcceptedManuscriptEdits` → `projectActions.updateManuscriptSection`, so edits
+stay redux-undo-reversible), `restore` (version-control snapshot restore).
+
+**Redux bridge (P4b):** `useProForgeMachine` subscribes the actor and, on each relevant transition,
+dispatches the same `proForgeSlice` actions the class dispatches today (`stageStarted`,
+`stageCompleted`, `stageFailed`, `submitStageReview`, `pipelineCompleted`, …) so existing ProForge UI,
+selectors, and IDB run-history persistence are unchanged. `useProForgeOrchestrator` becomes a façade:
+flag on → machine; flag off → existing class (fallback) — identical return shape.
+
+**Tests:** `tests/unit/proForgeMachine.test.ts` — happy path, retry, intake hard-fail, non-editing
+skip, abort, rollback.
+
+---
+
+## 2. Voice pipeline — **design only** (deferred)
+
+Wraps the engine lifecycle (`isAvailable → initialize → use → dispose`), permission/download gating,
+and cancellation currently spread across `useVoice`/`usePushToTalk`/`VoiceCommandService` (the
+single-flight guard, C-P1).
+
+**Proposed states:** `idle → requestingPermission → (denied | downloadingModel → ready) → listening →
+processingSTT → dispatchingIntent → speakingTTS → idle`, with `error` recovery and `cancelled`
+reachable from everywhere; `ecoMode` as a flag-guarded parallel variant.
+
+**Actors wrap, don't reimplement:** Web Speech event plumbing and worker/WASM handling
+(`wasmSttEngine`, `sileroVadEngine`) become actors. Intent dispatch goes through `runCommandById` +
+`appStoreRef`. **Never log transcripts.** E2E reads the existing `voiceTestSeam` harness, so actors
+must honor injected mocks the same way.
+
+**Starting scope when greenlit:** model permission + download + listen + cancel first; add TTS/eco as
+later parallel states. **Risk:** mic-permission + media-stream lifecycle is browser-flaky — keep it
+behind `enableVoiceSupport`/`enableVoiceWasm`.
+
+---
+
+## 3. Global Copilot session — **design only** (deferred)
+
+One `copilotSessionMachine` with a parametrized `generating` state (the action type — Continue,
+Improve, Tone, Dialogue, Brainstorm, Synopsis, Grammar, Critic, Plot-Hole, Consistency — lives in
+context), invoking an RTK Query / `useWorldScriptAI` streaming actor.
+
+**Proposed states:** `awaitingInput → assemblingPrompt → streaming → previewing →
+(applying | annotating | discarded)`, plus `retrying` (uses the `aiRetry` transient-error taxonomy)
+and `error`.
+
+**Same pattern as ProForge:** services-as-actors, Redux as the read-model. Copilot session state stays
+ephemeral (`copilotSlice`, not persisted, not undo-wrapped). Apply-to-chapter dispatches
+`projectActions` via `actionApplier` (the ≥70 %-length gate), so it remains redux-undo-reversible.
+
+**When to adopt:** after the ProForge machine proves the pattern in production. Initial scope = the
+streaming + retry + apply core for Continue/Improve; fold the other actions in by parametrization.
+
+---
+
+## Testing pattern
+
+```ts
+import { createActor, fromPromise, waitFor } from 'xstate';
+const machine = someMachine.provide({ actors: { runStage: fromPromise(async () => mockResult) } });
+const actor = createActor(machine, { input }); actor.start();
+actor.send({ type: 'START' });
+await waitFor(actor, (s) => s.matches({ running: 'awaitingReview' }));
+expect(actor.getSnapshot().context.currentStage).toBe('intake');
+```
+
+Drive events, assert `state.value` / `context`. No React, no store, fully deterministic — keep the
+existing slice/selector tests as the behavior-parity oracle during any migration.

--- a/docs/adr/0009-xstate-workflow-orchestration.md
+++ b/docs/adr/0009-xstate-workflow-orchestration.md
@@ -1,0 +1,85 @@
+# ADR 0009 — XState for complex workflow orchestration (Redux + RTK Query + XState)
+
+- **Status:** Accepted (ProForge machine landed additive; live wiring staged behind a gate)
+- **Date:** 2026-06-17
+- **Deciders:** Maintainer + Claude Code
+- **Context tags:** architecture, state, workflows, xstate, proforge, voice, copilot
+
+## Context
+
+Three workflows in the app are long-running, multi-step, and human-in-the-loop: the **ProForge**
+8-stage editing pipeline, the **Voice** command lifecycle, and the **Global Copilot** AI session.
+Today each is an imperative orchestrator: `services/proForge/proForgeOrchestrator.ts` is a class that
+hand-rolls a state machine (per-stage snapshot → run agent → supervisor gate with retry + intake
+hard-fail → human review → apply edits → advance, plus rollback/abort) over an ephemeral Redux slice;
+`VoiceCommandService` carries a single-flight guard and an implicit state machine across
+`useVoice`/`usePushToTalk`; Copilot sessions thread streaming + retry + apply through ad-hoc hook
+state. These hand-rolled machines enumerate states the type system already names (`StageStatus`,
+`PipelineRunStatus`) and are hard to unit-test without a live store, easy to drive into impossible
+states, and not visualizable.
+
+[[0001-state-management-boundaries]] set the Redux-vs-Zustand boundary (persistent domain state in
+Redux Toolkit, ephemeral UI in Zustand). `app/aiApi.ts` already adds RTK Query for AI side effects.
+Neither is the right home for *orchestration* of multi-step flows with guards, retries, and human
+gates — that logic currently leaks into services, hooks, and slice reducers.
+
+## Decision
+
+Adopt **XState v5** (`xstate` + `@xstate/react`) as the **third** state layer, dedicated to
+orchestrating complex multi-step workflows. The layering and ownership rules:
+
+| Concern | Layer |
+|---|---|
+| Persistent domain data (manuscript, characters, plot, …) | **Redux Toolkit** (`project` slice, undoable) — unchanged, [[0001-state-management-boundaries]] |
+| Synchronous local mutations | **Redux reducers** |
+| Async AI generation (request/response, cache, status) | **RTK Query** (`aiApi`) |
+| Multi-step workflow orchestration (guards, retries, rollback, human gates, cancel) | **XState** (ProForge; later Voice, Copilot) |
+| Ephemeral UI (palette open, drawers, flow mode) | **Zustand** / local `useState` |
+
+**Synchronization contract — the machine never becomes a second source of truth for domain data:**
+
+- **XState → Redux:** machine transitions dispatch the *existing* slice actions; Redux stays the
+  read-model the UI binds to. For ProForge the `proForgeSlice` shape is the integration contract, so
+  no UI component changes when the machine replaces the class.
+- **XState → RTK Query / services:** AI stages run inside `fromPromise` actors that call the AI layer
+  (or `services/ai` for streaming), keeping caching/retry/dedup in one place.
+- **Redux → XState:** actors read the live store via `appStoreRef` (the established pattern) and
+  receive snapshots, not subscriptions, so machines stay pure.
+- **Side effects live only in actors.** The machine definition is pure control flow — guards,
+  transitions, context assigns — and is unit-tested headless via `createActor` + `.provide({ actors })`
+  with no React and no live store. Offline-first and local-AI paths are unaffected: actors invoke the
+  same `localAiFacade`/worker pools and honor `assertCloudAiAllowed`.
+
+**Placement:** machine definitions in `features/<domain>/machine/`; React integration hooks in
+`hooks/use<Domain>Machine.ts`; actors wrap `services/*` (never inline service logic).
+
+**Rollout — incremental and flagged.** ProForge is first because it is already an explicit state
+machine. The machine + injectable actors + headless tests land **additive** (not imported by app
+code, zero bundle impact). The live façade — `useProForgeOrchestrator` delegating to a
+`useProForgeMachine` when `enableProForgeXState` is on, with the existing class as fallback — is a
+separate step, verified 1:1 against the existing ProForge tests before the flag defaults on. Voice
+and Copilot machines are **designed but deferred** (see [[../XSTATE-MACHINES]]); they adopt the same
+actor/read-model pattern once ProForge proves it in production.
+
+## Consequences
+
+- **Positive:** retry/gate/rollback/abort become declarative and guard-tested without a live store;
+  `@xstate/inspect` visualization; impossible states eliminated (a stage can't be "executing" and
+  "awaiting review" at once); orchestration logic leaves services/hooks/reducers for one inspectable
+  place. The pattern generalizes to Voice and Copilot.
+- **Negative:** a third state library to learn; a temporary period where the imperative orchestrator
+  and the machine coexist behind the flag; contributors must keep the "machine dispatches existing
+  slice actions, never owns domain data" rule or risk a second source of truth.
+- **Rejected — keep imperative orchestrators:** the status quo; untestable without a live store,
+  prone to impossible states, orchestration logic stays smeared across layers.
+- **Rejected — model workflows inside Redux (sagas/listener middleware):** RTK listener middleware can
+  sequence effects but has no first-class states/guards/visualization; complex human-gated flows
+  become a tangle of flags. XState is purpose-built for exactly this shape.
+- **Rejected — put orchestration in RTK Query:** RTK Query is for request/response caching, not
+  multi-step human-in-the-loop control flow.
+
+## References
+
+- [[../XSTATE-MACHINES]] — machine catalogue: ProForge (implemented), Voice + Copilot (designs).
+- [[0001-state-management-boundaries]] — the Redux/Zustand boundary this extends.
+- `features/proForge/machine/` — the implemented machine + types; `tests/unit/proForgeMachine.test.ts`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -14,6 +14,7 @@ than editing history.
 | [0006](0006-superseded.md) | (reserved, never issued) | Superseded / void |
 | [0007](0007-plugin-sandbox-model.md) | Plugin Sandbox Model | Accepted |
 | [0008](0008-local-first-data-model.md) | Local-first data model: Yjs document as source of truth | Accepted |
+| [0009](0009-xstate-workflow-orchestration.md) | XState for complex workflow orchestration (Redux + RTK Query + XState) | Accepted |
 
 **Format:** Context → Decision → Consequences (incl. rejected alternatives). Keep each ADR to one
 decision. Link related records with `[[slug]]`.


### PR DESCRIPTION
## **User description**
## Context

Phase 5 of the architecture refactor (docs only). Records the architectural decision behind the P4 XState work and documents the machine designs.

## What changed

- **`docs/adr/0009-xstate-workflow-orchestration.md`** — the decision: XState as the third state layer (Redux = persistent domain state, RTK Query = async AI, XState = workflow orchestration), the per-layer ownership table, the synchronization contract (machines dispatch existing slice actions and never own domain data), and the incremental flagged rollout. Rejected alternatives included.
- **`docs/XSTATE-MACHINES.md`** — machine catalogue: ProForge (implemented), Voice (design), Global Copilot session (design), plus the headless testing pattern.
- **`docs/adr/README.md`** — index updated to list ADR-0009.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Document XState as the workflow layer for complex app flows**

### What Changed
- Added an ADR that makes XState the workflow layer for multi-step, human-in-the-loop flows alongside Redux and RTK Query
- Defined the rule that workflow machines must drive existing Redux actions and never own domain data
- Added a machine catalogue for the shipped ProForge pipeline and the planned Voice and Global Copilot flows, plus a headless testing pattern
- Updated the ADR index to include the new decision record

### Impact
`✅ Clearer workflow architecture`
`✅ Safer future workflow changes`
`✅ Easier review of ProForge, Voice, and Copilot behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
