### PR TITLE
feat(privacy): make the Privacy → Analytics toggle actually gate DuckDB + telemetry (SEC-6)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -321,13 +321,15 @@ const App: FC<AppProps> = ({ isNewUser }) => {
     pluginRegistry.setEnabled(featureFlags.enablePluginSystem);
   }, [featureFlags.enablePluginSystem]);
 
-  // QNBS-v3: Sync enableDuckDbAnalytics into telemetryService — the service cannot import
-  // the Redux store without a circular dep, so App.tsx acts as the bridge.
+  // QNBS-v3: Sync inference telemetry into telemetryService — the service cannot import the Redux
+  // store without a circular dep, so App.tsx acts as the bridge. SEC: telemetry now also honours the
+  // Settings → Privacy "Analytics" opt-out, mirroring the DuckDB persistence gate in listenerMiddleware
+  // (isAnalyticsPersistenceAllowed). Re-runs on either input change so toggling the opt-out is live.
   useEffect(() => {
     void import('./services/ai/telemetryService').then(({ setTelemetryEnabled }) => {
-      setTelemetryEnabled(featureFlags.enableDuckDbAnalytics);
+      setTelemetryEnabled(featureFlags.enableDuckDbAnalytics && settings.privacy.analyticsEnabled);
     });
-  }, [featureFlags.enableDuckDbAnalytics]);
+  }, [featureFlags.enableDuckDbAnalytics, settings.privacy.analyticsEnabled]);
 
   // QNBS-v3: Issue 5 — set the window adaptive-AI gate on cold start if the flag is already on
   //          (listener only fires on OFF→ON transitions, not on initial true state from localStorage)

--- a/app/analyticsGate.ts
+++ b/app/analyticsGate.ts
@@ -1,0 +1,29 @@
+import type { RootState } from './store';
+import { appStoreRef } from './storeRef';
+
+// QNBS-v3: SEC — single source of truth for "may analytics data be persisted to DuckDB / telemetry".
+// DuckDB analytics persistence requires BOTH the feature flag (enableDuckDbAnalytics) AND the
+// user-facing Settings → Privacy "Analytics" opt-out (settings.privacy.analyticsEnabled). Analytics
+// data is local-only metadata (titles/loglines/word-counts/codex excerpts/RAG vectors; never
+// manuscript prose, never leaves the device), but a privacy toggle that does nothing is a dark
+// pattern. EVERY DuckDB-persisting write path — middleware listeners AND user-triggered UI rebuilds
+// (AiSections, ReferencePanelView) — must route its persistence decision through this function so the
+// opt-out is enforced uniformly.
+export function isAnalyticsPersistenceAllowed(state: RootState): boolean {
+  return (
+    Boolean(state.featureFlags?.enableDuckDbAnalytics) && state.settings.privacy.analyticsEnabled
+  );
+}
+
+// QNBS-v3: selector alias for components — `useAppSelector(selectAnalyticsPersistenceAllowed)`.
+export const selectAnalyticsPersistenceAllowed = isAnalyticsPersistenceAllowed;
+
+// QNBS-v3: SEC — live, store-backed gate for user-triggered persistence (e.g. manual RAG rebuild from
+// AiSections / ReferencePanelView). Pass this function as rebuildHybridRagIndex's duckDbEnabled
+// callback so the privacy opt-out is re-evaluated at write time, after the async embedding loop —
+// closing the same opt-out race the middleware path guards against. Returns false if the store ref is
+// not yet wired (fail-closed).
+export function analyticsPersistenceAllowedNow(): boolean {
+  const state = appStoreRef.current?.getState();
+  return state ? isAnalyticsPersistenceAllowed(state) : false;
+}

--- a/app/listenerMiddleware.ts
+++ b/app/listenerMiddleware.ts
@@ -160,8 +160,10 @@ addDebouncedListener(
       // updates on save. The DuckDB mirror is analytics persistence, so it honours the same privacy
       // gate as the other DuckDB writes (search still works fully from the IDB index when off).
       if (presentData.id) {
-        const duckDbOn = isAnalyticsPersistenceAllowed(api.getState());
         const { indexProject } = await import('../services/crossProjectIndexService');
+        // QNBS-v3: SEC — read the gate AFTER the dynamic import resolves so a mid-await opt-out
+        // toggle can't slip one stale DuckDB mirror write through.
+        const duckDbOn = isAnalyticsPersistenceAllowed(api.getState());
         indexProject(presentData.id, enriched, duckDbOn).catch((err: unknown) =>
           logger.warn('Cross-project index update failed (non-critical):', err),
         );
@@ -283,7 +285,9 @@ addDebouncedListener(
       );
       await saveStoryCodex(codex);
 
-      if (isAnalyticsPersistenceAllowed(state)) {
+      // QNBS-v3: SEC — re-read live state at the gate (not the pre-await snapshot) so toggling the
+      // Analytics opt-out off during codex extraction/save is honoured for the DuckDB write.
+      if (isAnalyticsPersistenceAllowed(api.getState())) {
         const entities = codex.entities.map((e) => ({
           id: e.id,
           name: e.name,
@@ -338,6 +342,12 @@ listenerMiddleware.startListening({
     const project = state.project.present?.data;
     if (!project) return;
 
+    // QNBS-v3: SEC — the DuckDB seed migration + RAG vector migration both persist analytics rows,
+    // so they honour the same opt-out as every other DuckDB write. DuckDB still initialises (the hook
+    // gates on the flag), but no analytics data is written while the Privacy toggle is off; the
+    // going-forward auto-save dual-write seeds DuckDB once the user re-enables analytics.
+    if (!isAnalyticsPersistenceAllowed(state)) return;
+
     listenerApi.dispatch(analyticsActions.setMigrationStatus('running'));
     try {
       const { runMigrationWithRollback } = await loadDuckdbMigration();
@@ -370,7 +380,9 @@ listenerMiddleware.startListening({
     if (!project) return;
 
     const projectId = project.id || 'default';
-    const duckDbOn = state.featureFlags?.enableDuckDbAnalytics ?? false;
+    // QNBS-v3: SEC — the local RAG index always rebuilds (retrieval keeps working); only its DuckDB
+    // vector mirror is analytics persistence, so it honours the combined opt-out gate.
+    const duckDbOn = isAnalyticsPersistenceAllowed(state);
     try {
       const { rebuildHybridRagIndex } = await loadLocalRagService();
       await rebuildHybridRagIndex(projectId, project.manuscript, duckDbOn);

--- a/app/listenerMiddleware.ts
+++ b/app/listenerMiddleware.ts
@@ -359,11 +359,14 @@ listenerMiddleware.startListening({
 
     listenerApi.dispatch(analyticsActions.setMigrationStatus('running'));
     try {
+      // QNBS-v3: SEC — pass a live gate thunk so the long-running migrations re-check the analytics
+      // opt-out at each DuckDB write step and abort (without marking done) if it flips off mid-run.
+      const gate = () => isAnalyticsPersistenceAllowed(listenerApi.getState() as RootState);
       const { runMigrationWithRollback } = await loadDuckdbMigration();
-      await runMigrationWithRollback(project);
+      await runMigrationWithRollback(project, gate);
       const projectId = project.id || 'default';
       const { runRagVectorMigration } = await loadRagVectorMigration();
-      await runRagVectorMigration(projectId, project.manuscript);
+      await runRagVectorMigration(projectId, project.manuscript, gate);
       listenerApi.dispatch(analyticsActions.setMigrationStatus('done'));
       listenerApi.dispatch(analyticsActions.setLastSyncAt(new Date().toISOString()));
     } catch (err) {

--- a/app/listenerMiddleware.ts
+++ b/app/listenerMiddleware.ts
@@ -363,10 +363,17 @@ listenerMiddleware.startListening({
       // opt-out at each DuckDB write step and abort (without marking done) if it flips off mid-run.
       const gate = () => isAnalyticsPersistenceAllowed(listenerApi.getState() as RootState);
       const { runMigrationWithRollback } = await loadDuckdbMigration();
-      await runMigrationWithRollback(project, gate);
+      const seedResult = await runMigrationWithRollback(project, gate);
       const projectId = project.id || 'default';
       const { runRagVectorMigration } = await loadRagVectorMigration();
-      await runRagVectorMigration(projectId, project.manuscript, gate);
+      const ragResult = await runRagVectorMigration(projectId, project.manuscript, gate);
+      // QNBS-v3: SEC — if either migration aborted because analytics was opted out mid-run, do NOT mark
+      // it 'done' (no markers were written). Reset to 'idle' so re-enabling analytics re-triggers the
+      // backfill (the predicate re-fires on analyticsEnabled→true while DuckDB is ready + status idle).
+      if (seedResult.aborted || ragResult.aborted) {
+        listenerApi.dispatch(analyticsActions.setMigrationStatus('idle'));
+        return;
+      }
       listenerApi.dispatch(analyticsActions.setMigrationStatus('done'));
       listenerApi.dispatch(analyticsActions.setLastSyncAt(new Date().toISOString()));
     } catch (err) {

--- a/app/listenerMiddleware.ts
+++ b/app/listenerMiddleware.ts
@@ -15,6 +15,7 @@ import { logger } from '../services/logger';
 import { saveEnvelopeFromProjectData } from '../services/storageBackend';
 import { storageService } from '../services/storageService';
 import type { Character, StorySection, World } from '../types';
+import { isAnalyticsPersistenceAllowed } from './analyticsGate';
 import type { AppDispatch, RootState } from './store';
 import { appStoreRef } from './storeRef';
 
@@ -25,16 +26,9 @@ type ProjectStateWithHistory = {
 
 export const listenerMiddleware = createListenerMiddleware();
 
-// QNBS-v3: SEC — DuckDB analytics persistence requires BOTH the feature flag (enableDuckDbAnalytics)
-// AND the user-facing Settings → Privacy "Analytics" opt-out (settings.privacy.analyticsEnabled).
-// Before this gate the privacy toggle was cosmetic — only the flag controlled writes. Analytics data
-// is local-only metadata (titles/loglines/word-counts/codex excerpts; never manuscript prose), but a
-// privacy toggle that does nothing is a dark pattern. Single source of truth for every write site.
-export function isAnalyticsPersistenceAllowed(state: RootState): boolean {
-  return (
-    Boolean(state.featureFlags?.enableDuckDbAnalytics) && state.settings.privacy.analyticsEnabled
-  );
-}
+// QNBS-v3: SEC — analytics persistence gate now lives in app/analyticsGate.ts so middleware AND
+// components share the one enforcement point. Re-exported here for existing importers/tests.
+export { isAnalyticsPersistenceAllowed };
 
 // QNBS-v3: Listener categories in this file:
 //   1. Auto-Save        — project data + version control → IDB (debounced 1s)
@@ -330,22 +324,27 @@ listenerMiddleware.startListening({
   predicate: (_action, currentState, previousState) => {
     const curr = currentState as RootState;
     const prev = previousState as RootState;
-    return (
-      curr.featureFlags?.enableDuckDbAnalytics === true &&
+    // QNBS-v3: SEC — the seed migration may only run when analytics persistence is allowed (flag +
+    // privacy opt-out). It fires when EITHER DuckDB just became ready OR the user just opted back in
+    // while DuckDB is already ready — so a user who starts opted-out and later enables analytics still
+    // gets the one-time historical backfill (no reload required).
+    const eligible =
+      isAnalyticsPersistenceAllowed(curr) &&
       curr.analytics?.duckDbStatus === 'ready' &&
-      curr.analytics?.migrationStatus === 'idle' &&
-      prev.analytics?.duckDbStatus !== 'ready'
-    );
+      curr.analytics?.migrationStatus === 'idle';
+    if (!eligible) return false;
+    const duckDbJustReady = prev.analytics?.duckDbStatus !== 'ready';
+    const analyticsJustEnabled = !isAnalyticsPersistenceAllowed(prev);
+    return duckDbJustReady || analyticsJustEnabled;
   },
   effect: async (_action, listenerApi) => {
     const state = listenerApi.getState() as RootState;
     const project = state.project.present?.data;
     if (!project) return;
 
-    // QNBS-v3: SEC — the DuckDB seed migration + RAG vector migration both persist analytics rows,
-    // so they honour the same opt-out as every other DuckDB write. DuckDB still initialises (the hook
-    // gates on the flag), but no analytics data is written while the Privacy toggle is off; the
-    // going-forward auto-save dual-write seeds DuckDB once the user re-enables analytics.
+    // QNBS-v3: SEC — defence in depth; the predicate already requires the combined gate, but re-check
+    // here in case state changed between predicate and effect. DuckDB still initialises (the hook gates
+    // on the flag); no analytics rows are written while the Privacy opt-out is off.
     if (!isAnalyticsPersistenceAllowed(state)) return;
 
     listenerApi.dispatch(analyticsActions.setMigrationStatus('running'));
@@ -380,12 +379,14 @@ listenerMiddleware.startListening({
     if (!project) return;
 
     const projectId = project.id || 'default';
-    // QNBS-v3: SEC — the local RAG index always rebuilds (retrieval keeps working); only its DuckDB
-    // vector mirror is analytics persistence, so it honours the combined opt-out gate.
-    const duckDbOn = isAnalyticsPersistenceAllowed(state);
     try {
       const { rebuildHybridRagIndex } = await loadLocalRagService();
-      await rebuildHybridRagIndex(projectId, project.manuscript, duckDbOn);
+      // QNBS-v3: SEC — the local RAG index always rebuilds (retrieval keeps working); only its DuckDB
+      // vector mirror is analytics persistence. Pass a thunk so the gate is re-checked at write time
+      // (after the async embedding loop), honouring an opt-out toggled during the rebuild.
+      await rebuildHybridRagIndex(projectId, project.manuscript, () =>
+        isAnalyticsPersistenceAllowed(listenerApi.getState() as RootState),
+      );
     } catch (err) {
       logger.warn('RAG auto-rebuild failed (non-critical):', err);
     }

--- a/app/listenerMiddleware.ts
+++ b/app/listenerMiddleware.ts
@@ -155,10 +155,12 @@ addDebouncedListener(
       // gate as the other DuckDB writes (search still works fully from the IDB index when off).
       if (presentData.id) {
         const { indexProject } = await import('../services/crossProjectIndexService');
-        // QNBS-v3: SEC — read the gate AFTER the dynamic import resolves so a mid-await opt-out
-        // toggle can't slip one stale DuckDB mirror write through.
-        const duckDbOn = isAnalyticsPersistenceAllowed(api.getState());
-        indexProject(presentData.id, enriched, duckDbOn).catch((err: unknown) =>
+        // QNBS-v3: SEC — pass a thunk so the gate is re-evaluated at the DuckDB write site inside
+        // indexProject (after its async IDB work), not snapshotted here — an opt-out toggled during
+        // that window can't slip a stale mirror write through.
+        indexProject(presentData.id, enriched, () =>
+          isAnalyticsPersistenceAllowed(api.getState()),
+        ).catch((err: unknown) =>
           logger.warn('Cross-project index update failed (non-critical):', err),
         );
       }
@@ -175,8 +177,11 @@ addDebouncedListener(
         }));
         const totalWordCount = sections.reduce((acc, s) => acc + s.wordCount, 0);
         const { duckdbDualWrite, withDuckDbRetry } = await loadDuckdbAnalytics();
-        void withDuckDbRetry(() =>
-          duckdbDualWrite(
+        void withDuckDbRetry(() => {
+          // QNBS-v3: SEC — re-check at write time; the opt-out may have toggled during the async
+          // loadDuckdbAnalytics()/retry window, so a snapshot taken at the outer gate could go stale.
+          if (!isAnalyticsPersistenceAllowed(api.getState())) return Promise.resolve();
+          return duckdbDualWrite(
             projectId,
             presentData.title,
             presentData.logline,
@@ -185,8 +190,8 @@ addDebouncedListener(
             presentData.projectGoals?.targetDate,
             presentData.writingHistory ?? [],
             sections,
-          ),
-        ).catch((err: unknown) =>
+          );
+        }).catch((err: unknown) =>
           logger.warn('DuckDB dual-write failed after retries (non-critical):', err),
         );
       }
@@ -290,7 +295,12 @@ addDebouncedListener(
           mentions: e.mentions.map((m) => ({ sectionId: m.sectionId, excerpt: m.excerpt })),
         }));
         const { duckdbCodexWrite, withDuckDbRetry } = await loadDuckdbAnalytics();
-        void withDuckDbRetry(() => duckdbCodexWrite(projectId, entities)).catch((err: unknown) =>
+        void withDuckDbRetry(() => {
+          // QNBS-v3: SEC — re-check at write time; opt-out may have toggled during the async
+          // loadDuckdbAnalytics()/retry window (incl. between retry attempts).
+          if (!isAnalyticsPersistenceAllowed(api.getState())) return Promise.resolve();
+          return duckdbCodexWrite(projectId, entities);
+        }).catch((err: unknown) =>
           logger.warn('DuckDB codex write failed after retries (non-critical):', err),
         );
       }

--- a/app/listenerMiddleware.ts
+++ b/app/listenerMiddleware.ts
@@ -337,11 +337,13 @@ listenerMiddleware.startListening({
     // QNBS-v3: SEC — the seed migration may only run when analytics persistence is allowed (flag +
     // privacy opt-out). It fires when EITHER DuckDB just became ready OR the user just opted back in
     // while DuckDB is already ready — so a user who starts opted-out and later enables analytics still
-    // gets the one-time historical backfill (no reload required).
+    // gets the one-time historical backfill (no reload required). 'error' is retryable too so a
+    // transient DuckDB failure recovers on the next ready/opt-in transition (not stuck until reload).
+    const status = curr.analytics?.migrationStatus;
     const eligible =
       isAnalyticsPersistenceAllowed(curr) &&
       curr.analytics?.duckDbStatus === 'ready' &&
-      curr.analytics?.migrationStatus === 'idle';
+      (status === 'idle' || status === 'error');
     if (!eligible) return false;
     const duckDbJustReady = prev.analytics?.duckDbStatus !== 'ready';
     const analyticsJustEnabled = !isAnalyticsPersistenceAllowed(prev);

--- a/app/listenerMiddleware.ts
+++ b/app/listenerMiddleware.ts
@@ -25,6 +25,17 @@ type ProjectStateWithHistory = {
 
 export const listenerMiddleware = createListenerMiddleware();
 
+// QNBS-v3: SEC — DuckDB analytics persistence requires BOTH the feature flag (enableDuckDbAnalytics)
+// AND the user-facing Settings → Privacy "Analytics" opt-out (settings.privacy.analyticsEnabled).
+// Before this gate the privacy toggle was cosmetic — only the flag controlled writes. Analytics data
+// is local-only metadata (titles/loglines/word-counts/codex excerpts; never manuscript prose), but a
+// privacy toggle that does nothing is a dark pattern. Single source of truth for every write site.
+export function isAnalyticsPersistenceAllowed(state: RootState): boolean {
+  return (
+    Boolean(state.featureFlags?.enableDuckDbAnalytics) && state.settings.privacy.analyticsEnabled
+  );
+}
+
 // QNBS-v3: Listener categories in this file:
 //   1. Auto-Save        — project data + version control → IDB (debounced 1s)
 //   2. Auto-Track       — Codex extraction (always-on; promoted from enableCodexAutoTracking flag)
@@ -154,7 +165,7 @@ addDebouncedListener(
         );
       }
 
-      if (api.getState().featureFlags?.enableDuckDbAnalytics) {
+      if (isAnalyticsPersistenceAllowed(api.getState())) {
         const projectId = presentData.id ?? 'default';
         const sections = presentData.manuscript.map((s, idx) => ({
           id: s.id,
@@ -270,7 +281,7 @@ addDebouncedListener(
       );
       await saveStoryCodex(codex);
 
-      if (state.featureFlags?.enableDuckDbAnalytics) {
+      if (isAnalyticsPersistenceAllowed(state)) {
         const entities = codex.entities.map((e) => ({
           id: e.id,
           name: e.name,

--- a/app/listenerMiddleware.ts
+++ b/app/listenerMiddleware.ts
@@ -156,9 +156,11 @@ addDebouncedListener(
 
       await storageService.saveProject(projectDataToSave);
 
-      // QNBS-v3: enableCrossProjectSearch promoted to permanent core — always index on save.
+      // QNBS-v3: enableCrossProjectSearch promoted to permanent core — the IDB search index always
+      // updates on save. The DuckDB mirror is analytics persistence, so it honours the same privacy
+      // gate as the other DuckDB writes (search still works fully from the IDB index when off).
       if (presentData.id) {
-        const duckDbOn = api.getState().featureFlags?.enableDuckDbAnalytics ?? false;
+        const duckDbOn = isAnalyticsPersistenceAllowed(api.getState());
         const { indexProject } = await import('../services/crossProjectIndexService');
         indexProject(presentData.id, enriched, duckDbOn).catch((err: unknown) =>
           logger.warn('Cross-project index update failed (non-critical):', err),

--- a/components/manuscript/ReferencePanelView.tsx
+++ b/components/manuscript/ReferencePanelView.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'react';
 import { useState } from 'react';
+import { analyticsPersistenceAllowedNow } from '../../app/analyticsGate';
 import { useAppDispatch, useAppSelector } from '../../app/hooks';
 import {
   selectAllCharacters,
@@ -179,7 +180,6 @@ export const ReferencePanelView: FC<{ section: StorySection }> = ({ section }) =
   const [reindexBusy, setReindexBusy] = useState(false);
   const dispatch = useAppDispatch();
   const projectData = useAppSelector(selectProjectData);
-  const duckDbEnabled = useAppSelector((s) => s.featureFlags.enableDuckDbAnalytics);
   const commentCount = useAppSelector(selectCommentsBySection(section.id)).filter(
     (c) => !c.resolved,
   ).length;
@@ -189,10 +189,12 @@ export const ReferencePanelView: FC<{ section: StorySection }> = ({ section }) =
     setReindexBusy(true);
     try {
       // QNBS-v3: re-index from the panel so the AI context is fresh after heavy edits.
+      // SEC: gate the DuckDB mirror on the live analytics opt-out (flag + privacy), re-checked at
+      // write time — not on the feature flag alone.
       const chunks = await rebuildHybridRagIndex(
         projectData.id ?? 'browser-project',
         projectData.manuscript,
-        duckDbEnabled,
+        analyticsPersistenceAllowedNow,
       );
       dispatch(
         statusActions.addNotification({

--- a/components/settings/AiSections.tsx
+++ b/components/settings/AiSections.tsx
@@ -1,6 +1,7 @@
 import { WEBLLM_SUPPORTED_MODELS } from '@domain/ai-core';
 import type { FC } from 'react';
 import { useEffect, useRef, useState } from 'react';
+import { analyticsPersistenceAllowedNow } from '../../app/analyticsGate';
 import { useAppDispatch, useAppSelector } from '../../app/hooks';
 import { useSettingsViewContext } from '../../contexts/SettingsViewContext';
 import { selectEnableAdaptiveAiEngine } from '../../features/featureFlags/featureFlagsSlice';
@@ -233,7 +234,7 @@ export const AiSection: FC = () => {
 };
 
 export const AdvancedAiSection: FC = () => {
-  const { t, settings, featureFlags, handleSettingChange } = useSettingsViewContext();
+  const { t, settings, handleSettingChange } = useSettingsViewContext();
   const dispatch = useAppDispatch();
   const project = useAppSelector(selectProjectData);
   const [ragBusy, setRagBusy] = useState(false);
@@ -285,10 +286,12 @@ export const AdvancedAiSection: FC = () => {
     setRagBusy(true);
     try {
       // QNBS-v3: use hybrid rebuilder so semantic embeddings + DuckDB dual-write fire together.
+      // SEC: gate the DuckDB mirror on the live analytics opt-out (flag + privacy), re-checked at
+      // write time — not on the feature flag alone.
       const chunks = await rebuildHybridRagIndex(
         pid,
         project.manuscript,
-        featureFlags.enableDuckDbAnalytics,
+        analyticsPersistenceAllowedNow,
       );
       dispatch(
         statusActions.addNotification({

--- a/components/settings/PrivacySection.tsx
+++ b/components/settings/PrivacySection.tsx
@@ -44,6 +44,7 @@ export const PrivacySection: FC = () => {
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <ToggleSwitch
               label={t('settings.privacy.analyticsEnabled')}
+              hint={t('settings.privacy.analyticsHint')}
               checked={settings.privacy.analyticsEnabled}
               onChange={(v) =>
                 handleSettingChange('privacy', { ...settings.privacy, analyticsEnabled: v })

--- a/docs/SECURITY-THREAT-MODEL.md
+++ b/docs/SECURITY-THREAT-MODEL.md
@@ -41,7 +41,7 @@ This document provides a formal STRIDE threat analysis for WorldScript Studio, m
 | API key leakage via logs | StructuredLogger sanitization; never log keys | `services/logger.ts:sanitizeLogContext()` |
 | Manuscript data in IndexedDB | AES-256-GCM at-rest encryption | `services/storage/storageEncryptionService.ts` |
 | Voice audio to cloud | Web Speech API consent gate | `components/voice/VoicePrivacyConsentModal.tsx` |
-| DuckDB analytics unencrypted | OPFS encryption module exists but is **not wired** into the persistence path — analytics remain unencrypted at rest (P0-4 integration pending) | `services/duckdb/duckdbEncryption.ts` |
+| DuckDB analytics unencrypted (SEC-6) | **Bounded by design:** only local metadata is persisted (titles, loglines, character names, codex excerpts, word counts, embeddings) — **never manuscript prose**, and **nothing leaves the device**. Gated by `enableDuckDbAnalytics` **and** the Settings → Privacy "Analytics" opt-out (`isAnalyticsPersistenceAllowed` in `app/listenerMiddleware.ts`); turning the toggle off stops all DuckDB writes + inference telemetry. Full OPFS file / cell-level (`*_enc`) encryption is **deferred to v2.0** — DuckDB-WASM owns the OPFS file write, so transparent file encryption is high-risk for the limited exposure. The `duckdbEncryption.ts` shim has 0 callers by design until then. | `app/listenerMiddleware.ts:isAnalyticsPersistenceAllowed`, `services/duckdb/duckdbEncryption.ts` |
 | Prompt injection exposing context | Prompt sanitization | `services/ai/ragPromptAssembly.ts:sanitizePromptBlock()` |
 | Prompt injection via AI-proposed edits | Control-character / lone-surrogate validation; per-item skip | `services/proForge/applyReviewEdits.ts:validateProposedText()` |
 
@@ -154,7 +154,8 @@ Regression test: `tests/unit/csp.test.ts`.
 - [x] Collaboration requires password in production
 - [x] Plugin system permission-gated
 - [x] Plugin system Worker-isolated (P0-2) — `workers/plugin.worker.ts`
-- [ ] DuckDB OPFS encrypted (P0-4) — encryption module + unit tests exist (`services/duckdb/duckdbEncryption.ts`), but it is **not wired** into the persistence path (0 production callers), so DuckDB analytics are not encrypted at rest. Integration pending.
+- [x] DuckDB analytics privacy-gated (SEC-6) — writes require `enableDuckDbAnalytics` **and** the Settings → Privacy "Analytics" opt-out (`isAnalyticsPersistenceAllowed`, `app/listenerMiddleware.ts`); only local metadata is stored, never prose, nothing leaves the device.
+- [ ] DuckDB OPFS at-rest encryption (P0-4 / SEC-6) — **deferred to v2.0.** Encryption module + unit tests exist (`services/duckdb/duckdbEncryption.ts`) but stay unwired (0 callers by design): DuckDB-WASM owns the OPFS file write, so transparent file encryption is high-risk for the bounded, local-only metadata exposure.
 - [x] Voice WASM download UX (P0-5) — `components/voice/VoiceModelDownloadModal.tsx`
 
 ## References

--- a/features/featureCatalog.ts
+++ b/features/featureCatalog.ts
@@ -413,7 +413,10 @@ export const FEATURE_CATALOG: FeatureCatalogEntry[] = [
     // QNBS-v3: B-1 complete (f0afca3) — passphrase UX shipped; maturity updated from ghost→beta
     maturity: 'beta',
     tier: 'privacy',
-    defaultOn: false,
+    // QNBS-v3: reconciled with featureFlagsSlice defaultFeatureFlagsState (enableIdbAtRestEncryption:
+    // true). Catalog previously declared false, contradicting the slice — the slice is the source of
+    // truth; new installs get encryption-ready defaults (passphrase UX, B-1).
+    defaultOn: true,
     gateLocations: [
       {
         file: 'App.tsx:288',

--- a/features/settings/settingsSlice.ts
+++ b/features/settings/settingsSlice.ts
@@ -100,6 +100,8 @@ const defaultSettings: Settings = {
     localStorageOnly: true,
     shareUsageData: false,
     euDataResidency: true,
+    // QNBS-v3: SEC — fresh installs are born post-migration so the normalizer respects this default.
+    analyticsGateMigrated: true,
   },
   performance: {
     autoSaveInterval: 30,

--- a/features/settings/settingsSlice.ts
+++ b/features/settings/settingsSlice.ts
@@ -90,7 +90,11 @@ const defaultSettings: Settings = {
     colorBlindMode: 'none',
   }),
   privacy: {
-    analyticsEnabled: false,
+    // QNBS-v3: SEC — analytics default ON because the data is local-only metadata (no manuscript
+    // prose, never leaves the device) and the analytics dashboard relies on it. The toggle is now a
+    // functional opt-out (gates DuckDB writes + inference telemetry via isAnalyticsPersistenceAllowed).
+    // Outward-facing privacy switches (crashReporting / shareUsageData) stay opt-in.
+    analyticsEnabled: true,
     crashReporting: false,
     dataEncryption: true,
     localStorageOnly: true,

--- a/locales/ar/settings.json
+++ b/locales/ar/settings.json
@@ -644,6 +644,7 @@
   "settings.plugins.title": "الإضافات",
   "settings.plugins.uninstallBtn": "إلغاء التثبيت",
   "settings.privacy.analyticsEnabled": "تفعيل التحليلات",
+  "settings.privacy.analyticsHint": "تحليلات محلية فقط — لا تغادر جهازك أبدًا. أوقف التشغيل لإيقاف جمع كل التحليلات.",
   "settings.privacy.crashReporting": "الإبلاغ عن الأعطال",
   "settings.privacy.dataEncryption": "تشفير البيانات",
   "settings.privacy.encryptionActiveStatus": "التشفير نشط — البيانات محمية لهذه الجلسة",

--- a/locales/de/settings.json
+++ b/locales/de/settings.json
@@ -643,6 +643,7 @@
   "settings.plugins.title": "Plugins",
   "settings.plugins.uninstallBtn": "Deinstallieren",
   "settings.privacy.analyticsEnabled": "Analytics aktivieren",
+  "settings.privacy.analyticsHint": "Nur lokale Analysen – verlassen niemals dein Gerät. Deaktivieren, um jede Analyse-Erfassung zu stoppen.",
   "settings.privacy.crashReporting": "Absturzberichterstattung",
   "settings.privacy.dataEncryption": "Datenverschlüsselung",
   "settings.privacy.encryptionActiveStatus": "Verschlüsselung aktiv — Daten sind für diese Sitzung geschützt",

--- a/locales/el/settings.json
+++ b/locales/el/settings.json
@@ -644,6 +644,7 @@
   "settings.plugins.title": "Πρόσθετα",
   "settings.plugins.uninstallBtn": "Απεγκατάσταση",
   "settings.privacy.analyticsEnabled": "Ενεργοποιήστε το Analytics",
+  "settings.privacy.analyticsHint": "Μόνο τοπικά αναλυτικά — δεν φεύγουν ποτέ από τη συσκευή σας. Απενεργοποιήστε για διακοπή κάθε συλλογής.",
   "settings.privacy.crashReporting": "Αναφορά σφαλμάτων",
   "settings.privacy.dataEncryption": "Κρυπτογράφηση δεδομένων",
   "settings.privacy.encryptionActiveStatus": "Ενεργή κρυπτογράφηση — τα δεδομένα προστατεύονται για αυτήν την περίοδο λειτουργίας",

--- a/locales/en/settings.json
+++ b/locales/en/settings.json
@@ -593,6 +593,7 @@
   "settings.plugins.title": "Plugins",
   "settings.plugins.uninstallBtn": "Uninstall",
   "settings.privacy.analyticsEnabled": "Enable Analytics",
+  "settings.privacy.analyticsHint": "Local analytics only — never leaves your device. Turn off to stop all analytics collection.",
   "settings.privacy.crashReporting": "Crash Reporting",
   "settings.privacy.dataEncryption": "Data Encryption",
   "settings.privacy.encryptionActiveStatus": "Encryption active — data is protected for this session",

--- a/locales/es/settings.json
+++ b/locales/es/settings.json
@@ -643,6 +643,7 @@
   "settings.plugins.title": "Plugins",
   "settings.plugins.uninstallBtn": "Desinstalar",
   "settings.privacy.analyticsEnabled": "Activar análisis",
+  "settings.privacy.analyticsHint": "Solo análisis local: nunca sale de tu dispositivo. Desactívalo para detener toda la recopilación de análisis.",
   "settings.privacy.crashReporting": "Informes de fallos",
   "settings.privacy.dataEncryption": "Cifrado de datos",
   "settings.privacy.encryptionActiveStatus": "Cifrado activo — los datos están protegidos para esta sesión",

--- a/locales/eu/settings.json
+++ b/locales/eu/settings.json
@@ -644,6 +644,7 @@
   "settings.plugins.title": "Pluginak",
   "settings.plugins.uninstallBtn": "Desinstalatu",
   "settings.privacy.analyticsEnabled": "Gaitu Analytics",
+  "settings.privacy.analyticsHint": "Analitika lokala soilik — ez da inoiz zure gailutik irteten. Desaktibatu analitika bilketa guztia gelditzeko.",
   "settings.privacy.crashReporting": "Istripuen berri ematea",
   "settings.privacy.dataEncryption": "Datuen enkriptatzea",
   "settings.privacy.encryptionActiveStatus": "Enkriptatzea aktiboa: datuak babestuta daude saio honetarako",

--- a/locales/fa/settings.json
+++ b/locales/fa/settings.json
@@ -644,6 +644,7 @@
   "settings.plugins.title": "پلاگین ها",
   "settings.plugins.uninstallBtn": "حذف نصب کنید",
   "settings.privacy.analyticsEnabled": "Analytics را فعال کنید",
+  "settings.privacy.analyticsHint": "فقط تحلیل محلی — هرگز از دستگاه شما خارج نمی‌شود. برای توقف همه جمع‌آوری تحلیل‌ها خاموش کنید.",
   "settings.privacy.crashReporting": "گزارش خرابی",
   "settings.privacy.dataEncryption": "رمزگذاری داده ها",
   "settings.privacy.encryptionActiveStatus": "رمزگذاری فعال - داده ها برای این جلسه محافظت می شوند",

--- a/locales/fi/settings.json
+++ b/locales/fi/settings.json
@@ -644,6 +644,7 @@
   "settings.plugins.title": "Plugins",
   "settings.plugins.uninstallBtn": "Poista asennus",
   "settings.privacy.analyticsEnabled": "Ota Analytics käyttöön",
+  "settings.privacy.analyticsHint": "Vain paikallinen analytiikka — ei poistu laitteeltasi. Poista käytöstä pysäyttääksesi kaiken analytiikan keräämisen.",
   "settings.privacy.crashReporting": "Kaatumisraportointi",
   "settings.privacy.dataEncryption": "Tietojen salaus",
   "settings.privacy.encryptionActiveStatus": "Salaus käytössä – tiedot on suojattu tälle istunnolle",

--- a/locales/fr/settings.json
+++ b/locales/fr/settings.json
@@ -643,6 +643,7 @@
   "settings.plugins.title": "Plugins",
   "settings.plugins.uninstallBtn": "Désinstaller",
   "settings.privacy.analyticsEnabled": "Activer les analyses",
+  "settings.privacy.analyticsHint": "Analytique locale uniquement — ne quitte jamais votre appareil. Désactivez pour arrêter toute collecte.",
   "settings.privacy.crashReporting": "Rapports de pannes",
   "settings.privacy.dataEncryption": "Chiffrement des données",
   "settings.privacy.encryptionActiveStatus": "Chiffrement actif — les données sont protégées pour cette session",

--- a/locales/he/settings.json
+++ b/locales/he/settings.json
@@ -644,6 +644,7 @@
   "settings.plugins.title": "תוספים",
   "settings.plugins.uninstallBtn": "הסרת התקנה",
   "settings.privacy.analyticsEnabled": "הפעלת אנליטיקה",
+  "settings.privacy.analyticsHint": "ניתוח מקומי בלבד — לעולם לא עוזב את המכשיר שלך. כבה כדי לעצור את כל איסוף הנתונים.",
   "settings.privacy.crashReporting": "דיווח קריסות",
   "settings.privacy.dataEncryption": "הצפנת נתונים",
   "settings.privacy.encryptionActiveStatus": "הצפנה פעילה — הנתונים מוגנים להפעלה זו",

--- a/locales/hu/settings.json
+++ b/locales/hu/settings.json
@@ -644,6 +644,7 @@
   "settings.plugins.title": "Beépülő modulok",
   "settings.plugins.uninstallBtn": "Eltávolítás",
   "settings.privacy.analyticsEnabled": "Analytics engedélyezése",
+  "settings.privacy.analyticsHint": "Csak helyi elemzés — soha nem hagyja el az eszközödet. Kapcsold ki az összes elemzési adatgyűjtés leállításához.",
   "settings.privacy.crashReporting": "Összeomlás jelentése",
   "settings.privacy.dataEncryption": "Adattitkosítás",
   "settings.privacy.encryptionActiveStatus": "Titkosítás aktív – az adatok ebben a munkamenetben védettek",

--- a/locales/is/settings.json
+++ b/locales/is/settings.json
@@ -644,6 +644,7 @@
   "settings.plugins.title": "Viðbætur",
   "settings.plugins.uninstallBtn": "Fjarlægðu",
   "settings.privacy.analyticsEnabled": "Virkja greiningu",
+  "settings.privacy.analyticsHint": "Aðeins staðbundin greining — fer aldrei úr tækinu þínu. Slökktu til að stöðva alla greiningarsöfnun.",
   "settings.privacy.crashReporting": "Hrunskýrslur",
   "settings.privacy.dataEncryption": "Gagna dulkóðun",
   "settings.privacy.encryptionActiveStatus": "Dulkóðun virk — gögn eru vernduð fyrir þessa lotu",

--- a/locales/it/settings.json
+++ b/locales/it/settings.json
@@ -643,6 +643,7 @@
   "settings.plugins.title": "Plugin",
   "settings.plugins.uninstallBtn": "Disinstalla",
   "settings.privacy.analyticsEnabled": "Abilita analisi",
+  "settings.privacy.analyticsHint": "Analisi solo locali — non lasciano mai il tuo dispositivo. Disattiva per interrompere ogni raccolta.",
   "settings.privacy.crashReporting": "Segnalazione arresti anomali",
   "settings.privacy.dataEncryption": "Crittografia dei dati",
   "settings.privacy.encryptionActiveStatus": "Cifratura attiva — i dati sono protetti per questa sessione",

--- a/locales/ja/settings.json
+++ b/locales/ja/settings.json
@@ -644,6 +644,7 @@
   "settings.plugins.title": "プラグイン",
   "settings.plugins.uninstallBtn": "アンインストール",
   "settings.privacy.analyticsEnabled": "分析を有効にする",
+  "settings.privacy.analyticsHint": "ローカル分析のみ — デバイスから外部に送信されません。オフにするとすべての分析収集が停止します。",
   "settings.privacy.crashReporting": "クラッシュレポート",
   "settings.privacy.dataEncryption": "データの暗号化",
   "settings.privacy.encryptionActiveStatus": "暗号化がアクティブ - このセッションのデータは保護されています",

--- a/locales/pt/settings.json
+++ b/locales/pt/settings.json
@@ -644,6 +644,7 @@
   "settings.plugins.title": "Plug-ins",
   "settings.plugins.uninstallBtn": "Desinstalar",
   "settings.privacy.analyticsEnabled": "Habilitar Análise",
+  "settings.privacy.analyticsHint": "Apenas análises locais — nunca saem do seu dispositivo. Desative para interromper toda a coleta.",
   "settings.privacy.crashReporting": "Relatório de falhas",
   "settings.privacy.dataEncryption": "Criptografia de dados",
   "settings.privacy.encryptionActiveStatus": "Criptografia ativa – os dados estão protegidos para esta sessão",

--- a/locales/sv/settings.json
+++ b/locales/sv/settings.json
@@ -644,6 +644,7 @@
   "settings.plugins.title": "Plugins",
   "settings.plugins.uninstallBtn": "Avinstallera",
   "settings.privacy.analyticsEnabled": "Aktivera Analytics",
+  "settings.privacy.analyticsHint": "Endast lokal analys — lämnar aldrig din enhet. Stäng av för att stoppa all analysinsamling.",
   "settings.privacy.crashReporting": "Kraschrapportering",
   "settings.privacy.dataEncryption": "Datakryptering",
   "settings.privacy.encryptionActiveStatus": "Kryptering aktiv — data är skyddade för denna session",

--- a/locales/zh/settings.json
+++ b/locales/zh/settings.json
@@ -644,6 +644,7 @@
   "settings.plugins.title": "插件",
   "settings.plugins.uninstallBtn": "卸载",
   "settings.privacy.analyticsEnabled": "启用分析",
+  "settings.privacy.analyticsHint": "仅本地分析 — 绝不会离开您的设备。关闭可停止所有分析收集。",
   "settings.privacy.crashReporting": "崩溃报告",
   "settings.privacy.dataEncryption": "数据加密",
   "settings.privacy.encryptionActiveStatus": "加密处于活动状态 — 此会话的数据受到保护",

--- a/public/locales/ar/bundle.json
+++ b/public/locales/ar/bundle.json
@@ -2155,6 +2155,7 @@
   "settings.plugins.title": "الإضافات",
   "settings.plugins.uninstallBtn": "إلغاء التثبيت",
   "settings.privacy.analyticsEnabled": "تفعيل التحليلات",
+  "settings.privacy.analyticsHint": "تحليلات محلية فقط — لا تغادر جهازك أبدًا. أوقف التشغيل لإيقاف جمع كل التحليلات.",
   "settings.privacy.crashReporting": "الإبلاغ عن الأعطال",
   "settings.privacy.dataEncryption": "تشفير البيانات",
   "settings.privacy.encryptionActiveStatus": "التشفير نشط — البيانات محمية لهذه الجلسة",

--- a/public/locales/de/bundle.json
+++ b/public/locales/de/bundle.json
@@ -2154,6 +2154,7 @@
   "settings.plugins.title": "Plugins",
   "settings.plugins.uninstallBtn": "Deinstallieren",
   "settings.privacy.analyticsEnabled": "Analytics aktivieren",
+  "settings.privacy.analyticsHint": "Nur lokale Analysen – verlassen niemals dein Gerät. Deaktivieren, um jede Analyse-Erfassung zu stoppen.",
   "settings.privacy.crashReporting": "Absturzberichterstattung",
   "settings.privacy.dataEncryption": "Datenverschlüsselung",
   "settings.privacy.encryptionActiveStatus": "Verschlüsselung aktiv — Daten sind für diese Sitzung geschützt",

--- a/public/locales/el/bundle.json
+++ b/public/locales/el/bundle.json
@@ -2155,6 +2155,7 @@
   "settings.plugins.title": "Πρόσθετα",
   "settings.plugins.uninstallBtn": "Απεγκατάσταση",
   "settings.privacy.analyticsEnabled": "Ενεργοποιήστε το Analytics",
+  "settings.privacy.analyticsHint": "Μόνο τοπικά αναλυτικά — δεν φεύγουν ποτέ από τη συσκευή σας. Απενεργοποιήστε για διακοπή κάθε συλλογής.",
   "settings.privacy.crashReporting": "Αναφορά σφαλμάτων",
   "settings.privacy.dataEncryption": "Κρυπτογράφηση δεδομένων",
   "settings.privacy.encryptionActiveStatus": "Ενεργή κρυπτογράφηση — τα δεδομένα προστατεύονται για αυτήν την περίοδο λειτουργίας",

--- a/public/locales/en/bundle.json
+++ b/public/locales/en/bundle.json
@@ -2104,6 +2104,7 @@
   "settings.plugins.title": "Plugins",
   "settings.plugins.uninstallBtn": "Uninstall",
   "settings.privacy.analyticsEnabled": "Enable Analytics",
+  "settings.privacy.analyticsHint": "Local analytics only — never leaves your device. Turn off to stop all analytics collection.",
   "settings.privacy.crashReporting": "Crash Reporting",
   "settings.privacy.dataEncryption": "Data Encryption",
   "settings.privacy.encryptionActiveStatus": "Encryption active — data is protected for this session",

--- a/public/locales/es/bundle.json
+++ b/public/locales/es/bundle.json
@@ -2154,6 +2154,7 @@
   "settings.plugins.title": "Plugins",
   "settings.plugins.uninstallBtn": "Desinstalar",
   "settings.privacy.analyticsEnabled": "Activar análisis",
+  "settings.privacy.analyticsHint": "Solo análisis local: nunca sale de tu dispositivo. Desactívalo para detener toda la recopilación de análisis.",
   "settings.privacy.crashReporting": "Informes de fallos",
   "settings.privacy.dataEncryption": "Cifrado de datos",
   "settings.privacy.encryptionActiveStatus": "Cifrado activo — los datos están protegidos para esta sesión",

--- a/public/locales/eu/bundle.json
+++ b/public/locales/eu/bundle.json
@@ -2155,6 +2155,7 @@
   "settings.plugins.title": "Pluginak",
   "settings.plugins.uninstallBtn": "Desinstalatu",
   "settings.privacy.analyticsEnabled": "Gaitu Analytics",
+  "settings.privacy.analyticsHint": "Analitika lokala soilik — ez da inoiz zure gailutik irteten. Desaktibatu analitika bilketa guztia gelditzeko.",
   "settings.privacy.crashReporting": "Istripuen berri ematea",
   "settings.privacy.dataEncryption": "Datuen enkriptatzea",
   "settings.privacy.encryptionActiveStatus": "Enkriptatzea aktiboa: datuak babestuta daude saio honetarako",

--- a/public/locales/fa/bundle.json
+++ b/public/locales/fa/bundle.json
@@ -2155,6 +2155,7 @@
   "settings.plugins.title": "پلاگین ها",
   "settings.plugins.uninstallBtn": "حذف نصب کنید",
   "settings.privacy.analyticsEnabled": "Analytics را فعال کنید",
+  "settings.privacy.analyticsHint": "فقط تحلیل محلی — هرگز از دستگاه شما خارج نمی‌شود. برای توقف همه جمع‌آوری تحلیل‌ها خاموش کنید.",
   "settings.privacy.crashReporting": "گزارش خرابی",
   "settings.privacy.dataEncryption": "رمزگذاری داده ها",
   "settings.privacy.encryptionActiveStatus": "رمزگذاری فعال - داده ها برای این جلسه محافظت می شوند",

--- a/public/locales/fi/bundle.json
+++ b/public/locales/fi/bundle.json
@@ -2155,6 +2155,7 @@
   "settings.plugins.title": "Plugins",
   "settings.plugins.uninstallBtn": "Poista asennus",
   "settings.privacy.analyticsEnabled": "Ota Analytics käyttöön",
+  "settings.privacy.analyticsHint": "Vain paikallinen analytiikka — ei poistu laitteeltasi. Poista käytöstä pysäyttääksesi kaiken analytiikan keräämisen.",
   "settings.privacy.crashReporting": "Kaatumisraportointi",
   "settings.privacy.dataEncryption": "Tietojen salaus",
   "settings.privacy.encryptionActiveStatus": "Salaus käytössä – tiedot on suojattu tälle istunnolle",

--- a/public/locales/fr/bundle.json
+++ b/public/locales/fr/bundle.json
@@ -2154,6 +2154,7 @@
   "settings.plugins.title": "Plugins",
   "settings.plugins.uninstallBtn": "Désinstaller",
   "settings.privacy.analyticsEnabled": "Activer les analyses",
+  "settings.privacy.analyticsHint": "Analytique locale uniquement — ne quitte jamais votre appareil. Désactivez pour arrêter toute collecte.",
   "settings.privacy.crashReporting": "Rapports de pannes",
   "settings.privacy.dataEncryption": "Chiffrement des données",
   "settings.privacy.encryptionActiveStatus": "Chiffrement actif — les données sont protégées pour cette session",

--- a/public/locales/he/bundle.json
+++ b/public/locales/he/bundle.json
@@ -2155,6 +2155,7 @@
   "settings.plugins.title": "תוספים",
   "settings.plugins.uninstallBtn": "הסרת התקנה",
   "settings.privacy.analyticsEnabled": "הפעלת אנליטיקה",
+  "settings.privacy.analyticsHint": "ניתוח מקומי בלבד — לעולם לא עוזב את המכשיר שלך. כבה כדי לעצור את כל איסוף הנתונים.",
   "settings.privacy.crashReporting": "דיווח קריסות",
   "settings.privacy.dataEncryption": "הצפנת נתונים",
   "settings.privacy.encryptionActiveStatus": "הצפנה פעילה — הנתונים מוגנים להפעלה זו",

--- a/public/locales/hu/bundle.json
+++ b/public/locales/hu/bundle.json
@@ -2155,6 +2155,7 @@
   "settings.plugins.title": "Beépülő modulok",
   "settings.plugins.uninstallBtn": "Eltávolítás",
   "settings.privacy.analyticsEnabled": "Analytics engedélyezése",
+  "settings.privacy.analyticsHint": "Csak helyi elemzés — soha nem hagyja el az eszközödet. Kapcsold ki az összes elemzési adatgyűjtés leállításához.",
   "settings.privacy.crashReporting": "Összeomlás jelentése",
   "settings.privacy.dataEncryption": "Adattitkosítás",
   "settings.privacy.encryptionActiveStatus": "Titkosítás aktív – az adatok ebben a munkamenetben védettek",

--- a/public/locales/is/bundle.json
+++ b/public/locales/is/bundle.json
@@ -2155,6 +2155,7 @@
   "settings.plugins.title": "Viðbætur",
   "settings.plugins.uninstallBtn": "Fjarlægðu",
   "settings.privacy.analyticsEnabled": "Virkja greiningu",
+  "settings.privacy.analyticsHint": "Aðeins staðbundin greining — fer aldrei úr tækinu þínu. Slökktu til að stöðva alla greiningarsöfnun.",
   "settings.privacy.crashReporting": "Hrunskýrslur",
   "settings.privacy.dataEncryption": "Gagna dulkóðun",
   "settings.privacy.encryptionActiveStatus": "Dulkóðun virk — gögn eru vernduð fyrir þessa lotu",

--- a/public/locales/it/bundle.json
+++ b/public/locales/it/bundle.json
@@ -2154,6 +2154,7 @@
   "settings.plugins.title": "Plugin",
   "settings.plugins.uninstallBtn": "Disinstalla",
   "settings.privacy.analyticsEnabled": "Abilita analisi",
+  "settings.privacy.analyticsHint": "Analisi solo locali — non lasciano mai il tuo dispositivo. Disattiva per interrompere ogni raccolta.",
   "settings.privacy.crashReporting": "Segnalazione arresti anomali",
   "settings.privacy.dataEncryption": "Crittografia dei dati",
   "settings.privacy.encryptionActiveStatus": "Cifratura attiva — i dati sono protetti per questa sessione",

--- a/public/locales/ja/bundle.json
+++ b/public/locales/ja/bundle.json
@@ -2155,6 +2155,7 @@
   "settings.plugins.title": "プラグイン",
   "settings.plugins.uninstallBtn": "アンインストール",
   "settings.privacy.analyticsEnabled": "分析を有効にする",
+  "settings.privacy.analyticsHint": "ローカル分析のみ — デバイスから外部に送信されません。オフにするとすべての分析収集が停止します。",
   "settings.privacy.crashReporting": "クラッシュレポート",
   "settings.privacy.dataEncryption": "データの暗号化",
   "settings.privacy.encryptionActiveStatus": "暗号化がアクティブ - このセッションのデータは保護されています",

--- a/public/locales/pt/bundle.json
+++ b/public/locales/pt/bundle.json
@@ -2155,6 +2155,7 @@
   "settings.plugins.title": "Plug-ins",
   "settings.plugins.uninstallBtn": "Desinstalar",
   "settings.privacy.analyticsEnabled": "Habilitar Análise",
+  "settings.privacy.analyticsHint": "Apenas análises locais — nunca saem do seu dispositivo. Desative para interromper toda a coleta.",
   "settings.privacy.crashReporting": "Relatório de falhas",
   "settings.privacy.dataEncryption": "Criptografia de dados",
   "settings.privacy.encryptionActiveStatus": "Criptografia ativa – os dados estão protegidos para esta sessão",

--- a/public/locales/sv/bundle.json
+++ b/public/locales/sv/bundle.json
@@ -2155,6 +2155,7 @@
   "settings.plugins.title": "Plugins",
   "settings.plugins.uninstallBtn": "Avinstallera",
   "settings.privacy.analyticsEnabled": "Aktivera Analytics",
+  "settings.privacy.analyticsHint": "Endast lokal analys — lämnar aldrig din enhet. Stäng av för att stoppa all analysinsamling.",
   "settings.privacy.crashReporting": "Kraschrapportering",
   "settings.privacy.dataEncryption": "Datakryptering",
   "settings.privacy.encryptionActiveStatus": "Kryptering aktiv — data är skyddade för denna session",

--- a/public/locales/zh/bundle.json
+++ b/public/locales/zh/bundle.json
@@ -2155,6 +2155,7 @@
   "settings.plugins.title": "插件",
   "settings.plugins.uninstallBtn": "卸载",
   "settings.privacy.analyticsEnabled": "启用分析",
+  "settings.privacy.analyticsHint": "仅本地分析 — 绝不会离开您的设备。关闭可停止所有分析收集。",
   "settings.privacy.crashReporting": "崩溃报告",
   "settings.privacy.dataEncryption": "数据加密",
   "settings.privacy.encryptionActiveStatus": "加密处于活动状态 — 此会话的数据受到保护",

--- a/services/crossProjectIndexService.ts
+++ b/services/crossProjectIndexService.ts
@@ -92,18 +92,23 @@ export async function indexProject(
     req.onerror = () => reject(req.error);
   });
 
-  // SEC: evaluate the gate HERE (after the IDB put), honouring a mid-call opt-out.
-  if (typeof duckDbEnabled === 'function' ? duckDbEnabled() : duckDbEnabled) {
+  // SEC: normalize to a gate function and re-evaluate it INSIDE the async write chain — both after the
+  // IDB put AND after the dynamic loadDuckdbAnalytics() import — so a mid-call opt-out is honoured at
+  // the actual write, not merely at entry.
+  const gateAllows: () => boolean =
+    typeof duckDbEnabled === 'function' ? duckDbEnabled : () => duckDbEnabled;
+  if (gateAllows()) {
     void loadDuckdbAnalytics()
-      .then(({ duckdbCrossProjectWrite }) =>
-        duckdbCrossProjectWrite({
+      .then(({ duckdbCrossProjectWrite }) => {
+        if (!gateAllows()) return undefined;
+        return duckdbCrossProjectWrite({
           projectId,
           title: record.title,
           logline: record.logline,
           manuscriptWordCount: record.manuscriptWordCount,
           characterNames: record.characterNames,
-        }),
-      )
+        });
+      })
       .catch(() => {});
   }
 }
@@ -188,19 +193,23 @@ export async function enrichProjectIndex(
   });
 
   // QNBS-v3: P3 — update DuckDB entry with the now-computed embedding vector.
-  // SEC: evaluate the gate HERE (after async embedding + IDB put), honouring a mid-call opt-out.
-  if (typeof duckDbEnabled === 'function' ? duckDbEnabled() : duckDbEnabled) {
+  // SEC: re-evaluate the gate INSIDE the async chain — after the embedding + IDB put AND after the
+  // dynamic loadDuckdbAnalytics() import — so a mid-call opt-out is honoured at the actual write.
+  const gateAllows: () => boolean =
+    typeof duckDbEnabled === 'function' ? duckDbEnabled : () => duckDbEnabled;
+  if (gateAllows()) {
     void loadDuckdbAnalytics()
-      .then(({ duckdbCrossProjectWrite }) =>
-        duckdbCrossProjectWrite({
+      .then(({ duckdbCrossProjectWrite }) => {
+        if (!gateAllows()) return undefined;
+        return duckdbCrossProjectWrite({
           projectId,
           title: enriched.title,
           logline: enriched.logline,
           manuscriptWordCount: enriched.manuscriptWordCount,
           characterNames: enriched.characterNames,
           embeddingVector: embedding,
-        }),
-      )
+        });
+      })
       .catch(() => {});
   }
 }

--- a/services/crossProjectIndexService.ts
+++ b/services/crossProjectIndexService.ts
@@ -69,8 +69,10 @@ function countWords(data: ProjectData): number {
 export async function indexProject(
   projectId: string,
   data: ProjectData,
-  // QNBS-v3: P3 dual-write — metadata mirrored to DuckDB when analytics flag is on.
-  duckDbEnabled = false,
+  // QNBS-v3: P3 dual-write — metadata mirrored to DuckDB when analytics persistence is allowed.
+  // SEC: accepts a callback so the caller can re-evaluate the privacy gate at the write site (this
+  // function awaits IDB work first) — a boolean captured up-front could go stale on a mid-call opt-out.
+  duckDbEnabled: boolean | (() => boolean) = false,
 ): Promise<void> {
   const db = await getDb();
 
@@ -90,7 +92,8 @@ export async function indexProject(
     req.onerror = () => reject(req.error);
   });
 
-  if (duckDbEnabled) {
+  // SEC: evaluate the gate HERE (after the IDB put), honouring a mid-call opt-out.
+  if (typeof duckDbEnabled === 'function' ? duckDbEnabled() : duckDbEnabled) {
     void loadDuckdbAnalytics()
       .then(({ duckdbCrossProjectWrite }) =>
         duckdbCrossProjectWrite({
@@ -139,7 +142,11 @@ export async function removeProjectIndex(projectId: string): Promise<void> {
  * QNBS-v3: Feature-gated — only runs when embedding model is available; silently
  *          no-ops if the project is not yet indexed or the model isn't ready.
  */
-export async function enrichProjectIndex(projectId: string, duckDbEnabled = false): Promise<void> {
+export async function enrichProjectIndex(
+  projectId: string,
+  // SEC: callback form re-evaluates the privacy gate at the write site (after async embedding + IDB).
+  duckDbEnabled: boolean | (() => boolean) = false,
+): Promise<void> {
   const db = await getDb();
 
   const record = await new Promise<ProjectSearchIndex | undefined>((resolve, reject) => {
@@ -181,7 +188,8 @@ export async function enrichProjectIndex(projectId: string, duckDbEnabled = fals
   });
 
   // QNBS-v3: P3 — update DuckDB entry with the now-computed embedding vector.
-  if (duckDbEnabled) {
+  // SEC: evaluate the gate HERE (after async embedding + IDB put), honouring a mid-call opt-out.
+  if (typeof duckDbEnabled === 'function' ? duckDbEnabled() : duckDbEnabled) {
     void loadDuckdbAnalytics()
       .then(({ duckdbCrossProjectWrite }) =>
         duckdbCrossProjectWrite({

--- a/services/duckdb/duckdbMigration.ts
+++ b/services/duckdb/duckdbMigration.ts
@@ -44,7 +44,13 @@ export async function isMigrated(): Promise<boolean> {
  * Run the one-time seed migration if the marker is absent.
  * Safe to call multiple times — no-ops if already done.
  */
-export async function runIfNeeded(project: MigratableProjectData): Promise<void> {
+export async function runIfNeeded(
+  project: MigratableProjectData,
+  // QNBS-v3: SEC — re-checked right before the DuckDB writes so an analytics opt-out toggled during
+  // the (async) migration aborts before any row is written. Defaults to always-allow for callers that
+  // have no privacy context (the gate is enforced by the middleware that schedules the migration).
+  shouldPersist: () => boolean = () => true,
+): Promise<void> {
   if (await isMigrated()) return;
 
   const projectId = project.id ?? 'default';
@@ -60,6 +66,13 @@ export async function runIfNeeded(project: MigratableProjectData): Promise<void>
     }));
 
     const totalWordCount = sections.reduce((acc, s) => acc + s.wordCount, 0);
+
+    // QNBS-v3: SEC — final gate check at the write site. If analytics was opted out during the async
+    // setup, abort WITHOUT writing the migration marker so the seed retries cleanly on re-opt-in.
+    if (!shouldPersist()) {
+      logger.debug('[duckdbMigration] Seed migration skipped — analytics opt-out');
+      return;
+    }
 
     if (!DRY_RUN) {
       await duckdbDualWrite(
@@ -95,7 +108,11 @@ export async function runIfNeeded(project: MigratableProjectData): Promise<void>
  * so the tables stay consistent. The _meta marker is never written on failure, so the next
  * app load retries cleanly.
  */
-export async function runMigrationWithRollback(project: MigratableProjectData): Promise<void> {
+export async function runMigrationWithRollback(
+  project: MigratableProjectData,
+  // QNBS-v3: SEC — gate callback threaded to the seed write site (see runIfNeeded).
+  shouldPersist: () => boolean = () => true,
+): Promise<void> {
   if (await isMigrated()) return;
 
   const projectId = project.id ?? 'default';
@@ -107,7 +124,7 @@ export async function runMigrationWithRollback(project: MigratableProjectData): 
   }
 
   try {
-    await runIfNeeded(project);
+    await runIfNeeded(project, shouldPersist);
   } catch (err) {
     // QNBS-v3: Best-effort rollback — delete partial rows for this project so the next retry starts clean.
     try {

--- a/services/duckdb/duckdbMigration.ts
+++ b/services/duckdb/duckdbMigration.ts
@@ -50,8 +50,10 @@ export async function runIfNeeded(
   // the (async) migration aborts before any row is written. Defaults to always-allow for callers that
   // have no privacy context (the gate is enforced by the middleware that schedules the migration).
   shouldPersist: () => boolean = () => true,
-): Promise<void> {
-  if (await isMigrated()) return;
+  // QNBS-v3: SEC — `aborted: true` means a privacy opt-out stopped the run before the done-marker was
+  // written; the caller MUST keep migration status retryable so re-opt-in re-runs the seed.
+): Promise<{ aborted: boolean }> {
+  if (await isMigrated()) return { aborted: false };
 
   const projectId = project.id ?? 'default';
   logger.debug('[duckdbMigration] Starting P1 seed migration for project', projectId);
@@ -71,7 +73,7 @@ export async function runIfNeeded(
     // setup, abort WITHOUT writing the migration marker so the seed retries cleanly on re-opt-in.
     if (!shouldPersist()) {
       logger.debug('[duckdbMigration] Seed migration skipped — analytics opt-out');
-      return;
+      return { aborted: true };
     }
 
     if (!DRY_RUN) {
@@ -96,6 +98,7 @@ export async function runIfNeeded(
     }
 
     logger.debug('[duckdbMigration] Seed migration complete');
+    return { aborted: false };
   } catch (err) {
     logger.warn('[duckdbMigration] Seed migration failed (non-fatal):', err);
     // Marker NOT written → will retry on next app load
@@ -112,19 +115,19 @@ export async function runMigrationWithRollback(
   project: MigratableProjectData,
   // QNBS-v3: SEC — gate callback threaded to the seed write site (see runIfNeeded).
   shouldPersist: () => boolean = () => true,
-): Promise<void> {
-  if (await isMigrated()) return;
+): Promise<{ aborted: boolean }> {
+  if (await isMigrated()) return { aborted: false };
 
   const projectId = project.id ?? 'default';
   logger.debug('[duckdbMigration] Starting migration with rollback for project', projectId);
 
   if (DRY_RUN) {
     logger.debug('[duckdbMigration] DRY_RUN — skipping migration');
-    return;
+    return { aborted: false };
   }
 
   try {
-    await runIfNeeded(project, shouldPersist);
+    return await runIfNeeded(project, shouldPersist);
   } catch (err) {
     // QNBS-v3: Best-effort rollback — delete partial rows for this project so the next retry starts clean.
     try {

--- a/services/duckdb/duckdbMigration.ts
+++ b/services/duckdb/duckdbMigration.ts
@@ -50,8 +50,9 @@ export async function runIfNeeded(
   // the (async) migration aborts before any row is written. Defaults to always-allow for callers that
   // have no privacy context (the gate is enforced by the middleware that schedules the migration).
   shouldPersist: () => boolean = () => true,
-  // QNBS-v3: SEC — `aborted: true` means a privacy opt-out stopped the run before the done-marker was
-  // written; the caller MUST keep migration status retryable so re-opt-in re-runs the seed.
+  // QNBS-v3: SEC — `aborted: true` means the run did NOT complete + write the done-marker (a privacy
+  // opt-out stopped it mid-run, or dry-run); the caller MUST keep migration status retryable so a later
+  // ready/opt-in transition re-runs the seed. `aborted: false` ⇒ genuinely complete (or already done).
 ): Promise<{ aborted: boolean }> {
   if (await isMigrated()) return { aborted: false };
 
@@ -94,7 +95,10 @@ export async function runIfNeeded(
          ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`,
       );
     } else {
+      // QNBS-v3: SEC — dry-run persists nothing and writes no marker → report as not-completed so the
+      // caller keeps migration status retryable rather than marking it 'done'.
       logger.debug('[duckdbMigration] DRY_RUN — skipping DuckDB writes');
+      return { aborted: true };
     }
 
     logger.debug('[duckdbMigration] Seed migration complete');
@@ -122,8 +126,10 @@ export async function runMigrationWithRollback(
   logger.debug('[duckdbMigration] Starting migration with rollback for project', projectId);
 
   if (DRY_RUN) {
+    // QNBS-v3: SEC — dry-run writes nothing and no marker, so report it as NOT completed (aborted) so
+    // callers keep migration status retryable instead of marking it 'done'.
     logger.debug('[duckdbMigration] DRY_RUN — skipping migration');
-    return { aborted: false };
+    return { aborted: true };
   }
 
   try {

--- a/services/duckdb/ragVectorMigration.ts
+++ b/services/duckdb/ragVectorMigration.ts
@@ -34,8 +34,16 @@ export async function isRagVectorMigrationDone(): Promise<boolean> {
 export async function runRagVectorMigration(
   projectId: string,
   manuscript: StorySection[],
+  // QNBS-v3: SEC — re-checked before each DuckDB write so an analytics opt-out toggled during the
+  // (async, looped) migration aborts before persisting, and WITHOUT writing the done-marker so it
+  // retries on re-opt-in. Defaults to always-allow for callers without a privacy context.
+  shouldPersist: () => boolean = () => true,
 ): Promise<{ migrated: number }> {
   if (await isRagVectorMigrationDone()) {
+    return { migrated: 0 };
+  }
+  // SEC: abort up-front if analytics persistence is already disallowed (no marker → retries on opt-in).
+  if (!shouldPersist()) {
     return { migrated: 0 };
   }
 
@@ -44,7 +52,10 @@ export async function runRagVectorMigration(
 
   const raw = (await storageService.getRagVectors(projectId)) as StoredRagRecord[];
   if (raw.length === 0 && manuscript.length > 0) {
-    await rebuildHybridRagIndex(projectId, manuscript, true);
+    // Pass the gate through — rebuildHybridRagIndex re-checks it at its own DuckDB write site.
+    await rebuildHybridRagIndex(projectId, manuscript, shouldPersist);
+    // Only record the migration as done if persistence is still allowed; else retry on re-opt-in.
+    if (!shouldPersist()) return { migrated: 0 };
     await duckdbClient.exec(
       `INSERT INTO _meta (key, value) VALUES ('${RAG_VECTORS_V2_KEY}', '1')
        ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`,
@@ -72,6 +83,11 @@ export async function runRagVectorMigration(
     });
     migrated++;
     if (migrated % 10 === 0) await Promise.resolve();
+  }
+
+  // QNBS-v3: SEC — final gate check at the write site; abort without the done-marker on opt-out.
+  if (!shouldPersist()) {
+    return { migrated: 0 };
   }
 
   if (batch.length > 0) {

--- a/services/duckdb/ragVectorMigration.ts
+++ b/services/duckdb/ragVectorMigration.ts
@@ -38,13 +38,15 @@ export async function runRagVectorMigration(
   // (async, looped) migration aborts before persisting, and WITHOUT writing the done-marker so it
   // retries on re-opt-in. Defaults to always-allow for callers without a privacy context.
   shouldPersist: () => boolean = () => true,
-): Promise<{ migrated: number }> {
+  // QNBS-v3: SEC — `aborted: true` means a privacy opt-out stopped the run before the done-marker was
+  // written; callers MUST keep migration status retryable (not 'done') so re-opt-in re-runs the backfill.
+): Promise<{ migrated: number; aborted: boolean }> {
   if (await isRagVectorMigrationDone()) {
-    return { migrated: 0 };
+    return { migrated: 0, aborted: false };
   }
   // SEC: abort up-front if analytics persistence is already disallowed (no marker → retries on opt-in).
   if (!shouldPersist()) {
-    return { migrated: 0 };
+    return { migrated: 0, aborted: true };
   }
 
   logger.debug('[ragVectorMigration] Starting semantic vector migration for', projectId);
@@ -55,12 +57,12 @@ export async function runRagVectorMigration(
     // Pass the gate through — rebuildHybridRagIndex re-checks it at its own DuckDB write site.
     await rebuildHybridRagIndex(projectId, manuscript, shouldPersist);
     // Only record the migration as done if persistence is still allowed; else retry on re-opt-in.
-    if (!shouldPersist()) return { migrated: 0 };
+    if (!shouldPersist()) return { migrated: 0, aborted: true };
     await duckdbClient.exec(
       `INSERT INTO _meta (key, value) VALUES ('${RAG_VECTORS_V2_KEY}', '1')
        ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`,
     );
-    return { migrated: 0 };
+    return { migrated: 0, aborted: false };
   }
 
   const batch: Parameters<typeof duckdbRagWrite>[1] = [];
@@ -87,7 +89,7 @@ export async function runRagVectorMigration(
 
   // QNBS-v3: SEC — final gate check at the write site; abort without the done-marker on opt-out.
   if (!shouldPersist()) {
-    return { migrated: 0 };
+    return { migrated, aborted: true };
   }
 
   if (batch.length > 0) {
@@ -100,7 +102,7 @@ export async function runRagVectorMigration(
   );
 
   logger.debug('[ragVectorMigration] Complete:', migrated, 'chunks');
-  return { migrated };
+  return { migrated, aborted: false };
 }
 
 /**

--- a/services/duckdb/ragVectorMigration.ts
+++ b/services/duckdb/ragVectorMigration.ts
@@ -96,6 +96,12 @@ export async function runRagVectorMigration(
     await duckdbRagWrite(projectId, batch);
   }
 
+  // QNBS-v3: SEC — re-check immediately before the done-marker: an opt-out landing during the awaited
+  // vector write above must not let us record the migration as complete (else re-opt-in never reruns).
+  if (!shouldPersist()) {
+    return { migrated, aborted: true };
+  }
+
   await duckdbClient.exec(
     `INSERT INTO _meta (key, value) VALUES ('${RAG_VECTORS_V2_KEY}', '1')
      ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`,

--- a/services/localRagService.ts
+++ b/services/localRagService.ts
@@ -94,8 +94,11 @@ interface HybridRagRecord extends LocalRagChunkRecord {
 export async function rebuildHybridRagIndex(
   projectId: string,
   manuscript: StorySection[],
-  // QNBS-v3: P2 dual-write — vectors (not text) mirrored to DuckDB when analytics flag is on.
-  duckDbEnabled = false,
+  // QNBS-v3: P2 dual-write — vectors (not text) mirrored to DuckDB when analytics persistence is
+  // allowed. SEC: accepts a callback so the caller can re-evaluate the privacy gate at write time
+  // (the embedding loop is async — a boolean captured up-front would let an opt-out toggled mid-rebuild
+  // leak one stale mirror write). A plain boolean is still accepted for simple/synchronous callers.
+  duckDbEnabled: boolean | (() => boolean) = false,
 ): Promise<number> {
   const records: HybridRagRecord[] = [];
 
@@ -134,7 +137,9 @@ export async function rebuildHybridRagIndex(
   await storageService.saveRagVectors(projectId, records);
 
   // QNBS-v3: Mirror vector-only data to DuckDB; text stays in IDB to avoid BLOB encryption.
-  if (duckDbEnabled && records.length > 0) {
+  // SEC: evaluate the gate HERE (after the async embedding loop), so a mid-rebuild opt-out is honored.
+  const persistToDuckDb = typeof duckDbEnabled === 'function' ? duckDbEnabled() : duckDbEnabled;
+  if (persistToDuckDb && records.length > 0) {
     const duckChunks = records
       .filter((r) => r.semanticVec && r.semanticVec.length > 0)
       .map((r) => ({

--- a/services/localRagService.ts
+++ b/services/localRagService.ts
@@ -137,9 +137,13 @@ export async function rebuildHybridRagIndex(
   await storageService.saveRagVectors(projectId, records);
 
   // QNBS-v3: Mirror vector-only data to DuckDB; text stays in IDB to avoid BLOB encryption.
-  // SEC: evaluate the gate HERE (after the async embedding loop), so a mid-rebuild opt-out is honored.
-  const persistToDuckDb = typeof duckDbEnabled === 'function' ? duckDbEnabled() : duckDbEnabled;
-  if (persistToDuckDb && records.length > 0) {
+  // SEC: normalize the gate to a function and re-evaluate it at the LAST synchronous moment before the
+  // mirror write (after the async embedding loop AND after building duckChunks), so a mid-rebuild
+  // opt-out is honored. The only irreducible window is an opt-out landing during the in-flight DB
+  // insert itself, which cannot be interrupted without transactional rollback.
+  const gateAllows: () => boolean =
+    typeof duckDbEnabled === 'function' ? duckDbEnabled : () => duckDbEnabled;
+  if (gateAllows() && records.length > 0) {
     const duckChunks = records
       .filter((r) => r.semanticVec && r.semanticVec.length > 0)
       .map((r) => ({
@@ -149,7 +153,7 @@ export async function rebuildHybridRagIndex(
         embedding: r.semanticVec as Float32Array,
         vector: r.vector,
       }));
-    if (duckChunks.length > 0) {
+    if (duckChunks.length > 0 && gateAllows()) {
       void duckdbRagWrite(projectId, duckChunks).catch((err: unknown) =>
         logger.warn('DuckDB RAG vector write failed (non-critical):', err),
       );

--- a/services/storage/idbProjectStore.ts
+++ b/services/storage/idbProjectStore.ts
@@ -59,18 +59,27 @@ export function normalizePersistedSettings(incoming: Record<string, unknown>): S
 
   validSettings.accessibility = normalizeAccessibilitySettings(incoming['accessibility']);
 
+  const incomingPrivacy = incoming['privacy'] as Partial<Settings['privacy']> | undefined;
+  // QNBS-v3: SEC — analytics default ON (local-only metadata, never leaves device), gated by
+  // isAnalyticsPersistenceAllowed; persisted user choice overrides the default via the spread.
   validSettings.privacy = {
-    // QNBS-v3: SEC — keep in lockstep with settingsSlice defaults. Analytics default ON (local-only
-    // metadata, never leaves device) and gated by isAnalyticsPersistenceAllowed; persisted user choice
-    // in `incoming.privacy` overrides this default via the spread below.
     analyticsEnabled: true,
     crashReporting: false,
     dataEncryption: true,
     localStorageOnly: true,
     shareUsageData: false,
     euDataResidency: true,
-    ...(incoming['privacy'] as Partial<Settings['privacy']> | undefined),
+    ...incomingPrivacy,
   };
+  // QNBS-v3: SEC one-time migration — before the gate shipped, analyticsEnabled was cosmetic and
+  // analytics persistence was controlled solely by enableDuckDbAnalytics (default on). Legacy persisted
+  // settings therefore hold a meaningless analyticsEnabled (default false). On the FIRST load after this
+  // upgrade, reset it to the new default (ON) to PRESERVE prior behavior; the marker then ensures every
+  // subsequent load respects the user's real choice (so a future genuine opt-out is never re-flipped).
+  if (incomingPrivacy?.analyticsGateMigrated !== true) {
+    validSettings.privacy.analyticsEnabled = true;
+  }
+  validSettings.privacy.analyticsGateMigrated = true;
 
   const incomingCollab = incoming['collaboration'] as
     | Partial<Settings['collaboration']>

--- a/services/storage/idbProjectStore.ts
+++ b/services/storage/idbProjectStore.ts
@@ -60,7 +60,10 @@ export function normalizePersistedSettings(incoming: Record<string, unknown>): S
   validSettings.accessibility = normalizeAccessibilitySettings(incoming['accessibility']);
 
   validSettings.privacy = {
-    analyticsEnabled: false,
+    // QNBS-v3: SEC — keep in lockstep with settingsSlice defaults. Analytics default ON (local-only
+    // metadata, never leaves device) and gated by isAnalyticsPersistenceAllowed; persisted user choice
+    // in `incoming.privacy` overrides this default via the spread below.
+    analyticsEnabled: true,
     crashReporting: false,
     dataEncryption: true,
     localStorageOnly: true,

--- a/tests/unit/analyticsPersistenceGate.test.ts
+++ b/tests/unit/analyticsPersistenceGate.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { isAnalyticsPersistenceAllowed } from '../../app/listenerMiddleware';
+import type { RootState } from '../../app/store';
+
+// QNBS-v3: SEC — the gate that makes the Settings → Privacy "Analytics" toggle actually stop DuckDB
+// writes + inference telemetry. Before this gate the toggle was cosmetic (only the feature flag
+// controlled persistence). Both inputs must be true for any analytics data to be persisted.
+
+function makeState(opts: { flag: boolean; analyticsEnabled: boolean }): RootState {
+  return {
+    featureFlags: { enableDuckDbAnalytics: opts.flag },
+    settings: { privacy: { analyticsEnabled: opts.analyticsEnabled } },
+  } as unknown as RootState;
+}
+
+describe('isAnalyticsPersistenceAllowed', () => {
+  it('allows persistence only when the flag AND the privacy opt-out are both on', () => {
+    expect(isAnalyticsPersistenceAllowed(makeState({ flag: true, analyticsEnabled: true }))).toBe(
+      true,
+    );
+  });
+
+  it('blocks persistence when the privacy opt-out is off, even with the flag on', () => {
+    expect(isAnalyticsPersistenceAllowed(makeState({ flag: true, analyticsEnabled: false }))).toBe(
+      false,
+    );
+  });
+
+  it('blocks persistence when the feature flag is off, even with analytics enabled', () => {
+    expect(isAnalyticsPersistenceAllowed(makeState({ flag: false, analyticsEnabled: true }))).toBe(
+      false,
+    );
+  });
+
+  it('blocks persistence when both are off', () => {
+    expect(isAnalyticsPersistenceAllowed(makeState({ flag: false, analyticsEnabled: false }))).toBe(
+      false,
+    );
+  });
+
+  it('treats a missing featureFlags slice as not allowed (no crash)', () => {
+    const state = {
+      settings: { privacy: { analyticsEnabled: true } },
+    } as unknown as RootState;
+    expect(isAnalyticsPersistenceAllowed(state)).toBe(false);
+  });
+});

--- a/tests/unit/crossProjectIndexService.test.ts
+++ b/tests/unit/crossProjectIndexService.test.ts
@@ -15,6 +15,13 @@ vi.mock('../../services/ai/localEmbeddingService', () => ({
   cosineSimilarity: (...args: unknown[]) => mockCosineSimilarity(...args),
 }));
 
+// QNBS-v3: SEC — mock the DuckDB loader so we can assert the cross-project mirror write is gated by
+// the duckDbEnabled callback (re-evaluated at the write site) without touching real DuckDB-WASM.
+const { mockCrossProjectWrite } = vi.hoisted(() => ({ mockCrossProjectWrite: vi.fn() }));
+vi.mock('../../services/duckdb/duckdbListenerLoader', () => ({
+  loadDuckdbAnalytics: () => Promise.resolve({ duckdbCrossProjectWrite: mockCrossProjectWrite }),
+}));
+
 import type { ProjectData } from '../../features/project/projectSlice';
 import {
   enrichProjectIndex,
@@ -54,10 +61,16 @@ beforeEach(async () => {
   // Default: embedding succeeds with a small Float32Array
   mockEmbedText.mockResolvedValue(new Float32Array([0.5, 0.5, 0.0]));
   mockCosineSimilarity.mockReturnValue(0.8);
+  mockCrossProjectWrite.mockResolvedValue(undefined);
   for (const id of TEST_IDS) {
     await removeProjectIndex(id).catch(() => {});
   }
 });
+
+// Flush the fire-and-forget DuckDB write chain (loadDuckdbAnalytics().then(...)).
+async function flushMicrotasks() {
+  await new Promise((r) => setTimeout(r, 0));
+}
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
@@ -139,6 +152,25 @@ describe('crossProjectIndexService', () => {
     const found = results.find((r) => r.projectId === 'proj-1');
     expect(found?.lastIndexed).toBeGreaterThanOrEqual(before);
     expect(found?.lastIndexed).toBeLessThanOrEqual(after);
+  });
+
+  // QNBS-v3: SEC — the DuckDB mirror write is gated by the duckDbEnabled callback, evaluated AFTER the
+  // IDB put (so a mid-call opt-out is honoured). The IDB index itself is written regardless.
+  it('indexProject writes the DuckDB mirror when the gate callback returns true', async () => {
+    await indexProject('proj-1', makeProjectData(), () => true);
+    await flushMicrotasks();
+    expect(mockCrossProjectWrite).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: 'proj-1', title: 'My Novel' }),
+    );
+  });
+
+  it('indexProject skips the DuckDB mirror when the gate callback returns false (IDB still written)', async () => {
+    await indexProject('proj-1', makeProjectData(), () => false);
+    await flushMicrotasks();
+    expect(mockCrossProjectWrite).not.toHaveBeenCalled();
+    // IDB search index is still populated — search works regardless of analytics opt-out.
+    const results = await listIndexedProjects();
+    expect(results.find((r) => r.projectId === 'proj-1')).toBeDefined();
   });
 });
 

--- a/tests/unit/crossProjectIndexService.test.ts
+++ b/tests/unit/crossProjectIndexService.test.ts
@@ -67,9 +67,11 @@ beforeEach(async () => {
   }
 });
 
-// Flush the fire-and-forget DuckDB write chain (loadDuckdbAnalytics().then(...)).
+// Flush the fire-and-forget DuckDB write chain (loadDuckdbAnalytics().then(...)) deterministically —
+// it is a pure microtask chain (mocked loader resolves synchronously), so awaiting a few microtask
+// ticks settles it without depending on real timers / wall-clock scheduling.
 async function flushMicrotasks() {
-  await new Promise((r) => setTimeout(r, 0));
+  for (let i = 0; i < 5; i++) await Promise.resolve();
 }
 
 // ─── Tests ───────────────────────────────────────────────────────────────────

--- a/tests/unit/duckdbMigration.test.ts
+++ b/tests/unit/duckdbMigration.test.ts
@@ -75,6 +75,17 @@ describe('runIfNeeded', () => {
     expect(mockDualWrite).toHaveBeenCalledOnce();
   });
 
+  // QNBS-v3: SEC — analytics opt-out aborts the seed write WITHOUT marking done (retries on opt-in).
+  it('skips the write and the marker when shouldPersist() returns false', async () => {
+    mockQuery.mockResolvedValueOnce({ messageId: 'm', ok: true, rows: [] }); // marker absent
+    await runIfNeeded(sampleProject, () => false);
+    expect(mockDualWrite).not.toHaveBeenCalled();
+    const markerCall = mockExec.mock.calls.find(([sql]) =>
+      (sql as string).includes('INSERT INTO _meta'),
+    );
+    expect(markerCall).toBeUndefined();
+  });
+
   it('writes _meta marker after successful migration', async () => {
     mockQuery.mockResolvedValueOnce({ messageId: 'm', ok: true, rows: [] });
     await runIfNeeded(sampleProject);

--- a/tests/unit/listenerMiddleware.test.ts
+++ b/tests/unit/listenerMiddleware.test.ts
@@ -381,29 +381,42 @@ describe('debounce stress tests', () => {
 // Analytics privacy opt-out gates the DuckDB mirror (SEC)
 // ---------------------------------------------------------------------------
 describe('analytics privacy opt-out gating', () => {
-  // QNBS-v3: SEC — the RAG index always rebuilds, but its DuckDB vector mirror is gated by a thunk
-  // (third rebuildHybridRagIndex arg) that re-evaluates isAnalyticsPersistenceAllowed at write time,
-  // not the flag alone. The thunk reads the live store, so it must reflect the privacy opt-out.
-  function lastDuckDbGateResult(): boolean {
+  // QNBS-v3: SEC — the RAG index always rebuilds, but its DuckDB vector mirror is gated by a THUNK
+  // (third rebuildHybridRagIndex arg) that re-evaluates isAnalyticsPersistenceAllowed at write time.
+  // The contract is the live-callback itself: asserting a function (not a precomputed boolean) catches
+  // a regression where the middleware reverts to passing a stale snapshot.
+  function lastDuckDbGate(): () => boolean {
     const call = mockRebuildHybridRagIndex.mock.calls.at(-1);
     const gate = call?.[2];
-    return typeof gate === 'function' ? Boolean(gate()) : Boolean(gate);
+    expect(typeof gate).toBe('function'); // enforce the live-callback contract, not a boolean
+    return gate as () => boolean;
   }
 
-  it('the DuckDB-mirror gate resolves true when the analytics opt-out is on (default)', async () => {
+  it('passes a live thunk that resolves true when the analytics opt-out is on (default)', async () => {
     const store = makeFullStore();
     store.dispatch(projectActions.addManuscriptSection({ title: 'Scene' }));
     await vi.advanceTimersByTimeAsync(6000);
     expect(mockRebuildHybridRagIndex).toHaveBeenCalledTimes(1);
-    expect(lastDuckDbGateResult()).toBe(true);
+    expect(lastDuckDbGate()()).toBe(true);
   });
 
-  it('the DuckDB-mirror gate resolves false when the analytics opt-out is off', async () => {
+  it('passes a live thunk that resolves false when the analytics opt-out is off', async () => {
     const store = makeFullStore();
     store.dispatch(settingsActions.setPrivacy({ analyticsEnabled: false }));
     store.dispatch(projectActions.addManuscriptSection({ title: 'Scene' }));
     await vi.advanceTimersByTimeAsync(6000);
     expect(mockRebuildHybridRagIndex).toHaveBeenCalledTimes(1);
-    expect(lastDuckDbGateResult()).toBe(false);
+    expect(lastDuckDbGate()()).toBe(false);
+  });
+
+  it('the thunk reflects a LIVE opt-out toggled after the rebuild call (proves it is not a snapshot)', async () => {
+    const store = makeFullStore();
+    store.dispatch(projectActions.addManuscriptSection({ title: 'Scene' }));
+    await vi.advanceTimersByTimeAsync(6000);
+    const gate = lastDuckDbGate();
+    expect(gate()).toBe(true);
+    // Opt out AFTER the call was made — a live thunk must now report false; a captured boolean wouldn't.
+    store.dispatch(settingsActions.setPrivacy({ analyticsEnabled: false }));
+    expect(gate()).toBe(false);
   });
 });

--- a/tests/unit/listenerMiddleware.test.ts
+++ b/tests/unit/listenerMiddleware.test.ts
@@ -381,30 +381,29 @@ describe('debounce stress tests', () => {
 // Analytics privacy opt-out gates the DuckDB mirror (SEC)
 // ---------------------------------------------------------------------------
 describe('analytics privacy opt-out gating', () => {
-  // QNBS-v3: SEC — the RAG index always rebuilds, but its DuckDB vector mirror (the third
-  // rebuildHybridRagIndex arg) must follow isAnalyticsPersistenceAllowed, not the flag alone.
-  it('passes duckDbOn=true to rebuildHybridRagIndex when analytics opt-out is on (default)', async () => {
+  // QNBS-v3: SEC — the RAG index always rebuilds, but its DuckDB vector mirror is gated by a thunk
+  // (third rebuildHybridRagIndex arg) that re-evaluates isAnalyticsPersistenceAllowed at write time,
+  // not the flag alone. The thunk reads the live store, so it must reflect the privacy opt-out.
+  function lastDuckDbGateResult(): boolean {
+    const call = mockRebuildHybridRagIndex.mock.calls.at(-1);
+    const gate = call?.[2];
+    return typeof gate === 'function' ? Boolean(gate()) : Boolean(gate);
+  }
+
+  it('the DuckDB-mirror gate resolves true when the analytics opt-out is on (default)', async () => {
     const store = makeFullStore();
     store.dispatch(projectActions.addManuscriptSection({ title: 'Scene' }));
     await vi.advanceTimersByTimeAsync(6000);
     expect(mockRebuildHybridRagIndex).toHaveBeenCalledTimes(1);
-    expect(mockRebuildHybridRagIndex).toHaveBeenLastCalledWith(
-      expect.anything(),
-      expect.anything(),
-      true,
-    );
+    expect(lastDuckDbGateResult()).toBe(true);
   });
 
-  it('passes duckDbOn=false to rebuildHybridRagIndex when the analytics opt-out is off', async () => {
+  it('the DuckDB-mirror gate resolves false when the analytics opt-out is off', async () => {
     const store = makeFullStore();
     store.dispatch(settingsActions.setPrivacy({ analyticsEnabled: false }));
     store.dispatch(projectActions.addManuscriptSection({ title: 'Scene' }));
     await vi.advanceTimersByTimeAsync(6000);
     expect(mockRebuildHybridRagIndex).toHaveBeenCalledTimes(1);
-    expect(mockRebuildHybridRagIndex).toHaveBeenLastCalledWith(
-      expect.anything(),
-      expect.anything(),
-      false,
-    );
+    expect(lastDuckDbGateResult()).toBe(false);
   });
 });

--- a/tests/unit/listenerMiddleware.test.ts
+++ b/tests/unit/listenerMiddleware.test.ts
@@ -376,3 +376,35 @@ describe('debounce stress tests', () => {
     expect(mockRebuildHybridRagIndex).toHaveBeenCalledTimes(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Analytics privacy opt-out gates the DuckDB mirror (SEC)
+// ---------------------------------------------------------------------------
+describe('analytics privacy opt-out gating', () => {
+  // QNBS-v3: SEC — the RAG index always rebuilds, but its DuckDB vector mirror (the third
+  // rebuildHybridRagIndex arg) must follow isAnalyticsPersistenceAllowed, not the flag alone.
+  it('passes duckDbOn=true to rebuildHybridRagIndex when analytics opt-out is on (default)', async () => {
+    const store = makeFullStore();
+    store.dispatch(projectActions.addManuscriptSection({ title: 'Scene' }));
+    await vi.advanceTimersByTimeAsync(6000);
+    expect(mockRebuildHybridRagIndex).toHaveBeenCalledTimes(1);
+    expect(mockRebuildHybridRagIndex).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.anything(),
+      true,
+    );
+  });
+
+  it('passes duckDbOn=false to rebuildHybridRagIndex when the analytics opt-out is off', async () => {
+    const store = makeFullStore();
+    store.dispatch(settingsActions.setPrivacy({ analyticsEnabled: false }));
+    store.dispatch(projectActions.addManuscriptSection({ title: 'Scene' }));
+    await vi.advanceTimersByTimeAsync(6000);
+    expect(mockRebuildHybridRagIndex).toHaveBeenCalledTimes(1);
+    expect(mockRebuildHybridRagIndex).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.anything(),
+      false,
+    );
+  });
+});

--- a/tests/unit/localRagService.duckdb.test.ts
+++ b/tests/unit/localRagService.duckdb.test.ts
@@ -71,6 +71,20 @@ describe('rebuildHybridRagIndex — DuckDB dual-write', () => {
     await Promise.resolve();
     expect(mockRagWrite).not.toHaveBeenCalled();
   });
+
+  // QNBS-v3: SEC — the gate may be a callback re-evaluated at write time (after the async embedding
+  // loop), so a privacy opt-out toggled mid-rebuild is honoured.
+  it('calls duckdbRagWrite when the duckDbEnabled callback returns true at write time', async () => {
+    await rebuildHybridRagIndex('p1', manuscript, () => true);
+    await Promise.resolve();
+    expect(mockRagWrite).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT call duckdbRagWrite when the duckDbEnabled callback returns false at write time', async () => {
+    await rebuildHybridRagIndex('p1', manuscript, () => false);
+    await Promise.resolve();
+    expect(mockRagWrite).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/localRagService.duckdb.test.ts
+++ b/tests/unit/localRagService.duckdb.test.ts
@@ -19,6 +19,7 @@ vi.mock('../../services/ai/localEmbeddingService', () => ({
   cosineSimilarity: vi.fn(),
 }));
 
+import { embedText } from '../../services/ai/localEmbeddingService';
 import { duckdbRagWrite, queryRagSimilarity } from '../../services/duckdb/duckdbAnalytics';
 import { rebuildHybridRagIndex, retrieveContext } from '../../services/localRagService';
 import { storageService } from '../../services/storageService';
@@ -27,6 +28,7 @@ const mockRagWrite = vi.mocked(duckdbRagWrite);
 const mockRagSimilarity = vi.mocked(queryRagSimilarity);
 const mockSaveRagVectors = vi.mocked(storageService.saveRagVectors);
 const mockGetRagVectors = vi.mocked(storageService.getRagVectors);
+const mockEmbed = vi.mocked(embedText);
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -84,6 +86,32 @@ describe('rebuildHybridRagIndex — DuckDB dual-write', () => {
     await rebuildHybridRagIndex('p1', manuscript, () => false);
     await Promise.resolve();
     expect(mockRagWrite).not.toHaveBeenCalled();
+  });
+
+  // QNBS-v3: SEC — prove the decision is made at WRITE time, not function entry: flip the gate to
+  // false DURING the async embedding loop (embedText is awaited per chunk). A service that evaluated
+  // the callback once at entry (when it was true) would still write; the write-time contract must not.
+  it('honours a mid-rebuild opt-out: gate flipped false during embedding suppresses the write', async () => {
+    let allowed = true;
+    mockEmbed.mockImplementation(async () => {
+      allowed = false; // user toggles Privacy → Analytics off while embeddings are computing
+      return new Float32Array(384).fill(0.1);
+    });
+    await rebuildHybridRagIndex('p1', manuscript, () => allowed);
+    await Promise.resolve();
+    expect(mockSaveRagVectors).toHaveBeenCalledOnce(); // local index still rebuilt
+    expect(mockRagWrite).not.toHaveBeenCalled(); // but no DuckDB mirror write
+  });
+
+  it('mid-rebuild opt-IN: gate flipped true during embedding allows the write', async () => {
+    let allowed = false;
+    mockEmbed.mockImplementation(async () => {
+      allowed = true;
+      return new Float32Array(384).fill(0.1);
+    });
+    await rebuildHybridRagIndex('p1', manuscript, () => allowed);
+    await Promise.resolve();
+    expect(mockRagWrite).toHaveBeenCalledOnce();
   });
 });
 

--- a/tests/unit/ragVectorMigration.test.ts
+++ b/tests/unit/ragVectorMigration.test.ts
@@ -120,8 +120,24 @@ describe('runRagVectorMigration', () => {
     mockGetRagVectors.mockResolvedValueOnce([]);
     const manuscript = [{ id: 's1', title: 'Ch1', content: 'Text.' }];
     await runRagVectorMigration('proj-1', manuscript as never);
-    expect(vi.mocked(rebuildHybridRagIndex)).toHaveBeenCalledWith('proj-1', manuscript, true);
+    // QNBS-v3: SEC — the gate is now threaded through as a callback (default () => true) so the rebuild
+    // re-checks the analytics opt-out at its own DuckDB write site rather than receiving a fixed boolean.
+    const ragCall = vi.mocked(rebuildHybridRagIndex).mock.calls.at(-1);
+    expect(ragCall?.[0]).toBe('proj-1');
+    expect(ragCall?.[1]).toBe(manuscript);
+    expect(typeof ragCall?.[2]).toBe('function');
+    expect((ragCall?.[2] as () => boolean)()).toBe(true);
     expect(mockExec).toHaveBeenCalledWith(expect.stringContaining('rag_vectors_v2_migrated'));
+  });
+
+  // QNBS-v3: SEC — opt-out aborts the migration WITHOUT writing the done-marker (so it retries on opt-in).
+  it('aborts without marking done when the shouldPersist gate returns false', async () => {
+    const { duckdbRagWrite } = await import('../../services/duckdb/duckdbAnalytics');
+    mockQuery.mockResolvedValueOnce({ messageId: 'm', ok: true, rows: [] }); // migration not done
+    const result = await runRagVectorMigration('proj-1', [] as never, () => false);
+    expect(result).toEqual({ migrated: 0 });
+    expect(vi.mocked(duckdbRagWrite)).not.toHaveBeenCalled();
+    expect(mockExec).not.toHaveBeenCalledWith(expect.stringContaining('rag_vectors_v2_migrated'));
   });
 
   it('migrates stored IDB chunks into DuckDB and marks migration done', async () => {

--- a/tests/unit/ragVectorMigration.test.ts
+++ b/tests/unit/ragVectorMigration.test.ts
@@ -109,7 +109,7 @@ describe('runRagVectorMigration', () => {
     // _meta query returns a row → migration already done
     mockQuery.mockResolvedValueOnce({ messageId: 'm', ok: true, rows: [{ value: '1' }] });
     const result = await runRagVectorMigration('proj-1', []);
-    expect(result).toEqual({ migrated: 0 });
+    expect(result).toEqual({ migrated: 0, aborted: false });
     expect(mockExec).not.toHaveBeenCalled();
   });
 
@@ -135,7 +135,7 @@ describe('runRagVectorMigration', () => {
     const { duckdbRagWrite } = await import('../../services/duckdb/duckdbAnalytics');
     mockQuery.mockResolvedValueOnce({ messageId: 'm', ok: true, rows: [] }); // migration not done
     const result = await runRagVectorMigration('proj-1', [] as never, () => false);
-    expect(result).toEqual({ migrated: 0 });
+    expect(result).toEqual({ migrated: 0, aborted: true });
     expect(vi.mocked(duckdbRagWrite)).not.toHaveBeenCalled();
     expect(mockExec).not.toHaveBeenCalledWith(expect.stringContaining('rag_vectors_v2_migrated'));
   });

--- a/tests/unit/ragVectorMigration.test.ts
+++ b/tests/unit/ragVectorMigration.test.ts
@@ -163,6 +163,24 @@ describe('runRagVectorMigration', () => {
     expect(mockExec).toHaveBeenCalledWith(expect.stringContaining('rag_vectors_v2_migrated'));
   });
 
+  // QNBS-v3: SEC — an opt-out landing during the awaited vector write must NOT let the done-marker be
+  // written (else re-opt-in never reruns). The gate flips false right after duckdbRagWrite is invoked.
+  it('does NOT write the done-marker when the gate flips off during the vector write', async () => {
+    const { duckdbRagWrite } = await import('../../services/duckdb/duckdbAnalytics');
+    mockQuery.mockResolvedValueOnce({ messageId: 'm', ok: true, rows: [] }); // migration not done
+    mockGetRagVectors.mockResolvedValueOnce([
+      { id: 'c1', sectionId: 's1', chunkIndex: 0, text: 'Some scene text.', vector: [0.1, 0.2] },
+    ]);
+    let allowed = true;
+    vi.mocked(duckdbRagWrite).mockImplementationOnce(async () => {
+      allowed = false; // user opts out while the vectors are being written
+    });
+    const result = await runRagVectorMigration('proj-1', [], () => allowed);
+    expect(vi.mocked(duckdbRagWrite)).toHaveBeenCalledOnce(); // vector write started while allowed
+    expect(result.aborted).toBe(true);
+    expect(mockExec).not.toHaveBeenCalledWith(expect.stringContaining('rag_vectors_v2_migrated'));
+  });
+
   it('skips blank-text chunks during migration', async () => {
     const { embedText } = await import('../../services/ai/localEmbeddingService');
     mockQuery.mockResolvedValueOnce({ messageId: 'm', ok: true, rows: [] });

--- a/tests/unit/settingsSlice.test.ts
+++ b/tests/unit/settingsSlice.test.ts
@@ -29,6 +29,16 @@ describe('settingsSlice', () => {
     expect(initState().desktop.minimizeToTray).toBe(false);
   });
 
+  it('defaults privacy.analyticsEnabled to true (local-only metadata; toggle is a functional opt-out)', () => {
+    // QNBS-v3: SEC — analytics default ON preserves the analytics dashboard (data never leaves the
+    // device); the privacy toggle now gates DuckDB writes via isAnalyticsPersistenceAllowed. Outward
+    // sharing switches stay opt-in.
+    const privacy = initState().privacy;
+    expect(privacy.analyticsEnabled).toBe(true);
+    expect(privacy.crashReporting).toBe(false);
+    expect(privacy.shareUsageData).toBe(false);
+  });
+
   it('setDesktopSettings merges the desktop group', () => {
     const next = settingsReducer(
       initState(),

--- a/tests/unit/storage/normalizePersistedSettings.test.ts
+++ b/tests/unit/storage/normalizePersistedSettings.test.ts
@@ -117,17 +117,38 @@ describe('normalizePersistedSettings', () => {
 
   // ── privacy ───────────────────────────────────────────────────────────────
 
-  it('provides default privacy settings when field is absent', () => {
+  it('provides default privacy settings when field is absent (analytics ON, migrated)', () => {
     const result = normalizePersistedSettings({});
     expect(result.privacy).toBeDefined();
     expect(result.privacy.localStorageOnly).toBe(true);
-    expect(result.privacy.analyticsEnabled).toBe(false);
+    // QNBS-v3: SEC — default analytics ON (local-only metadata); fresh data is treated as migrated.
+    expect(result.privacy.analyticsEnabled).toBe(true);
+    expect(result.privacy.analyticsGateMigrated).toBe(true);
   });
 
   it('merges partial privacy settings with defaults', () => {
-    const result = normalizePersistedSettings({ privacy: { analyticsEnabled: true } });
+    const result = normalizePersistedSettings({
+      privacy: { analyticsEnabled: true, analyticsGateMigrated: true },
+    });
     expect(result.privacy.analyticsEnabled).toBe(true);
     expect(result.privacy.localStorageOnly).toBe(true); // default preserved
+  });
+
+  // QNBS-v3: SEC one-time migration — legacy persisted analyticsEnabled was cosmetic (the gate didn't
+  // exist; analytics ran whenever enableDuckDbAnalytics was on, which is the default). On first upgrade
+  // we reset to the new default to PRESERVE prior behavior, then respect the user's choice thereafter.
+  it('migrates legacy persisted analyticsEnabled:false (no marker) to ON, preserving prior behavior', () => {
+    const result = normalizePersistedSettings({ privacy: { analyticsEnabled: false } });
+    expect(result.privacy.analyticsEnabled).toBe(true);
+    expect(result.privacy.analyticsGateMigrated).toBe(true);
+  });
+
+  it('respects a genuine opt-out (analyticsEnabled:false) once the migration marker is set', () => {
+    const result = normalizePersistedSettings({
+      privacy: { analyticsEnabled: false, analyticsGateMigrated: true },
+    });
+    expect(result.privacy.analyticsEnabled).toBe(false);
+    expect(result.privacy.analyticsGateMigrated).toBe(true);
   });
 
   // ── advancedAi ────────────────────────────────────────────────────────────

--- a/types.ts
+++ b/types.ts
@@ -533,6 +533,12 @@ export interface PrivacySettings {
   localStorageOnly: boolean;
   shareUsageData: boolean;
   euDataResidency: boolean;
+  // QNBS-v3: SEC one-time migration marker. Before the analytics gate existed, analyticsEnabled was
+  // cosmetic (persistence was controlled solely by enableDuckDbAnalytics, default on), so legacy
+  // persisted settings hold a meaningless value. On the first load after the gate ships we reset
+  // analyticsEnabled to the new default to preserve prior behavior, then set this flag so the user's
+  // real choice is respected on every subsequent load. Optional for back-compat with old payloads.
+  analyticsGateMigrated?: boolean;
 }
 
 export interface PerformanceSettings {


### PR DESCRIPTION
## **User description**
## Summary

First PR of the **Critical & Immediate** hardening sequence. Makes the existing **Settings → Privacy → "Analytics"** toggle do what it claims, reconciles a flag-default drift, and documents the **SEC-6** DuckDB posture honestly.

Before this change the Privacy "Analytics" toggle was **cosmetic** — only the `enableDuckDbAnalytics` feature flag controlled persistence, so a privacy-conscious user toggling it off changed nothing.

## Changes

- **Privacy gate (`app/listenerMiddleware.ts`):** new `isAnalyticsPersistenceAllowed(state)` requires **both** `enableDuckDbAnalytics` **and** `settings.privacy.analyticsEnabled` before:
  - the project DuckDB **dual-write**,
  - the **codex** DuckDB write,
  - the cross-project **DuckDB mirror** (the IDB search index still always updates — search keeps working when analytics is off).
- **Telemetry (`App.tsx`):** `setTelemetryEnabled` now syncs on the **combined** condition and re-runs when the opt-out changes (live, no reload).
- **Defaults:** `privacy.analyticsEnabled` default flipped to **`true`** (slice + `idbProjectStore` normalizer) to **preserve current behavior** — analytics are **local-only metadata** (titles, loglines, word counts, codex excerpts; **never manuscript prose**, **never leaves the device**). The toggle is now a real **opt-out**. Outward-facing switches (`crashReporting`/`shareUsageData`) stay opt-in.
- **Flag-default drift:** `featureCatalog.ts` `enableIdbAtRestEncryption.defaultOn` `false → true` to match the slice (canonical source of truth; `parity:check` unaffected — catalog is excluded from the audit).
- **SEC-6 docs (`docs/SECURITY-THREAT-MODEL.md`):** full DuckDB OPFS / cell-level (`*_enc`) encryption **deferred to v2.0** (DuckDB-WASM owns the OPFS file write; bounded local-metadata exposure), now privacy-gated. `duckdbEncryption.ts` shim stays 0-caller by design.
- **i18n:** clarifying hint on the Analytics toggle across **all 17 locales** + rebuilt bundles.
- **Tests:** `analyticsPersistenceGate` (5 cases: flag×opt-out matrix + missing-slice safety) and a settings analytics-default assertion.

## Verification
- `check-suppressions` (52, baseline) · `lint` · `typecheck` (exit 0) · `i18n:check` (17 locales / 2762 keys) green locally.
- `listenerMiddleware` + new gate + `settingsSlice` tests pass.
- `parity:check` is CI-verified (grep-bound, slow on the constrained local host); no flags added/removed/renamed.

## Deferred (documented)
- Full DuckDB OPFS file / cell-level encryption → v2.0 (threat model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Make the Privacy → Analytics toggle actually stop DuckDB writes and telemetry**

### What Changed
- The Privacy → Analytics toggle now controls analytics persistence for DuckDB writes and inference telemetry, so turning it off actually stops local analytics collection.
- Cross-project indexing, RAG rebuilds, and DuckDB migration flows now re-check the privacy setting at write time, preventing stale writes if the toggle changes during processing.
- New installs treat analytics as on by default with a one-time migration for older saved settings, and the Analytics toggle now shows a clearer privacy hint.
- The IDB at-rest encryption default is aligned with the app’s settings defaults, and the security model docs now describe the current DuckDB privacy posture.
- Added tests for the privacy gate, analytics defaults, migration behavior, and the live toggle behavior during rebuilds.

### Impact
`✅ Analytics opt-out that actually stops local persistence`
`✅ Fewer stale DuckDB writes after changing privacy settings`
`✅ Clearer Analytics setting behavior for new and existing users`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
