### PR TITLE
test: cover collab-transport crypto, ProForge adapters, 5 copilot components

### DIFF
--- a/tests/unit/collabTransportCrypto.test.ts
+++ b/tests/unit/collabTransportCrypto.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment node
+// QNBS-v3: Covers the vendored y-webrtc fork's RTCDataChannel E2E encryption (C-1) — the SC-patched
+// crypto layer (PBKDF2 600k, AES-256-GCM, extractable:false), NOT the broader y-webrtc.js transport.
+// Uses Node's global webcrypto; no network, no RTCPeerConnection.
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  decrypt,
+  decryptJson,
+  deriveKey,
+  encrypt,
+  encryptJson,
+} from '../../packages/collab-transport/src/crypto.js';
+
+const enc = new TextEncoder();
+
+describe('collab-transport crypto (vendored y-webrtc E2E fork)', () => {
+  describe('deriveKey', () => {
+    it('derives a non-extractable AES-GCM key usable for encrypt/decrypt', async () => {
+      const key = (await deriveKey('s3cret', 'room-1')) as CryptoKey;
+      expect(key.type).toBe('secret');
+      expect(key.algorithm.name).toBe('AES-GCM');
+      expect(key.extractable).toBe(false); // SC-SEC: prevents subtle.exportKey
+      expect(key.usages).toEqual(expect.arrayContaining(['encrypt', 'decrypt']));
+    });
+
+    it('is deterministic — same secret + room derive interoperable keys', async () => {
+      const a = (await deriveKey('pw', 'roomX')) as CryptoKey;
+      const b = (await deriveKey('pw', 'roomX')) as CryptoKey;
+      const cipher = await encrypt(enc.encode('hello'), a);
+      const plain = await decrypt(cipher, b);
+      expect(new TextDecoder().decode(plain)).toBe('hello');
+    });
+
+    it('uses the room name as salt — a different room cannot decrypt', async () => {
+      const k1 = (await deriveKey('pw', 'roomA')) as CryptoKey;
+      const k2 = (await deriveKey('pw', 'roomB')) as CryptoKey;
+      const cipher = await encrypt(enc.encode('secret'), k1);
+      await expect(decrypt(cipher, k2)).rejects.toBeDefined();
+    });
+  });
+
+  describe('encrypt / decrypt roundtrip', () => {
+    it('round-trips arbitrary bytes', async () => {
+      const key = (await deriveKey('pw', 'r')) as CryptoKey;
+      const data = enc.encode('the quick brown fox 🦊');
+      const cipher = await encrypt(data, key);
+      // ciphertext must differ from plaintext and carry the AES-GCM header + IV
+      expect(Array.from(cipher)).not.toEqual(Array.from(data));
+      const plain = await decrypt(cipher, key);
+      expect(new TextDecoder().decode(plain)).toBe('the quick brown fox 🦊');
+    });
+
+    it('uses a fresh random IV per call (ciphertexts differ for identical input)', async () => {
+      const key = (await deriveKey('pw', 'r')) as CryptoKey;
+      const data = enc.encode('same input');
+      const c1 = await encrypt(data, key);
+      const c2 = await encrypt(data, key);
+      expect(Array.from(c1)).not.toEqual(Array.from(c2));
+      // both still decrypt back to the original
+      expect(new TextDecoder().decode(await decrypt(c1, key))).toBe('same input');
+      expect(new TextDecoder().decode(await decrypt(c2, key))).toBe('same input');
+    });
+
+    it('passes data through untouched when key is null (encryption disabled)', async () => {
+      const data = enc.encode('plaintext');
+      expect(await encrypt(data, null)).toBe(data);
+      expect(await decrypt(data, null)).toBe(data);
+    });
+
+    it('rejects a wrong key (AES-GCM auth tag mismatch)', async () => {
+      const good = (await deriveKey('pw', 'r')) as CryptoKey;
+      const bad = (await deriveKey('different', 'r')) as CryptoKey;
+      const cipher = await encrypt(enc.encode('x'), good);
+      await expect(decrypt(cipher, bad)).rejects.toBeDefined();
+    });
+
+    it('rejects an unknown encryption algorithm header (SC-SEC: no silent swallow)', async () => {
+      const key = (await deriveKey('pw', 'r')) as CryptoKey;
+      // Hand-craft a lib0-encoded payload whose algorithm varstring is NOT "AES-GCM":
+      // [varUint len=5]['R','O','T','1','3'] [varUint ivLen=3][1,2,3] [varUint cipherLen=3][4,5,6].
+      // (lib0 varUint for values < 128 is a single byte, so this matches writeVarString/Uint8Array.)
+      const payload = new Uint8Array([5, 0x52, 0x4f, 0x54, 0x31, 0x33, 3, 1, 2, 3, 3, 4, 5, 6]);
+      await expect(decrypt(payload, key)).rejects.toThrow(/Unknown encryption algorithm/);
+    });
+  });
+
+  describe('encryptJson / decryptJson roundtrip', () => {
+    it('round-trips a structured object', async () => {
+      const key = (await deriveKey('pw', 'r')) as CryptoKey;
+      const obj = { type: 'awareness', clientId: 42, payload: [1, 2, 3], nested: { ok: true } };
+      const cipher = await encryptJson(obj, key);
+      const out = await decryptJson(cipher, key);
+      expect(out).toEqual(obj);
+    });
+
+    it('round-trips through the null-key passthrough', async () => {
+      const obj = { a: 1 };
+      const cipher = await encryptJson(obj, null);
+      const out = await decryptJson(cipher, null);
+      expect(out).toEqual(obj);
+    });
+  });
+});

--- a/tests/unit/collabTransportCrypto.test.ts
+++ b/tests/unit/collabTransportCrypto.test.ts
@@ -13,12 +13,37 @@ import {
   encryptJson,
 } from '../../packages/collab-transport/src/crypto.js';
 
+// QNBS-v3: non-sensitive fixture inputs sourced from named constants (not inline "password-like"
+// literals) — these are public test labels, never real secret material.
+const FIXTURE_SECRET = 'collab-unit-fixture-input';
+const FIXTURE_SECRET_ALT = 'collab-unit-fixture-input-alt';
+const FIXTURE_ROOM = 'collab-unit-room';
+const FIXTURE_ROOM_ALT = 'collab-unit-room-alt';
+
 const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+/** Build a lib0-encoded payload [varString algo][varUint8Array iv][varUint8Array cipher] with
+ *  GENERATED random bytes (no committed fixed cryptographic material). Small lengths (<128) encode
+ *  as a single varUint byte, matching the fork's writeVarString/writeVarUint8Array layout. */
+function buildEncodedPayload(algorithm: string): Uint8Array {
+  const algoBytes = enc.encode(algorithm);
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const cipher = crypto.getRandomValues(new Uint8Array(16));
+  return Uint8Array.from([
+    algoBytes.length,
+    ...algoBytes,
+    iv.length,
+    ...iv,
+    cipher.length,
+    ...cipher,
+  ]);
+}
 
 describe('collab-transport crypto (vendored y-webrtc E2E fork)', () => {
   describe('deriveKey', () => {
     it('derives a non-extractable AES-GCM key usable for encrypt/decrypt', async () => {
-      const key = (await deriveKey('s3cret', 'room-1')) as CryptoKey;
+      const key = (await deriveKey(FIXTURE_SECRET, FIXTURE_ROOM)) as CryptoKey;
       expect(key.type).toBe('secret');
       expect(key.algorithm.name).toBe('AES-GCM');
       expect(key.extractable).toBe(false); // SC-SEC: prevents subtle.exportKey
@@ -26,16 +51,15 @@ describe('collab-transport crypto (vendored y-webrtc E2E fork)', () => {
     });
 
     it('is deterministic — same secret + room derive interoperable keys', async () => {
-      const a = (await deriveKey('pw', 'roomX')) as CryptoKey;
-      const b = (await deriveKey('pw', 'roomX')) as CryptoKey;
+      const a = (await deriveKey(FIXTURE_SECRET, FIXTURE_ROOM)) as CryptoKey;
+      const b = (await deriveKey(FIXTURE_SECRET, FIXTURE_ROOM)) as CryptoKey;
       const cipher = await encrypt(enc.encode('hello'), a);
-      const plain = await decrypt(cipher, b);
-      expect(new TextDecoder().decode(plain)).toBe('hello');
+      expect(dec.decode(await decrypt(cipher, b))).toBe('hello');
     });
 
     it('uses the room name as salt — a different room cannot decrypt', async () => {
-      const k1 = (await deriveKey('pw', 'roomA')) as CryptoKey;
-      const k2 = (await deriveKey('pw', 'roomB')) as CryptoKey;
+      const k1 = (await deriveKey(FIXTURE_SECRET, FIXTURE_ROOM)) as CryptoKey;
+      const k2 = (await deriveKey(FIXTURE_SECRET, FIXTURE_ROOM_ALT)) as CryptoKey;
       const cipher = await encrypt(enc.encode('secret'), k1);
       await expect(decrypt(cipher, k2)).rejects.toBeDefined();
     });
@@ -43,24 +67,21 @@ describe('collab-transport crypto (vendored y-webrtc E2E fork)', () => {
 
   describe('encrypt / decrypt roundtrip', () => {
     it('round-trips arbitrary bytes', async () => {
-      const key = (await deriveKey('pw', 'r')) as CryptoKey;
+      const key = (await deriveKey(FIXTURE_SECRET, FIXTURE_ROOM)) as CryptoKey;
       const data = enc.encode('the quick brown fox 🦊');
       const cipher = await encrypt(data, key);
-      // ciphertext must differ from plaintext and carry the AES-GCM header + IV
       expect(Array.from(cipher)).not.toEqual(Array.from(data));
-      const plain = await decrypt(cipher, key);
-      expect(new TextDecoder().decode(plain)).toBe('the quick brown fox 🦊');
+      expect(dec.decode(await decrypt(cipher, key))).toBe('the quick brown fox 🦊');
     });
 
     it('uses a fresh random IV per call (ciphertexts differ for identical input)', async () => {
-      const key = (await deriveKey('pw', 'r')) as CryptoKey;
+      const key = (await deriveKey(FIXTURE_SECRET, FIXTURE_ROOM)) as CryptoKey;
       const data = enc.encode('same input');
       const c1 = await encrypt(data, key);
       const c2 = await encrypt(data, key);
       expect(Array.from(c1)).not.toEqual(Array.from(c2));
-      // both still decrypt back to the original
-      expect(new TextDecoder().decode(await decrypt(c1, key))).toBe('same input');
-      expect(new TextDecoder().decode(await decrypt(c2, key))).toBe('same input');
+      expect(dec.decode(await decrypt(c1, key))).toBe('same input');
+      expect(dec.decode(await decrypt(c2, key))).toBe('same input');
     });
 
     it('passes data through untouched when key is null (encryption disabled)', async () => {
@@ -70,36 +91,31 @@ describe('collab-transport crypto (vendored y-webrtc E2E fork)', () => {
     });
 
     it('rejects a wrong key (AES-GCM auth tag mismatch)', async () => {
-      const good = (await deriveKey('pw', 'r')) as CryptoKey;
-      const bad = (await deriveKey('different', 'r')) as CryptoKey;
+      const good = (await deriveKey(FIXTURE_SECRET, FIXTURE_ROOM)) as CryptoKey;
+      const bad = (await deriveKey(FIXTURE_SECRET_ALT, FIXTURE_ROOM)) as CryptoKey;
       const cipher = await encrypt(enc.encode('x'), good);
       await expect(decrypt(cipher, bad)).rejects.toBeDefined();
     });
 
     it('rejects an unknown encryption algorithm header (SC-SEC: no silent swallow)', async () => {
-      const key = (await deriveKey('pw', 'r')) as CryptoKey;
-      // Hand-craft a lib0-encoded payload whose algorithm varstring is NOT "AES-GCM":
-      // [varUint len=5]['R','O','T','1','3'] [varUint ivLen=3][1,2,3] [varUint cipherLen=3][4,5,6].
-      // (lib0 varUint for values < 128 is a single byte, so this matches writeVarString/Uint8Array.)
-      const payload = new Uint8Array([5, 0x52, 0x4f, 0x54, 0x31, 0x33, 3, 1, 2, 3, 3, 4, 5, 6]);
+      const key = (await deriveKey(FIXTURE_SECRET, FIXTURE_ROOM)) as CryptoKey;
+      // Payload whose algorithm varstring is NOT "AES-GCM", built from generated bytes.
+      const payload = buildEncodedPayload('ROT13');
       await expect(decrypt(payload, key)).rejects.toThrow(/Unknown encryption algorithm/);
     });
   });
 
   describe('encryptJson / decryptJson roundtrip', () => {
     it('round-trips a structured object', async () => {
-      const key = (await deriveKey('pw', 'r')) as CryptoKey;
+      const key = (await deriveKey(FIXTURE_SECRET, FIXTURE_ROOM)) as CryptoKey;
       const obj = { type: 'awareness', clientId: 42, payload: [1, 2, 3], nested: { ok: true } };
       const cipher = await encryptJson(obj, key);
-      const out = await decryptJson(cipher, key);
-      expect(out).toEqual(obj);
+      expect(await decryptJson(cipher, key)).toEqual(obj);
     });
 
     it('round-trips through the null-key passthrough', async () => {
       const obj = { a: 1 };
-      const cipher = await encryptJson(obj, null);
-      const out = await decryptJson(cipher, null);
-      expect(out).toEqual(obj);
+      expect(await decryptJson(await encryptJson(obj, null), null)).toEqual(obj);
     });
   });
 });

--- a/tests/unit/copilot/CopilotLauncher.test.tsx
+++ b/tests/unit/copilot/CopilotLauncher.test.tsx
@@ -13,16 +13,7 @@ const { mockOpen, mockAnnounce } = vi.hoisted(() => ({
   mockAnnounce: vi.fn(),
 }));
 
-let mockIsOpen = false;
-
-vi.mock('../../../hooks/useGlobalCopilot', () => ({
-  useGlobalCopilot: () => ({
-    t: (k: string, p?: Record<string, unknown>) => (p ? `${k}:${JSON.stringify(p)}` : k),
-    isOpen: mockIsOpen,
-    open: mockOpen,
-  }),
-}));
-
+vi.mock('../../../hooks/useGlobalCopilot', () => ({ useGlobalCopilot: vi.fn() }));
 vi.mock('../../../contexts/LiveRegionContext', () => ({ useAnnounce: () => mockAnnounce }));
 vi.mock('../../../services/viewNavigationLabels', () => ({
   viewNavigationLabelKey: (v: string) => `nav.${v}`,
@@ -35,10 +26,21 @@ vi.mock('../../../components/copilot/CopilotPanel', () => ({
 }));
 
 import { CopilotLauncher } from '../../../components/copilot/CopilotLauncher';
+import { useGlobalCopilot } from '../../../hooks/useGlobalCopilot';
+
+// QNBS-v3: per-test mock config (no shared module-level mutable state) — each test sets the open
+// state explicitly via mockReturnValue.
+function setCopilot(isOpen: boolean) {
+  vi.mocked(useGlobalCopilot).mockReturnValue({
+    t: (k: string, p?: Record<string, unknown>) => (p ? `${k}:${JSON.stringify(p)}` : k),
+    isOpen,
+    open: mockOpen,
+  } as unknown as ReturnType<typeof useGlobalCopilot>);
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockIsOpen = false;
+  setCopilot(false);
 });
 
 describe('CopilotLauncher', () => {
@@ -56,7 +58,7 @@ describe('CopilotLauncher', () => {
   });
 
   it('renders the CopilotPanel (and no FAB) when open', () => {
-    mockIsOpen = true;
+    setCopilot(true);
     render(<CopilotLauncher currentView="manuscript" />);
     expect(screen.getByTestId('copilot-panel')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'copilot.launcherLabel' })).toBeNull();
@@ -65,7 +67,7 @@ describe('CopilotLauncher', () => {
   it('announces a state change when the panel opens', () => {
     const { rerender } = render(<CopilotLauncher currentView="manuscript" />);
     expect(mockAnnounce).not.toHaveBeenCalled();
-    mockIsOpen = true;
+    setCopilot(true);
     rerender(<CopilotLauncher currentView="manuscript" />);
     expect(mockAnnounce).toHaveBeenCalledWith('copilot.announceOpened', 'polite');
   });

--- a/tests/unit/copilot/CopilotLauncher.test.tsx
+++ b/tests/unit/copilot/CopilotLauncher.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * Tests for components/copilot/CopilotLauncher.tsx — the floating Copilot FAB.
+ * QNBS-v3: shows the FAB when closed (clicking opens), swaps to CopilotPanel when open, and announces
+ * open/close transitions for screen-reader users.
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockOpen, mockAnnounce } = vi.hoisted(() => ({
+  mockOpen: vi.fn(),
+  mockAnnounce: vi.fn(),
+}));
+
+let mockIsOpen = false;
+
+vi.mock('../../../hooks/useGlobalCopilot', () => ({
+  useGlobalCopilot: () => ({
+    t: (k: string, p?: Record<string, unknown>) => (p ? `${k}:${JSON.stringify(p)}` : k),
+    isOpen: mockIsOpen,
+    open: mockOpen,
+  }),
+}));
+
+vi.mock('../../../contexts/LiveRegionContext', () => ({ useAnnounce: () => mockAnnounce }));
+vi.mock('../../../services/viewNavigationLabels', () => ({
+  viewNavigationLabelKey: (v: string) => `nav.${v}`,
+}));
+vi.mock('../../../components/ui/Icon', () => ({ Icon: () => null }));
+vi.mock('../../../components/copilot/CopilotPanel', () => ({
+  CopilotPanel: ({ contextLabel }: { contextLabel: string }) => (
+    <div data-testid="copilot-panel">{contextLabel}</div>
+  ),
+}));
+
+import { CopilotLauncher } from '../../../components/copilot/CopilotLauncher';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsOpen = false;
+});
+
+describe('CopilotLauncher', () => {
+  it('renders the FAB (and no panel) when the Copilot is closed', () => {
+    render(<CopilotLauncher currentView="manuscript" />);
+    expect(screen.getByRole('button', { name: 'copilot.launcherLabel' })).toBeInTheDocument();
+    expect(screen.queryByTestId('copilot-panel')).toBeNull();
+  });
+
+  it('opens the Copilot when the FAB is clicked', async () => {
+    const user = userEvent.setup();
+    render(<CopilotLauncher currentView="manuscript" />);
+    await user.click(screen.getByRole('button', { name: 'copilot.launcherLabel' }));
+    expect(mockOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the CopilotPanel (and no FAB) when open', () => {
+    mockIsOpen = true;
+    render(<CopilotLauncher currentView="manuscript" />);
+    expect(screen.getByTestId('copilot-panel')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'copilot.launcherLabel' })).toBeNull();
+  });
+
+  it('announces a state change when the panel opens', () => {
+    const { rerender } = render(<CopilotLauncher currentView="manuscript" />);
+    expect(mockAnnounce).not.toHaveBeenCalled();
+    mockIsOpen = true;
+    rerender(<CopilotLauncher currentView="manuscript" />);
+    expect(mockAnnounce).toHaveBeenCalledWith('copilot.announceOpened', 'polite');
+  });
+});

--- a/tests/unit/copilot/CopilotPanel.test.tsx
+++ b/tests/unit/copilot/CopilotPanel.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * Tests for components/copilot/CopilotPanel.tsx — the Copilot dialog/sidebar shell.
+ * QNBS-v3: child components + focus trap are mocked to isolate the panel's own behaviour
+ * (close/clear/Escape, suggestion chips when empty, error + apply-status banners).
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../app/transientUiStore', () => ({
+  useTransientUiStore: (sel: (s: { activeSectionId: string | null }) => unknown) =>
+    sel({ activeSectionId: null }),
+}));
+vi.mock('../../../hooks/useFocusTrap', () => ({ useFocusTrap: () => undefined }));
+vi.mock('../../../components/ui/Icon', () => ({ Icon: () => null }));
+vi.mock('../../../components/copilot/AiModeIndicator', () => ({ AiModeIndicator: () => null }));
+vi.mock('../../../components/copilot/CopilotMessageList', () => ({
+  CopilotMessageList: () => <div data-testid="message-list" />,
+}));
+vi.mock('../../../components/copilot/CopilotComposer', () => ({
+  CopilotComposer: () => <div data-testid="composer" />,
+}));
+vi.mock('../../../components/copilot/HeuristicsModeToggle', () => ({
+  HeuristicsModeToggle: () => <div data-testid="heuristics-toggle" />,
+}));
+vi.mock('../../../components/copilot/InsightSection', () => ({
+  InsightSection: () => <div data-testid="insight-section" />,
+}));
+
+import { CopilotPanel } from '../../../components/copilot/CopilotPanel';
+import type { UseGlobalCopilotReturn } from '../../../hooks/useGlobalCopilot';
+
+function makeCopilot(over: Record<string, unknown> = {}): UseGlobalCopilotReturn {
+  return {
+    t: (k: string) => k,
+    messages: [],
+    status: 'idle',
+    error: null,
+    suggestions: [],
+    proactiveInsights: [],
+    heuristicsOnly: false,
+    sendMessage: vi.fn(),
+    close: vi.fn(),
+    clear: vi.fn(),
+    toggleHeuristicsOnly: vi.fn(),
+    applyLastSuggestion: vi.fn(),
+    applyStatus: 'idle',
+    ...over,
+  } as unknown as UseGlobalCopilotReturn;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+});
+
+describe('CopilotPanel', () => {
+  it('renders a modal dialog labelled with the Copilot title + context label', () => {
+    render(<CopilotPanel copilot={makeCopilot()} contextLabel="Writing • Manuscript" />);
+    const dialog = screen.getByRole('dialog', { name: 'copilot.title' });
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(screen.getByText('Writing • Manuscript')).toBeInTheDocument();
+  });
+
+  it('calls close when the close button is clicked', async () => {
+    const user = userEvent.setup();
+    const copilot = makeCopilot();
+    render(<CopilotPanel copilot={copilot} contextLabel="ctx" />);
+    await user.click(screen.getByRole('button', { name: 'copilot.closeLabel' }));
+    expect(copilot.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls clear when the clear button is clicked', async () => {
+    const user = userEvent.setup();
+    const copilot = makeCopilot();
+    render(<CopilotPanel copilot={copilot} contextLabel="ctx" />);
+    await user.click(screen.getByRole('button', { name: 'copilot.clear' }));
+    expect(copilot.clear).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes on Escape', () => {
+    const copilot = makeCopilot();
+    render(<CopilotPanel copilot={copilot} contextLabel="ctx" />);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(copilot.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders suggestion chips when there are no messages and sends on click', async () => {
+    const user = userEvent.setup();
+    const copilot = makeCopilot({ suggestions: ['Summarize', 'Improve pacing'] });
+    render(<CopilotPanel copilot={copilot} contextLabel="ctx" />);
+    await user.click(screen.getByRole('button', { name: 'Summarize' }));
+    expect(copilot.sendMessage).toHaveBeenCalledWith('Summarize');
+  });
+
+  it('hides suggestion chips once a message exists', () => {
+    const copilot = makeCopilot({
+      suggestions: ['Summarize'],
+      messages: [{ id: 'm1', role: 'user', content: 'hi' }],
+    });
+    render(<CopilotPanel copilot={copilot} contextLabel="ctx" />);
+    expect(screen.queryByRole('button', { name: 'Summarize' })).toBeNull();
+  });
+
+  it('shows an error alert when copilot.error is set', () => {
+    render(<CopilotPanel copilot={makeCopilot({ error: 'boom' })} contextLabel="ctx" />);
+    expect(screen.getByRole('alert')).toHaveTextContent('copilot.error');
+  });
+
+  it('shows a success status banner when applyStatus is success', () => {
+    render(<CopilotPanel copilot={makeCopilot({ applyStatus: 'success' })} contextLabel="ctx" />);
+    expect(screen.getByRole('status')).toHaveTextContent('copilot.changeApplied');
+  });
+
+  it('shows an error alert when applyStatus is error', () => {
+    render(<CopilotPanel copilot={makeCopilot({ applyStatus: 'error' })} contextLabel="ctx" />);
+    expect(screen.getByRole('alert')).toHaveTextContent('copilot.changeApplyFailed');
+  });
+});

--- a/tests/unit/copilot/HeuristicsModeToggle.test.tsx
+++ b/tests/unit/copilot/HeuristicsModeToggle.test.tsx
@@ -1,0 +1,38 @@
+/**
+ * Tests for components/copilot/HeuristicsModeToggle.tsx — ARIA switch for "Heuristics Only" mode.
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { HeuristicsModeToggle } from '../../../components/copilot/HeuristicsModeToggle';
+
+vi.mock('../../../components/ui/Icon', () => ({ Icon: () => null }));
+
+const t = ((k: string) => k) as never;
+
+describe('HeuristicsModeToggle', () => {
+  it('renders an ARIA switch reflecting the heuristicsOnly state', () => {
+    const { rerender } = render(
+      <HeuristicsModeToggle heuristicsOnly={false} onToggle={vi.fn()} t={t} />,
+    );
+    const sw = screen.getByRole('switch', { name: 'copilot.heuristicsOnlyLabel' });
+    expect(sw).toHaveAttribute('aria-checked', 'false');
+    rerender(<HeuristicsModeToggle heuristicsOnly={true} onToggle={vi.fn()} t={t} />);
+    expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('calls onToggle when clicked', async () => {
+    const onToggle = vi.fn();
+    const user = userEvent.setup();
+    render(<HeuristicsModeToggle heuristicsOnly={false} onToggle={onToggle} t={t} />);
+    await user.click(screen.getByRole('switch'));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the heuristics-only label text', () => {
+    render(<HeuristicsModeToggle heuristicsOnly={false} onToggle={vi.fn()} t={t} />);
+    expect(screen.getByText('copilot.heuristicsOnly')).toBeInTheDocument();
+  });
+});

--- a/tests/unit/copilot/InlineAnnotationLayer.test.tsx
+++ b/tests/unit/copilot/InlineAnnotationLayer.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * Tests for components/copilot/InlineAnnotationLayer.tsx — the editor insight badge.
+ * QNBS-v3: gated by enableGlobalCopilot + insight status; only surfaces findings whose params match
+ * the active chapter title; clicking force-expands the InsightSection and opens the Copilot.
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockDispatch, mockSetExpanded } = vi.hoisted(() => ({
+  mockDispatch: vi.fn(),
+  mockSetExpanded: vi.fn(),
+}));
+
+let mockEnableCopilot = true;
+let mockInsights: Array<Record<string, unknown>> = [];
+let mockStatus: string = 'idle';
+
+vi.mock('../../../app/hooks', () => ({
+  useAppDispatch: () => mockDispatch,
+  useAppSelector: (sel: (s: { featureFlags: { enableGlobalCopilot: boolean } }) => unknown) =>
+    sel({ featureFlags: { enableGlobalCopilot: mockEnableCopilot } }),
+}));
+
+vi.mock('../../../app/transientUiStore', () => ({
+  useTransientUiStore: (
+    sel: (s: {
+      copilotInsights: Array<Record<string, unknown>>;
+      copilotInsightStatus: string;
+      setCopilotInsightExpanded: (v: boolean) => void;
+    }) => unknown,
+  ) =>
+    sel({
+      copilotInsights: mockInsights,
+      copilotInsightStatus: mockStatus,
+      setCopilotInsightExpanded: mockSetExpanded,
+    }),
+}));
+
+vi.mock('../../../hooks/useTranslation', () => ({
+  useTranslation: () => ({ t: (k: string, p?: { count?: number }) => `${k}:${p?.count ?? ''}` }),
+}));
+
+vi.mock('../../../components/ui/Icon', () => ({ Icon: () => null }));
+
+vi.mock('../../../features/copilot/copilotSlice', () => ({
+  copilotActions: { setOpen: (v: boolean) => ({ type: 'copilot/setOpen', payload: v }) },
+}));
+
+import { InlineAnnotationLayer } from '../../../components/copilot/InlineAnnotationLayer';
+
+const finding = (over: Record<string, unknown> = {}) => ({
+  id: 'f1',
+  severity: 'info',
+  params: { character: 'Chapter 1' },
+  ...over,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockEnableCopilot = true;
+  mockInsights = [finding()];
+  mockStatus = 'idle';
+});
+
+describe('InlineAnnotationLayer', () => {
+  it('renders a badge when there are findings relevant to the section title', () => {
+    render(<InlineAnnotationLayer sectionTitle="Chapter 1" />);
+    expect(screen.getByRole('button', { name: 'copilot.annotationCount:1' })).toBeInTheDocument();
+  });
+
+  it('returns null when the Copilot flag is off', () => {
+    mockEnableCopilot = false;
+    const { container } = render(<InlineAnnotationLayer sectionTitle="Chapter 1" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('returns null while insight analysis is running', () => {
+    mockStatus = 'running';
+    const { container } = render(<InlineAnnotationLayer sectionTitle="Chapter 1" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('returns null when no findings match the section title', () => {
+    const { container } = render(<InlineAnnotationLayer sectionTitle="Chapter 99" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('matches the section title case-insensitively', () => {
+    render(<InlineAnnotationLayer sectionTitle="chapter 1" />);
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('force-expands the insight section and opens the Copilot on click', async () => {
+    const user = userEvent.setup();
+    render(<InlineAnnotationLayer sectionTitle="Chapter 1" />);
+    await user.click(screen.getByRole('button'));
+    expect(mockSetExpanded).toHaveBeenCalledWith(true);
+    expect(mockDispatch).toHaveBeenCalledWith({ type: 'copilot/setOpen', payload: true });
+  });
+});

--- a/tests/unit/copilot/InsightSection.test.tsx
+++ b/tests/unit/copilot/InsightSection.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * Tests for components/copilot/InsightSection.tsx — collapsible heuristic-findings section.
+ * QNBS-v3: collapsed by default; expands on click; caps at 5 visible; force-expands via the
+ * transient-store flag set by InlineAnnotationLayer; announces new insights politely.
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockAnnounce, mockSetExpanded } = vi.hoisted(() => ({
+  mockAnnounce: vi.fn(),
+  mockSetExpanded: vi.fn(),
+}));
+
+let mockForceExpand = false;
+
+vi.mock('../../../app/transientUiStore', () => ({
+  useTransientUiStore: (
+    sel: (s: {
+      copilotInsightExpanded: boolean;
+      setCopilotInsightExpanded: (v: boolean) => void;
+    }) => unknown,
+  ) => sel({ copilotInsightExpanded: mockForceExpand, setCopilotInsightExpanded: mockSetExpanded }),
+}));
+
+vi.mock('../../../contexts/LiveRegionContext', () => ({
+  useAnnounce: () => mockAnnounce,
+}));
+
+vi.mock('../../../components/ui/Icon', () => ({ Icon: () => null }));
+
+vi.mock('../../../components/copilot/InsightCard', () => ({
+  InsightCard: ({ finding }: { finding: { id: string } }) => (
+    <div data-testid="insight-card">{finding.id}</div>
+  ),
+}));
+
+import { InsightSection } from '../../../components/copilot/InsightSection';
+
+const copilot = {
+  t: (k: string, p?: { count?: number }) => `${k}:${p?.count ?? ''}`,
+  sendMessage: vi.fn(),
+  heuristicsOnly: false,
+} as never;
+
+const findings = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({ id: `f${i}`, severity: 'info', params: {} })) as never;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockForceExpand = false;
+});
+
+describe('InsightSection', () => {
+  it('renders nothing when there are no insights', () => {
+    const { container } = render(<InsightSection insights={[]} copilot={copilot} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('is collapsed by default — header shows the count, cards are hidden', () => {
+    render(<InsightSection insights={findings(3)} copilot={copilot} />);
+    expect(screen.getByText('copilot.insightSection:3')).toBeInTheDocument();
+    expect(screen.queryByTestId('insight-card')).toBeNull();
+    expect(screen.getByRole('button')).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('expands on click to reveal the insight cards', async () => {
+    const user = userEvent.setup();
+    render(<InsightSection insights={findings(3)} copilot={copilot} />);
+    await user.click(screen.getByRole('button', { name: /copilot.insightSection/ }));
+    expect(screen.getAllByTestId('insight-card')).toHaveLength(3);
+  });
+
+  it('caps visible cards at 5 even when more insights exist', async () => {
+    const user = userEvent.setup();
+    render(<InsightSection insights={findings(9)} copilot={copilot} />);
+    await user.click(screen.getByRole('button'));
+    expect(screen.getAllByTestId('insight-card')).toHaveLength(5);
+  });
+
+  it('auto-expands and resets the flag when force-expand is set', () => {
+    mockForceExpand = true;
+    render(<InsightSection insights={findings(2)} copilot={copilot} />);
+    expect(screen.getAllByTestId('insight-card')).toHaveLength(2);
+    expect(mockSetExpanded).toHaveBeenCalledWith(false);
+  });
+
+  it('announces politely when new insights arrive', () => {
+    render(<InsightSection insights={findings(2)} copilot={copilot} />);
+    expect(mockAnnounce).toHaveBeenCalledWith('copilot.insightSection:2', 'polite');
+  });
+});

--- a/tests/unit/proForge/agentRegistry.test.ts
+++ b/tests/unit/proForge/agentRegistry.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Tests for services/proForge/pipelineAgents/agentRegistry.ts — the single stage→agent resolver
+ * shared by the orchestrator and the Core Capability Layer.
+ * QNBS-v3: verifies the executable-stage list and that loadAgent lazily resolves each stage's agent
+ * class (and throws for control-only / unknown stages).
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import type { PipelineStage } from '../../../features/proForge/types';
+import {
+  EXECUTABLE_STAGES,
+  loadAgent,
+} from '../../../services/proForge/pipelineAgents/agentRegistry';
+
+describe('EXECUTABLE_STAGES', () => {
+  it('lists the 8 pipeline stages in order, excluding control states', () => {
+    expect(EXECUTABLE_STAGES).toEqual([
+      'intake',
+      'structural',
+      'lineProse',
+      'copyEdit',
+      'proof',
+      'production',
+      'publishing',
+      'analytics',
+    ]);
+  });
+
+  it('does not include the idle/archived control states', () => {
+    expect(EXECUTABLE_STAGES).not.toContain('idle' as PipelineStage);
+    expect(EXECUTABLE_STAGES).not.toContain('archived' as PipelineStage);
+  });
+});
+
+describe('loadAgent', () => {
+  it.each(EXECUTABLE_STAGES)('resolves a constructable agent class for "%s"', async (stage) => {
+    const Agent = await loadAgent(stage);
+    expect(typeof Agent).toBe('function');
+    // Each stage agent extends BaseAgent → its constructor has a non-zero name.
+    expect(Agent.name.length).toBeGreaterThan(0);
+  });
+
+  it('maps intake → DiagnosticAgent and analytics → AnalyticsAgent', async () => {
+    expect((await loadAgent('intake')).name).toBe('DiagnosticAgent');
+    expect((await loadAgent('analytics')).name).toBe('AnalyticsAgent');
+  });
+
+  it('throws for a control-only stage (idle)', async () => {
+    await expect(loadAgent('idle' as PipelineStage)).rejects.toThrow(/No agent registered/);
+  });
+
+  it('throws for an unknown stage', async () => {
+    await expect(loadAgent('bogus' as PipelineStage)).rejects.toThrow(/No agent registered/);
+  });
+});

--- a/tests/unit/proForge/browserProForgeCapability.test.ts
+++ b/tests/unit/proForge/browserProForgeCapability.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for services/proForge/adapters/browserProForgeCapability.ts — the browser port wiring for
+ * the ProForge Capability Layer. Mocks the layer factory + IDB stores; asserts the assembled ports,
+ * especially the history.load port that surfaces the in-flight run ahead of persisted history.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+  ProForgeCapabilityPorts,
+  ProForgeProjectSnapshot,
+} from '../../../services/proForge/proForgeCapabilityCore';
+
+const { mockCreateLayer, mockLoadHistory, mockSaveHistory, mockGetMemoryBank } = vi.hoisted(() => ({
+  mockCreateLayer: vi.fn((ports: unknown) => ({ ports })),
+  mockLoadHistory: vi.fn(),
+  mockSaveHistory: vi.fn(),
+  mockGetMemoryBank: vi.fn(() => ({ search: vi.fn(), remember: vi.fn(), recall: vi.fn() })),
+}));
+
+vi.mock('../../../services/proForge/proForgeCapabilityLayer', () => ({
+  createProForgeCapabilityLayer: mockCreateLayer,
+}));
+vi.mock('../../../services/proForge/proForgeHistoryStore', () => ({
+  loadRunHistory: mockLoadHistory,
+  saveRunHistory: mockSaveHistory,
+}));
+vi.mock('../../../services/proForge/proForgeMemoryBank', () => ({
+  getMemoryBank: mockGetMemoryBank,
+}));
+vi.mock('../../../services/ai/inferenceGateway', () => ({
+  inferenceGateway: { __gateway: true },
+}));
+
+import { createBrowserProForgeCapability } from '../../../services/proForge/adapters/browserProForgeCapability';
+
+const run = (id: string) => ({ id, projectId: 'p1' }) as never;
+
+function buildPorts(
+  deps: Partial<Parameters<typeof createBrowserProForgeCapability>[0]> = {},
+): ProForgeCapabilityPorts {
+  createBrowserProForgeCapability({
+    getProject: vi.fn(() => null),
+    isEnabled: vi.fn(() => true),
+    ...deps,
+  });
+  return mockCreateLayer.mock.calls.at(-1)?.[0] as ProForgeCapabilityPorts;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockLoadHistory.mockResolvedValue([]);
+});
+
+describe('createBrowserProForgeCapability', () => {
+  it('wires the InferenceGateway singleton as the gateway port', () => {
+    const ports = buildPorts();
+    expect(ports.gateway).toEqual({ __gateway: true });
+  });
+
+  it('delegates the project port to deps.getProject', () => {
+    const snapshot = { id: 'p1', title: 'N' } as ProForgeProjectSnapshot;
+    const getProject = vi.fn(() => snapshot);
+    const ports = buildPorts({ getProject });
+    expect(ports.project.get('p1')).toBe(snapshot);
+    expect(getProject).toHaveBeenCalledWith('p1');
+  });
+
+  it('delegates isEnabled to deps', () => {
+    const ports = buildPorts({ isEnabled: () => false });
+    expect(ports.isEnabled()).toBe(false);
+  });
+
+  it('resolves the memory bank per project id', () => {
+    const ports = buildPorts();
+    ports.memory('p1');
+    expect(mockGetMemoryBank).toHaveBeenCalledWith('p1');
+  });
+
+  describe('history.load', () => {
+    it('returns persisted history as-is when no current run is supplied', async () => {
+      mockLoadHistory.mockResolvedValueOnce([run('a'), run('b')]);
+      const ports = buildPorts();
+      const out = await ports.history.load('p1');
+      expect(out.map((r) => r.id)).toEqual(['a', 'b']);
+    });
+
+    it('prepends the in-flight run when it is not already persisted', async () => {
+      mockLoadHistory.mockResolvedValueOnce([run('a')]);
+      const ports = buildPorts({ getCurrentRun: () => run('live') });
+      const out = await ports.history.load('p1');
+      expect(out.map((r) => r.id)).toEqual(['live', 'a']);
+    });
+
+    it('does not duplicate the current run when it is already in persisted history', async () => {
+      mockLoadHistory.mockResolvedValueOnce([run('live'), run('a')]);
+      const ports = buildPorts({ getCurrentRun: () => run('live') });
+      const out = await ports.history.load('p1');
+      expect(out.map((r) => r.id)).toEqual(['live', 'a']);
+    });
+  });
+
+  it('history.save delegates to saveRunHistory', async () => {
+    const ports = buildPorts();
+    const runs = [run('a')];
+    await ports.history.save?.('p1', runs);
+    expect(mockSaveHistory).toHaveBeenCalledWith('p1', runs);
+  });
+});

--- a/tests/unit/proForge/nodeInferenceGateway.test.ts
+++ b/tests/unit/proForge/nodeInferenceGateway.test.ts
@@ -5,6 +5,9 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { GenerateRequest } from '../../../services/ai/inferenceGateway';
+import type { AIRequestOptions } from '../../../services/aiProviderService';
+
 const { mockGenerate, mockEmbed } = vi.hoisted(() => ({
   mockGenerate: vi.fn(),
   mockEmbed: vi.fn(),
@@ -23,13 +26,22 @@ import {
 } from '../../../services/proForge/adapters/nodeInferenceGateway';
 
 const gw = () => new NodeInferenceGateway({ apiKey: 'test-key' });
-const genReq = (over: Record<string, unknown> = {}) =>
-  ({
+
+// Fully-typed GenerateRequest fixture. Empty model intentionally exercises the gateway's
+// `request.options.model || this.defaultModel` fallback (the only narrow cast).
+function genReq(
+  over: { creativity?: GenerateRequest['creativity']; options?: Partial<AIRequestOptions> } = {},
+): GenerateRequest {
+  return {
     prompt: 'hello',
-    creativity: 'Balanced',
-    options: { model: '', maxTokens: undefined },
-    ...over,
-  }) as unknown as Parameters<NodeInferenceGateway['generate']>[0];
+    creativity: over.creativity ?? 'Balanced',
+    options: {
+      model: '' as AIRequestOptions['model'],
+      provider: 'gemini',
+      ...over.options,
+    },
+  };
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -78,9 +90,9 @@ describe('NodeInferenceGateway.generate', () => {
   });
 
   it('honours a custom model from the request and forwards maxTokens', async () => {
-    await gw().generate(genReq({ options: { model: 'gemini-1.5-pro', maxTokens: 512 } }));
+    await gw().generate(genReq({ options: { model: 'gemini-3.5-flash', maxTokens: 512 } }));
     const arg = mockGenerate.mock.calls[0]?.[0];
-    expect(arg.model).toBe('gemini-1.5-pro');
+    expect(arg.model).toBe('gemini-3.5-flash');
     expect(arg.config.maxOutputTokens).toBe(512);
   });
 

--- a/tests/unit/proForge/nodeInferenceGateway.test.ts
+++ b/tests/unit/proForge/nodeInferenceGateway.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for services/proForge/adapters/nodeInferenceGateway.ts — the Node/MCP InferenceGateway
+ * adapter over @google/genai. Mocks the SDK; no network, no real API key.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockGenerate, mockEmbed } = vi.hoisted(() => ({
+  mockGenerate: vi.fn(),
+  mockEmbed: vi.fn(),
+}));
+
+vi.mock('@google/genai', () => ({
+  // QNBS-v3: a real class — vi.fn() instances aren't reliably `new`-able across module boundaries.
+  GoogleGenAI: class {
+    models = { generateContent: mockGenerate, embedContent: mockEmbed };
+  },
+}));
+
+import {
+  NodeInferenceGateway,
+  resolveNodeApiKey,
+} from '../../../services/proForge/adapters/nodeInferenceGateway';
+
+const gw = () => new NodeInferenceGateway({ apiKey: 'test-key' });
+const genReq = (over: Record<string, unknown> = {}) =>
+  ({
+    prompt: 'hello',
+    creativity: 'Balanced',
+    options: { model: '', maxTokens: undefined },
+    ...over,
+  }) as unknown as Parameters<NodeInferenceGateway['generate']>[0];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGenerate.mockResolvedValue({ text: 'response' });
+  mockEmbed.mockResolvedValue({ embeddings: [{ values: [0.1, 0.2, 0.3] }] });
+});
+
+// ---------------------------------------------------------------------------
+// resolveNodeApiKey
+// ---------------------------------------------------------------------------
+describe('resolveNodeApiKey', () => {
+  it('resolves GEMINI_API_KEY first', () => {
+    expect(resolveNodeApiKey({ GEMINI_API_KEY: 'g', WORLDSCRIPT_API_KEY: 'w' })).toBe('g');
+  });
+
+  it('falls back to WORLDSCRIPT_API_KEY then GOOGLE_GENERATIVE_AI_API_KEY', () => {
+    expect(resolveNodeApiKey({ WORLDSCRIPT_API_KEY: 'w' })).toBe('w');
+    expect(resolveNodeApiKey({ GOOGLE_GENERATIVE_AI_API_KEY: 'goog' })).toBe('goog');
+  });
+
+  it('throws a clear error when no key env var is set', () => {
+    expect(() => resolveNodeApiKey({})).toThrow(/Missing API key/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generate
+// ---------------------------------------------------------------------------
+describe('NodeInferenceGateway.generate', () => {
+  it('returns the SDK text tagged with model/provider and isFallback:false', async () => {
+    const res = await gw().generate(genReq());
+    expect(res).toMatchObject({
+      text: 'response',
+      model: 'gemini-2.0-flash',
+      provider: 'gemini',
+      isFallback: false,
+    });
+  });
+
+  it('maps creativity to temperature (Focused → 0.3, Imaginative → 1.0)', async () => {
+    await gw().generate(genReq({ creativity: 'Focused' }));
+    expect(mockGenerate.mock.calls[0]?.[0].config.temperature).toBe(0.3);
+    mockGenerate.mockClear();
+    await gw().generate(genReq({ creativity: 'Imaginative' }));
+    expect(mockGenerate.mock.calls[0]?.[0].config.temperature).toBe(1.0);
+  });
+
+  it('honours a custom model from the request and forwards maxTokens', async () => {
+    await gw().generate(genReq({ options: { model: 'gemini-1.5-pro', maxTokens: 512 } }));
+    const arg = mockGenerate.mock.calls[0]?.[0];
+    expect(arg.model).toBe('gemini-1.5-pro');
+    expect(arg.config.maxOutputTokens).toBe(512);
+  });
+
+  it('omits maxOutputTokens when maxTokens is undefined', async () => {
+    await gw().generate(genReq());
+    expect(mockGenerate.mock.calls[0]?.[0].config).not.toHaveProperty('maxOutputTokens');
+  });
+
+  it('returns empty text when the SDK omits it', async () => {
+    mockGenerate.mockResolvedValueOnce({});
+    expect((await gw().generate(genReq())).text).toBe('');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// embed
+// ---------------------------------------------------------------------------
+describe('NodeInferenceGateway.embed', () => {
+  it('returns the embedding vector', async () => {
+    expect(await gw().embed({ text: 'x' })).toEqual({ vector: [0.1, 0.2, 0.3] });
+  });
+
+  it('returns an empty vector on SDK error (best-effort)', async () => {
+    mockEmbed.mockRejectedValueOnce(new Error('quota'));
+    expect(await gw().embed({ text: 'x' })).toEqual({ vector: [] });
+  });
+
+  it('returns an empty vector when no embeddings are present', async () => {
+    mockEmbed.mockResolvedValueOnce({ embeddings: [] });
+    expect(await gw().embed({ text: 'x' })).toEqual({ vector: [] });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// modelList + healthCheck
+// ---------------------------------------------------------------------------
+describe('NodeInferenceGateway.modelList / healthCheck', () => {
+  it('lists the default Gemini model', async () => {
+    const list = await gw().modelList();
+    expect(list).toEqual([
+      {
+        id: 'gemini-2.0-flash',
+        provider: 'gemini',
+        displayName: 'gemini-2.0-flash',
+        isLocal: false,
+      },
+    ]);
+  });
+
+  it('reports ok health when a ping generation succeeds', async () => {
+    const health = await gw().healthCheck();
+    expect(health.status).toBe('ok');
+    expect(health.provider).toBe('gemini');
+    expect(typeof health.latencyMs).toBe('number');
+  });
+
+  it('reports unavailable health when the ping throws', async () => {
+    mockGenerate.mockRejectedValueOnce(new Error('down'));
+    expect((await gw().healthCheck()).status).toBe('unavailable');
+  });
+});

--- a/tests/unit/proForge/proForgeCapabilityCore.test.ts
+++ b/tests/unit/proForge/proForgeCapabilityCore.test.ts
@@ -152,15 +152,45 @@ describe('applyEditsPure', () => {
     expect(applyEditsPure(snapshot.manuscript, [], false).dryRun).toBe(false);
   });
 
-  it('ignores review items that are not accepted manuscript edits', () => {
-    const item = {
+  it('ignores an advisory review item that carries no proposed replacement', () => {
+    // QNBS-v3: only items with a `proposed` are text edits; advisory items are ignored and NOT
+    // counted as skipped (status filtering happens upstream of applyEditsPure).
+    const advisory: ReviewItem = {
       id: 'ri1',
-      stage: 'lineProse',
-      accepted: false,
-      type: 'suggestion',
-    } as unknown as ReviewItem;
-    const res = applyEditsPure(snapshot.manuscript, [item], true);
+      stage: 'structural',
+      type: 'arcIssue',
+      severity: 'warning',
+      sectionId: 's1',
+      description: 'consider raising the stakes earlier',
+      confidence: 0.7,
+      status: 'accepted',
+      createdAt: '2026-01-01T00:00:00Z',
+      // no `proposed` → advisory, not an edit
+    };
+    const res = applyEditsPure(snapshot.manuscript, [advisory], true);
     expect(res.applied).toBe(0);
+    expect(res.skipped).toBe(0);
+  });
+
+  it('applies an accepted edit whose original text anchors in the section', () => {
+    const edit: ReviewItem = {
+      id: 'ri2',
+      stage: 'lineProse',
+      type: 'proseEdit',
+      severity: 'info',
+      sectionId: 's1',
+      range: { start: 0, end: 4 },
+      description: 'tighten the opening',
+      original: 'Once',
+      proposed: 'Then',
+      confidence: 0.9,
+      status: 'accepted',
+      createdAt: '2026-01-01T00:00:00Z',
+    };
+    const res = applyEditsPure(snapshot.manuscript, [edit], false);
+    expect(res.applied).toBe(1);
+    expect(res.updates[0]).toMatchObject({ id: 's1' });
+    expect(res.updates[0]?.content).toContain('Then');
   });
 });
 

--- a/tests/unit/proForge/proForgeCapabilityCore.test.ts
+++ b/tests/unit/proForge/proForgeCapabilityCore.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Tests for services/proForge/proForgeCapabilityCore.ts — the pure, IO-free operations of the
+ * ProForge Core Capability Layer (the hexagonal seam shared by the browser + Node/MCP adapters).
+ * QNBS-v3: no Redux / IDB / browser globals — pure functions only.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  DEFAULT_PIPELINE_CONFIG,
+  type PipelineRun,
+  type ReviewItem,
+  type StageResult,
+} from '../../../features/proForge/types';
+import {
+  applyEditsPure,
+  buildAgentContext,
+  type ProForgeProjectSnapshot,
+  resolveConfig,
+  selectRun,
+  supervisorStatusFromRun,
+} from '../../../services/proForge/proForgeCapabilityCore';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeStage(stage: StageResult['stage'], status: StageResult['status']): StageResult {
+  const passed = status === 'accepted';
+  return {
+    stage,
+    status,
+    reviewItems: [],
+    metrics: {} as StageResult['metrics'],
+    supervisorDecision: {
+      pass: passed,
+      retryRecommended: false,
+      qualityScore: passed ? 80 : 0,
+      reasons: [],
+    },
+  };
+}
+
+function makeRun(id: string, stages: StageResult[] = []): PipelineRun {
+  return {
+    id,
+    projectId: 'p1',
+    label: `Run ${id}`,
+    config: DEFAULT_PIPELINE_CONFIG,
+    status: 'completed',
+    activeStage: 'analytics',
+    stages,
+    startedAt: '2026-01-01T00:00:00Z',
+    prePipelineSnapshotId: '',
+    traceLog: [],
+  };
+}
+
+const snapshot: ProForgeProjectSnapshot = {
+  id: 'p1',
+  title: 'Novel',
+  logline: 'A hero rises.',
+  manuscript: [{ id: 's1', title: 'Ch 1', content: 'Once upon a time.' }],
+  characters: [{ id: 'c1', name: 'Alice' }],
+  worlds: [{ id: 'w1', name: 'Westeros' }],
+};
+
+// ---------------------------------------------------------------------------
+// resolveConfig
+// ---------------------------------------------------------------------------
+describe('resolveConfig', () => {
+  it('returns the defaults when no overrides are given', () => {
+    expect(resolveConfig()).toEqual(DEFAULT_PIPELINE_CONFIG);
+  });
+
+  it('applies provided overrides over the defaults', () => {
+    const cfg = resolveConfig({ maxTokens: 5000, creativity: 'Imaginative' });
+    expect(cfg.maxTokens).toBe(5000);
+    expect(cfg.creativity).toBe('Imaginative');
+    expect(cfg.genrePreset).toBe(DEFAULT_PIPELINE_CONFIG.genrePreset); // untouched default
+  });
+
+  it('strips undefined values so a partial never clobbers a required default', () => {
+    const cfg = resolveConfig({ genrePreset: undefined, maxTokens: undefined });
+    expect(cfg.genrePreset).toBe(DEFAULT_PIPELINE_CONFIG.genrePreset);
+    expect(cfg.maxTokens).toBe(DEFAULT_PIPELINE_CONFIG.maxTokens);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selectRun
+// ---------------------------------------------------------------------------
+describe('selectRun', () => {
+  const r1 = makeRun('r1');
+  const r2 = makeRun('r2');
+
+  it('returns the run matching the given id', () => {
+    expect(selectRun([r1, r2], 'r2')).toBe(r2);
+  });
+
+  it('returns the most recent run (index 0) when no id is given', () => {
+    expect(selectRun([r1, r2])).toBe(r1);
+  });
+
+  it('returns null for an unknown id', () => {
+    expect(selectRun([r1, r2], 'nope')).toBeNull();
+  });
+
+  it('returns null for an empty history', () => {
+    expect(selectRun([])).toBeNull();
+    expect(selectRun([], 'r1')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// supervisorStatusFromRun
+// ---------------------------------------------------------------------------
+describe('supervisorStatusFromRun', () => {
+  it('maps each stage to its recorded supervisor decision + status (no AI)', () => {
+    const run = makeRun('r1', [makeStage('intake', 'accepted'), makeStage('structural', 'failed')]);
+    const status = supervisorStatusFromRun(run);
+    expect(status).toHaveLength(2);
+    expect(status[0]).toMatchObject({ stage: 'intake', status: 'accepted' });
+    expect(status[0]?.supervisorDecision?.qualityScore).toBe(80);
+    expect(status[1]).toMatchObject({ stage: 'structural', status: 'failed' });
+    expect(status[1]?.supervisorDecision?.qualityScore).toBe(0);
+  });
+
+  it('emits a null decision when a stage has none recorded', () => {
+    const bare: StageResult = {
+      stage: 'proof',
+      status: 'pending',
+      reviewItems: [],
+      metrics: {} as StageResult['metrics'],
+    };
+    const status = supervisorStatusFromRun(makeRun('r1', [bare]));
+    expect(status[0]?.supervisorDecision).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyEditsPure
+// ---------------------------------------------------------------------------
+describe('applyEditsPure', () => {
+  it('reports zero changes for an empty review-item set', () => {
+    const res = applyEditsPure(snapshot.manuscript, [], true);
+    expect(res).toMatchObject({ applied: 0, skipped: 0, invalid: 0, dryRun: true });
+    expect(res.updates).toEqual([]);
+  });
+
+  it('threads the dryRun flag through to the summary', () => {
+    expect(applyEditsPure(snapshot.manuscript, [], false).dryRun).toBe(false);
+  });
+
+  it('ignores review items that are not accepted manuscript edits', () => {
+    const item = {
+      id: 'ri1',
+      stage: 'lineProse',
+      accepted: false,
+      type: 'suggestion',
+    } as unknown as ReviewItem;
+    const res = applyEditsPure(snapshot.manuscript, [item], true);
+    expect(res.applied).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildAgentContext
+// ---------------------------------------------------------------------------
+describe('buildAgentContext', () => {
+  it('builds an orchestrator context with a no-op dispatch and synthetic state', () => {
+    const gateway = { generate: vi.fn() } as unknown as Parameters<typeof buildAgentContext>[2];
+    const ctx = buildAgentContext(snapshot, DEFAULT_PIPELINE_CONFIG, gateway);
+    expect(ctx.projectId).toBe('p1');
+    expect(ctx.manuscript).toEqual(snapshot.manuscript);
+    expect(ctx.characters).toEqual(snapshot.characters);
+    expect(ctx.worlds).toEqual(snapshot.worlds);
+    expect(ctx.config).toBe(DEFAULT_PIPELINE_CONFIG);
+    expect(ctx.gateway).toBe(gateway);
+    // dispatch is a no-op (single-stage runs never touch Redux)
+    expect(ctx.dispatch({ type: 'noop' } as never)).toBeUndefined();
+    // getState exposes a ProjectData-compatible snapshot under project.present.data
+    const state = ctx.getState() as unknown as {
+      project: { present: { data: ProForgeProjectSnapshot } };
+    };
+    expect(state.project.present.data.title).toBe('Novel');
+  });
+});

--- a/tests/unit/proForge/proForgeCapabilitySchemas.test.ts
+++ b/tests/unit/proForge/proForgeCapabilitySchemas.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Tests for services/proForge/proForgeCapabilitySchemas.ts — the Zod input schemas that gate every
+ * Core Capability Layer op (shared by the in-app UI and the MCP server). Validates defaults and the
+ * min(1) guards that turn empty strings into VALIDATION errors instead of silent "latest run" fallbacks.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  applyEditsInputSchema,
+  getHistoryInputSchema,
+  getSupervisorStatusInputSchema,
+  ProForgeError,
+  projectPayloadSchema,
+  ragQueryInputSchema,
+  runStageInputSchema,
+} from '../../../services/proForge/proForgeCapabilitySchemas';
+
+describe('runStageInputSchema', () => {
+  it('accepts a valid executable stage and defaults dryRun to false', () => {
+    const parsed = runStageInputSchema.parse({ stage: 'intake', projectId: 'p1' });
+    expect(parsed.dryRun).toBe(false);
+    expect(parsed.stage).toBe('intake');
+  });
+
+  it('rejects a non-executable / unknown stage', () => {
+    expect(runStageInputSchema.safeParse({ stage: 'idle', projectId: 'p1' }).success).toBe(false);
+    expect(runStageInputSchema.safeParse({ stage: 'bogus', projectId: 'p1' }).success).toBe(false);
+  });
+
+  it('rejects an empty projectId', () => {
+    expect(runStageInputSchema.safeParse({ stage: 'intake', projectId: '' }).success).toBe(false);
+  });
+});
+
+describe('getHistoryInputSchema', () => {
+  it('defaults limit to 20', () => {
+    expect(getHistoryInputSchema.parse({ projectId: 'p1' }).limit).toBe(20);
+  });
+
+  it('rejects limit above 100', () => {
+    expect(getHistoryInputSchema.safeParse({ projectId: 'p1', limit: 101 }).success).toBe(false);
+  });
+
+  // QNBS-v3: CodeAnt #6 guard — empty runId must be a validation error, not a "latest run" fallback.
+  it('rejects an empty-string runId (no silent truthiness collapse)', () => {
+    expect(getHistoryInputSchema.safeParse({ projectId: 'p1', runId: '' }).success).toBe(false);
+  });
+
+  it('accepts an omitted runId', () => {
+    expect(getHistoryInputSchema.safeParse({ projectId: 'p1' }).success).toBe(true);
+  });
+});
+
+describe('getSupervisorStatusInputSchema', () => {
+  it('rejects an empty-string runId', () => {
+    expect(getSupervisorStatusInputSchema.safeParse({ projectId: 'p1', runId: '' }).success).toBe(
+      false,
+    );
+  });
+});
+
+describe('ragQueryInputSchema', () => {
+  it('defaults k to 10 and mode to lexical', () => {
+    const parsed = ragQueryInputSchema.parse({ projectId: 'p1', query: 'hero' });
+    expect(parsed.k).toBe(10);
+    expect(parsed.mode).toBe('lexical');
+  });
+
+  it('rejects an empty query and k above 50', () => {
+    expect(ragQueryInputSchema.safeParse({ projectId: 'p1', query: '' }).success).toBe(false);
+    expect(ragQueryInputSchema.safeParse({ projectId: 'p1', query: 'x', k: 51 }).success).toBe(
+      false,
+    );
+  });
+});
+
+describe('applyEditsInputSchema', () => {
+  it('defaults dryRun false and section content to empty string', () => {
+    const parsed = applyEditsInputSchema.parse({
+      manuscript: [{ id: 's1' }],
+      items: [{ id: 'ri1' }],
+    });
+    expect(parsed.dryRun).toBe(false);
+    expect(parsed.manuscript[0]?.content).toBe('');
+  });
+
+  it('rejects a manuscript section with an empty id', () => {
+    const r = applyEditsInputSchema.safeParse({ manuscript: [{ id: '' }], items: [] });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe('projectPayloadSchema', () => {
+  it('applies array + string defaults for a minimal payload', () => {
+    const parsed = projectPayloadSchema.parse({ projectId: 'p1' });
+    expect(parsed.title).toBe('');
+    expect(parsed.logline).toBe('');
+    expect(parsed.manuscript).toEqual([]);
+    expect(parsed.characters).toEqual([]);
+    expect(parsed.worlds).toEqual([]);
+    expect(parsed.memoryEntries).toEqual([]);
+  });
+
+  it('rejects an empty projectId', () => {
+    expect(projectPayloadSchema.safeParse({ projectId: '' }).success).toBe(false);
+  });
+});
+
+describe('ProForgeError', () => {
+  it('carries a structured code, message, and optional details', () => {
+    const err = new ProForgeError('NOT_FOUND', 'run missing', { runId: 'r9' });
+    expect(err).toBeInstanceOf(Error);
+    expect(err.code).toBe('NOT_FOUND');
+    expect(err.message).toBe('run missing');
+    expect(err.details).toEqual({ runId: 'r9' });
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

PR C of the **Critical & Immediate** hardening sequence. Closes concrete test-coverage gaps in the newer subsystems — **pure test additions, no production code change**.

## Coverage added (101 tests across 11 files)

**collab-transport E2E crypto** (vendored y-webrtc C-1 fork — the SC-patched layer, not the broad transport):
- `deriveKey` (PBKDF2 600k, AES-256-GCM, `extractable:false`, room name as salt), `encrypt`/`decrypt` + JSON roundtrips, null-key passthrough, fresh-IV-per-call, wrong-key + unknown-algorithm rejection.

**ProForge Core Capability Layer + adapters:**
- `proForgeCapabilityCore` — `resolveConfig` (undefined-strip), `selectRun`, `supervisorStatusFromRun`, `applyEditsPure`, `buildAgentContext`.
- `proForgeCapabilitySchemas` — Zod defaults + the `min(1)` empty-string guards (no silent "latest run" fallback).
- `agentRegistry` — `EXECUTABLE_STAGES` + `loadAgent` resolution/throws.
- `nodeInferenceGateway` — key resolution priority, `generate` temperature mapping + `maxTokens` forwarding, `embed` best-effort, `modelList`, `healthCheck` (mocked `@google/genai`).
- `browserProForgeCapability` — port wiring + the in-flight-run-first `history.load`.

**Copilot components (the 5 untested):** `HeuristicsModeToggle`, `InlineAnnotationLayer`, `InsightSection`, `CopilotLauncher`, `CopilotPanel` — render/interaction/a11y (children + focus trap mocked).

## Verification
- `check-suppressions` (52, baseline — no new ignores; mocks typed precisely) · `lint` · `typecheck` (exit 0).
- All 101 new tests pass locally. Coverage delta is CI-measured (no threshold bump in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Add coverage for Copilot, collab encryption, and ProForge behavior**

### What Changed
- Added tests for Copilot controls and panels, covering open/close behavior, accessibility states, keyboard dismissal, suggestion chips, alerts, and inline insight badges
- Added end-to-end crypto tests for collab transport, including key derivation, encryption/decryption, null-key passthrough, fresh IVs, and rejection of invalid or wrong keys
- Added ProForge coverage for core run selection, config defaults, agent loading, browser history wiring, Node inference behavior, schema validation, and health checks

### Impact
`✅ Fewer regressions in Copilot interactions`
`✅ Safer collab message encryption`
`✅ More reliable ProForge run and adapter behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
