### PR TITLE
chore: dependency hygiene + contributor onboarding + docs/README truth-up

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,7 +32,7 @@ contexts/         → React context providers (one per major view + I18nContext 
 features/         → Redux Toolkit slices: project, settings, status, writer, versionControl, featureFlags
 hooks/            → Custom hooks with view business logic (one hook per view)
 services/         → External adapters: geminiService, aiProviderService, dbService (dual IndexedDB + migration), storageService, collaborationService; **ai/** (aiModeService — execution modes, aiPolicy, aiRetry; **providers/** — openrouterProvider with circuit breaker); **copilot/** (heuristicEngine 8 rules, insightGenerator, copilotContextService, actionApplier); **commands/** (palette registry); **keyboard/** (shortcut matching); **help/** (doc retrieval for AI); **settingsExchange** (settings JSON)
-locales/          → i18n source files — de/en/es/fr/it (core) + ar/he (RTL Beta) + el/ja/pt/zh (Beta) × 15-20 JSON modules (2 594 keys × 11 locales)
+locales/          → i18n source files — de/en/es/fr/it (core) + ar/he/fa (RTL Beta) + el/ja/pt/zh/fi/sv/hu/is/eu (Beta) × ~20 JSON modules (17 locales; see the README badge for the live key count)
 public/locales/   → i18n runtime files served at BASE_URL
 tests/            → Unit + E2E tests (Vitest + Playwright)
 types/            → Additional TypeScript type definitions
@@ -144,7 +144,7 @@ types.ts          → Core shared interfaces and types
 
 - All user-facing strings must use `t('key.path')` from `useTranslation()`
 - Source files: `locales/{lang}/{module}.json` (15 modules). Runtime: **one** merged **`public/locales/{lang}/bundle.json`** per language — regenerate with **`pnpm run i18n:bundle`** or **`pnpm run i18n:check`** (parity check **and** bundle build); **`predev`** / **`prebuild`** also rebuild bundles so the UI never shows raw keys after editing locale JSON.
-- **the in-app selector exposes five locales:** **de**, **en**, **fr**, **es**, **it** — keep key parity with English (`pnpm run i18n:check` in CI)
+- **17 locales ship** (de/en/es/fr/it core + ar/he/fa RTL + el/ja/pt/zh/fi/sv/hu/is/eu Beta); all must keep key parity with English (`pnpm run i18n:check` in CI). The `/i18n-key` skill auto-fills the **5 core** (de/en/es/fr/it); update Beta/RTL locales manually afterward.
 - English is the fallback language
 - New keys: add to **`locales/en/`** first, then **de**, **fr**, **es**, **it** (or run `node scripts/check-i18n-keys.mjs --fix` and translate), then commit updated **`bundle.json`** files
 
@@ -152,12 +152,8 @@ types.ts          → Core shared interfaces and types
 
 - Conventional Commits format: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`
 - Pre-commit: `simple-git-hooks` runs Biome check on staged files
-- Before every commit and push, run the full local preflight:
-  - `pnpm install --frozen-lockfile`
-  - `pnpm run lint`
-  - `pnpm run typecheck`
-  - `pnpm run test:run`
-  - `pnpm run build`
+- **⚠️ Constrained local hardware — do NOT run heavy suites locally.** This machine has ~3–4 GB RAM. **Never** run the full Vitest **coverage** suite, **Playwright E2E**, **Stryker mutation**, **Lighthouse CI**, or the **Storybook test-runner** locally — they are **CI-only by design**. Run **one heavy command at a time** (no parallel `vitest`/`biome`/`tsc`/`vite`).
+- Local preflight (sequential, minimal): `pnpm run lint` → `pnpm run typecheck` → `pnpm run i18n:check` (only when locale JSON changed) → **targeted** `pnpm exec vitest run <path>` (no `--coverage`). Run `pnpm run build && pnpm run smoke:prod` only when you touched `vite.config.ts`, `packages/ai-core`, or `workers/`. Coverage, E2E, Lighthouse, Stryker, and Storybook are **CI gate jobs** — let GitHub Actions run them.
 - CI pipeline (see [`docs/CI.md`](../docs/CI.md)): **`security` → `quality`** (Biome + `tsc` + Vitest matrix) **→ `build` / `e2e` / `storybook` in parallel** → **`lighthouse`** after build → **`deploy`** on `main` after build+e2e
 - Branch protection should require the **`quality`** job (and other checks your team enables); job ids match `.github/workflows/ci.yml`
 - CI runs **`pnpm audit`** every workflow; **dependency-review** on pull requests

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -8,6 +8,16 @@
 
 **Quality gate (2026-06-16 — v1.23.0):** lint ✅ · typecheck ✅ · i18n:check ✅ (**2709 keys × 11 locales**) · placeholder guard ✅ · unit tests ✅ (5807+ / 485 files) · coverage thresholds L74/B60/F67/S72 ✅. Toolchain: Node 22/24, **pnpm 11**, Vite 8, TypeScript 7 (tsgo).
 
+**Quality gate (2026-06-21 — v1.24.0 Critical & Immediate hardening sequence):** lint ✅ · typecheck ✅ (tsgo) · i18n:check ✅ (**2786 keys × 17 locales**) · suppressions ratchet ✅ (52, no new) · targeted unit tests ✅. Stacked PRs A–F: privacy analytics gating (SEC-6), reusable Badge + experimental labeling, coverage (collab-transport/ProForge/copilot, +101 tests), voice consent clarity, device-aware Ollama pull, hygiene/docs. Coverage/E2E/Lighthouse/Stryker remain CI-gate jobs.
+
+## v1.24.0 Dependency Hygiene + Onboarding + Docs Truth-up (2026-06-21, PR F)
+
+- **`joi` override (accepted risk, KEPT):** `pnpm-workspace.yaml` `overrides.joi: ^18.2.1` pins the patched `joi` pulled transitively via `wait-on` (Storybook/test-runner wait helper), mitigating **GHSA-q7cg-457f-vx79** (unpublished jsdom exposure in `@hapi/statehood`). Still required — `wait-on@9.x` still depends on `joi`. `pnpm audit --audit-level=high` clean with the override in place; rationale documented inline in `pnpm-workspace.yaml` and here.
+- **SBOM — deferred (decision):** evaluated a `@cyclonedx/cyclonedx-npm` generate-on-tag step; **not adopted in 1.24.0** to keep the release scope tight. Socket Security (PR + project report) already runs every CI run and provides dependency-risk + an SBOM dashboard, so the marginal value is low. Revisit when a formal SBOM artifact is required by a downstream consumer.
+- **README metric drift fixed:** `scripts/sync-readme-metrics.mjs` had its locale count **hard-coded to `11`**, so its regexes stopped matching after the 11→17 expansion and silently froze the key count at a stale value. Locale count is now **dynamic** (counts `locales/` dirs) and the regexes match any digit count; re-run → README reads **2786 keys × 17 locales** with the drift guard green.
+- **Docs truth-up:** corrected the stale `public/sw.js` "must hand-sync `APP_VERSION`" note in `CLAUDE.md` (it is auto-synced by `scripts/sync-sw-version.mjs` + `sync-tauri-version.mjs` via `predev`/`prebuild`); refreshed the stale 5-locale / `2 594 keys × 11 locales` strings in `CONTRIBUTING.md` + `.github/copilot-instructions.md` to 17 locales.
+- **Onboarding:** added a prominent **"Do NOT run heavy suites locally"** callout + a **Minimal Change Checklist** to `CONTRIBUTING.md`, and mirrored the heavy-suite warning into `.github/copilot-instructions.md` (its old preflight wrongly told contributors to run `test:run` + `build` on every commit — now aligned with the low-end CI-first policy already in `AGENTS.md`).
+
 ## v1.23.0 Post-Release Documentation Perfection Pass (2026-06-16)
 
 **Scope:** Bring the entire doc corpus into lockstep with the shipped v1.23.0 code, curate/restructure historical material, clear the Dependabot queue, and complete the GitHub release/package rebrand.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -417,7 +417,7 @@ See `AUDIT.md` and `TODO.md`. Key items:
 - **DS-5:** Delete legacy bridge block from `index.css` — deferred until DS-1 verified in production.
 - **B-1 (IDB encryption):** Passphrase UX complete (`IdbUnlockModal`, `PassphraseModal`). Actual IDB read/write integration for stores is Phase 4 (service-layer only currently).
 - **B-2 (Voice WASM):** Engine + download UI shipped. Remaining: E2E integration test coverage.
-- **SW version sync:** `public/sw.js` `APP_VERSION` is hardcoded and must be manually kept in sync with `package.json` `version` on every release. Long-term fix: move `sw.js` → `src/sw.ts` so Vite's `define` can inject `__APP_VERSION__` at build time.
+- **SW version sync:** `public/sw.js` `APP_VERSION` and the Tauri versions are **auto-synced** from `package.json` `version` by `scripts/sync-sw-version.mjs` + `scripts/sync-tauri-version.mjs`, which run on every `predev`/`prebuild` — no manual edit needed (just bump `package.json` for a release). The earlier "must hand-sync" note is obsolete.
 
 ## graphify
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,7 +122,7 @@ WorldScript-Studio/
 ├── contexts/         # React contexts per view + I18n + CommandExecutor
 ├── features/         # Redux slices (project, settings, writer, status, featureFlags, plotBoard, progressTracker, sceneComments)
 ├── hooks/            # Custom React hooks per view + shared hooks (e.g. useGlobalKeyboardShortcuts)
-├── locales/          # i18n source JSON (de, en, fr, es, it — key parity vs en)
+├── locales/          # i18n source JSON — 17 locales: de/en/es/fr/it core + ar/he/fa RTL + el/ja/pt/zh/fi/sv/hu/is/eu Beta (key parity vs en)
 ├── services/         # Adapters: AI, DB, storage, collaboration, EPUB; commands/, keyboard/, help/, settingsExchange
 ├── stories/          # Storybook stories for UI components
 ├── docs/             # Deep-dive docs (CI reference, history, graphify)
@@ -170,6 +170,25 @@ chore: update dependencies
 ---
 
 ## Testing
+
+> ### ⚠️ Do NOT run the heavy suites locally
+>
+> This repo is developed on constrained hardware (~3–4 GB RAM). **Never** run the full Vitest **coverage** suite, **Playwright E2E**, **Stryker mutation**, **Lighthouse CI**, or the **Storybook test-runner** locally — they OOM weak machines and are **CI-only by design**. Push to a branch and let GitHub Actions run the heavy tier; a green CI run is the merge bar.
+
+### Minimal Change Checklist (what to actually run locally)
+
+Run the smallest gate that matches your change — sequentially, one heavy command at a time:
+
+| Your change… | Run locally before pushing |
+|---|---|
+| **Always** | `pnpm run lint` · `pnpm run typecheck` · targeted `pnpm exec vitest run <path>` (no `--coverage`) |
+| **Touched any locale JSON** | `pnpm run i18n:check` (parity + bundle rebuild) |
+| **Added/removed a feature flag** | `pnpm exec tsx scripts/audit-feature-parity.ts` (must report 0 drifts) |
+| **Touched `packages/ai-core`, `workers/`, or `vite.config.ts`** | `pnpm run build && pnpm run smoke:prod` (prod-only crash guard) |
+| **Added a `components/ui/` primitive** | add a `.stories.tsx`; the Storybook test-runner verifies it in CI |
+| **Added a dependency** | `pnpm audit --audit-level=high` (override + document in `AUDIT.md` if needed) |
+
+Coverage, E2E, Lighthouse, Stryker, and Storybook test-runner are **CI gate jobs** — do not attempt them locally.
 
 ### Local vs CI (low-end friendly)
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
   <img src="https://img.shields.io/badge/Version-v1.23.1-6366F1" alt="v1.23.1">
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
-  <img src="https://img.shields.io/badge/i18n-17_locales-2716_keys-0EA5E9" alt="i18n 17 locales — 2716 keys">
-  <img src="https://img.shields.io/badge/Tests-5807%2B_%2F_491_files-22C55E" alt="5807+ tests / 491 files">
+  <img src="https://img.shields.io/badge/i18n-17_locales-2786_keys-0EA5E9" alt="i18n 17 locales — 2786 keys">
+  <img src="https://img.shields.io/badge/Tests-5807%2B_%2F_506_files-22C55E" alt="5807+ tests / 506 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -351,7 +351,7 @@ One-click encrypted export of your entire project library from **Settings → Da
 
 ### 🌐 Full Multi-Language Support
 
-Shipped UI locales with **2743 i18n keys** across all 17 languages — zero hardcoded user-facing strings:
+Shipped UI locales with **2786 i18n keys** across all 17 languages — zero hardcoded user-facing strings:
 
 - 🇩🇪 **German** (Deutsch)
 - 🇬🇧 **English**
@@ -456,8 +456,8 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **PDF Export**       | jsPDF                                                     | Client-side, configurable PDF document generation                    |
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
-| **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2716 keys × 17 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (5807+ tests / 491 files) + Playwright E2E    | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2786 keys × 17 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu Beta); EN fallback; `localStorage` persistence |
+| **Testing**          | Vitest 4.x (5807+ tests / 506 files) + Playwright E2E    | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -494,7 +494,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (5807+ tests, 491 files)
+│   ├── unit/             # Vitest unit tests (5807+ tests, 506 files)
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -653,9 +653,9 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-06-16):**
-- **5807+ unit tests** across **491 test files** — all passing
+- **5807+ unit tests** across **506 test files** — all passing
 - Coverage thresholds: lines ≥ 74 · branches ≥ 60 · functions ≥ 67 · statements ≥ 72 — enforced in CI (see Codecov badge for live metrics)
-- i18n: **2716 keys × 17 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu Beta)
+- i18n: **2786 keys × 17 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu Beta)
 
 **CI-cloud-first workflow (recommended):** On constrained hardware run **`pnpm run lint && pnpm run i18n:check && pnpm run typecheck`** locally, then push and let CI handle coverage, E2E, Lighthouse, and Stryker. Authoritative numbers come from CI artifacts (Codecov, JUnit). After CI goes green, update the README badges and `AUDIT.md` quality-gate line from the reported metrics. See **[`docs/CI.md`](docs/CI.md) § Cloud CI-first vs local development** for the full post-merge doc-update checklist.
 

--- a/scripts/sync-readme-metrics.mjs
+++ b/scripts/sync-readme-metrics.mjs
@@ -74,6 +74,14 @@ function getKeyCount() {
   return total;
 }
 
+// QNBS-v3: locale count is the number of per-language directories under locales/ (each ships a
+// bundle). Dynamic so the README never drifts when a locale is added (was hard-coded "11" — went
+// stale at the 11→17 expansion, which silently froze the key-count sync too).
+function getLocaleCount() {
+  return readdirSync(join(root, 'locales'), { withFileTypes: true }).filter((e) => e.isDirectory())
+    .length;
+}
+
 /** numTotalTests from test-results.json, else the current README badge value (preserve). */
 function getTestCaseCount(readme) {
   const resultsPath = join(root, 'test-results.json');
@@ -97,11 +105,15 @@ const original = readme;
 
 const fileCount = getTestFileCount();
 const keyCount = getKeyCount();
+const localeCount = getLocaleCount();
 const testCount = getTestCaseCount(readme);
 
 // --- Badges (shields.io URL + alt text) -------------------------------------
-readme = readme.replace(/i18n-11_locales-\d+_keys/g, `i18n-11_locales-${keyCount}_keys`);
-readme = readme.replace(/(11 locales — )\d+( keys)/g, `$1${keyCount}$2`);
+readme = readme.replace(
+  /i18n-\d+_locales-\d+_keys/g,
+  `i18n-${localeCount}_locales-${keyCount}_keys`,
+);
+readme = readme.replace(/\d+ locales — \d+ keys/g, `${localeCount} locales — ${keyCount} keys`);
 if (testCount != null) {
   readme = readme.replace(
     /Tests-\d+%2B_%2F_\d+_files/g,
@@ -119,12 +131,15 @@ readme = readme.replace(
   new RegExp(`(Shipped UI locales with \\*\\*)${NUM}( i18n keys\\*\\*)`),
   `$1${keyCount}$2`,
 );
-// Line ~453: "| 2 594 keys × 11 locales" — keep the table-cell leading space.
-readme = readme.replace(new RegExp(`(\\| )${NUM}(keys × 11 locales)`), `$1${keyCount} $2`);
-// Line ~652: "- i18n: **2 594 keys × 11 locales**" — non-table bold summary bullet.
+// Line ~453: "| 2716 keys × 17 locales" — keep the table-cell leading space; locale count dynamic.
 readme = readme.replace(
-  new RegExp(`(i18n: \\*\\*)${NUM}(keys × 11 locales\\*\\*)`),
-  `$1${keyCount} $2`,
+  new RegExp(`(\\| )${NUM}keys × \\d+ locales`),
+  `$1${keyCount} keys × ${localeCount} locales`,
+);
+// Line ~652: "- i18n: **2716 keys × 17 locales**" — non-table bold summary bullet.
+readme = readme.replace(
+  new RegExp(`(i18n: \\*\\*)${NUM}keys × \\d+ locales(\\*\\*)`),
+  `$1${keyCount} keys × ${localeCount} locales$2`,
 );
 if (testCount != null) {
   // Line ~454: "Vitest 4.x (5 475+ tests / 449 files)"
@@ -159,7 +174,8 @@ const assertAll = (label, regex, expected) => {
       drift.push(`${label}: found "${m[1].trim()}", expected ${expected}`);
   }
 };
-assertAll('i18n keys (× 11 locales)', new RegExp(`(${NUM_D})keys × 11 locales`, 'g'), keyCount);
+assertAll('i18n keys (× locales)', new RegExp(`(${NUM_D})keys × \\d+ locales`, 'g'), keyCount);
+assertAll('locale count', new RegExp(`keys × (${NUM_D})locales`, 'g'), localeCount);
 assertAll('i18n keys (bold)', new RegExp(`\\*\\*(${NUM_D})i18n keys\\*\\*`, 'g'), keyCount);
 assertAll('test cases', new RegExp(`(${NUM_D})\\+ (?:unit )?tests\\b`, 'g'), testCount);
 assertAll('test files', new RegExp(`(${NUM_D})(?:test )?files\\b`, 'g'), fileCount);


### PR DESCRIPTION
## **User description**
## Summary

PR F of the **Critical & Immediate** hardening sequence — cleanup + truth-up ahead of the 1.24.0 release.

## Changes

- **README metric drift fixed:** `scripts/sync-readme-metrics.mjs` hard-coded the locale count to `11`, so its regexes stopped matching after the 11→17 locale expansion and **silently froze the key count** at a stale value. Locale count is now **dynamic** (counts `locales/` dirs) and the regexes match any digit count → README reads **2786 keys × 17 locales**; drift guard green; re-run is idempotent.
- **`joi` override:** confirmed **still required** (`wait-on@9` → `joi`; **GHSA-q7cg-457f-vx79**); accepted-risk rationale documented in `AUDIT.md`; `pnpm audit --audit-level=high` **clean**.
- **SBOM:** evaluated `@cyclonedx/cyclonedx-npm` — **deferred** (Socket Security already runs every CI run with an SBOM dashboard); decision recorded in `AUDIT.md`.
- **Docs truth-up:** corrected the stale `public/sw.js` *"must hand-sync `APP_VERSION`"* note in `CLAUDE.md` (it's auto-synced via `predev`/`prebuild`); refreshed stale **5-locale / "2 594 keys × 11 locales"** strings in `CONTRIBUTING.md` + `.github/copilot-instructions.md` to **17 locales**.
- **Onboarding:** added a prominent **"Do NOT run heavy suites locally"** callout + a **Minimal Change Checklist** to `CONTRIBUTING.md`, and mirrored the heavy-suite warning into `.github/copilot-instructions.md` — whose old preflight wrongly told contributors to run `test:run` + `build` on every commit, now aligned with the low-end CI-first policy already in `AGENTS.md`.

## Verification
- `check-suppressions` (52) · `lint` · `pnpm audit --audit-level=high` (clean) · metrics script idempotent + drift-guard green. Docs-only + one build-script change; no app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Refresh README metrics and contributor guidance**

### What Changed
- README badges and text now show the current i18n key count and locale count, along with the updated test file count
- The README sync script now detects locale count automatically, so future locale additions do not leave stale numbers behind
- Contributor docs now tell people not to run heavy test suites locally, and list the small checks that should be run before pushing
- Setup notes were updated to reflect that service worker and desktop version numbers are synced automatically, not by hand

### Impact
`✅ Fewer stale README stats`
`✅ Clearer contributor setup`
`✅ Less confusion about release version syncing`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
