### PR TITLE
ci: native Intel-Mac desktop builds + voice-nightly annotation cleanup

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -27,7 +27,11 @@ jobs:
         include:
           - os: ubuntu-22.04
           - os: windows-latest
+          # QNBS-v3: macos-latest is the Apple-Silicon (aarch64) runner; macos-13 is the last
+          # Intel (x86_64) runner. Both are needed so Intel Macs get a native build + auto-update
+          # (the latest.json generator already maps *_x64.app.tar.gz → darwin-x86_64).
           - os: macos-latest
+          - os: macos-13
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -184,7 +188,7 @@ jobs:
               *_aarch64.app.tar.gz)
                 # QNBS-v3: macOS updater bundle is .app.tar.gz (not .dmg).
                 # .dmg is the user-facing installer; .app.tar.gz is what Tauri downloads for in-app updates.
-                # aarch64 = macos-latest ARM runner. x64 runner not yet in matrix.
+                # aarch64 = macos-latest ARM runner; x64 = macos-13 Intel runner (both in matrix).
                 MAC_AARCH64_URL="${REPO_URL}/${URLNAME}"; MAC_AARCH64_SIG="$SIG_CONTENT" ;;
               *_x64.app.tar.gz)
                 MAC_X64_URL="${REPO_URL}/${URLNAME}"; MAC_X64_SIG="$SIG_CONTENT" ;;
@@ -194,7 +198,16 @@ jobs:
             esac
           done
 
-          # Hard-fail if secrets are set but no .sig files were produced
+          # QNBS-v3: report per-arch sig coverage so a half-failed matrix (e.g. macos-13 dropped its
+          # bundle while macos-latest succeeded) is diagnosable instead of a bare "no sigs" failure.
+          MISSING=""
+          [ -z "$LINUX_SIG" ]       && MISSING="${MISSING} linux-x86_64"
+          [ -z "$WIN_SIG" ]         && MISSING="${MISSING} windows-x86_64"
+          [ -z "$MAC_AARCH64_SIG" ] && MISSING="${MISSING} darwin-aarch64"
+          [ -z "$MAC_X64_SIG" ]     && MISSING="${MISSING} darwin-x86_64"
+          [ -n "$MISSING" ] && echo "::warning::No signed bundle for platform(s):${MISSING}. They will be omitted from latest.json."
+
+          # Hard-fail only if NO platform produced a signed bundle.
           if [ -z "$LINUX_SIG" ] && [ -z "$WIN_SIG" ] && [ -z "$MAC_AARCH64_SIG" ] && [ -z "$MAC_X64_SIG" ]; then
             echo "::error::No signed bundles found in release-assets/. Verify TAURI_SIGNING_PRIVATE_KEY secret and that createUpdaterArtifacts=true."
             exit 1

--- a/.github/workflows/voice-nightly.yml
+++ b/.github/workflows/voice-nightly.yml
@@ -32,17 +32,47 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/ms-playwright
+          # QNBS-v3: the lockfile hash already changes when @playwright/test bumps, so this key is
+          # version-sensitive; restore-keys gives a graceful partial-restore on a lockfile-only churn.
           key: playwright-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
 
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps chromium
 
       - name: Run real Whisper E2E
-        run: pnpm exec playwright test tests/e2e/deep/voice/whisper-real.spec.ts --project=chromium
+        id: realwhisper
+        # QNBS-v3: step-level continue-on-error keeps a transient HF-CDN download timeout from
+        # surfacing as a red "Process completed with exit code 1" annotation. The job is already
+        # non-blocking; moving neutrality to the step silences the annotation while the summary
+        # step below preserves the pass/fail signal. Two attempts absorb CDN flakiness.
+        continue-on-error: true
+        run: |
+          set -uo pipefail
+          for attempt in 1 2; do
+            echo "::group::Real Whisper E2E — attempt ${attempt}/2"
+            if pnpm exec playwright test tests/e2e/deep/voice/whisper-real.spec.ts --project=chromium; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            echo "Attempt ${attempt} failed (likely transient HF-CDN slowness)."
+          done
+          exit 1
         env:
           CI: 'true'
           RUN_DEEP_E2E: '1'
           RUN_REAL_VOICE_E2E: '1'
+
+      - name: Report result to summary
+        if: always()
+        run: |
+          if [ "${{ steps.realwhisper.outcome }}" = "success" ]; then
+            echo "✅ **Real Whisper pipeline:** download + init succeeded." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "⚠️ **Real Whisper pipeline:** failed (non-blocking — usually transient HF-CDN download timeout). See the uploaded report artifact." >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Upload report
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Native Intel-Mac (x86_64) desktop builds.** `tauri-build.yml` now builds on `macos-13` (Intel) in
+  addition to `macos-latest` (Apple Silicon), so Intel Macs get a native bundle and in-app updates.
+  The `latest.json` updater manifest already mapped `*_x64.app.tar.gz` → `darwin-x86_64`, so the Intel
+  entry appears automatically; the generator now also emits a per-arch warning when one arch produces
+  no signed bundle (a half-failed matrix is diagnosable) and hard-fails only if **no** arch signed.
+  Builds remain unsigned/un-notarized (cert provisioning still deferred). See [`docs/TAURI-CI.md`](docs/TAURI-CI.md).
+
+### Changed
+
+- **Voice-nightly annotation cleanup.** The informational `voice-nightly.yml` real-Whisper job no
+  longer surfaces a red "Process completed with exit code 1" annotation when the HF-CDN model download
+  times out (a known transient). The download step is now step-level `continue-on-error` with a
+  bounded 2-attempt retry, and a summary step writes the pass/fail signal to `$GITHUB_STEP_SUMMARY`,
+  so the nightly signal is preserved without the misleading error annotation.
+
 ## [1.24.0] — 2026-06-21
 
 > **Critical & Immediate hardening sequence** — six stacked PRs (privacy, experimental labeling, coverage, voice consent, local-AI, hygiene/docs) plus the 11→17 locale expansion, shipped as a minor release.

--- a/docs/TAURI-CI.md
+++ b/docs/TAURI-CI.md
@@ -7,7 +7,22 @@ Workflow: [`.github/workflows/tauri-build.yml`](../.github/workflows/tauri-build
 ## Triggers
 
 - **Manual:** Actions → “Tauri desktop build” → Run workflow  
-- **Tags:** pushing `v*` (e.g. `v1.2.0`) starts a build on Ubuntu, Windows, and macOS in parallel.
+- **Tags:** pushing `v*` (e.g. `v1.2.0`) starts a build on Ubuntu, Windows, and **both macOS arches** in parallel.
+
+### Build matrix
+
+| Runner | Target arch | Updater platform key |
+|--------|-------------|----------------------|
+| `ubuntu-22.04` | x86_64 (AppImage / deb / rpm) | `linux-x86_64` |
+| `windows-latest` | x86_64 (NSIS `-setup.exe`, MSI fallback) | `windows-x86_64` |
+| `macos-latest` | **aarch64** (Apple Silicon) | `darwin-aarch64` |
+| `macos-13` | **x86_64** (Intel) | `darwin-x86_64` |
+
+`macos-latest` is GitHub's Apple-Silicon runner and `macos-13` is the last Intel runner — both are
+required so Intel Macs get a native build and in-app updates. Tauri infers the target arch from the
+runner (no `--target` flag needed), and the `latest.json` generator maps `*_x64.app.tar.gz` →
+`darwin-x86_64` automatically. A **per-arch warning** is emitted (and that platform omitted from
+`latest.json`) if any arch produces no signed bundle; the step hard-fails only if **no** arch did.
 
 ## Outputs
 
@@ -103,8 +118,9 @@ Complete these steps once before pushing the first signed release tag:
 4. Verify release-assets in the GitHub Release:
    - tauri-bundle-ubuntu-22.04  → .deb, .AppImage + .sig files
    - tauri-bundle-windows-latest → .msi/.exe + .sig files
-   - tauri-bundle-macos-latest  → .dmg + .sig files
-   - latest.json  (auto-updater manifest with signatures)
+   - tauri-bundle-macos-latest  → .dmg + .app.tar.gz (aarch64) + .sig files
+   - tauri-bundle-macos-13      → .dmg + .app.tar.gz (x64 / Intel) + .sig files
+   - latest.json  (auto-updater manifest with linux/windows/darwin-aarch64/darwin-x86_64 entries)
 
 5. Download the installer for your OS, install the app, open it.
 


### PR DESCRIPTION
## **User description**
## What

Two contained CI hardening changes (no app code, no i18n):

### 1. Native Intel-Mac (x86_64) desktop builds
`tauri-build.yml`'s matrix was Apple-Silicon-only (`macos-latest`), so **Intel Macs got no native build or auto-update** — even though the `latest.json` generator already maps `*_x64.app.tar.gz` → `darwin-x86_64`. This adds `macos-13` (GitHub's last Intel runner) to the matrix; the Intel updater entry now appears automatically.

- Per-arch **"no signed bundle" warning** so a half-failed matrix (e.g. `macos-13` drops its bundle while `macos-latest` succeeds) is diagnosable; the step still hard-fails only when **no** arch produced a signed bundle.
- ⚠️ Builds remain **unsigned / un-notarized** — Developer-ID / Authenticode cert provisioning is still deferred (per the existing `QNBS-v3` comment in the build step). Adding the runner does not change that; users still see Gatekeeper/SmartScreen warnings until certs land.

### 2. Voice-nightly "exit code 1" annotation cleanup
The informational `voice-nightly.yml` real-Whisper job is already `continue-on-error: true` at the **job** level, but a transient HF-CDN model-download timeout still surfaced a red **"Process completed with exit code 1"** annotation. This:
- moves the download step to **step-level** `continue-on-error` with a bounded **2-attempt retry**,
- adds a `$GITHUB_STEP_SUMMARY` pass/fail line so the signal is preserved (just not a red annotation),
- adds `restore-keys` to the Playwright browser cache for graceful partial restore.

### Docs
- `docs/TAURI-CI.md`: build-matrix table (incl. Intel) + updated release checklist + per-arch warning note.
- `CHANGELOG.md` `[Unreleased]`.

## Verification
- YAML parses clean (both workflows).
- Post-merge / on-branch: `gh workflow run tauri-build.yml --ref <branch>` should show a `macos-13` job producing `*_x64.app.tar.gz`; `gh workflow run voice-nightly.yml --ref <branch>` should show **no error annotation** + a summary line + the report artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Add Intel Mac builds and reduce noisy voice-nightly failures**

### What Changed
- Desktop releases now include a native Intel Mac build, so Intel Macs can get the app and its in-app updates without relying on Apple Silicon bundles.
- If one release platform fails to produce a signed bundle, the updater now warns about the missing platform instead of hiding which one failed.
- The voice-nightly check now retries a flaky model download and records the result in the workflow summary, so transient download timeouts no longer show as a red exit-code error.

### Impact
`✅ Native Intel Mac downloads`
`✅ Fewer misleading nightly failures`
`✅ Clearer release-updater warnings`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
