### PR TITLE
feat(help): auto first-run tour + view-aware Help

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -445,8 +445,13 @@ const App: FC<AppProps> = ({ isNewUser }) => {
     // real users, so this is invisible in production.
     if (typeof navigator !== 'undefined' && navigator.webdriver) return;
     if (tourStartedRef.current || hasCompletedSpotlightTour()) return;
-    tourStartedRef.current = true;
-    const id = window.setTimeout(() => startSpotlightTour(t), 600);
+    // QNBS-v3 (CodeAnt): set the once-guard when the timer actually fires, not before it. If a dep
+    // changes during the 600ms delay the effect cleanup cancels the timer; setting the guard early
+    // would then permanently suppress the tour for a genuine first-run user.
+    const id = window.setTimeout(() => {
+      tourStartedRef.current = true;
+      startSpotlightTour(t);
+    }, 600);
     return () => window.clearTimeout(id);
   }, [isNewUser, isInitialLoad, isPortalActive, t]);
 

--- a/App.tsx
+++ b/App.tsx
@@ -440,6 +440,10 @@ const App: FC<AppProps> = ({ isNewUser }) => {
   const tourStartedRef = useRef(false);
   useEffect(() => {
     if (!isNewUser || isInitialLoad || isPortalActive) return;
+    // QNBS-v3: never hijack an automated browser session — the tour's full-screen overlay intercepts
+    // pointer events and breaks E2E. navigator.webdriver is true only under automation, never for
+    // real users, so this is invisible in production.
+    if (typeof navigator !== 'undefined' && navigator.webdriver) return;
     if (tourStartedRef.current || hasCompletedSpotlightTour()) return;
     tourStartedRef.current = true;
     const id = window.setTimeout(() => startSpotlightTour(t), 600);

--- a/App.tsx
+++ b/App.tsx
@@ -64,6 +64,7 @@ import { installDesktopMenu } from './services/desktop/desktopMenu';
 import { installCloseToTray, installDesktopTray } from './services/desktop/desktopTray';
 import { pluginRegistry } from './services/pluginRegistry';
 import { repairProjectI18nFields } from './services/projectI18nRepair';
+import { hasCompletedSpotlightTour, startSpotlightTour } from './services/spotlightTour';
 import {
   clearIdbPassphrase,
   hasPassphraseSentinel,
@@ -433,6 +434,18 @@ const App: FC<AppProps> = ({ isNewUser }) => {
     }
   }, [project, isPortalActive, isI18nReady, dispatch, t]);
 
+  // QNBS-v3: PR3 — auto-launch the product tour once for first-run installs, after the welcome
+  // portal closes and the nav has rendered. Returning users (or anyone who already finished/closed
+  // it) are never interrupted; they can still start it manually from the Dashboard or Help.
+  const tourStartedRef = useRef(false);
+  useEffect(() => {
+    if (!isNewUser || isInitialLoad || isPortalActive) return;
+    if (tourStartedRef.current || hasCompletedSpotlightTour()) return;
+    tourStartedRef.current = true;
+    const id = window.setTimeout(() => startSpotlightTour(t), 600);
+    return () => window.clearTimeout(id);
+  }, [isNewUser, isInitialLoad, isPortalActive, t]);
+
   const wordCountApprox = useMemo(() => approximateManuscriptWordCount(project), [project]);
 
   const togglePalette = useCallback(() => {
@@ -619,7 +632,7 @@ const App: FC<AppProps> = ({ isNewUser }) => {
       case 'settings':
         return <SettingsView />;
       case 'help':
-        return <HelpView />;
+        return <HelpView contextView={appState.previousView} />;
       case 'sceneboard':
         return <SceneBoardView />;
       case 'characterGraph':

--- a/components/HelpView.tsx
+++ b/components/HelpView.tsx
@@ -9,7 +9,7 @@ import { useHelpView } from '../hooks/useHelpView';
 import { useTranslation } from '../hooks/useTranslation';
 import { getLocaleInfo } from '../i18n/locales';
 import { startSpotlightTour } from '../services/spotlightTour';
-import type { HelpCategory } from '../types';
+import type { HelpCategory, View } from '../types';
 import { HelpSearchInput, HelpSearchPanel } from './help/HelpSearchPanel';
 import { Button } from './ui/Button';
 import { Card, CardContent, CardHeader } from './ui/Card';
@@ -247,8 +247,8 @@ const HelpViewUI: FC = () => {
   );
 };
 
-export const HelpView: FC = () => {
-  const contextValue = useHelpView();
+export const HelpView: FC<{ contextView?: View }> = ({ contextView }) => {
+  const contextValue = useHelpView(contextView);
   return (
     <HelpViewContext.Provider value={contextValue}>
       <PageContainer>

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,12 +1,12 @@
 # Graph Report - StoryCraft-Studio  (2026-06-23)
 
 ## Corpus Check
-- 1155 files · ~1,302,684 words
+- 1155 files · ~1,302,978 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 5010 nodes · 8801 edges · 86 communities detected
-- Extraction: 76% EXTRACTED · 24% INFERRED · 0% AMBIGUOUS · INFERRED: 2154 edges (avg confidence: 0.8)
+- 5011 nodes · 8803 edges · 94 communities detected
+- Extraction: 76% EXTRACTED · 24% INFERRED · 0% AMBIGUOUS · INFERRED: 2155 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Community Hubs (Navigation)
@@ -40,46 +40,45 @@
 - [[_COMMUNITY_Community 27|Community 27]]
 - [[_COMMUNITY_Community 28|Community 28]]
 - [[_COMMUNITY_Community 29|Community 29]]
-- [[_COMMUNITY_Community 32|Community 32]]
-- [[_COMMUNITY_Community 33|Community 33]]
+- [[_COMMUNITY_Community 30|Community 30]]
+- [[_COMMUNITY_Community 31|Community 31]]
+- [[_COMMUNITY_Community 34|Community 34]]
 - [[_COMMUNITY_Community 35|Community 35]]
-- [[_COMMUNITY_Community 37|Community 37]]
+- [[_COMMUNITY_Community 36|Community 36]]
 - [[_COMMUNITY_Community 38|Community 38]]
-- [[_COMMUNITY_Community 39|Community 39]]
+- [[_COMMUNITY_Community 40|Community 40]]
+- [[_COMMUNITY_Community 41|Community 41]]
 - [[_COMMUNITY_Community 42|Community 42]]
-- [[_COMMUNITY_Community 43|Community 43]]
 - [[_COMMUNITY_Community 45|Community 45]]
 - [[_COMMUNITY_Community 46|Community 46]]
+- [[_COMMUNITY_Community 47|Community 47]]
 - [[_COMMUNITY_Community 49|Community 49]]
-- [[_COMMUNITY_Community 52|Community 52]]
-- [[_COMMUNITY_Community 57|Community 57]]
-- [[_COMMUNITY_Community 60|Community 60]]
+- [[_COMMUNITY_Community 50|Community 50]]
+- [[_COMMUNITY_Community 53|Community 53]]
+- [[_COMMUNITY_Community 54|Community 54]]
+- [[_COMMUNITY_Community 55|Community 55]]
+- [[_COMMUNITY_Community 58|Community 58]]
 - [[_COMMUNITY_Community 63|Community 63]]
-- [[_COMMUNITY_Community 64|Community 64]]
-- [[_COMMUNITY_Community 65|Community 65]]
+- [[_COMMUNITY_Community 66|Community 66]]
 - [[_COMMUNITY_Community 69|Community 69]]
+- [[_COMMUNITY_Community 70|Community 70]]
 - [[_COMMUNITY_Community 71|Community 71]]
-- [[_COMMUNITY_Community 72|Community 72]]
+- [[_COMMUNITY_Community 75|Community 75]]
 - [[_COMMUNITY_Community 77|Community 77]]
+- [[_COMMUNITY_Community 78|Community 78]]
 - [[_COMMUNITY_Community 83|Community 83]]
-- [[_COMMUNITY_Community 86|Community 86]]
-- [[_COMMUNITY_Community 97|Community 97]]
-- [[_COMMUNITY_Community 130|Community 130]]
-- [[_COMMUNITY_Community 141|Community 141]]
-- [[_COMMUNITY_Community 147|Community 147]]
-- [[_COMMUNITY_Community 180|Community 180]]
-- [[_COMMUNITY_Community 228|Community 228]]
-- [[_COMMUNITY_Community 268|Community 268]]
-- [[_COMMUNITY_Community 273|Community 273]]
-- [[_COMMUNITY_Community 742|Community 742]]
-- [[_COMMUNITY_Community 743|Community 743]]
-- [[_COMMUNITY_Community 744|Community 744]]
-- [[_COMMUNITY_Community 745|Community 745]]
-- [[_COMMUNITY_Community 746|Community 746]]
-- [[_COMMUNITY_Community 747|Community 747]]
-- [[_COMMUNITY_Community 748|Community 748]]
-- [[_COMMUNITY_Community 749|Community 749]]
-- [[_COMMUNITY_Community 750|Community 750]]
+- [[_COMMUNITY_Community 89|Community 89]]
+- [[_COMMUNITY_Community 92|Community 92]]
+- [[_COMMUNITY_Community 94|Community 94]]
+- [[_COMMUNITY_Community 104|Community 104]]
+- [[_COMMUNITY_Community 107|Community 107]]
+- [[_COMMUNITY_Community 139|Community 139]]
+- [[_COMMUNITY_Community 150|Community 150]]
+- [[_COMMUNITY_Community 156|Community 156]]
+- [[_COMMUNITY_Community 189|Community 189]]
+- [[_COMMUNITY_Community 237|Community 237]]
+- [[_COMMUNITY_Community 277|Community 277]]
+- [[_COMMUNITY_Community 282|Community 282]]
 - [[_COMMUNITY_Community 751|Community 751]]
 - [[_COMMUNITY_Community 752|Community 752]]
 - [[_COMMUNITY_Community 753|Community 753]]
@@ -96,6 +95,15 @@
 - [[_COMMUNITY_Community 764|Community 764]]
 - [[_COMMUNITY_Community 765|Community 765]]
 - [[_COMMUNITY_Community 766|Community 766]]
+- [[_COMMUNITY_Community 767|Community 767]]
+- [[_COMMUNITY_Community 768|Community 768]]
+- [[_COMMUNITY_Community 769|Community 769]]
+- [[_COMMUNITY_Community 770|Community 770]]
+- [[_COMMUNITY_Community 771|Community 771]]
+- [[_COMMUNITY_Community 772|Community 772]]
+- [[_COMMUNITY_Community 773|Community 773]]
+- [[_COMMUNITY_Community 774|Community 774]]
+- [[_COMMUNITY_Community 775|Community 775]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `mt()` - 104 edges
@@ -118,460 +126,502 @@
   features/featureFlags/featureFlagsStorage.ts → components/copilot/CopilotPanel.tsx
 - `setItem()` --calls--> `writeMode()`  [INFERRED]
   features/featureFlags/featureFlagsStorage.ts → components/copilot/CopilotPanel.tsx
-- `setItem()` --calls--> `enableDebugLogging()`  [INFERRED]
-  features/featureFlags/featureFlagsStorage.ts → services/logger.ts
+- `Ja()` --calls--> `matches()`  [INFERRED]
+  e2e-deep-report/trace/assets/codeMirrorModule-Ds_H_9Yq.js → tests/unit/ai/localModelStorageService.test.ts
 
 ## Communities
 
 ### Community 0 - "Community 0"
 Cohesion: 0.01
-Nodes (320): md(), flushMicrotasks(), _0, _2(), A0, a2(), aA(), ab() (+312 more)
+Nodes (439): af(), ef(), ff(), Ja(), lf(), mt(), nf(), of() (+431 more)
 
 ### Community 1 - "Community 1"
 Cohesion: 0.01
-Nodes (188): af(), ef(), ff(), Ja(), lf(), mt(), nf(), of() (+180 more)
+Nodes (127): applyTextEdit(), recordLatency(), AiInferenceCacheService, hashKey(), _cleanupPendingRequest(), _clearPendingRequestsForTest(), _deduplicateRequest(), applyReviewEditsToSection() (+119 more)
 
 ### Community 2 - "Community 2"
 Cohesion: 0.01
-Nodes (119): applyTextEdit(), _clearLatencyHistory(), estimateLatency(), getTaskConfig(), recordLatency(), AiInferenceCacheService, hashKey(), _clearPendingRequestsForTest() (+111 more)
+Nodes (83): handleCopyForNotion(), handleDocxImport(), handleExport(), handlePasteImport(), loadAgent(), analyticsPersistenceAllowedNow(), isAnalyticsPersistenceAllowed(), setRetryFeedback() (+75 more)
 
 ### Community 3 - "Community 3"
-Cohesion: 0.01
-Nodes (88): handleCopyForNotion(), handleDocxImport(), handleExport(), handlePasteImport(), loadAgent(), analyticsPersistenceAllowedNow(), isAnalyticsPersistenceAllowed(), setRetryFeedback() (+80 more)
+Cohesion: 0.02
+Nodes (115): getLocalFallbackModel(), getOpenRouterFallbackProvider(), getOpenRouterModel(), isCloudOnlyMode(), isOffline(), notifyLocalModelsReady(), shouldRouteLocally(), shouldUseOpenRouter() (+107 more)
 
 ### Community 4 - "Community 4"
 Cohesion: 0.02
-Nodes (91): accessibilityPresetDefaults(), normalizeAccessibilitySettings(), applyPreset(), handleBuildLocalRag(), handleWebllmDownload(), isCustomOllamaModel(), handleRemoveKey(), handleSaveKey() (+83 more)
+Nodes (29): hasMigrationMarker(), legacyDatabaseListed(), migrateLegacyWorldscriptDbIfNeeded(), openLegacyDatabase(), promisifyRequest(), readAllFromStore(), setMigrationMarker(), stateDbHasProjectOrSettings() (+21 more)
 
 ### Community 5 - "Community 5"
 Cohesion: 0.02
-Nodes (77): FsAssetStore, glossaryTranslate(), loadCheckpoint(), loadGlossary(), main(), maskPlaceholders(), parseArgs(), restorePlaceholders() (+69 more)
+Nodes (55): accessibilityPresetDefaults(), normalizeAccessibilitySettings(), applyPreset(), handleBuildLocalRag(), handleWebllmDownload(), isCustomOllamaModel(), handleRemoveKey(), handleSaveKey() (+47 more)
 
 ### Community 6 - "Community 6"
-Cohesion: 0.03
-Nodes (19): a_(), bh, Dh(), eA(), el(), GE(), Gh(), lv() (+11 more)
+Cohesion: 0.01
+Nodes (78): categoryFromMessage(), categoryFromStatus(), classificationFor(), classifyAiError(), extractStatus(), getAiErrorMessage(), isOffline(), clampRetryAfter() (+70 more)
 
 ### Community 7 - "Community 7"
 Cohesion: 0.02
-Nodes (66): makeContext(), makeContext(), renderSheet(), makeDeps(), renderPanel(), makeStoreState(), createFakeAdapter(), createFakeDevice() (+58 more)
+Nodes (71): createCancellationToken(), decryptCloudPayload(), deriveCloudSyncKey(), CollabEncryptionRequiredError, CollaborationService, resolveWebRtcSignalingUrls(), MockDoc, MockWebrtcProvider (+63 more)
 
 ### Community 8 - "Community 8"
 Cohesion: 0.02
-Nodes (29): isEcoMode(), getFocusable(), onKeyDown(), onPointerUp(), n2(), getFocusable(), handleEsc(), handleTabKey() (+21 more)
+Nodes (40): assertNoSeriousViolations(), AudioNavigator, navigateToCollaborationSettings(), md(), connectSrcTokens(), group1(), tauriCsp(), webCsp() (+32 more)
 
 ### Community 9 - "Community 9"
-Cohesion: 0.02
-Nodes (62): AnalyticsBootstrap(), App(), ViewLoader(), BookPreviewView(), useCommandExecutor(), CopilotLauncher(), Header(), useAppDispatch() (+54 more)
+Cohesion: 0.03
+Nodes (32): pipeline(), isEcoMode(), applyPreset(), async(), close(), isSidebar(), onKey(), onPointerDown() (+24 more)
 
 ### Community 10 - "Community 10"
 Cohesion: 0.02
-Nodes (52): createCancellationToken(), applyPreset(), async(), close(), isSidebar(), onKey(), onPointerDown(), readMode() (+44 more)
+Nodes (63): AnalyticsBootstrap(), App(), ViewLoader(), BookPreviewView(), useCommandExecutor(), CopilotLauncher(), Header(), useAppDispatch() (+55 more)
 
 ### Community 11 - "Community 11"
-Cohesion: 0.02
-Nodes (60): item(), clearBenchmarkResults(), getLastBenchmarkResults(), loadResults(), runAllBenchmarks(), runInferenceBenchmark(), saveResults(), getLocalUser() (+52 more)
+Cohesion: 0.03
+Nodes (88): AiModeIndicator(), getActiveAiMode(), assertCloudAiAllowed(), assertCloudAiAllowedSync(), assertLoraLocalOnly(), generateTextSingleProvider(), isAbortError(), _pendingKey() (+80 more)
 
 ### Community 12 - "Community 12"
-Cohesion: 0.04
-Nodes (68): getActiveAiMode(), getLocalFallbackModel(), generateJson(), attachCause(), cleanPrompt(), sanitizePromptBlock(), stripControlChars(), stripJsonFences() (+60 more)
+Cohesion: 0.02
+Nodes (58): item(), clearBenchmarkResults(), getLocalUser(), getRandomColor(), handleKeyDown(), sanitizeRoomInput(), stripControlChars(), deleteIdb() (+50 more)
 
 ### Community 13 - "Community 13"
-Cohesion: 0.03
-Nodes (50): AdaptiveAiEngine, selectModelForBackend(), start(), ld(), classifyDevice(), detectIsMobile(), getBatteryLevel(), getHealthReport() (+42 more)
+Cohesion: 0.02
+Nodes (53): AdaptiveAiEngine, _clearLatencyHistory(), estimateLatency(), getTaskConfig(), selectModelForBackend(), start(), getLastBenchmarkResults(), loadResults() (+45 more)
 
 ### Community 14 - "Community 14"
-Cohesion: 0.03
-Nodes (85): AiModeIndicator(), getOpenRouterFallbackProvider(), getOpenRouterModel(), isCloudOnlyMode(), isOffline(), notifyLocalModelsReady(), shouldRouteLocally(), shouldUseOpenRouter() (+77 more)
+Cohesion: 0.02
+Nodes (71): pipeline(), collectSubtreeIds(), installDesktopMenu(), installCloseToTray(), installDesktopTray(), buildTimeoutSignal(), createWorldScriptFetch(), resolveTauriFetch() (+63 more)
 
 ### Community 15 - "Community 15"
 Cohesion: 0.03
-Nodes (62): pipeline(), pipeline(), categoryFromMessage(), categoryFromStatus(), classificationFor(), classifyAiError(), extractStatus(), getAiErrorMessage() (+54 more)
+Nodes (21): bs(), dt(), Es(), fa, gs(), ha, hr, In() (+13 more)
 
 ### Community 16 - "Community 16"
 Cohesion: 0.03
-Nodes (58): MockDoc, MockWebrtcProvider, buildPaletteCommandModels(), collectAllDefinitions(), resolveTitle(), runCommandById(), createAttentionPipeline(), createComputePipeline() (+50 more)
+Nodes (57): buildEncodedPayload(), makeCommands(), countWords(), enrichProjectIndex(), extractCharacterNames(), getDb(), indexProject(), listIndexedProjects() (+49 more)
 
 ### Community 17 - "Community 17"
 Cohesion: 0.03
-Nodes (58): AudioNavigator, buildEncodedPayload(), makeCommands(), countWords(), enrichProjectIndex(), extractCharacterNames(), getDb(), indexProject() (+50 more)
+Nodes (27): getFocusable(), onKeyDown(), onPointerUp(), handler(), k2, n2(), getFocusable(), handleEsc() (+19 more)
 
 ### Community 18 - "Community 18"
-Cohesion: 0.04
-Nodes (39): CollabEncryptionRequiredError, CollaborationService, resolveWebRtcSignalingUrls(), NT, getDuckDb(), handleExec(), handleQuery(), handleShutdown() (+31 more)
+Cohesion: 0.06
+Nodes (17): aS(), bb(), d_, f_, h_, kS(), mc(), ps() (+9 more)
 
 ### Community 19 - "Community 19"
-Cohesion: 0.04
-Nodes (32): assertNoSeriousViolations(), navigateToCollaborationSettings(), connectSrcTokens(), group1(), tauriCsp(), webCsp(), clickNavItem(), ensureBlankProject() (+24 more)
+Cohesion: 0.08
+Nodes (18): FsAssetStore, FsCodexStore, countProjectWords(), decompressData(), decryptText(), deriveFileSystemCryptoKey(), encryptText(), FsCore (+10 more)
 
 ### Community 20 - "Community 20"
 Cohesion: 0.07
-Nodes (22): cE(), fr(), fx, Go(), jS(), ri(), v_(), wb() (+14 more)
+Nodes (34): NT, getDuckDb(), handleExec(), handleQuery(), handleShutdown(), initDuckDb(), isOPFSSupported(), duckdbCodexWrite() (+26 more)
 
 ### Community 21 - "Community 21"
+Cohesion: 0.06
+Nodes (32): collect(), buildPaletteCommandModels(), collectAllDefinitions(), resolveTitle(), runCommandById(), id, install_app_menu(), run() (+24 more)
+
+### Community 22 - "Community 22"
 Cohesion: 0.07
 Nodes (13): createBrowserProForgeCapability(), buildPorts(), runCopilotDiagnostic(), buildNormManuscriptExport(), paginateNormLines(), stripLightMarkdown(), wrapParagraphToLines(), wrapPlainTextToNormLines() (+5 more)
 
-### Community 22 - "Community 22"
+### Community 23 - "Community 23"
 Cohesion: 0.11
 Nodes (1): StorageManager
 
-### Community 23 - "Community 23"
+### Community 24 - "Community 24"
 Cohesion: 0.07
 Nodes (16): smallProject(), buildCharacter(), buildLargeManuscript(), buildParagraph(), buildSectionContent(), buildWorld(), countWords(), makeRng() (+8 more)
 
-### Community 24 - "Community 24"
-Cohesion: 0.23
-Nodes (3): LS, xn(), aa
-
 ### Community 25 - "Community 25"
-Cohesion: 0.14
-Nodes (1): k2
+Cohesion: 0.21
+Nodes (4): LS, Th(), xn(), aa
 
 ### Community 26 - "Community 26"
+Cohesion: 0.1
+Nodes (11): handleEvaluate(), ScoreGauge(), comparePromptOutputs(), computeStyleConsistencyScore(), cosineSimilarity(), getEmbeddingService(), meanSimilarity(), scoreLabel() (+3 more)
+
+### Community 27 - "Community 27"
+Cohesion: 0.11
+Nodes (19): classifyDevice(), detectIsMobile(), getBatteryLevel(), getHealthReport(), getMemoryInfo(), getStorageQuotaMb(), detectBattery(), detectCpuCores() (+11 more)
+
+### Community 28 - "Community 28"
 Cohesion: 0.14
 Nodes (21): handleToggle(), handleDelete(), handleFileChange(), activateAdapter(), clearDatasetEntries(), deactivateAdapter(), deleteAdapter(), exportAdapter() (+13 more)
 
-### Community 27 - "Community 27"
+### Community 29 - "Community 29"
 Cohesion: 0.16
 Nodes (14): buildExcerpt(), extractCharacters(), extractManuscriptSections(), searchAcrossProjectIndex(), searchAcrossProjects(), normalizeSearch(), scoreAgainstQuery(), subsequenceScore() (+6 more)
 
-### Community 28 - "Community 28"
+### Community 30 - "Community 30"
 Cohesion: 0.35
 Nodes (2): cc, Gb()
 
-### Community 29 - "Community 29"
+### Community 31 - "Community 31"
 Cohesion: 0.17
 Nodes (8): check(), extractCatalogFlags(), extractHiddenFlags(), extractSectionFlags(), green(), grep(), hasRuntimeConsumption(), red()
 
-### Community 32 - "Community 32"
+### Community 34 - "Community 34"
+Cohesion: 0.29
+Nodes (1): PriorityTaskQueue
+
+### Community 35 - "Community 35"
 Cohesion: 0.42
 Nodes (6): emit(), main(), merge(), ProgressCallback, Emits JSON progress events on each training log step., train()
 
-### Community 33 - "Community 33"
+### Community 36 - "Community 36"
 Cohesion: 0.25
 Nodes (3): useManuscriptLayout(), useMediaQuery(), useResizablePanels()
 
-### Community 35 - "Community 35"
+### Community 38 - "Community 38"
 Cohesion: 0.29
 Nodes (5): MockAudioContext, MockBufferSource, MockGain, NonEndingSource, TrackingContext
 
-### Community 37 - "Community 37"
+### Community 40 - "Community 40"
 Cohesion: 0.33
 Nodes (3): useSwipeGesture(), useWriterLayout(), useWriterViewContext()
 
-### Community 38 - "Community 38"
+### Community 41 - "Community 41"
 Cohesion: 0.53
 Nodes (4): buildWebNNExecutionProviders(), detectWebNN(), isDirectMLAvailable(), isDirectMLHeuristic()
 
-### Community 39 - "Community 39"
+### Community 42 - "Community 42"
 Cohesion: 0.7
 Nodes (4): check_cuda_and_vram(), check_package(), check_python_version(), main()
 
-### Community 42 - "Community 42"
-Cohesion: 0.4
-Nodes (1): O0
-
-### Community 43 - "Community 43"
-Cohesion: 0.5
-Nodes (3): createStorageMock(), setupStorage(), SpeechSynthesisUtteranceMock
-
 ### Community 45 - "Community 45"
 Cohesion: 0.4
-Nodes (2): useDashboardContext(), DashboardHeader()
+Nodes (1): m0
 
 ### Community 46 - "Community 46"
 Cohesion: 0.4
-Nodes (4): Room, SignalingConn, WebrtcConn, WebrtcProvider
+Nodes (1): O0
+
+### Community 47 - "Community 47"
+Cohesion: 0.5
+Nodes (3): createStorageMock(), setupStorage(), SpeechSynthesisUtteranceMock
 
 ### Community 49 - "Community 49"
+Cohesion: 0.4
+Nodes (4): Room, SignalingConn, WebrtcConn, WebrtcProvider
+
+### Community 50 - "Community 50"
+Cohesion: 0.4
+Nodes (2): useDashboardContext(), DashboardHeader()
+
+### Community 53 - "Community 53"
 Cohesion: 0.6
 Nodes (4): applyFormula(), computeReadabilitySnapshot(), estimateSyllables(), getSyllablePattern()
 
-### Community 52 - "Community 52"
+### Community 54 - "Community 54"
+Cohesion: 0.5
+Nodes (1): oa
+
+### Community 55 - "Community 55"
+Cohesion: 0.5
+Nodes (1): rc
+
+### Community 58 - "Community 58"
 Cohesion: 0.67
 Nodes (2): makeConfig(), startPipelinePayload()
 
-### Community 57 - "Community 57"
+### Community 63 - "Community 63"
 Cohesion: 0.67
 Nodes (2): make(), noop()
 
-### Community 60 - "Community 60"
+### Community 66 - "Community 66"
 Cohesion: 0.67
 Nodes (2): defaultProject(), setProjectData()
 
-### Community 63 - "Community 63"
+### Community 69 - "Community 69"
 Cohesion: 0.83
 Nodes (3): makeChars(), makeProject(), makeWorlds()
 
-### Community 64 - "Community 64"
+### Community 70 - "Community 70"
 Cohesion: 0.83
 Nodes (3): emptyChars(), emptyWorlds(), makeProject()
 
-### Community 65 - "Community 65"
+### Community 71 - "Community 71"
 Cohesion: 0.5
 Nodes (3): AsyncDuckDB, AsyncDuckDBConnection, ConsoleLogger
 
-### Community 69 - "Community 69"
+### Community 75 - "Community 75"
 Cohesion: 0.5
 Nodes (2): ManuscriptDesktopLayout(), useManuscriptViewContext()
 
-### Community 71 - "Community 71"
+### Community 77 - "Community 77"
 Cohesion: 0.67
 Nodes (2): getQuestionsForArchetype(), getTemplateForArchetype()
 
-### Community 72 - "Community 72"
+### Community 78 - "Community 78"
 Cohesion: 0.83
 Nodes (3): esc(), inline(), renderExportMarkdownToHtml()
 
-### Community 77 - "Community 77"
+### Community 83 - "Community 83"
 Cohesion: 0.67
 Nodes (1): makeSection()
 
-### Community 83 - "Community 83"
+### Community 89 - "Community 89"
 Cohesion: 0.67
 Nodes (1): MockGoogleGenAI
 
-### Community 86 - "Community 86"
+### Community 92 - "Community 92"
 Cohesion: 0.67
 Nodes (1): makeDeps()
 
-### Community 97 - "Community 97"
+### Community 94 - "Community 94"
+Cohesion: 1.0
+Nodes (2): fireSwipe(), makePointerEvent()
+
+### Community 104 - "Community 104"
 Cohesion: 0.67
 Nodes (1): TaskError
 
-### Community 130 - "Community 130"
+### Community 107 - "Community 107"
+Cohesion: 0.67
+Nodes (1): handleApply()
+
+### Community 139 - "Community 139"
 Cohesion: 1.0
 Nodes (1): MockIntersectionObserver
 
-### Community 141 - "Community 141"
+### Community 150 - "Community 150"
 Cohesion: 1.0
 Nodes (1): MockWorker
 
-### Community 147 - "Community 147"
+### Community 156 - "Community 156"
 Cohesion: 1.0
 Nodes (1): MockBroadcastChannel
 
-### Community 180 - "Community 180"
+### Community 189 - "Community 189"
 Cohesion: 1.0
 Nodes (1): MockIntersectionObserver
 
-### Community 228 - "Community 228"
+### Community 237 - "Community 237"
 Cohesion: 1.0
 Nodes (1): MockWorker
 
-### Community 268 - "Community 268"
+### Community 277 - "Community 277"
 Cohesion: 1.0
 Nodes (1): FileSystemService
 
-### Community 273 - "Community 273"
+### Community 282 - "Community 282"
 Cohesion: 1.0
 Nodes (1): IndexedDBService
 
-### Community 742 - "Community 742"
+### Community 751 - "Community 751"
 Cohesion: 1.0
 Nodes (1): Remove ANSI escape codes from text.
 
-### Community 743 - "Community 743"
+### Community 752 - "Community 752"
 Cohesion: 1.0
 Nodes (1): Remove timestamp strings from text.
 
-### Community 744 - "Community 744"
+### Community 753 - "Community 753"
 Cohesion: 1.0
 Nodes (1): Replace long base64 strings with placeholder.
 
-### Community 745 - "Community 745"
+### Community 754 - "Community 754"
 Cohesion: 1.0
 Nodes (1): Remove NPM/pnpm warning lines.
 
-### Community 746 - "Community 746"
+### Community 755 - "Community 755"
 Cohesion: 1.0
 Nodes (1): Remove redundant success messages.
 
-### Community 747 - "Community 747"
+### Community 756 - "Community 756"
 Cohesion: 1.0
 Nodes (1): Apply all preprocessing steps to reduce token payload.
 
-### Community 748 - "Community 748"
+### Community 757 - "Community 757"
 Cohesion: 1.0
 Nodes (1): Extract only error-related sections from log.
 
-### Community 749 - "Community 749"
+### Community 758 - "Community 758"
 Cohesion: 1.0
 Nodes (1): Pydantic models for CI Analyzer structured output. QNBS-v3: These models enforce
 
-### Community 750 - "Community 750"
+### Community 759 - "Community 759"
 Cohesion: 1.0
 Nodes (1): Structured CI error for VS Code problem matcher integration.
 
-### Community 751 - "Community 751"
+### Community 760 - "Community 760"
 Cohesion: 1.0
 Nodes (1): Vitest JSON test result structure.
 
-### Community 752 - "Community 752"
+### Community 761 - "Community 761"
 Cohesion: 1.0
 Nodes (1): Full Vitest JSON report structure.
 
-### Community 753 - "Community 753"
+### Community 762 - "Community 762"
 Cohesion: 1.0
 Nodes (1): Stryker per-file mutation report.
 
-### Community 754 - "Community 754"
+### Community 763 - "Community 763"
 Cohesion: 1.0
 Nodes (1): Full Stryker JSON report structure.
 
-### Community 755 - "Community 755"
+### Community 764 - "Community 764"
 Cohesion: 1.0
 Nodes (1): Initialize OpenRouter client for Poolside Laguna model.
 
-### Community 756 - "Community 756"
+### Community 765 - "Community 765"
 Cohesion: 1.0
 Nodes (1): Analyze Vitest JSON report and raw logs for errors.
 
-### Community 757 - "Community 757"
+### Community 766 - "Community 766"
 Cohesion: 1.0
 Nodes (1): Analyze Stryker JSON report for surviving mutants.
 
-### Community 758 - "Community 758"
+### Community 767 - "Community 767"
 Cohesion: 1.0
 Nodes (1): Send preprocessed errors to LLM for analysis.
 
-### Community 759 - "Community 759"
+### Community 768 - "Community 768"
 Cohesion: 1.0
 Nodes (1): Format errors for VS Code problem matcher.
 
-### Community 760 - "Community 760"
+### Community 769 - "Community 769"
 Cohesion: 1.0
 Nodes (1): Main entry point for CI analyzer.
 
-### Community 761 - "Community 761"
+### Community 770 - "Community 770"
 Cohesion: 1.0
 Nodes (1): Execute gh CLI command and return parsed JSON output.
 
-### Community 762 - "Community 762"
+### Community 771 - "Community 771"
 Cohesion: 1.0
 Nodes (1): Get the ID of the most recent failed CI run.
 
-### Community 763 - "Community 763"
+### Community 772 - "Community 772"
 Cohesion: 1.0
 Nodes (1): Download a specific artifact from a workflow run.
 
-### Community 764 - "Community 764"
+### Community 773 - "Community 773"
 Cohesion: 1.0
 Nodes (1): Get raw logs from a failed workflow run.
 
-### Community 765 - "Community 765"
+### Community 774 - "Community 774"
 Cohesion: 1.0
 Nodes (1): Parse Vitest JSON report for failing tests.
 
-### Community 766 - "Community 766"
+### Community 775 - "Community 775"
 Cohesion: 1.0
 Nodes (1): Parse Stryker JSON report for surviving mutants.
 
 ## Knowledge Gaps
 - **53 isolated node(s):** `Emits JSON progress events on each training log step.`, `qb`, `v2`, `MockIntersectionObserver`, `MockWorker` (+48 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 22`** (36 nodes): `storageService.ts`, `StorageManager`, `.clearApiKey()`, `.clearGeminiApiKey()`, `.constructor()`, `.deleteAllBinderAssetsForProject()`, `.deleteBinderAsset()`, `.deleteImage()`, `.deleteProject()`, `.deleteRagVectors()`, `.deleteSnapshot()`, `.deleteStoryCodex()`, `.getApiKey()`, `.getBackend()`, `.getBinderAsset()`, `.getGeminiApiKey()`, `.getImage()`, `.getRagVectors()`, `.getSnapshotData()`, `.getStoryCodex()`, `.hasSavedData()`, `.initializeBackend()`, `.listBinderAssetIds()`, `.listProjects()`, `.listSnapshots()`, `.loadProject()`, `.loadSettings()`, `.saveApiKey()`, `.saveBinderAsset()`, `.saveGeminiApiKey()`, `.saveImage()`, `.saveProject()`, `.saveRagVectors()`, `.saveSettings()`, `.saveSnapshot()`, `.saveStoryCodex()`
+- **Thin community `Community 23`** (36 nodes): `storageService.ts`, `StorageManager`, `.clearApiKey()`, `.clearGeminiApiKey()`, `.constructor()`, `.deleteAllBinderAssetsForProject()`, `.deleteBinderAsset()`, `.deleteImage()`, `.deleteProject()`, `.deleteRagVectors()`, `.deleteSnapshot()`, `.deleteStoryCodex()`, `.getApiKey()`, `.getBackend()`, `.getBinderAsset()`, `.getGeminiApiKey()`, `.getImage()`, `.getRagVectors()`, `.getSnapshotData()`, `.getStoryCodex()`, `.hasSavedData()`, `.initializeBackend()`, `.listBinderAssetIds()`, `.listProjects()`, `.listSnapshots()`, `.loadProject()`, `.loadSettings()`, `.saveApiKey()`, `.saveBinderAsset()`, `.saveGeminiApiKey()`, `.saveImage()`, `.saveProject()`, `.saveRagVectors()`, `.saveSettings()`, `.saveSnapshot()`, `.saveStoryCodex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 25`** (27 nodes): `.fire()`, `k2`, `.checkBrowsers()`, `.clearCache()`, `.closeGracefully()`, `._dispatchEvent()`, `.findRelatedTestFiles()`, `.initialize()`, `.installBrowsers()`, `.isClosed()`, `.listFiles()`, `.listTests()`, `.open()`, `.openNoReply()`, `.ping()`, `.pingNoReply()`, `.resizeTerminal()`, `.resizeTerminalNoReply()`, `.runGlobalSetup()`, `.runGlobalTeardown()`, `.runTests()`, `._sendMessage()`, `._sendMessageNoReply()`, `.stopTests()`, `.stopTestsNoReply()`, `.watch()`, `.watchNoReply()`
+- **Thin community `Community 30`** (17 nodes): `cc`, `._applyAttribute()`, `._assert()`, `.constructor()`, `._eof()`, `._isWhitespace()`, `._next()`, `.parse()`, `._peek()`, `._readAttributes()`, `._readIdentifier()`, `._readRegex()`, `._readString()`, `._readStringOrRegex()`, `._skipWhitespace()`, `._throwError()`, `Gb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 28`** (17 nodes): `cc`, `._applyAttribute()`, `._assert()`, `.constructor()`, `._eof()`, `._isWhitespace()`, `._next()`, `.parse()`, `._peek()`, `._readAttributes()`, `._readIdentifier()`, `._readRegex()`, `._readString()`, `._readStringOrRegex()`, `._skipWhitespace()`, `._throwError()`, `Gb()`
+- **Thin community `Community 34`** (10 nodes): `taskQueue.ts`, `PriorityTaskQueue`, `.constructor()`, `.dequeue()`, `.effectivePriority()`, `.enqueue()`, `.peek()`, `.promoteStarvedTasks()`, `.stats()`, `.totalDepth()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 42`** (5 nodes): `O0`, `.constructor()`, `.toJSON()`, `.toSource()`, `.toString()`
+- **Thin community `Community 45`** (5 nodes): `m0`, `.constructor()`, `.toJSON()`, `.toSource()`, `.toString()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 45`** (5 nodes): `DashboardHeader.tsx`, `DashboardContext.ts`, `useDashboardContext()`, `Chip()`, `DashboardHeader()`
+- **Thin community `Community 46`** (5 nodes): `O0`, `.constructor()`, `.toJSON()`, `.toSource()`, `.toString()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 52`** (4 nodes): `makeConfig()`, `makeReviewItem()`, `startPipelinePayload()`, `proForgeSlice.test.ts`
+- **Thin community `Community 50`** (5 nodes): `DashboardHeader.tsx`, `DashboardContext.ts`, `useDashboardContext()`, `Chip()`, `DashboardHeader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 57`** (4 nodes): `make()`, `noop()`, `aiRetry.test.ts`, `aiRetry.test.ts`
+- **Thin community `Community 54`** (4 nodes): `oa`, `.constructor()`, `.getData()`, `.writeUint8Array()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 60`** (4 nodes): `useDashboard.test.ts`, `defaultProject()`, `defaultSection()`, `setProjectData()`
+- **Thin community `Community 55`** (4 nodes): `rc`, `.constructor()`, `.toSource()`, `.toString()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 69`** (4 nodes): `ManuscriptDesktopLayout.tsx`, `ManuscriptViewContext.ts`, `ManuscriptDesktopLayout()`, `useManuscriptViewContext()`
+- **Thin community `Community 58`** (4 nodes): `makeConfig()`, `makeReviewItem()`, `startPipelinePayload()`, `proForgeSlice.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 71`** (4 nodes): `getAllTemplates()`, `getQuestionsForArchetype()`, `getTemplateForArchetype()`, `characterInterviewTemplates.ts`
+- **Thin community `Community 63`** (4 nodes): `make()`, `noop()`, `aiRetry.test.ts`, `aiRetry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 77`** (3 nodes): `makeSection()`, `plotBoardService.test.ts`, `plotBoardService.test.ts`
+- **Thin community `Community 66`** (4 nodes): `useDashboard.test.ts`, `defaultProject()`, `defaultSection()`, `setProjectData()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 83`** (3 nodes): `makeStream()`, `MockGoogleGenAI`, `geminiService.test.ts`
+- **Thin community `Community 75`** (4 nodes): `ManuscriptDesktopLayout.tsx`, `ManuscriptViewContext.ts`, `ManuscriptDesktopLayout()`, `useManuscriptViewContext()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 86`** (3 nodes): `makeDeps()`, `aiSuggestions.test.ts`, `aiSuggestions.test.ts`
+- **Thin community `Community 77`** (4 nodes): `getAllTemplates()`, `getQuestionsForArchetype()`, `getTemplateForArchetype()`, `characterInterviewTemplates.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 97`** (3 nodes): `types.ts`, `TaskError`, `.constructor()`
+- **Thin community `Community 83`** (3 nodes): `makeSection()`, `plotBoardService.test.ts`, `plotBoardService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 130`** (2 nodes): `MockIntersectionObserver`, `BookPreviewView.test.tsx`
+- **Thin community `Community 89`** (3 nodes): `makeStream()`, `MockGoogleGenAI`, `geminiService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 141`** (2 nodes): `MockWorker`, `duckdbClient.test.ts`
+- **Thin community `Community 92`** (3 nodes): `makeDeps()`, `aiSuggestions.test.ts`, `aiSuggestions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 147`** (2 nodes): `MockBroadcastChannel`, `tabLeaderElection.test.ts`
+- **Thin community `Community 94`** (3 nodes): `useSwipeGesture.test.ts`, `fireSwipe()`, `makePointerEvent()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 180`** (2 nodes): `useBookPreviewView.test.ts`, `MockIntersectionObserver`
+- **Thin community `Community 104`** (3 nodes): `types.ts`, `TaskError`, `.constructor()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 228`** (2 nodes): `workerPool.test.ts`, `MockWorker`
+- **Thin community `Community 107`** (3 nodes): `TemplateView.tsx`, `expanded()`, `handleApply()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 268`** (2 nodes): `FileSystemService`, `index.ts`
+- **Thin community `Community 139`** (2 nodes): `MockIntersectionObserver`, `BookPreviewView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 273`** (2 nodes): `IndexedDBService`, `index.ts`
+- **Thin community `Community 150`** (2 nodes): `MockWorker`, `duckdbClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (1 nodes): `Remove ANSI escape codes from text.`
+- **Thin community `Community 156`** (2 nodes): `MockBroadcastChannel`, `tabLeaderElection.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (1 nodes): `Remove timestamp strings from text.`
+- **Thin community `Community 189`** (2 nodes): `useBookPreviewView.test.ts`, `MockIntersectionObserver`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (1 nodes): `Replace long base64 strings with placeholder.`
+- **Thin community `Community 237`** (2 nodes): `workerPool.test.ts`, `MockWorker`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (1 nodes): `Remove NPM/pnpm warning lines.`
+- **Thin community `Community 277`** (2 nodes): `FileSystemService`, `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (1 nodes): `Remove redundant success messages.`
+- **Thin community `Community 282`** (2 nodes): `IndexedDBService`, `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (1 nodes): `Apply all preprocessing steps to reduce token payload.`
+- **Thin community `Community 751`** (1 nodes): `Remove ANSI escape codes from text.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (1 nodes): `Extract only error-related sections from log.`
+- **Thin community `Community 752`** (1 nodes): `Remove timestamp strings from text.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (1 nodes): `Pydantic models for CI Analyzer structured output. QNBS-v3: These models enforce`
+- **Thin community `Community 753`** (1 nodes): `Replace long base64 strings with placeholder.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (1 nodes): `Structured CI error for VS Code problem matcher integration.`
+- **Thin community `Community 754`** (1 nodes): `Remove NPM/pnpm warning lines.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (1 nodes): `Vitest JSON test result structure.`
+- **Thin community `Community 755`** (1 nodes): `Remove redundant success messages.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (1 nodes): `Full Vitest JSON report structure.`
+- **Thin community `Community 756`** (1 nodes): `Apply all preprocessing steps to reduce token payload.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (1 nodes): `Stryker per-file mutation report.`
+- **Thin community `Community 757`** (1 nodes): `Extract only error-related sections from log.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (1 nodes): `Full Stryker JSON report structure.`
+- **Thin community `Community 758`** (1 nodes): `Pydantic models for CI Analyzer structured output. QNBS-v3: These models enforce`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (1 nodes): `Initialize OpenRouter client for Poolside Laguna model.`
+- **Thin community `Community 759`** (1 nodes): `Structured CI error for VS Code problem matcher integration.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (1 nodes): `Analyze Vitest JSON report and raw logs for errors.`
+- **Thin community `Community 760`** (1 nodes): `Vitest JSON test result structure.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (1 nodes): `Analyze Stryker JSON report for surviving mutants.`
+- **Thin community `Community 761`** (1 nodes): `Full Vitest JSON report structure.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (1 nodes): `Send preprocessed errors to LLM for analysis.`
+- **Thin community `Community 762`** (1 nodes): `Stryker per-file mutation report.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (1 nodes): `Format errors for VS Code problem matcher.`
+- **Thin community `Community 763`** (1 nodes): `Full Stryker JSON report structure.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (1 nodes): `Main entry point for CI analyzer.`
+- **Thin community `Community 764`** (1 nodes): `Initialize OpenRouter client for Poolside Laguna model.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (1 nodes): `Execute gh CLI command and return parsed JSON output.`
+- **Thin community `Community 765`** (1 nodes): `Analyze Vitest JSON report and raw logs for errors.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (1 nodes): `Get the ID of the most recent failed CI run.`
+- **Thin community `Community 766`** (1 nodes): `Analyze Stryker JSON report for surviving mutants.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (1 nodes): `Download a specific artifact from a workflow run.`
+- **Thin community `Community 767`** (1 nodes): `Send preprocessed errors to LLM for analysis.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (1 nodes): `Get raw logs from a failed workflow run.`
+- **Thin community `Community 768`** (1 nodes): `Format errors for VS Code problem matcher.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (1 nodes): `Parse Vitest JSON report for failing tests.`
+- **Thin community `Community 769`** (1 nodes): `Main entry point for CI analyzer.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (1 nodes): `Parse Stryker JSON report for surviving mutants.`
+- **Thin community `Community 770`** (1 nodes): `Execute gh CLI command and return parsed JSON output.`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 771`** (1 nodes): `Get the ID of the most recent failed CI run.`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 772`** (1 nodes): `Download a specific artifact from a workflow run.`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 773`** (1 nodes): `Get raw logs from a failed workflow run.`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 774`** (1 nodes): `Parse Vitest JSON report for failing tests.`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 775`** (1 nodes): `Parse Stryker JSON report for surviving mutants.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `mt()` connect `Community 1` to `Community 0`, `Community 2`, `Community 3`, `Community 6`, `Community 8`, `Community 10`, `Community 12`, `Community 13`, `Community 17`, `Community 20`, `Community 21`, `Community 24`?**
-  _High betweenness centrality (0.081) - this node is a cross-community bridge._
-- **Why does `t()` connect `Community 3` to `Community 1`, `Community 2`, `Community 4`, `Community 9`, `Community 10`, `Community 13`, `Community 14`, `Community 15`, `Community 16`, `Community 20`, `Community 26`?**
-  _High betweenness centrality (0.076) - this node is a cross-community bridge._
-- **Why does `wx()` connect `Community 1` to `Community 0`, `Community 3`, `Community 5`, `Community 8`, `Community 16`?**
-  _High betweenness centrality (0.043) - this node is a cross-community bridge._
+- **Why does `mt()` connect `Community 0` to `Community 1`, `Community 2`, `Community 3`, `Community 4`, `Community 8`, `Community 9`, `Community 11`, `Community 13`, `Community 15`, `Community 16`, `Community 17`, `Community 18`, `Community 22`, `Community 25`?**
+  _High betweenness centrality (0.083) - this node is a cross-community bridge._
+- **Why does `t()` connect `Community 2` to `Community 0`, `Community 1`, `Community 5`, `Community 6`, `Community 7`, `Community 9`, `Community 10`, `Community 11`, `Community 12`, `Community 13`, `Community 14`, `Community 15`, `Community 21`, `Community 28`?**
+  _High betweenness centrality (0.065) - this node is a cross-community bridge._
+- **Why does `wx()` connect `Community 0` to `Community 2`, `Community 4`, `Community 7`, `Community 13`, `Community 17`, `Community 18`, `Community 19`?**
+  _High betweenness centrality (0.051) - this node is a cross-community bridge._
 - **Are the 87 inferred relationships involving `mt()` (e.g. with `pE()` and `xE()`) actually correct?**
   _`mt()` has 87 INFERRED edges - model-reasoned connections that need verification._
 - **Are the 62 inferred relationships involving `fn()` (e.g. with `makeMediaQuery()` and `MockSpeechRecognition()`) actually correct?**

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - StoryCraft-Studio  (2026-06-23)
 
 ## Corpus Check
-- 1155 files · ~1,302,334 words
+- 1155 files · ~1,302,684 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 5009 nodes · 8800 edges · 84 communities detected
+- 5010 nodes · 8801 edges · 86 communities detected
 - Extraction: 76% EXTRACTED · 24% INFERRED · 0% AMBIGUOUS · INFERRED: 2154 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
@@ -39,38 +39,38 @@
 - [[_COMMUNITY_Community 26|Community 26]]
 - [[_COMMUNITY_Community 27|Community 27]]
 - [[_COMMUNITY_Community 28|Community 28]]
-- [[_COMMUNITY_Community 31|Community 31]]
+- [[_COMMUNITY_Community 29|Community 29]]
 - [[_COMMUNITY_Community 32|Community 32]]
-- [[_COMMUNITY_Community 34|Community 34]]
-- [[_COMMUNITY_Community 36|Community 36]]
+- [[_COMMUNITY_Community 33|Community 33]]
+- [[_COMMUNITY_Community 35|Community 35]]
 - [[_COMMUNITY_Community 37|Community 37]]
 - [[_COMMUNITY_Community 38|Community 38]]
-- [[_COMMUNITY_Community 41|Community 41]]
+- [[_COMMUNITY_Community 39|Community 39]]
+- [[_COMMUNITY_Community 42|Community 42]]
 - [[_COMMUNITY_Community 43|Community 43]]
-- [[_COMMUNITY_Community 44|Community 44]]
-- [[_COMMUNITY_Community 47|Community 47]]
-- [[_COMMUNITY_Community 50|Community 50]]
-- [[_COMMUNITY_Community 55|Community 55]]
-- [[_COMMUNITY_Community 58|Community 58]]
-- [[_COMMUNITY_Community 61|Community 61]]
-- [[_COMMUNITY_Community 62|Community 62]]
+- [[_COMMUNITY_Community 45|Community 45]]
+- [[_COMMUNITY_Community 46|Community 46]]
+- [[_COMMUNITY_Community 49|Community 49]]
+- [[_COMMUNITY_Community 52|Community 52]]
+- [[_COMMUNITY_Community 57|Community 57]]
+- [[_COMMUNITY_Community 60|Community 60]]
 - [[_COMMUNITY_Community 63|Community 63]]
-- [[_COMMUNITY_Community 67|Community 67]]
+- [[_COMMUNITY_Community 64|Community 64]]
+- [[_COMMUNITY_Community 65|Community 65]]
 - [[_COMMUNITY_Community 69|Community 69]]
-- [[_COMMUNITY_Community 70|Community 70]]
-- [[_COMMUNITY_Community 75|Community 75]]
-- [[_COMMUNITY_Community 81|Community 81]]
-- [[_COMMUNITY_Community 84|Community 84]]
-- [[_COMMUNITY_Community 95|Community 95]]
-- [[_COMMUNITY_Community 128|Community 128]]
-- [[_COMMUNITY_Community 139|Community 139]]
-- [[_COMMUNITY_Community 145|Community 145]]
-- [[_COMMUNITY_Community 178|Community 178]]
-- [[_COMMUNITY_Community 226|Community 226]]
-- [[_COMMUNITY_Community 266|Community 266]]
-- [[_COMMUNITY_Community 271|Community 271]]
-- [[_COMMUNITY_Community 740|Community 740]]
-- [[_COMMUNITY_Community 741|Community 741]]
+- [[_COMMUNITY_Community 71|Community 71]]
+- [[_COMMUNITY_Community 72|Community 72]]
+- [[_COMMUNITY_Community 77|Community 77]]
+- [[_COMMUNITY_Community 83|Community 83]]
+- [[_COMMUNITY_Community 86|Community 86]]
+- [[_COMMUNITY_Community 97|Community 97]]
+- [[_COMMUNITY_Community 130|Community 130]]
+- [[_COMMUNITY_Community 141|Community 141]]
+- [[_COMMUNITY_Community 147|Community 147]]
+- [[_COMMUNITY_Community 180|Community 180]]
+- [[_COMMUNITY_Community 228|Community 228]]
+- [[_COMMUNITY_Community 268|Community 268]]
+- [[_COMMUNITY_Community 273|Community 273]]
 - [[_COMMUNITY_Community 742|Community 742]]
 - [[_COMMUNITY_Community 743|Community 743]]
 - [[_COMMUNITY_Community 744|Community 744]]
@@ -94,6 +94,8 @@
 - [[_COMMUNITY_Community 762|Community 762]]
 - [[_COMMUNITY_Community 763|Community 763]]
 - [[_COMMUNITY_Community 764|Community 764]]
+- [[_COMMUNITY_Community 765|Community 765]]
+- [[_COMMUNITY_Community 766|Community 766]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `mt()` - 104 edges
@@ -123,99 +125,99 @@
 
 ### Community 0 - "Community 0"
 Cohesion: 0.01
-Nodes (308): flushMicrotasks(), _0, _2(), A0, a2(), aA(), ac(), ad() (+300 more)
+Nodes (320): md(), flushMicrotasks(), _0, _2(), A0, a2(), aA(), ab() (+312 more)
 
 ### Community 1 - "Community 1"
 Cohesion: 0.01
-Nodes (145): recordLatency(), AiInferenceCacheService, hashKey(), _clearPendingRequestsForTest(), binderDepth(), createCancellationToken(), CloudSyncClient, buildConsistencyHints() (+137 more)
+Nodes (188): af(), ef(), ff(), Ja(), lf(), mt(), nf(), of() (+180 more)
 
 ### Community 2 - "Community 2"
 Cohesion: 0.01
-Nodes (171): af(), ef(), ff(), Ja(), lf(), mt(), nf(), of() (+163 more)
+Nodes (119): applyTextEdit(), _clearLatencyHistory(), estimateLatency(), getTaskConfig(), recordLatency(), AiInferenceCacheService, hashKey(), _clearPendingRequestsForTest() (+111 more)
 
 ### Community 3 - "Community 3"
 Cohesion: 0.01
-Nodes (150): getActiveAiMode(), getLocalFallbackModel(), getOpenRouterFallbackProvider(), getOpenRouterModel(), isCloudOnlyMode(), isOffline(), notifyLocalModelsReady(), shouldRouteLocally() (+142 more)
+Nodes (88): handleCopyForNotion(), handleDocxImport(), handleExport(), handlePasteImport(), loadAgent(), analyticsPersistenceAllowedNow(), isAnalyticsPersistenceAllowed(), setRetryFeedback() (+80 more)
 
 ### Community 4 - "Community 4"
-Cohesion: 0.01
-Nodes (103): handleCopyForNotion(), handleDocxImport(), handleExport(), handlePasteImport(), loadAgent(), handleBuildLocalRag(), handleWebllmDownload(), isCustomOllamaModel() (+95 more)
+Cohesion: 0.02
+Nodes (91): accessibilityPresetDefaults(), normalizeAccessibilitySettings(), applyPreset(), handleBuildLocalRag(), handleWebllmDownload(), isCustomOllamaModel(), handleRemoveKey(), handleSaveKey() (+83 more)
 
 ### Community 5 - "Community 5"
 Cohesion: 0.02
-Nodes (59): pipeline(), pipeline(), isEcoMode(), EcoModeService, FeedbackService, handleEcoToggle(), routeTask(), KokoroTtsEngine (+51 more)
+Nodes (77): FsAssetStore, glossaryTranslate(), loadCheckpoint(), loadGlossary(), main(), maskPlaceholders(), parseArgs(), restorePlaceholders() (+69 more)
 
 ### Community 6 - "Community 6"
-Cohesion: 0.02
-Nodes (69): accessibilityPresetDefaults(), normalizeAccessibilitySettings(), applyPreset(), handleRemoveKey(), handleSaveKey(), handleTestConnection(), CloudSyncBackend, decryptCloudPayload() (+61 more)
+Cohesion: 0.03
+Nodes (19): a_(), bh, Dh(), eA(), el(), GE(), Gh(), lv() (+11 more)
 
 ### Community 7 - "Community 7"
 Cohesion: 0.02
-Nodes (47): AudioNavigator, md(), ab(), av(), br(), bs(), Bv, CA() (+39 more)
+Nodes (66): makeContext(), makeContext(), renderSheet(), makeDeps(), renderPanel(), makeStoreState(), createFakeAdapter(), createFakeDevice() (+58 more)
 
 ### Community 8 - "Community 8"
-Cohesion: 0.03
-Nodes (18): a_(), bh, Dh(), eA(), el(), GE(), Gh(), lv() (+10 more)
+Cohesion: 0.02
+Nodes (29): isEcoMode(), getFocusable(), onKeyDown(), onPointerUp(), n2(), getFocusable(), handleEsc(), handleTabKey() (+21 more)
 
 ### Community 9 - "Community 9"
-Cohesion: 0.01
-Nodes (81): categoryFromMessage(), categoryFromStatus(), classificationFor(), classifyAiError(), extractStatus(), getAiErrorMessage(), isOffline(), clampRetryAfter() (+73 more)
+Cohesion: 0.02
+Nodes (62): AnalyticsBootstrap(), App(), ViewLoader(), BookPreviewView(), useCommandExecutor(), CopilotLauncher(), Header(), useAppDispatch() (+54 more)
 
 ### Community 10 - "Community 10"
 Cohesion: 0.02
-Nodes (78): AiModeIndicator(), item(), getLocalUser(), getRandomColor(), handleKeyDown(), sanitizeRoomInput(), stripControlChars(), loadFeatureFlagsState() (+70 more)
+Nodes (52): createCancellationToken(), applyPreset(), async(), close(), isSidebar(), onKey(), onPointerDown(), readMode() (+44 more)
 
 ### Community 11 - "Community 11"
 Cohesion: 0.02
-Nodes (64): AnalyticsBootstrap(), App(), ViewLoader(), BookPreviewView(), useCommandExecutor(), CopilotLauncher(), Header(), useAppDispatch() (+56 more)
+Nodes (60): item(), clearBenchmarkResults(), getLastBenchmarkResults(), loadResults(), runAllBenchmarks(), runInferenceBenchmark(), saveResults(), getLocalUser() (+52 more)
 
 ### Community 12 - "Community 12"
-Cohesion: 0.02
-Nodes (58): AdaptiveAiEngine, _clearLatencyHistory(), estimateLatency(), getTaskConfig(), selectModelForBackend(), start(), clearBenchmarkResults(), getLastBenchmarkResults() (+50 more)
+Cohesion: 0.04
+Nodes (68): getActiveAiMode(), getLocalFallbackModel(), generateJson(), attachCause(), cleanPrompt(), sanitizePromptBlock(), stripControlChars(), stripJsonFences() (+60 more)
 
 ### Community 13 - "Community 13"
 Cohesion: 0.03
-Nodes (76): countWords(), enrichProjectIndex(), extractCharacterNames(), getDb(), indexProject(), listIndexedProjects(), removeProjectIndex(), semanticSearchProjects() (+68 more)
+Nodes (50): AdaptiveAiEngine, selectModelForBackend(), start(), ld(), classifyDevice(), detectIsMobile(), getBatteryLevel(), getHealthReport() (+42 more)
 
 ### Community 14 - "Community 14"
 Cohesion: 0.03
-Nodes (43): CollabEncryptionRequiredError, CollaborationService, resolveWebRtcSignalingUrls(), MockDoc, MockWebrtcProvider, createAttentionPipeline(), createComputePipeline(), createKvCachePipeline() (+35 more)
+Nodes (85): AiModeIndicator(), getOpenRouterFallbackProvider(), getOpenRouterModel(), isCloudOnlyMode(), isOffline(), notifyLocalModelsReady(), shouldRouteLocally(), shouldUseOpenRouter() (+77 more)
 
 ### Community 15 - "Community 15"
-Cohesion: 0.04
-Nodes (53): applyTextEdit(), applyReviewEditsToSection(), containsDisallowedControlChar(), isValidRange(), nearestFreeOccurrence(), planAcceptedManuscriptEdits(), validateProposedText(), collectSubtreeIds() (+45 more)
+Cohesion: 0.03
+Nodes (62): pipeline(), pipeline(), categoryFromMessage(), categoryFromStatus(), classificationFor(), classifyAiError(), extractStatus(), getAiErrorMessage() (+54 more)
 
 ### Community 16 - "Community 16"
-Cohesion: 0.07
-Nodes (22): FsAssetStore, FsCodexStore, deleteIdb(), formatStorageError(), initializeStorage(), resetAllDatabases(), countProjectWords(), decompressData() (+14 more)
+Cohesion: 0.03
+Nodes (58): MockDoc, MockWebrtcProvider, buildPaletteCommandModels(), collectAllDefinitions(), resolveTitle(), runCommandById(), createAttentionPipeline(), createComputePipeline() (+50 more)
 
 ### Community 17 - "Community 17"
+Cohesion: 0.03
+Nodes (58): AudioNavigator, buildEncodedPayload(), makeCommands(), countWords(), enrichProjectIndex(), extractCharacterNames(), getDb(), indexProject() (+50 more)
+
+### Community 18 - "Community 18"
+Cohesion: 0.04
+Nodes (39): CollabEncryptionRequiredError, CollaborationService, resolveWebRtcSignalingUrls(), NT, getDuckDb(), handleExec(), handleQuery(), handleShutdown() (+31 more)
+
+### Community 19 - "Community 19"
 Cohesion: 0.04
 Nodes (32): assertNoSeriousViolations(), navigateToCollaborationSettings(), connectSrcTokens(), group1(), tauriCsp(), webCsp(), clickNavItem(), ensureBlankProject() (+24 more)
 
-### Community 18 - "Community 18"
-Cohesion: 0.05
-Nodes (15): installDesktopMenu(), installCloseToTray(), installDesktopTray(), buildTimeoutSignal(), createWorldScriptFetch(), resolveTauriFetch(), StorageManager, registerTauriMenuHandler() (+7 more)
-
-### Community 19 - "Community 19"
-Cohesion: 0.07
-Nodes (9): getFocusable(), onKeyDown(), onPointerUp(), k2, n2(), getFocusable(), handleEsc(), handleTabKey() (+1 more)
-
 ### Community 20 - "Community 20"
 Cohesion: 0.07
-Nodes (26): applyPreset(), async(), close(), isSidebar(), onKey(), onPointerDown(), readMode(), writeMode() (+18 more)
+Nodes (22): cE(), fr(), fx, Go(), jS(), ri(), v_(), wb() (+14 more)
 
 ### Community 21 - "Community 21"
 Cohesion: 0.07
 Nodes (13): createBrowserProForgeCapability(), buildPorts(), runCopilotDiagnostic(), buildNormManuscriptExport(), paginateNormLines(), stripLightMarkdown(), wrapParagraphToLines(), wrapPlainTextToNormLines() (+5 more)
 
 ### Community 22 - "Community 22"
-Cohesion: 0.07
-Nodes (16): smallProject(), buildCharacter(), buildLargeManuscript(), buildParagraph(), buildSectionContent(), buildWorld(), countWords(), makeRng() (+8 more)
+Cohesion: 0.11
+Nodes (1): StorageManager
 
 ### Community 23 - "Community 23"
-Cohesion: 0.09
-Nodes (21): collect(), DeadLetterQueue, openDlqDb(), storeClear(), storeGetAll(), analyze_text(), count_sentences(), count_syllables() (+13 more)
+Cohesion: 0.07
+Nodes (16): smallProject(), buildCharacter(), buildLargeManuscript(), buildParagraph(), buildSectionContent(), buildWorld(), countWords(), makeRng() (+8 more)
 
 ### Community 24 - "Community 24"
 Cohesion: 0.23
@@ -223,339 +225,353 @@ Nodes (3): LS, xn(), aa
 
 ### Community 25 - "Community 25"
 Cohesion: 0.14
-Nodes (21): handleToggle(), handleDelete(), handleFileChange(), activateAdapter(), clearDatasetEntries(), deactivateAdapter(), deleteAdapter(), exportAdapter() (+13 more)
+Nodes (1): k2
 
 ### Community 26 - "Community 26"
-Cohesion: 0.15
-Nodes (14): buildExcerpt(), extractCharacters(), extractManuscriptSections(), searchAcrossProjectIndex(), searchAcrossProjects(), normalizeSearch(), scoreAgainstQuery(), subsequenceScore() (+6 more)
+Cohesion: 0.14
+Nodes (21): handleToggle(), handleDelete(), handleFileChange(), activateAdapter(), clearDatasetEntries(), deactivateAdapter(), deleteAdapter(), exportAdapter() (+13 more)
 
 ### Community 27 - "Community 27"
+Cohesion: 0.16
+Nodes (14): buildExcerpt(), extractCharacters(), extractManuscriptSections(), searchAcrossProjectIndex(), searchAcrossProjects(), normalizeSearch(), scoreAgainstQuery(), subsequenceScore() (+6 more)
+
+### Community 28 - "Community 28"
 Cohesion: 0.35
 Nodes (2): cc, Gb()
 
-### Community 28 - "Community 28"
+### Community 29 - "Community 29"
 Cohesion: 0.17
 Nodes (8): check(), extractCatalogFlags(), extractHiddenFlags(), extractSectionFlags(), green(), grep(), hasRuntimeConsumption(), red()
 
-### Community 31 - "Community 31"
+### Community 32 - "Community 32"
 Cohesion: 0.42
 Nodes (6): emit(), main(), merge(), ProgressCallback, Emits JSON progress events on each training log step., train()
 
-### Community 32 - "Community 32"
+### Community 33 - "Community 33"
 Cohesion: 0.25
 Nodes (3): useManuscriptLayout(), useMediaQuery(), useResizablePanels()
 
-### Community 34 - "Community 34"
+### Community 35 - "Community 35"
 Cohesion: 0.29
 Nodes (5): MockAudioContext, MockBufferSource, MockGain, NonEndingSource, TrackingContext
 
-### Community 36 - "Community 36"
+### Community 37 - "Community 37"
 Cohesion: 0.33
 Nodes (3): useSwipeGesture(), useWriterLayout(), useWriterViewContext()
 
-### Community 37 - "Community 37"
+### Community 38 - "Community 38"
 Cohesion: 0.53
 Nodes (4): buildWebNNExecutionProviders(), detectWebNN(), isDirectMLAvailable(), isDirectMLHeuristic()
 
-### Community 38 - "Community 38"
+### Community 39 - "Community 39"
 Cohesion: 0.7
 Nodes (4): check_cuda_and_vram(), check_package(), check_python_version(), main()
 
-### Community 41 - "Community 41"
+### Community 42 - "Community 42"
+Cohesion: 0.4
+Nodes (1): O0
+
+### Community 43 - "Community 43"
 Cohesion: 0.5
 Nodes (3): createStorageMock(), setupStorage(), SpeechSynthesisUtteranceMock
 
-### Community 43 - "Community 43"
-Cohesion: 0.4
-Nodes (4): Room, SignalingConn, WebrtcConn, WebrtcProvider
-
-### Community 44 - "Community 44"
+### Community 45 - "Community 45"
 Cohesion: 0.4
 Nodes (2): useDashboardContext(), DashboardHeader()
 
-### Community 47 - "Community 47"
+### Community 46 - "Community 46"
+Cohesion: 0.4
+Nodes (4): Room, SignalingConn, WebrtcConn, WebrtcProvider
+
+### Community 49 - "Community 49"
 Cohesion: 0.6
 Nodes (4): applyFormula(), computeReadabilitySnapshot(), estimateSyllables(), getSyllablePattern()
 
-### Community 50 - "Community 50"
+### Community 52 - "Community 52"
 Cohesion: 0.67
 Nodes (2): makeConfig(), startPipelinePayload()
 
-### Community 55 - "Community 55"
+### Community 57 - "Community 57"
 Cohesion: 0.67
 Nodes (2): make(), noop()
 
-### Community 58 - "Community 58"
+### Community 60 - "Community 60"
 Cohesion: 0.67
 Nodes (2): defaultProject(), setProjectData()
 
-### Community 61 - "Community 61"
+### Community 63 - "Community 63"
 Cohesion: 0.83
 Nodes (3): makeChars(), makeProject(), makeWorlds()
 
-### Community 62 - "Community 62"
+### Community 64 - "Community 64"
 Cohesion: 0.83
 Nodes (3): emptyChars(), emptyWorlds(), makeProject()
 
-### Community 63 - "Community 63"
+### Community 65 - "Community 65"
 Cohesion: 0.5
 Nodes (3): AsyncDuckDB, AsyncDuckDBConnection, ConsoleLogger
 
-### Community 67 - "Community 67"
+### Community 69 - "Community 69"
 Cohesion: 0.5
 Nodes (2): ManuscriptDesktopLayout(), useManuscriptViewContext()
 
-### Community 69 - "Community 69"
+### Community 71 - "Community 71"
 Cohesion: 0.67
 Nodes (2): getQuestionsForArchetype(), getTemplateForArchetype()
 
-### Community 70 - "Community 70"
+### Community 72 - "Community 72"
 Cohesion: 0.83
 Nodes (3): esc(), inline(), renderExportMarkdownToHtml()
 
-### Community 75 - "Community 75"
+### Community 77 - "Community 77"
 Cohesion: 0.67
 Nodes (1): makeSection()
 
-### Community 81 - "Community 81"
+### Community 83 - "Community 83"
 Cohesion: 0.67
 Nodes (1): MockGoogleGenAI
 
-### Community 84 - "Community 84"
+### Community 86 - "Community 86"
 Cohesion: 0.67
 Nodes (1): makeDeps()
 
-### Community 95 - "Community 95"
+### Community 97 - "Community 97"
 Cohesion: 0.67
 Nodes (1): TaskError
 
-### Community 128 - "Community 128"
+### Community 130 - "Community 130"
 Cohesion: 1.0
 Nodes (1): MockIntersectionObserver
 
-### Community 139 - "Community 139"
+### Community 141 - "Community 141"
 Cohesion: 1.0
 Nodes (1): MockWorker
 
-### Community 145 - "Community 145"
+### Community 147 - "Community 147"
 Cohesion: 1.0
 Nodes (1): MockBroadcastChannel
 
-### Community 178 - "Community 178"
+### Community 180 - "Community 180"
 Cohesion: 1.0
 Nodes (1): MockIntersectionObserver
 
-### Community 226 - "Community 226"
+### Community 228 - "Community 228"
 Cohesion: 1.0
 Nodes (1): MockWorker
 
-### Community 266 - "Community 266"
+### Community 268 - "Community 268"
 Cohesion: 1.0
 Nodes (1): FileSystemService
 
-### Community 271 - "Community 271"
+### Community 273 - "Community 273"
 Cohesion: 1.0
 Nodes (1): IndexedDBService
 
-### Community 740 - "Community 740"
+### Community 742 - "Community 742"
 Cohesion: 1.0
 Nodes (1): Remove ANSI escape codes from text.
 
-### Community 741 - "Community 741"
+### Community 743 - "Community 743"
 Cohesion: 1.0
 Nodes (1): Remove timestamp strings from text.
 
-### Community 742 - "Community 742"
+### Community 744 - "Community 744"
 Cohesion: 1.0
 Nodes (1): Replace long base64 strings with placeholder.
 
-### Community 743 - "Community 743"
+### Community 745 - "Community 745"
 Cohesion: 1.0
 Nodes (1): Remove NPM/pnpm warning lines.
 
-### Community 744 - "Community 744"
+### Community 746 - "Community 746"
 Cohesion: 1.0
 Nodes (1): Remove redundant success messages.
 
-### Community 745 - "Community 745"
+### Community 747 - "Community 747"
 Cohesion: 1.0
 Nodes (1): Apply all preprocessing steps to reduce token payload.
 
-### Community 746 - "Community 746"
+### Community 748 - "Community 748"
 Cohesion: 1.0
 Nodes (1): Extract only error-related sections from log.
 
-### Community 747 - "Community 747"
+### Community 749 - "Community 749"
 Cohesion: 1.0
 Nodes (1): Pydantic models for CI Analyzer structured output. QNBS-v3: These models enforce
 
-### Community 748 - "Community 748"
+### Community 750 - "Community 750"
 Cohesion: 1.0
 Nodes (1): Structured CI error for VS Code problem matcher integration.
 
-### Community 749 - "Community 749"
+### Community 751 - "Community 751"
 Cohesion: 1.0
 Nodes (1): Vitest JSON test result structure.
 
-### Community 750 - "Community 750"
+### Community 752 - "Community 752"
 Cohesion: 1.0
 Nodes (1): Full Vitest JSON report structure.
 
-### Community 751 - "Community 751"
+### Community 753 - "Community 753"
 Cohesion: 1.0
 Nodes (1): Stryker per-file mutation report.
 
-### Community 752 - "Community 752"
+### Community 754 - "Community 754"
 Cohesion: 1.0
 Nodes (1): Full Stryker JSON report structure.
 
-### Community 753 - "Community 753"
+### Community 755 - "Community 755"
 Cohesion: 1.0
 Nodes (1): Initialize OpenRouter client for Poolside Laguna model.
 
-### Community 754 - "Community 754"
+### Community 756 - "Community 756"
 Cohesion: 1.0
 Nodes (1): Analyze Vitest JSON report and raw logs for errors.
 
-### Community 755 - "Community 755"
+### Community 757 - "Community 757"
 Cohesion: 1.0
 Nodes (1): Analyze Stryker JSON report for surviving mutants.
 
-### Community 756 - "Community 756"
+### Community 758 - "Community 758"
 Cohesion: 1.0
 Nodes (1): Send preprocessed errors to LLM for analysis.
 
-### Community 757 - "Community 757"
+### Community 759 - "Community 759"
 Cohesion: 1.0
 Nodes (1): Format errors for VS Code problem matcher.
 
-### Community 758 - "Community 758"
+### Community 760 - "Community 760"
 Cohesion: 1.0
 Nodes (1): Main entry point for CI analyzer.
 
-### Community 759 - "Community 759"
+### Community 761 - "Community 761"
 Cohesion: 1.0
 Nodes (1): Execute gh CLI command and return parsed JSON output.
 
-### Community 760 - "Community 760"
+### Community 762 - "Community 762"
 Cohesion: 1.0
 Nodes (1): Get the ID of the most recent failed CI run.
 
-### Community 761 - "Community 761"
+### Community 763 - "Community 763"
 Cohesion: 1.0
 Nodes (1): Download a specific artifact from a workflow run.
 
-### Community 762 - "Community 762"
+### Community 764 - "Community 764"
 Cohesion: 1.0
 Nodes (1): Get raw logs from a failed workflow run.
 
-### Community 763 - "Community 763"
+### Community 765 - "Community 765"
 Cohesion: 1.0
 Nodes (1): Parse Vitest JSON report for failing tests.
 
-### Community 764 - "Community 764"
+### Community 766 - "Community 766"
 Cohesion: 1.0
 Nodes (1): Parse Stryker JSON report for surviving mutants.
 
 ## Knowledge Gaps
 - **53 isolated node(s):** `Emits JSON progress events on each training log step.`, `qb`, `v2`, `MockIntersectionObserver`, `MockWorker` (+48 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 27`** (17 nodes): `cc`, `._applyAttribute()`, `._assert()`, `.constructor()`, `._eof()`, `._isWhitespace()`, `._next()`, `.parse()`, `._peek()`, `._readAttributes()`, `._readIdentifier()`, `._readRegex()`, `._readString()`, `._readStringOrRegex()`, `._skipWhitespace()`, `._throwError()`, `Gb()`
+- **Thin community `Community 22`** (36 nodes): `storageService.ts`, `StorageManager`, `.clearApiKey()`, `.clearGeminiApiKey()`, `.constructor()`, `.deleteAllBinderAssetsForProject()`, `.deleteBinderAsset()`, `.deleteImage()`, `.deleteProject()`, `.deleteRagVectors()`, `.deleteSnapshot()`, `.deleteStoryCodex()`, `.getApiKey()`, `.getBackend()`, `.getBinderAsset()`, `.getGeminiApiKey()`, `.getImage()`, `.getRagVectors()`, `.getSnapshotData()`, `.getStoryCodex()`, `.hasSavedData()`, `.initializeBackend()`, `.listBinderAssetIds()`, `.listProjects()`, `.listSnapshots()`, `.loadProject()`, `.loadSettings()`, `.saveApiKey()`, `.saveBinderAsset()`, `.saveGeminiApiKey()`, `.saveImage()`, `.saveProject()`, `.saveRagVectors()`, `.saveSettings()`, `.saveSnapshot()`, `.saveStoryCodex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 44`** (5 nodes): `DashboardHeader.tsx`, `DashboardContext.ts`, `useDashboardContext()`, `Chip()`, `DashboardHeader()`
+- **Thin community `Community 25`** (27 nodes): `.fire()`, `k2`, `.checkBrowsers()`, `.clearCache()`, `.closeGracefully()`, `._dispatchEvent()`, `.findRelatedTestFiles()`, `.initialize()`, `.installBrowsers()`, `.isClosed()`, `.listFiles()`, `.listTests()`, `.open()`, `.openNoReply()`, `.ping()`, `.pingNoReply()`, `.resizeTerminal()`, `.resizeTerminalNoReply()`, `.runGlobalSetup()`, `.runGlobalTeardown()`, `.runTests()`, `._sendMessage()`, `._sendMessageNoReply()`, `.stopTests()`, `.stopTestsNoReply()`, `.watch()`, `.watchNoReply()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 50`** (4 nodes): `makeConfig()`, `makeReviewItem()`, `startPipelinePayload()`, `proForgeSlice.test.ts`
+- **Thin community `Community 28`** (17 nodes): `cc`, `._applyAttribute()`, `._assert()`, `.constructor()`, `._eof()`, `._isWhitespace()`, `._next()`, `.parse()`, `._peek()`, `._readAttributes()`, `._readIdentifier()`, `._readRegex()`, `._readString()`, `._readStringOrRegex()`, `._skipWhitespace()`, `._throwError()`, `Gb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 55`** (4 nodes): `make()`, `noop()`, `aiRetry.test.ts`, `aiRetry.test.ts`
+- **Thin community `Community 42`** (5 nodes): `O0`, `.constructor()`, `.toJSON()`, `.toSource()`, `.toString()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 58`** (4 nodes): `useDashboard.test.ts`, `defaultProject()`, `defaultSection()`, `setProjectData()`
+- **Thin community `Community 45`** (5 nodes): `DashboardHeader.tsx`, `DashboardContext.ts`, `useDashboardContext()`, `Chip()`, `DashboardHeader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 67`** (4 nodes): `ManuscriptDesktopLayout.tsx`, `ManuscriptViewContext.ts`, `ManuscriptDesktopLayout()`, `useManuscriptViewContext()`
+- **Thin community `Community 52`** (4 nodes): `makeConfig()`, `makeReviewItem()`, `startPipelinePayload()`, `proForgeSlice.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 69`** (4 nodes): `getAllTemplates()`, `getQuestionsForArchetype()`, `getTemplateForArchetype()`, `characterInterviewTemplates.ts`
+- **Thin community `Community 57`** (4 nodes): `make()`, `noop()`, `aiRetry.test.ts`, `aiRetry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 75`** (3 nodes): `makeSection()`, `plotBoardService.test.ts`, `plotBoardService.test.ts`
+- **Thin community `Community 60`** (4 nodes): `useDashboard.test.ts`, `defaultProject()`, `defaultSection()`, `setProjectData()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 81`** (3 nodes): `makeStream()`, `MockGoogleGenAI`, `geminiService.test.ts`
+- **Thin community `Community 69`** (4 nodes): `ManuscriptDesktopLayout.tsx`, `ManuscriptViewContext.ts`, `ManuscriptDesktopLayout()`, `useManuscriptViewContext()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 84`** (3 nodes): `makeDeps()`, `aiSuggestions.test.ts`, `aiSuggestions.test.ts`
+- **Thin community `Community 71`** (4 nodes): `getAllTemplates()`, `getQuestionsForArchetype()`, `getTemplateForArchetype()`, `characterInterviewTemplates.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 95`** (3 nodes): `types.ts`, `TaskError`, `.constructor()`
+- **Thin community `Community 77`** (3 nodes): `makeSection()`, `plotBoardService.test.ts`, `plotBoardService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 128`** (2 nodes): `MockIntersectionObserver`, `BookPreviewView.test.tsx`
+- **Thin community `Community 83`** (3 nodes): `makeStream()`, `MockGoogleGenAI`, `geminiService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 139`** (2 nodes): `MockWorker`, `duckdbClient.test.ts`
+- **Thin community `Community 86`** (3 nodes): `makeDeps()`, `aiSuggestions.test.ts`, `aiSuggestions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 145`** (2 nodes): `MockBroadcastChannel`, `tabLeaderElection.test.ts`
+- **Thin community `Community 97`** (3 nodes): `types.ts`, `TaskError`, `.constructor()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 178`** (2 nodes): `useBookPreviewView.test.ts`, `MockIntersectionObserver`
+- **Thin community `Community 130`** (2 nodes): `MockIntersectionObserver`, `BookPreviewView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 226`** (2 nodes): `workerPool.test.ts`, `MockWorker`
+- **Thin community `Community 141`** (2 nodes): `MockWorker`, `duckdbClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 266`** (2 nodes): `FileSystemService`, `index.ts`
+- **Thin community `Community 147`** (2 nodes): `MockBroadcastChannel`, `tabLeaderElection.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 271`** (2 nodes): `IndexedDBService`, `index.ts`
+- **Thin community `Community 180`** (2 nodes): `useBookPreviewView.test.ts`, `MockIntersectionObserver`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 740`** (1 nodes): `Remove ANSI escape codes from text.`
+- **Thin community `Community 228`** (2 nodes): `workerPool.test.ts`, `MockWorker`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 741`** (1 nodes): `Remove timestamp strings from text.`
+- **Thin community `Community 268`** (2 nodes): `FileSystemService`, `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 742`** (1 nodes): `Replace long base64 strings with placeholder.`
+- **Thin community `Community 273`** (2 nodes): `IndexedDBService`, `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 743`** (1 nodes): `Remove NPM/pnpm warning lines.`
+- **Thin community `Community 742`** (1 nodes): `Remove ANSI escape codes from text.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 744`** (1 nodes): `Remove redundant success messages.`
+- **Thin community `Community 743`** (1 nodes): `Remove timestamp strings from text.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 745`** (1 nodes): `Apply all preprocessing steps to reduce token payload.`
+- **Thin community `Community 744`** (1 nodes): `Replace long base64 strings with placeholder.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 746`** (1 nodes): `Extract only error-related sections from log.`
+- **Thin community `Community 745`** (1 nodes): `Remove NPM/pnpm warning lines.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 747`** (1 nodes): `Pydantic models for CI Analyzer structured output. QNBS-v3: These models enforce`
+- **Thin community `Community 746`** (1 nodes): `Remove redundant success messages.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (1 nodes): `Structured CI error for VS Code problem matcher integration.`
+- **Thin community `Community 747`** (1 nodes): `Apply all preprocessing steps to reduce token payload.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (1 nodes): `Vitest JSON test result structure.`
+- **Thin community `Community 748`** (1 nodes): `Extract only error-related sections from log.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (1 nodes): `Full Vitest JSON report structure.`
+- **Thin community `Community 749`** (1 nodes): `Pydantic models for CI Analyzer structured output. QNBS-v3: These models enforce`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (1 nodes): `Stryker per-file mutation report.`
+- **Thin community `Community 750`** (1 nodes): `Structured CI error for VS Code problem matcher integration.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (1 nodes): `Full Stryker JSON report structure.`
+- **Thin community `Community 751`** (1 nodes): `Vitest JSON test result structure.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (1 nodes): `Initialize OpenRouter client for Poolside Laguna model.`
+- **Thin community `Community 752`** (1 nodes): `Full Vitest JSON report structure.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (1 nodes): `Analyze Vitest JSON report and raw logs for errors.`
+- **Thin community `Community 753`** (1 nodes): `Stryker per-file mutation report.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (1 nodes): `Analyze Stryker JSON report for surviving mutants.`
+- **Thin community `Community 754`** (1 nodes): `Full Stryker JSON report structure.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (1 nodes): `Send preprocessed errors to LLM for analysis.`
+- **Thin community `Community 755`** (1 nodes): `Initialize OpenRouter client for Poolside Laguna model.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (1 nodes): `Format errors for VS Code problem matcher.`
+- **Thin community `Community 756`** (1 nodes): `Analyze Vitest JSON report and raw logs for errors.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (1 nodes): `Main entry point for CI analyzer.`
+- **Thin community `Community 757`** (1 nodes): `Analyze Stryker JSON report for surviving mutants.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (1 nodes): `Execute gh CLI command and return parsed JSON output.`
+- **Thin community `Community 758`** (1 nodes): `Send preprocessed errors to LLM for analysis.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (1 nodes): `Get the ID of the most recent failed CI run.`
+- **Thin community `Community 759`** (1 nodes): `Format errors for VS Code problem matcher.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (1 nodes): `Download a specific artifact from a workflow run.`
+- **Thin community `Community 760`** (1 nodes): `Main entry point for CI analyzer.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (1 nodes): `Get raw logs from a failed workflow run.`
+- **Thin community `Community 761`** (1 nodes): `Execute gh CLI command and return parsed JSON output.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (1 nodes): `Parse Vitest JSON report for failing tests.`
+- **Thin community `Community 762`** (1 nodes): `Get the ID of the most recent failed CI run.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (1 nodes): `Parse Stryker JSON report for surviving mutants.`
+- **Thin community `Community 763`** (1 nodes): `Download a specific artifact from a workflow run.`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 764`** (1 nodes): `Get raw logs from a failed workflow run.`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 765`** (1 nodes): `Parse Vitest JSON report for failing tests.`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 766`** (1 nodes): `Parse Stryker JSON report for surviving mutants.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `mt()` connect `Community 2` to `Community 0`, `Community 1`, `Community 3`, `Community 4`, `Community 5`, `Community 7`, `Community 8`, `Community 12`, `Community 15`, `Community 20`, `Community 21`, `Community 24`?**
-  _High betweenness centrality (0.085) - this node is a cross-community bridge._
-- **Why does `t()` connect `Community 4` to `Community 0`, `Community 1`, `Community 2`, `Community 6`, `Community 9`, `Community 10`, `Community 11`, `Community 12`, `Community 18`, `Community 20`, `Community 25`?**
-  _High betweenness centrality (0.073) - this node is a cross-community bridge._
-- **Why does `wx()` connect `Community 0` to `Community 2`, `Community 4`, `Community 5`, `Community 7`, `Community 14`, `Community 16`, `Community 20`?**
-  _High betweenness centrality (0.046) - this node is a cross-community bridge._
+- **Why does `mt()` connect `Community 1` to `Community 0`, `Community 2`, `Community 3`, `Community 6`, `Community 8`, `Community 10`, `Community 12`, `Community 13`, `Community 17`, `Community 20`, `Community 21`, `Community 24`?**
+  _High betweenness centrality (0.081) - this node is a cross-community bridge._
+- **Why does `t()` connect `Community 3` to `Community 1`, `Community 2`, `Community 4`, `Community 9`, `Community 10`, `Community 13`, `Community 14`, `Community 15`, `Community 16`, `Community 20`, `Community 26`?**
+  _High betweenness centrality (0.076) - this node is a cross-community bridge._
+- **Why does `wx()` connect `Community 1` to `Community 0`, `Community 3`, `Community 5`, `Community 8`, `Community 16`?**
+  _High betweenness centrality (0.043) - this node is a cross-community bridge._
 - **Are the 87 inferred relationships involving `mt()` (e.g. with `pE()` and `xE()`) actually correct?**
   _`mt()` has 87 INFERRED edges - model-reasoned connections that need verification._
 - **Are the 62 inferred relationships involving `fn()` (e.g. with `makeMediaQuery()` and `MockSpeechRecognition()`) actually correct?**

--- a/hooks/useApp.ts
+++ b/hooks/useApp.ts
@@ -68,6 +68,16 @@ export const useApp = ({ isNewUser }: { isNewUser: boolean }) => {
   const [isPortalActive, setIsPortalActive] = useState(false);
   const [isInitialLoad, setIsInitialLoad] = useState(true);
 
+  // QNBS-v3 (CodeAnt): the single place that mutates currentView, so previousView is tracked on
+  // EVERY navigation path — handleNavigate, hashchange (browser back/forward + deep links), and
+  // portal exit — not just sidebar clicks. Otherwise view-aware Help opens with a stale origin view.
+  const switchView = useCallback((view: View) => {
+    setCurrentView((prev) => {
+      if (prev !== view) previousViewRef.current = prev;
+      return view;
+    });
+  }, []);
+
   useEffect(() => {
     if (isNewUser) {
       setIsPortalActive(true);
@@ -101,12 +111,12 @@ export const useApp = ({ isNewUser }: { isNewUser: boolean }) => {
     function onHashChange() {
       const { view } = parseHash(window.location.hash);
       if (view && view !== currentView) {
-        setCurrentView(view);
+        switchView(view);
       }
     }
     window.addEventListener('hashchange', onHashChange);
     return () => window.removeEventListener('hashchange', onHashChange);
-  }, [currentView]);
+  }, [currentView, switchView]);
 
   // Save the current view to localStorage whenever it changes.
   useEffect(() => {
@@ -117,22 +127,25 @@ export const useApp = ({ isNewUser }: { isNewUser: boolean }) => {
     }
   }, [currentView]);
 
-  const handlePortalExit = useCallback((view?: View) => {
-    if (view) {
-      setCurrentView(view);
-      pushHash(view);
-    }
-    setIsPortalActive(false);
-  }, []);
+  const handlePortalExit = useCallback(
+    (view?: View) => {
+      if (view) {
+        switchView(view);
+        pushHash(view);
+      }
+      setIsPortalActive(false);
+    },
+    [switchView],
+  );
 
   // QNBS-v3: Keep URL hash in sync with navigation so all views are shareable/bookmarkable.
-  const handleNavigate = useCallback((view: View) => {
-    setCurrentView((prev) => {
-      if (prev !== view) previousViewRef.current = prev;
-      return view;
-    });
-    pushHash(view);
-  }, []);
+  const handleNavigate = useCallback(
+    (view: View) => {
+      switchView(view);
+      pushHash(view);
+    },
+    [switchView],
+  );
 
   return {
     currentView,

--- a/hooks/useApp.ts
+++ b/hooks/useApp.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { parseHash, pushHash } from '../services/deepLinkService';
 import { logger } from '../services/logger';
 import type { View } from '../types';
@@ -61,6 +61,9 @@ function readInitialView(): View {
 
 export const useApp = ({ isNewUser }: { isNewUser: boolean }) => {
   const [currentView, setCurrentView] = useState<View>(() => readInitialView());
+  // QNBS-v3: remember the view navigated away from, so view-aware Help can open to the matching
+  // category (once inside Help, currentView is 'help' and no longer tells us where the user was).
+  const previousViewRef = useRef<View>('dashboard');
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [isPortalActive, setIsPortalActive] = useState(false);
   const [isInitialLoad, setIsInitialLoad] = useState(true);
@@ -124,12 +127,16 @@ export const useApp = ({ isNewUser }: { isNewUser: boolean }) => {
 
   // QNBS-v3: Keep URL hash in sync with navigation so all views are shareable/bookmarkable.
   const handleNavigate = useCallback((view: View) => {
-    setCurrentView(view);
+    setCurrentView((prev) => {
+      if (prev !== view) previousViewRef.current = prev;
+      return view;
+    });
     pushHash(view);
   }, []);
 
   return {
     currentView,
+    previousView: previousViewRef.current,
     isSidebarOpen,
     isPortalActive,
     isInitialLoad,

--- a/hooks/useHelpView.ts
+++ b/hooks/useHelpView.ts
@@ -31,7 +31,9 @@ const VIEW_TO_HELP_CATEGORY: Partial<Record<View, string>> = {
   progress: 'analysis',
   export: 'management',
   settings: 'settings-guide',
-  lora: 'ai-studio',
+  // QNBS-v3 (CodeAnt): LoRA help content lives under the 'advanced' category (help.advanced.lora.*),
+  // not 'ai-studio' — map there so Help opens on the actual LoRA docs.
+  lora: 'advanced',
 };
 
 /** Resolve the initial help category from the originating view (defaults to getting-started). */

--- a/hooks/useHelpView.ts
+++ b/hooks/useHelpView.ts
@@ -5,17 +5,50 @@ import {
   flattenHelpArticles,
   searchHelpArticlesIndexed,
 } from '../services/help/helpSearch';
-import type { HelpArticle } from '../types';
+import type { HelpArticle, View } from '../types';
 import { useTranslation } from './useTranslation';
 
-export const useHelpView = () => {
+// QNBS-v3: PR3 — view-aware Help. Maps the view the user came from to the most relevant help
+// category so Help opens contextually instead of always on "getting-started".
+const VIEW_TO_HELP_CATEGORY: Partial<Record<View, string>> = {
+  dashboard: 'getting-started',
+  templates: 'getting-started',
+  manuscript: 'writing',
+  writer: 'writing',
+  zen: 'writing',
+  outline: 'writing',
+  preview: 'writing',
+  sceneboard: 'writing',
+  mindmap: 'writing',
+  characters: 'worldbuilding',
+  world: 'worldbuilding',
+  objects: 'worldbuilding',
+  characterGraph: 'worldbuilding',
+  characterInterviews: 'worldbuilding',
+  consistencyChecker: 'analysis',
+  critic: 'analysis',
+  analytics: 'analysis',
+  progress: 'analysis',
+  export: 'management',
+  settings: 'settings-guide',
+  lora: 'ai-studio',
+};
+
+/** Resolve the initial help category from the originating view (defaults to getting-started). */
+export function helpCategoryForView(view?: View): string {
+  return (view && VIEW_TO_HELP_CATEGORY[view]) || 'getting-started';
+}
+
+export const useHelpView = (contextView?: View) => {
   const { t } = useTranslation();
 
   const helpContent = useMemo(() => catalogToHelpCategories(), []);
   const flatArticles = useMemo(() => flattenHelpArticles(helpContent), [helpContent]);
   const searchIndex = useMemo(() => buildHelpSearchIndex(flatArticles, t), [flatArticles, t]);
 
-  const [activeCategory, setActiveCategory] = useState<string>('getting-started');
+  const [activeCategory, setActiveCategory] = useState<string>(() =>
+    helpCategoryForView(contextView),
+  );
   const [selectedArticle, setSelectedArticle] = useState<HelpArticle | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
 

--- a/tests/unit/useApp.test.ts
+++ b/tests/unit/useApp.test.ts
@@ -59,6 +59,20 @@ describe('useApp', () => {
     expect(result.current.previousView).toBe('manuscript');
   });
 
+  it('tracks previousView on hashchange (browser back/forward + deep links)', () => {
+    const { result } = renderHook(() => useApp({ isNewUser: false }));
+    act(() => {
+      result.current.handleNavigate('manuscript');
+    });
+    // Simulate a browser back/forward or external deep-link that bypasses handleNavigate.
+    act(() => {
+      window.history.replaceState(null, '', '#/settings');
+      window.dispatchEvent(new Event('hashchange'));
+    });
+    expect(result.current.currentView).toBe('settings');
+    expect(result.current.previousView).toBe('manuscript');
+  });
+
   it('does not change previousView when navigating to the already-active view', () => {
     const { result } = renderHook(() => useApp({ isNewUser: false }));
     act(() => {

--- a/tests/unit/useApp.test.ts
+++ b/tests/unit/useApp.test.ts
@@ -4,6 +4,9 @@ import { useApp } from '../../hooks/useApp';
 
 beforeEach(() => {
   localStorage.clear();
+  // QNBS-v3: handleNavigate/pushHash mutate window.location.hash, and jsdom does not reset it
+  // between tests — a leaked hash makes readInitialView() non-deterministic (it reads hash first).
+  window.history.replaceState(null, '', '/');
 });
 
 describe('useApp', () => {
@@ -54,6 +57,19 @@ describe('useApp', () => {
 
     // previousView is the view the user came from before opening Help.
     expect(result.current.previousView).toBe('manuscript');
+  });
+
+  it('does not change previousView when navigating to the already-active view', () => {
+    const { result } = renderHook(() => useApp({ isNewUser: false }));
+    act(() => {
+      result.current.handleNavigate('manuscript');
+    });
+    // Re-navigating to the same view must NOT overwrite previousView with the current view.
+    act(() => {
+      result.current.handleNavigate('manuscript');
+    });
+    expect(result.current.currentView).toBe('manuscript');
+    expect(result.current.previousView).toBe('dashboard');
   });
 
   it('handlePortalExit sets isPortalActive to false', () => {

--- a/tests/unit/useApp.test.ts
+++ b/tests/unit/useApp.test.ts
@@ -41,6 +41,21 @@ describe('useApp', () => {
     expect(localStorage.getItem('worldscript-last-view')).toBe('settings');
   });
 
+  it('tracks the previous view across navigations (for view-aware Help)', () => {
+    const { result } = renderHook(() => useApp({ isNewUser: false }));
+    expect(result.current.previousView).toBe('dashboard');
+
+    act(() => {
+      result.current.handleNavigate('manuscript');
+    });
+    act(() => {
+      result.current.handleNavigate('help');
+    });
+
+    // previousView is the view the user came from before opening Help.
+    expect(result.current.previousView).toBe('manuscript');
+  });
+
   it('handlePortalExit sets isPortalActive to false', () => {
     const { result } = renderHook(() => useApp({ isNewUser: true }));
 

--- a/tests/unit/useHelpView.test.tsx
+++ b/tests/unit/useHelpView.test.tsx
@@ -23,6 +23,8 @@ describe('useHelpView', () => {
     expect(helpCategoryForView('export')).toBe('management');
     expect(helpCategoryForView('settings')).toBe('settings-guide');
     expect(helpCategoryForView('world')).toBe('worldbuilding');
+    // LoRA docs live under the 'advanced' help category, not 'ai-studio'.
+    expect(helpCategoryForView('lora')).toBe('advanced');
     expect(helpCategoryForView('help')).toBe('getting-started');
     expect(helpCategoryForView(undefined)).toBe('getting-started');
   });

--- a/tests/unit/useHelpView.test.tsx
+++ b/tests/unit/useHelpView.test.tsx
@@ -1,6 +1,6 @@
 import { act, renderHook } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import { useHelpView } from '../../hooks/useHelpView';
+import { helpCategoryForView, useHelpView } from '../../hooks/useHelpView';
 
 vi.mock('../../hooks/useTranslation', () => ({
   useTranslation: () => ({ t: (key: string) => key, language: 'en' }),
@@ -12,6 +12,19 @@ describe('useHelpView', () => {
     expect(result.current.activeCategory).toBe('getting-started');
     expect(result.current.selectedArticle).toBeNull();
     expect(result.current.searchQuery).toBe('');
+  });
+
+  it('opens to the help category matching the originating view (view-aware help)', () => {
+    const { result } = renderHook(() => useHelpView('manuscript'));
+    expect(result.current.activeCategory).toBe('writing');
+  });
+
+  it('helpCategoryForView maps views and falls back to getting-started', () => {
+    expect(helpCategoryForView('export')).toBe('management');
+    expect(helpCategoryForView('settings')).toBe('settings-guide');
+    expect(helpCategoryForView('world')).toBe('worldbuilding');
+    expect(helpCategoryForView('help')).toBe('getting-started');
+    expect(helpCategoryForView(undefined)).toBe('getting-started');
   });
 
   it('handleSelectCategory changes category and clears article + search', () => {


### PR DESCRIPTION
## **User description**
## Wave A · PR3 — Help & Onboarding completeness (P1)

Stacked on #209 → #208. Auto-retargets up the stack as each base merges.

The driver.js spotlight tour already existed but was **only launchable manually**, and Help always opened to `getting-started` regardless of context.

### Changes
- **Auto first-run tour**: launches once for fresh installs (`isNewUser`), after the welcome portal closes and the nav has painted. Guarded by `hasCompletedSpotlightTour()`, dismissible, marks complete on destroy. Returning users (and anyone who already saw it) are never interrupted; the Dashboard/Help manual launchers still work.
- **View-aware Help**: `useApp` now tracks the **previous view**, and Help opens to the category matching where the user came from (`manuscript→writing`, `export→management`, `settings→settings-guide`, …) via `helpCategoryForView()`.

### Tests
- `useApp`: previous-view tracking across navigations.
- `useHelpView`: view→category mapping + `contextView` initial category.

No new i18n keys (reuses existing `tour.*` strings). 22 unit tests green; typecheck + lint + i18n parity clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Show the first-run tour automatically and open Help to the most relevant topic**

### What Changed
- New users now see the spotlight tour automatically after the welcome screen closes, instead of having to start it manually.
- Help now opens to the section that matches the place the user came from, so opening Help from writing, worldbuilding, analysis, export, or settings lands on the most relevant topic.
- If Help is opened from an unrelated place, it still falls back to the general getting-started section.
- Automated browser sessions are excluded from the auto-start tour, so test flows are not interrupted.

### Impact
`✅ Shorter first-time onboarding`
`✅ Fewer clicks to reach the right help topic`
`✅ Fewer blocked automated test runs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
