### PR TITLE
feat(voice): live mic-level meter + confidence display

### DIFF
--- a/components/voice/VoiceControlPanel.tsx
+++ b/components/voice/VoiceControlPanel.tsx
@@ -83,9 +83,9 @@ export const VoiceControlPanel = React.memo(function VoiceControlPanel() {
               {transcript}
             </p>
           )}
-          {/* QNBS-v3 (CodeAnt): not in dictation — that path appends text without updating
-              lastConfidence, so its value would be stale. */}
-          {confidencePct > 0 && mode !== 'dictating' && (
+          {/* QNBS-v3 (CodeAnt): only with a current transcript + not in dictation — otherwise a
+              prior utterance's lastConfidence (unchanged on session start) would show stale. */}
+          {confidencePct > 0 && !!transcript && mode !== 'dictating' && (
             <span className="text-[10px] text-[var(--sc-text-muted)] tabular-nums">
               {t('voice.feedback.confidence', { percent: String(confidencePct) })}
             </span>

--- a/components/voice/VoiceControlPanel.tsx
+++ b/components/voice/VoiceControlPanel.tsx
@@ -26,8 +26,10 @@ export const VoiceControlPanel = React.memo(function VoiceControlPanel() {
     transcript,
     confidence,
   } = useVoice();
-  const level = useMicLevel(isListening);
-  const confidencePct = Math.round(Math.min(1, Math.max(0, confidence)) * 100);
+  // QNBS-v3 (CodeAnt): gate the (shared) mic meter on `enabled` so it never runs if voice was
+  // disabled while a stale listening mode lingers.
+  const level = useMicLevel(enabled && isListening);
+  const confidencePct = Math.round(Math.min(1, Math.max(0, confidence ?? 0)) * 100);
 
   const handleToggleListening = useCallback(() => {
     if (isListening) {
@@ -81,7 +83,9 @@ export const VoiceControlPanel = React.memo(function VoiceControlPanel() {
               {transcript}
             </p>
           )}
-          {confidencePct > 0 && (
+          {/* QNBS-v3 (CodeAnt): not in dictation — that path appends text without updating
+              lastConfidence, so its value would be stale. */}
+          {confidencePct > 0 && mode !== 'dictating' && (
             <span className="text-[10px] text-[var(--sc-text-muted)] tabular-nums">
               {t('voice.feedback.confidence', { percent: String(confidencePct) })}
             </span>

--- a/components/voice/VoiceControlPanel.tsx
+++ b/components/voice/VoiceControlPanel.tsx
@@ -4,9 +4,11 @@
  */
 
 import React, { useCallback } from 'react';
+import { useMicLevel } from '../../hooks/useMicLevel';
 import { useTranslation } from '../../hooks/useTranslation';
 import { useVoice } from '../../hooks/useVoice';
 import { Icon } from '../ui/Icon';
+import { VoiceLevelMeter } from './VoiceLevelMeter';
 
 export const VoiceControlPanel = React.memo(function VoiceControlPanel() {
   const { t } = useTranslation();
@@ -21,7 +23,11 @@ export const VoiceControlPanel = React.memo(function VoiceControlPanel() {
     stopDictation,
     cancelSpeech,
     microphonePermission,
+    transcript,
+    confidence,
   } = useVoice();
+  const level = useMicLevel(isListening);
+  const confidencePct = Math.round(Math.min(1, Math.max(0, confidence)) * 100);
 
   const handleToggleListening = useCallback(() => {
     if (isListening) {
@@ -65,6 +71,22 @@ export const VoiceControlPanel = React.memo(function VoiceControlPanel() {
         <span className="text-[10px] text-center px-2 py-0.5 rounded-full bg-[var(--sc-surface-subtle)] text-[var(--sc-text-secondary)]">
           {dictationActive ? t('voice.modeChip.dictation') : t('voice.modeChip.commands')}
         </span>
+      )}
+      {/* QNBS-v3: PR5 — live feedback: mic level meter, interim transcript, and confidence. */}
+      {isActive && (
+        <div className="flex flex-col items-center gap-1 px-1">
+          {isListening && <VoiceLevelMeter level={level} />}
+          {transcript && (
+            <p className="text-[10px] text-[var(--sc-text-secondary)] text-center max-w-[140px] line-clamp-2">
+              {transcript}
+            </p>
+          )}
+          {confidencePct > 0 && (
+            <span className="text-[10px] text-[var(--sc-text-muted)] tabular-nums">
+              {t('voice.feedback.confidence', { percent: String(confidencePct) })}
+            </span>
+          )}
+        </div>
       )}
       <button
         type="button"

--- a/components/voice/VoiceIndicator.tsx
+++ b/components/voice/VoiceIndicator.tsx
@@ -52,10 +52,11 @@ export const VoiceIndicator = React.memo(function VoiceIndicator() {
 
   const config = MODE_CONFIG[mode as VoiceModeKey] ?? MODE_CONFIG.inactive;
   const confidencePct = Math.round(Math.min(1, Math.max(0, confidence ?? 0)) * 100);
-  // QNBS-v3 (CodeAnt): show confidence for listening/processing/speaking (where it reflects the last
-  // transcription) but NOT dictation (which appends text without updating lastConfidence → stale) or
-  // inactive.
-  const showConfidence = confidencePct > 0 && mode !== 'dictating' && mode !== 'inactive';
+  // QNBS-v3 (CodeAnt): show confidence only alongside a current transcript (a new listening session
+  // clears transcript but leaves lastConfidence), and not in dictation (which appends text without
+  // updating lastConfidence) or inactive — so a stale prior-utterance score is never shown.
+  const showConfidence =
+    confidencePct > 0 && !!transcript && mode !== 'dictating' && mode !== 'inactive';
 
   return (
     <div

--- a/components/voice/VoiceIndicator.tsx
+++ b/components/voice/VoiceIndicator.tsx
@@ -44,12 +44,18 @@ export const VoiceIndicator = React.memo(function VoiceIndicator() {
   const { mode, enabled, transcript, confidence } = useVoice();
   const { t } = useTranslation();
   const isActive = mode === 'listening' || mode === 'dictating';
-  const level = useMicLevel(isActive);
+  // QNBS-v3 (CodeAnt): gate the (shared) mic meter on `enabled` too, so it never runs if voice was
+  // disabled while a stale listening/dictating mode lingers.
+  const level = useMicLevel(enabled && isActive);
 
   if (!enabled) return null;
 
   const config = MODE_CONFIG[mode as VoiceModeKey] ?? MODE_CONFIG.inactive;
-  const confidencePct = Math.round(Math.min(1, Math.max(0, confidence)) * 100);
+  const confidencePct = Math.round(Math.min(1, Math.max(0, confidence ?? 0)) * 100);
+  // QNBS-v3 (CodeAnt): show confidence for listening/processing/speaking (where it reflects the last
+  // transcription) but NOT dictation (which appends text without updating lastConfidence → stale) or
+  // inactive.
+  const showConfidence = confidencePct > 0 && mode !== 'dictating' && mode !== 'inactive';
 
   return (
     <div
@@ -70,7 +76,7 @@ export const VoiceIndicator = React.memo(function VoiceIndicator() {
           {transcript}
         </span>
       )}
-      {isActive && confidencePct > 0 && (
+      {showConfidence && (
         <span className="text-[10px] text-[var(--sc-text-muted)] tabular-nums shrink-0">
           {t('voice.feedback.confidence', { percent: String(confidencePct) })}
         </span>

--- a/components/voice/VoiceIndicator.tsx
+++ b/components/voice/VoiceIndicator.tsx
@@ -4,7 +4,10 @@
  */
 
 import React from 'react';
+import { useMicLevel } from '../../hooks/useMicLevel';
+import { useTranslation } from '../../hooks/useTranslation';
 import { useVoice } from '../../hooks/useVoice';
+import { VoiceLevelMeter } from './VoiceLevelMeter';
 
 type VoiceModeKey = 'inactive' | 'listening' | 'processing' | 'speaking' | 'dictating';
 
@@ -38,11 +41,15 @@ const MODE_CONFIG: Record<VoiceModeKey, { labelKey: string; colorClass: string; 
   };
 
 export const VoiceIndicator = React.memo(function VoiceIndicator() {
-  const { mode, enabled, transcript } = useVoice();
+  const { mode, enabled, transcript, confidence } = useVoice();
+  const { t } = useTranslation();
+  const isActive = mode === 'listening' || mode === 'dictating';
+  const level = useMicLevel(isActive);
 
   if (!enabled) return null;
 
   const config = MODE_CONFIG[mode as VoiceModeKey] ?? MODE_CONFIG.inactive;
+  const confidencePct = Math.round(Math.min(1, Math.max(0, confidence)) * 100);
 
   return (
     <div
@@ -57,9 +64,15 @@ export const VoiceIndicator = React.memo(function VoiceIndicator() {
         aria-hidden="true"
       />
       <span className="text-xs font-medium capitalize">{mode}</span>
+      {isActive && <VoiceLevelMeter level={level} />}
       {transcript && mode !== 'inactive' && (
         <span className="text-xs text-[var(--sc-text-muted)] truncate max-w-[120px]">
           {transcript}
+        </span>
+      )}
+      {isActive && confidencePct > 0 && (
+        <span className="text-[10px] text-[var(--sc-text-muted)] tabular-nums shrink-0">
+          {t('voice.feedback.confidence', { percent: String(confidencePct) })}
         </span>
       )}
     </div>

--- a/components/voice/VoiceLevelMeter.tsx
+++ b/components/voice/VoiceLevelMeter.tsx
@@ -1,0 +1,31 @@
+import type { FC } from 'react';
+
+// QNBS-v3: PR5 — decorative microphone-level meter (5 bars). Driven by useMicLevel's 0–1 value.
+// aria-hidden: the meaningful state (listening/confidence/transcript) is conveyed by adjacent text.
+const METER_BARS = [
+  { id: 'b1', h: 30 },
+  { id: 'b2', h: 47 },
+  { id: 'b3', h: 64 },
+  { id: 'b4', h: 81 },
+  { id: 'b5', h: 98 },
+];
+
+export const VoiceLevelMeter: FC<{ level: number }> = ({ level }) => {
+  const clamped = Math.min(1, Math.max(0, level));
+  const filled = Math.round(clamped * METER_BARS.length);
+  return (
+    <span
+      className="inline-flex items-end gap-0.5 h-3"
+      aria-hidden="true"
+      data-testid="voice-level-meter"
+    >
+      {METER_BARS.map((bar, i) => (
+        <span
+          key={bar.id}
+          className={`w-0.5 rounded-sm transition-[background-color] ${i < filled ? 'bg-[var(--sc-accent)]' : 'bg-[var(--sc-border-subtle)]'}`}
+          style={{ height: `${bar.h}%` }}
+        />
+      ))}
+    </span>
+  );
+};

--- a/features/voice/voiceSlice.ts
+++ b/features/voice/voiceSlice.ts
@@ -61,10 +61,10 @@ export const voiceSlice = createSlice({
   reducers: {
     setVoiceMode: (state, action: PayloadAction<VoiceMode>) => {
       const next = action.payload;
-      // QNBS-v3 (CodeAnt): a fresh listening/dictation cycle starts with no confidence — drop any
-      // prior utterance's score at the source so the UI never shows a stale value before a new
-      // result arrives (the transcript-gated display is the second line of defence).
-      if ((next === 'listening' || next === 'dictating') && state.mode !== next) {
+      // QNBS-v3 (CodeAnt): a fresh listening cycle starts with no confidence — drop any prior
+      // utterance's score at the source so the UI never shows a stale value before a new result
+      // arrives. (Dictation starts via setDictationActive, not here — reset is handled there.)
+      if (next === 'listening' && state.mode !== next) {
         state.lastConfidence = 0;
       }
       state.mode = next;
@@ -123,6 +123,9 @@ export const voiceSlice = createSlice({
     setDictationActive: (state, action: PayloadAction<boolean>) => {
       state.dictationActive = action.payload;
       if (action.payload) {
+        // QNBS-v3 (CodeAnt): dictation starts here (not via setVoiceMode), so reset confidence here
+        // too — a fresh dictation session must not surface a prior utterance's score.
+        if (state.mode !== 'dictating') state.lastConfidence = 0;
         state.mode = 'dictating';
       } else if (state.mode === 'dictating') {
         state.mode = 'inactive';

--- a/features/voice/voiceSlice.ts
+++ b/features/voice/voiceSlice.ts
@@ -161,3 +161,5 @@ export const selectWakeWordStatus = (state: { voice: VoiceState }) => state.voic
 export const selectMicrophonePermission = (state: { voice: VoiceState }) =>
   state.voice.microphonePermission;
 export const selectDictationActive = (state: { voice: VoiceState }) => state.voice.dictationActive;
+// QNBS-v3: PR5 — confidence of the last transcription (0-1), surfaced for voice feedback UI.
+export const selectLastConfidence = (state: { voice: VoiceState }) => state.voice.lastConfidence;

--- a/features/voice/voiceSlice.ts
+++ b/features/voice/voiceSlice.ts
@@ -60,8 +60,15 @@ export const voiceSlice = createSlice({
   initialState,
   reducers: {
     setVoiceMode: (state, action: PayloadAction<VoiceMode>) => {
-      state.mode = action.payload;
-      if (action.payload !== 'inactive') {
+      const next = action.payload;
+      // QNBS-v3 (CodeAnt): a fresh listening/dictation cycle starts with no confidence — drop any
+      // prior utterance's score at the source so the UI never shows a stale value before a new
+      // result arrives (the transcript-gated display is the second line of defence).
+      if ((next === 'listening' || next === 'dictating') && state.mode !== next) {
+        state.lastConfidence = 0;
+      }
+      state.mode = next;
+      if (next !== 'inactive') {
         state.lastActivityAt = new Date().toISOString();
       }
     },

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,11 +1,11 @@
 # Graph Report - StoryCraft-Studio  (2026-06-23)
 
 ## Corpus Check
-- 1158 files · ~1,304,619 words
+- 1162 files · ~1,304,844 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 5017 nodes · 8809 edges · 90 communities detected
+- 5025 nodes · 8812 edges · 85 communities detected
 - Extraction: 76% EXTRACTED · 24% INFERRED · 0% AMBIGUOUS · INFERRED: 2157 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
@@ -40,41 +40,38 @@
 - [[_COMMUNITY_Community 27|Community 27]]
 - [[_COMMUNITY_Community 28|Community 28]]
 - [[_COMMUNITY_Community 29|Community 29]]
-- [[_COMMUNITY_Community 30|Community 30]]
+- [[_COMMUNITY_Community 32|Community 32]]
 - [[_COMMUNITY_Community 33|Community 33]]
 - [[_COMMUNITY_Community 35|Community 35]]
 - [[_COMMUNITY_Community 37|Community 37]]
 - [[_COMMUNITY_Community 38|Community 38]]
 - [[_COMMUNITY_Community 39|Community 39]]
 - [[_COMMUNITY_Community 42|Community 42]]
-- [[_COMMUNITY_Community 43|Community 43]]
+- [[_COMMUNITY_Community 44|Community 44]]
 - [[_COMMUNITY_Community 45|Community 45]]
-- [[_COMMUNITY_Community 46|Community 46]]
-- [[_COMMUNITY_Community 49|Community 49]]
-- [[_COMMUNITY_Community 50|Community 50]]
-- [[_COMMUNITY_Community 53|Community 53]]
+- [[_COMMUNITY_Community 48|Community 48]]
+- [[_COMMUNITY_Community 51|Community 51]]
 - [[_COMMUNITY_Community 58|Community 58]]
-- [[_COMMUNITY_Community 61|Community 61]]
+- [[_COMMUNITY_Community 60|Community 60]]
+- [[_COMMUNITY_Community 62|Community 62]]
+- [[_COMMUNITY_Community 63|Community 63]]
 - [[_COMMUNITY_Community 64|Community 64]]
-- [[_COMMUNITY_Community 65|Community 65]]
-- [[_COMMUNITY_Community 66|Community 66]]
-- [[_COMMUNITY_Community 67|Community 67]]
-- [[_COMMUNITY_Community 72|Community 72]]
-- [[_COMMUNITY_Community 73|Community 73]]
-- [[_COMMUNITY_Community 78|Community 78]]
-- [[_COMMUNITY_Community 82|Community 82]]
-- [[_COMMUNITY_Community 85|Community 85]]
-- [[_COMMUNITY_Community 88|Community 88]]
-- [[_COMMUNITY_Community 90|Community 90]]
-- [[_COMMUNITY_Community 100|Community 100]]
-- [[_COMMUNITY_Community 101|Community 101]]
-- [[_COMMUNITY_Community 135|Community 135]]
-- [[_COMMUNITY_Community 146|Community 146]]
-- [[_COMMUNITY_Community 152|Community 152]]
-- [[_COMMUNITY_Community 185|Community 185]]
-- [[_COMMUNITY_Community 233|Community 233]]
-- [[_COMMUNITY_Community 273|Community 273]]
-- [[_COMMUNITY_Community 278|Community 278]]
+- [[_COMMUNITY_Community 68|Community 68]]
+- [[_COMMUNITY_Community 70|Community 70]]
+- [[_COMMUNITY_Community 71|Community 71]]
+- [[_COMMUNITY_Community 77|Community 77]]
+- [[_COMMUNITY_Community 83|Community 83]]
+- [[_COMMUNITY_Community 86|Community 86]]
+- [[_COMMUNITY_Community 97|Community 97]]
+- [[_COMMUNITY_Community 131|Community 131]]
+- [[_COMMUNITY_Community 142|Community 142]]
+- [[_COMMUNITY_Community 148|Community 148]]
+- [[_COMMUNITY_Community 181|Community 181]]
+- [[_COMMUNITY_Community 229|Community 229]]
+- [[_COMMUNITY_Community 270|Community 270]]
+- [[_COMMUNITY_Community 275|Community 275]]
+- [[_COMMUNITY_Community 746|Community 746]]
+- [[_COMMUNITY_Community 747|Community 747]]
 - [[_COMMUNITY_Community 748|Community 748]]
 - [[_COMMUNITY_Community 749|Community 749]]
 - [[_COMMUNITY_Community 750|Community 750]]
@@ -98,8 +95,6 @@
 - [[_COMMUNITY_Community 768|Community 768]]
 - [[_COMMUNITY_Community 769|Community 769]]
 - [[_COMMUNITY_Community 770|Community 770]]
-- [[_COMMUNITY_Community 771|Community 771]]
-- [[_COMMUNITY_Community 772|Community 772]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `mt()` - 104 edges
@@ -116,140 +111,140 @@
 ## Surprising Connections (you probably didn't know these)
 - `useTranslation()` --calls--> `IdbUnlockModal()`  [INFERRED]
   hooks/useTranslation.ts → components/settings/IdbUnlockModal.tsx
+- `getItem()` --calls--> `isLoggerEnabled()`  [INFERRED]
+  features/featureFlags/featureFlagsStorage.ts → app/store.ts
 - `getItem()` --calls--> `readMode()`  [INFERRED]
   features/featureFlags/featureFlagsStorage.ts → components/copilot/CopilotPanel.tsx
 - `setItem()` --calls--> `writeMode()`  [INFERRED]
   features/featureFlags/featureFlagsStorage.ts → components/copilot/CopilotPanel.tsx
-- `removeItem()` --calls--> `clearBenchmarkResults()`  [INFERRED]
-  features/featureFlags/featureFlagsStorage.ts → services/ai/benchmarkService.ts
-- `Ja()` --calls--> `matches()`  [INFERRED]
-  e2e-deep-report/trace/assets/codeMirrorModule-Ds_H_9Yq.js → tests/unit/ai/localModelStorageService.test.ts
+- `setItem()` --calls--> `enableDebugLogging()`  [INFERRED]
+  features/featureFlags/featureFlagsStorage.ts → services/logger.ts
 
 ## Communities
 
 ### Community 0 - "Community 0"
 Cohesion: 0.01
-Nodes (337): mt(), _0, _2(), A0, a2(), aA(), ab(), ac() (+329 more)
+Nodes (323): flushMicrotasks(), _0, _2(), A0, a2(), aA(), ac(), ad() (+315 more)
 
 ### Community 1 - "Community 1"
 Cohesion: 0.01
-Nodes (166): af(), ef(), ff(), Ja(), lf(), nf(), of(), po() (+158 more)
+Nodes (174): af(), ef(), ff(), Ja(), lf(), mt(), nf(), of() (+166 more)
 
 ### Community 2 - "Community 2"
 Cohesion: 0.01
-Nodes (134): applyTextEdit(), _clearLatencyHistory(), recordLatency(), AiInferenceCacheService, hashKey(), assertCloudAiAllowed(), assertCloudAiAllowedSync(), assertLoraLocalOnly() (+126 more)
+Nodes (135): recordLatency(), AiInferenceCacheService, hashKey(), _cleanupPendingRequest(), _clearPendingRequestsForTest(), _deduplicateRequest(), collectSubtreeIds(), buildConsistencyHints() (+127 more)
 
 ### Community 3 - "Community 3"
 Cohesion: 0.01
-Nodes (87): handleCopyForNotion(), handleDocxImport(), handleExport(), handlePasteImport(), loadAgent(), analyticsPersistenceAllowedNow(), isAnalyticsPersistenceAllowed(), binderDepth() (+79 more)
+Nodes (92): accessibilityPresetDefaults(), normalizeAccessibilitySettings(), applyPreset(), loadAgent(), analyticsPersistenceAllowedNow(), isAnalyticsPersistenceAllowed(), handleRemoveKey(), handleSaveKey() (+84 more)
 
 ### Community 4 - "Community 4"
-Cohesion: 0.02
-Nodes (77): accessibilityPresetDefaults(), normalizeAccessibilitySettings(), applyPreset(), CloudSyncBackend, decryptCloudPayload(), deriveCloudSyncKey(), encryptCloudPayload(), deleteIdb() (+69 more)
+Cohesion: 0.01
+Nodes (78): handleCopyForNotion(), handleDocxImport(), handleExport(), handlePasteImport(), binderDepth(), handleAddFolder(), handleAddLink(), handleAddNote() (+70 more)
 
 ### Community 5 - "Community 5"
 Cohesion: 0.02
-Nodes (60): isEcoMode(), n2(), generateMessageId(), getWorker(), send(), EcoModeService, FeedbackService, handleEcoToggle() (+52 more)
+Nodes (32): hasMigrationMarker(), legacyDatabaseListed(), migrateLegacyWorldscriptDbIfNeeded(), openLegacyDatabase(), promisifyRequest(), readAllFromStore(), setMigrationMarker(), stateDbHasProjectOrSettings() (+24 more)
 
 ### Community 6 - "Community 6"
 Cohesion: 0.02
-Nodes (75): FsAssetStore, glossaryTranslate(), loadCheckpoint(), loadGlossary(), main(), maskPlaceholders(), parseArgs(), restorePlaceholders() (+67 more)
+Nodes (59): pipeline(), pipeline(), isEcoMode(), applyPreset(), async(), close(), isSidebar(), onKey() (+51 more)
 
 ### Community 7 - "Community 7"
-Cohesion: 0.03
-Nodes (18): a_(), bh, Dh(), eA(), el(), GE(), Gh(), lv() (+10 more)
+Cohesion: 0.02
+Nodes (68): FsAssetStore, glossaryTranslate(), loadCheckpoint(), loadGlossary(), main(), maskPlaceholders(), parseArgs(), restorePlaceholders() (+60 more)
 
 ### Community 8 - "Community 8"
-Cohesion: 0.02
-Nodes (91): handleBuildLocalRag(), handleWebllmDownload(), isCustomOllamaModel(), countWords(), enrichProjectIndex(), extractCharacterNames(), getDb(), indexProject() (+83 more)
+Cohesion: 0.03
+Nodes (80): getActiveAiMode(), getLocalFallbackModel(), getOpenRouterFallbackProvider(), getOpenRouterModel(), isCloudOnlyMode(), isOffline(), notifyLocalModelsReady(), shouldRouteLocally() (+72 more)
 
 ### Community 9 - "Community 9"
 Cohesion: 0.02
-Nodes (66): makeContext(), makeContext(), renderSheet(), makeDeps(), renderPanel(), makeStoreState(), createFakeAdapter(), createFakeDevice() (+58 more)
+Nodes (61): getFocusable(), onKeyDown(), onPointerUp(), handler(), decrypt(), decryptJson(), encrypt(), encryptJson() (+53 more)
 
 ### Community 10 - "Community 10"
-Cohesion: 0.02
-Nodes (65): AnalyticsBootstrap(), App(), ViewLoader(), BookPreviewView(), useCommandExecutor(), CopilotLauncher(), Header(), useAppDispatch() (+57 more)
+Cohesion: 0.01
+Nodes (67): makeContext(), makeContext(), renderSheet(), makeDeps(), renderPanel(), makeStoreState(), createFakeAdapter(), createFakeDevice() (+59 more)
 
 ### Community 11 - "Community 11"
-Cohesion: 0.02
-Nodes (68): item(), getLocalUser(), getRandomColor(), handleKeyDown(), sanitizeRoomInput(), stripControlChars(), loadFeatureFlagsState(), saveFeatureFlagsState() (+60 more)
+Cohesion: 0.03
+Nodes (77): handleBuildLocalRag(), handleWebllmDownload(), isCustomOllamaModel(), countWords(), enrichProjectIndex(), extractCharacterNames(), getDb(), indexProject() (+69 more)
 
 ### Community 12 - "Community 12"
-Cohesion: 0.03
-Nodes (70): getActiveAiMode(), getLocalFallbackModel(), getOpenRouterFallbackProvider(), getOpenRouterModel(), isCloudOnlyMode(), isOffline(), notifyLocalModelsReady(), shouldRouteLocally() (+62 more)
+Cohesion: 0.02
+Nodes (63): AnalyticsBootstrap(), App(), ViewLoader(), BookPreviewView(), useCommandExecutor(), CopilotLauncher(), Header(), useAppDispatch() (+55 more)
 
 ### Community 13 - "Community 13"
-Cohesion: 0.03
-Nodes (54): AdaptiveAiEngine, estimateLatency(), getTaskConfig(), selectModelForBackend(), start(), clearBenchmarkResults(), getLastBenchmarkResults(), loadResults() (+46 more)
+Cohesion: 0.02
+Nodes (76): AiModeIndicator(), item(), getLocalUser(), getRandomColor(), handleKeyDown(), sanitizeRoomInput(), stripControlChars(), deleteIdb() (+68 more)
 
 ### Community 14 - "Community 14"
 Cohesion: 0.03
-Nodes (78): AiModeIndicator(), generateTextSingleProvider(), isAbortError(), _pendingKey(), streamAiHelpResponse(), streamAnthropic(), streamGrok(), streamOpenAI() (+70 more)
+Nodes (44): assertNoSeriousViolations(), navigateToCollaborationSettings(), md(), connectSrcTokens(), group1(), tauriCsp(), webCsp(), ab() (+36 more)
 
 ### Community 15 - "Community 15"
 Cohesion: 0.03
-Nodes (40): CollabEncryptionRequiredError, CollaborationService, resolveWebRtcSignalingUrls(), MockDoc, MockWebrtcProvider, createAttentionPipeline(), createComputePipeline(), createKvCachePipeline() (+32 more)
+Nodes (57): AdaptiveAiEngine, _clearLatencyHistory(), estimateLatency(), getTaskConfig(), selectModelForBackend(), start(), clearBenchmarkResults(), getLastBenchmarkResults() (+49 more)
 
 ### Community 16 - "Community 16"
-Cohesion: 0.04
-Nodes (38): AudioNavigator, getFocusable(), onKeyDown(), onPointerUp(), buildEncodedPayload(), makeCommands(), makeProjectData(), makeContext() (+30 more)
+Cohesion: 0.03
+Nodes (41): AudioNavigator, buildEncodedPayload(), makeCommands(), makeProjectData(), Hb(), makeContext(), makeLargeContext(), makeSection() (+33 more)
 
 ### Community 17 - "Community 17"
-Cohesion: 0.08
-Nodes (11): bb(), cc, d_, f_, Gb(), h_, r0(), u_ (+3 more)
+Cohesion: 0.04
+Nodes (37): applyTextEdit(), applyReviewEditsToSection(), containsDisallowedControlChar(), isValidRange(), nearestFreeOccurrence(), planAcceptedManuscriptEdits(), validateProposedText(), mockT() (+29 more)
 
 ### Community 18 - "Community 18"
-Cohesion: 0.04
-Nodes (31): pipeline(), pipeline(), applyPreset(), async(), close(), isSidebar(), onKey(), onPointerDown() (+23 more)
+Cohesion: 0.05
+Nodes (22): CollabEncryptionRequiredError, CollaborationService, resolveWebRtcSignalingUrls(), MockDoc, MockWebrtcProvider, createAttentionPipeline(), createComputePipeline(), createKvCachePipeline() (+14 more)
 
 ### Community 19 - "Community 19"
 Cohesion: 0.07
 Nodes (5): createCancellationToken(), PriorityTaskQueue, WorkerBus, shutdownWorkerBus(), WorkerPool
 
 ### Community 20 - "Community 20"
-Cohesion: 0.06
-Nodes (33): collect(), buildPaletteCommandModels(), collectAllDefinitions(), resolveTitle(), runCommandById(), id, install_app_menu(), run() (+25 more)
+Cohesion: 0.07
+Nodes (29): check(), extractCatalogFlags(), extractHiddenFlags(), extractSectionFlags(), green(), grep(), hasRuntimeConsumption(), read() (+21 more)
 
 ### Community 21 - "Community 21"
 Cohesion: 0.07
-Nodes (12): k2, installDesktopMenu(), installCloseToTray(), installDesktopTray(), registerTauriMenuHandler(), applyDesktopRuntimeFlags(), getDesktopOs(), getTauriAppVersion() (+4 more)
-
-### Community 22 - "Community 22"
-Cohesion: 0.06
 Nodes (13): createBrowserProForgeCapability(), buildPorts(), runCopilotDiagnostic(), buildNormManuscriptExport(), paginateNormLines(), stripLightMarkdown(), wrapParagraphToLines(), wrapPlainTextToNormLines() (+5 more)
 
-### Community 23 - "Community 23"
-Cohesion: 0.07
-Nodes (21): assertNoSeriousViolations(), navigateToCollaborationSettings(), connectSrcTokens(), group1(), tauriCsp(), webCsp(), clickNavItem(), ensureBlankProject() (+13 more)
+### Community 22 - "Community 22"
+Cohesion: 0.08
+Nodes (27): collect(), install_app_menu(), run(), abort_lora_training(), check_lora_environment(), LoraEnvReport, LoraTrainPayload, merge_lora() (+19 more)
 
-### Community 24 - "Community 24"
-Cohesion: 0.11
+### Community 23 - "Community 23"
+Cohesion: 0.1
 Nodes (1): StorageManager
 
-### Community 25 - "Community 25"
-Cohesion: 0.07
-Nodes (16): smallProject(), buildCharacter(), buildLargeManuscript(), buildParagraph(), buildSectionContent(), buildWorld(), countWords(), makeRng() (+8 more)
-
-### Community 26 - "Community 26"
+### Community 24 - "Community 24"
 Cohesion: 0.23
 Nodes (3): LS, xn(), aa
 
-### Community 27 - "Community 27"
+### Community 25 - "Community 25"
+Cohesion: 0.1
+Nodes (11): handleEvaluate(), ScoreGauge(), comparePromptOutputs(), computeStyleConsistencyScore(), cosineSimilarity(), getEmbeddingService(), meanSimilarity(), scoreLabel() (+3 more)
+
+### Community 26 - "Community 26"
 Cohesion: 0.14
 Nodes (21): handleToggle(), handleDelete(), handleFileChange(), activateAdapter(), clearDatasetEntries(), deactivateAdapter(), deleteAdapter(), exportAdapter() (+13 more)
 
-### Community 28 - "Community 28"
-Cohesion: 0.19
-Nodes (7): fr(), Go(), jS(), Xd, getProjectIdFromPath(), initTauriDeepLink(), isWorldScriptProjectFile()
-
-### Community 29 - "Community 29"
+### Community 27 - "Community 27"
 Cohesion: 0.14
 Nodes (15): normalize(), buildExcerpt(), extractCharacters(), extractManuscriptSections(), searchAcrossProjectIndex(), searchAcrossProjects(), normalizeSearch(), scoreAgainstQuery() (+7 more)
 
-### Community 30 - "Community 30"
+### Community 28 - "Community 28"
+Cohesion: 0.35
+Nodes (2): cc, Gb()
+
+### Community 29 - "Community 29"
 Cohesion: 0.2
 Nodes (14): categoryFromMessage(), categoryFromStatus(), classificationFor(), classifyAiError(), extractStatus(), getAiErrorMessage(), isOffline(), clampRetryAfter() (+6 more)
+
+### Community 32 - "Community 32"
+Cohesion: 0.42
+Nodes (6): emit(), main(), merge(), ProgressCallback, Emits JSON progress events on each training log step., train()
 
 ### Community 33 - "Community 33"
 Cohesion: 0.25
@@ -272,330 +267,302 @@ Cohesion: 0.7
 Nodes (4): check_cuda_and_vram(), check_package(), check_python_version(), main()
 
 ### Community 42 - "Community 42"
-Cohesion: 0.4
-Nodes (1): O0
-
-### Community 43 - "Community 43"
 Cohesion: 0.5
 Nodes (3): createStorageMock(), setupStorage(), SpeechSynthesisUtteranceMock
+
+### Community 44 - "Community 44"
+Cohesion: 0.4
+Nodes (4): Room, SignalingConn, WebrtcConn, WebrtcProvider
 
 ### Community 45 - "Community 45"
 Cohesion: 0.4
 Nodes (2): useDashboardContext(), DashboardHeader()
 
-### Community 46 - "Community 46"
-Cohesion: 0.4
-Nodes (4): Room, SignalingConn, WebrtcConn, WebrtcProvider
-
-### Community 49 - "Community 49"
+### Community 48 - "Community 48"
 Cohesion: 0.6
 Nodes (4): applyFormula(), computeReadabilitySnapshot(), estimateSyllables(), getSyllablePattern()
 
-### Community 50 - "Community 50"
-Cohesion: 0.5
-Nodes (1): rc
-
-### Community 53 - "Community 53"
+### Community 51 - "Community 51"
 Cohesion: 0.67
 Nodes (2): makeConfig(), startPipelinePayload()
 
 ### Community 58 - "Community 58"
 Cohesion: 0.67
-Nodes (2): make(), noop()
-
-### Community 61 - "Community 61"
-Cohesion: 0.67
 Nodes (2): defaultProject(), setProjectData()
 
-### Community 64 - "Community 64"
+### Community 60 - "Community 60"
+Cohesion: 0.67
+Nodes (2): make(), noop()
+
+### Community 62 - "Community 62"
 Cohesion: 0.83
 Nodes (3): makeChars(), makeProject(), makeWorlds()
 
-### Community 65 - "Community 65"
+### Community 63 - "Community 63"
 Cohesion: 0.83
 Nodes (3): emptyChars(), emptyWorlds(), makeProject()
 
-### Community 66 - "Community 66"
-Cohesion: 0.5
-Nodes (2): ManuscriptDesktopLayout(), useManuscriptViewContext()
-
-### Community 67 - "Community 67"
+### Community 64 - "Community 64"
 Cohesion: 0.5
 Nodes (3): AsyncDuckDB, AsyncDuckDBConnection, ConsoleLogger
 
-### Community 72 - "Community 72"
+### Community 68 - "Community 68"
+Cohesion: 0.5
+Nodes (2): ManuscriptDesktopLayout(), useManuscriptViewContext()
+
+### Community 70 - "Community 70"
 Cohesion: 0.67
 Nodes (2): getQuestionsForArchetype(), getTemplateForArchetype()
 
-### Community 73 - "Community 73"
+### Community 71 - "Community 71"
 Cohesion: 0.83
 Nodes (3): esc(), inline(), renderExportMarkdownToHtml()
 
-### Community 78 - "Community 78"
+### Community 77 - "Community 77"
 Cohesion: 0.67
 Nodes (1): makeSection()
 
-### Community 82 - "Community 82"
-Cohesion: 0.67
-Nodes (1): flushMicrotasks()
-
-### Community 85 - "Community 85"
+### Community 83 - "Community 83"
 Cohesion: 0.67
 Nodes (1): MockGoogleGenAI
 
-### Community 88 - "Community 88"
+### Community 86 - "Community 86"
 Cohesion: 0.67
 Nodes (1): makeDeps()
 
-### Community 90 - "Community 90"
-Cohesion: 1.0
-Nodes (2): fireSwipe(), makePointerEvent()
-
-### Community 100 - "Community 100"
-Cohesion: 0.67
-Nodes (1): md()
-
-### Community 101 - "Community 101"
+### Community 97 - "Community 97"
 Cohesion: 0.67
 Nodes (1): TaskError
 
-### Community 135 - "Community 135"
+### Community 131 - "Community 131"
 Cohesion: 1.0
 Nodes (1): MockIntersectionObserver
 
-### Community 146 - "Community 146"
+### Community 142 - "Community 142"
 Cohesion: 1.0
 Nodes (1): MockWorker
 
-### Community 152 - "Community 152"
+### Community 148 - "Community 148"
 Cohesion: 1.0
 Nodes (1): MockBroadcastChannel
 
-### Community 185 - "Community 185"
+### Community 181 - "Community 181"
 Cohesion: 1.0
 Nodes (1): MockIntersectionObserver
 
-### Community 233 - "Community 233"
+### Community 229 - "Community 229"
 Cohesion: 1.0
 Nodes (1): MockWorker
 
-### Community 273 - "Community 273"
+### Community 270 - "Community 270"
 Cohesion: 1.0
 Nodes (1): FileSystemService
 
-### Community 278 - "Community 278"
+### Community 275 - "Community 275"
 Cohesion: 1.0
 Nodes (1): IndexedDBService
 
-### Community 748 - "Community 748"
+### Community 746 - "Community 746"
 Cohesion: 1.0
 Nodes (1): Remove ANSI escape codes from text.
 
-### Community 749 - "Community 749"
+### Community 747 - "Community 747"
 Cohesion: 1.0
 Nodes (1): Remove timestamp strings from text.
 
-### Community 750 - "Community 750"
+### Community 748 - "Community 748"
 Cohesion: 1.0
 Nodes (1): Replace long base64 strings with placeholder.
 
-### Community 751 - "Community 751"
+### Community 749 - "Community 749"
 Cohesion: 1.0
 Nodes (1): Remove NPM/pnpm warning lines.
 
-### Community 752 - "Community 752"
+### Community 750 - "Community 750"
 Cohesion: 1.0
 Nodes (1): Remove redundant success messages.
 
-### Community 753 - "Community 753"
+### Community 751 - "Community 751"
 Cohesion: 1.0
 Nodes (1): Apply all preprocessing steps to reduce token payload.
 
-### Community 754 - "Community 754"
+### Community 752 - "Community 752"
 Cohesion: 1.0
 Nodes (1): Extract only error-related sections from log.
 
-### Community 755 - "Community 755"
+### Community 753 - "Community 753"
 Cohesion: 1.0
 Nodes (1): Pydantic models for CI Analyzer structured output. QNBS-v3: These models enforce
 
-### Community 756 - "Community 756"
+### Community 754 - "Community 754"
 Cohesion: 1.0
 Nodes (1): Structured CI error for VS Code problem matcher integration.
 
-### Community 757 - "Community 757"
+### Community 755 - "Community 755"
 Cohesion: 1.0
 Nodes (1): Vitest JSON test result structure.
 
-### Community 758 - "Community 758"
+### Community 756 - "Community 756"
 Cohesion: 1.0
 Nodes (1): Full Vitest JSON report structure.
 
-### Community 759 - "Community 759"
+### Community 757 - "Community 757"
 Cohesion: 1.0
 Nodes (1): Stryker per-file mutation report.
 
-### Community 760 - "Community 760"
+### Community 758 - "Community 758"
 Cohesion: 1.0
 Nodes (1): Full Stryker JSON report structure.
 
-### Community 761 - "Community 761"
+### Community 759 - "Community 759"
 Cohesion: 1.0
 Nodes (1): Initialize OpenRouter client for Poolside Laguna model.
 
-### Community 762 - "Community 762"
+### Community 760 - "Community 760"
 Cohesion: 1.0
 Nodes (1): Analyze Vitest JSON report and raw logs for errors.
 
-### Community 763 - "Community 763"
+### Community 761 - "Community 761"
 Cohesion: 1.0
 Nodes (1): Analyze Stryker JSON report for surviving mutants.
 
-### Community 764 - "Community 764"
+### Community 762 - "Community 762"
 Cohesion: 1.0
 Nodes (1): Send preprocessed errors to LLM for analysis.
 
-### Community 765 - "Community 765"
+### Community 763 - "Community 763"
 Cohesion: 1.0
 Nodes (1): Format errors for VS Code problem matcher.
 
-### Community 766 - "Community 766"
+### Community 764 - "Community 764"
 Cohesion: 1.0
 Nodes (1): Main entry point for CI analyzer.
 
-### Community 767 - "Community 767"
+### Community 765 - "Community 765"
 Cohesion: 1.0
 Nodes (1): Execute gh CLI command and return parsed JSON output.
 
-### Community 768 - "Community 768"
+### Community 766 - "Community 766"
 Cohesion: 1.0
 Nodes (1): Get the ID of the most recent failed CI run.
 
-### Community 769 - "Community 769"
+### Community 767 - "Community 767"
 Cohesion: 1.0
 Nodes (1): Download a specific artifact from a workflow run.
 
-### Community 770 - "Community 770"
+### Community 768 - "Community 768"
 Cohesion: 1.0
 Nodes (1): Get raw logs from a failed workflow run.
 
-### Community 771 - "Community 771"
+### Community 769 - "Community 769"
 Cohesion: 1.0
 Nodes (1): Parse Vitest JSON report for failing tests.
 
-### Community 772 - "Community 772"
+### Community 770 - "Community 770"
 Cohesion: 1.0
 Nodes (1): Parse Stryker JSON report for surviving mutants.
 
 ## Knowledge Gaps
 - **53 isolated node(s):** `Emits JSON progress events on each training log step.`, `qb`, `v2`, `MockIntersectionObserver`, `MockWorker` (+48 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 24`** (36 nodes): `storageService.ts`, `StorageManager`, `.clearApiKey()`, `.clearGeminiApiKey()`, `.constructor()`, `.deleteAllBinderAssetsForProject()`, `.deleteBinderAsset()`, `.deleteImage()`, `.deleteProject()`, `.deleteRagVectors()`, `.deleteSnapshot()`, `.deleteStoryCodex()`, `.getApiKey()`, `.getBackend()`, `.getBinderAsset()`, `.getGeminiApiKey()`, `.getImage()`, `.getRagVectors()`, `.getSnapshotData()`, `.getStoryCodex()`, `.hasSavedData()`, `.initializeBackend()`, `.listBinderAssetIds()`, `.listProjects()`, `.listSnapshots()`, `.loadProject()`, `.loadSettings()`, `.saveApiKey()`, `.saveBinderAsset()`, `.saveGeminiApiKey()`, `.saveImage()`, `.saveProject()`, `.saveRagVectors()`, `.saveSettings()`, `.saveSnapshot()`, `.saveStoryCodex()`
+- **Thin community `Community 23`** (37 nodes): `.initialize()`, `storageService.ts`, `StorageManager`, `.clearApiKey()`, `.clearGeminiApiKey()`, `.constructor()`, `.deleteAllBinderAssetsForProject()`, `.deleteBinderAsset()`, `.deleteImage()`, `.deleteProject()`, `.deleteRagVectors()`, `.deleteSnapshot()`, `.deleteStoryCodex()`, `.getApiKey()`, `.getBackend()`, `.getBinderAsset()`, `.getGeminiApiKey()`, `.getImage()`, `.getRagVectors()`, `.getSnapshotData()`, `.getStoryCodex()`, `.hasSavedData()`, `.initializeBackend()`, `.listBinderAssetIds()`, `.listProjects()`, `.listSnapshots()`, `.loadProject()`, `.loadSettings()`, `.saveApiKey()`, `.saveBinderAsset()`, `.saveGeminiApiKey()`, `.saveImage()`, `.saveProject()`, `.saveRagVectors()`, `.saveSettings()`, `.saveSnapshot()`, `.saveStoryCodex()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 42`** (5 nodes): `O0`, `.constructor()`, `.toJSON()`, `.toSource()`, `.toString()`
+- **Thin community `Community 28`** (17 nodes): `cc`, `._applyAttribute()`, `._assert()`, `.constructor()`, `._eof()`, `._isWhitespace()`, `._next()`, `.parse()`, `._peek()`, `._readAttributes()`, `._readIdentifier()`, `._readRegex()`, `._readString()`, `._readStringOrRegex()`, `._skipWhitespace()`, `._throwError()`, `Gb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 45`** (5 nodes): `DashboardHeader.tsx`, `DashboardContext.ts`, `useDashboardContext()`, `Chip()`, `DashboardHeader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 50`** (4 nodes): `rc`, `.constructor()`, `.toSource()`, `.toString()`
+- **Thin community `Community 51`** (4 nodes): `makeConfig()`, `makeReviewItem()`, `startPipelinePayload()`, `proForgeSlice.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 53`** (4 nodes): `makeConfig()`, `makeReviewItem()`, `startPipelinePayload()`, `proForgeSlice.test.ts`
+- **Thin community `Community 58`** (4 nodes): `useDashboard.test.ts`, `defaultProject()`, `defaultSection()`, `setProjectData()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 58`** (4 nodes): `make()`, `noop()`, `aiRetry.test.ts`, `aiRetry.test.ts`
+- **Thin community `Community 60`** (4 nodes): `make()`, `noop()`, `aiRetry.test.ts`, `aiRetry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 61`** (4 nodes): `useDashboard.test.ts`, `defaultProject()`, `defaultSection()`, `setProjectData()`
+- **Thin community `Community 68`** (4 nodes): `ManuscriptDesktopLayout.tsx`, `ManuscriptViewContext.ts`, `ManuscriptDesktopLayout()`, `useManuscriptViewContext()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 66`** (4 nodes): `ManuscriptDesktopLayout.tsx`, `ManuscriptViewContext.ts`, `ManuscriptDesktopLayout()`, `useManuscriptViewContext()`
+- **Thin community `Community 70`** (4 nodes): `getAllTemplates()`, `getQuestionsForArchetype()`, `getTemplateForArchetype()`, `characterInterviewTemplates.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 72`** (4 nodes): `getAllTemplates()`, `getQuestionsForArchetype()`, `getTemplateForArchetype()`, `characterInterviewTemplates.ts`
+- **Thin community `Community 77`** (3 nodes): `makeSection()`, `plotBoardService.test.ts`, `plotBoardService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 78`** (3 nodes): `makeSection()`, `plotBoardService.test.ts`, `plotBoardService.test.ts`
+- **Thin community `Community 83`** (3 nodes): `makeStream()`, `MockGoogleGenAI`, `geminiService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 82`** (3 nodes): `flushMicrotasks()`, `makeProjectData()`, `crossProjectIndexService.test.ts`
+- **Thin community `Community 86`** (3 nodes): `makeDeps()`, `aiSuggestions.test.ts`, `aiSuggestions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 85`** (3 nodes): `makeStream()`, `MockGoogleGenAI`, `geminiService.test.ts`
+- **Thin community `Community 97`** (3 nodes): `types.ts`, `TaskError`, `.constructor()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 88`** (3 nodes): `makeDeps()`, `aiSuggestions.test.ts`, `aiSuggestions.test.ts`
+- **Thin community `Community 131`** (2 nodes): `MockIntersectionObserver`, `BookPreviewView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 90`** (3 nodes): `useSwipeGesture.test.ts`, `fireSwipe()`, `makePointerEvent()`
+- **Thin community `Community 142`** (2 nodes): `MockWorker`, `duckdbClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 100`** (3 nodes): `md()`, `msg()`, `CopilotMessageList.test.tsx`
+- **Thin community `Community 148`** (2 nodes): `MockBroadcastChannel`, `tabLeaderElection.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 101`** (3 nodes): `types.ts`, `TaskError`, `.constructor()`
+- **Thin community `Community 181`** (2 nodes): `useBookPreviewView.test.ts`, `MockIntersectionObserver`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 135`** (2 nodes): `MockIntersectionObserver`, `BookPreviewView.test.tsx`
+- **Thin community `Community 229`** (2 nodes): `workerPool.test.ts`, `MockWorker`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 146`** (2 nodes): `MockWorker`, `duckdbClient.test.ts`
+- **Thin community `Community 270`** (2 nodes): `FileSystemService`, `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 152`** (2 nodes): `MockBroadcastChannel`, `tabLeaderElection.test.ts`
+- **Thin community `Community 275`** (2 nodes): `IndexedDBService`, `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 185`** (2 nodes): `useBookPreviewView.test.ts`, `MockIntersectionObserver`
+- **Thin community `Community 746`** (1 nodes): `Remove ANSI escape codes from text.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 233`** (2 nodes): `workerPool.test.ts`, `MockWorker`
+- **Thin community `Community 747`** (1 nodes): `Remove timestamp strings from text.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 273`** (2 nodes): `FileSystemService`, `index.ts`
+- **Thin community `Community 748`** (1 nodes): `Replace long base64 strings with placeholder.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 278`** (2 nodes): `IndexedDBService`, `index.ts`
+- **Thin community `Community 749`** (1 nodes): `Remove NPM/pnpm warning lines.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 748`** (1 nodes): `Remove ANSI escape codes from text.`
+- **Thin community `Community 750`** (1 nodes): `Remove redundant success messages.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (1 nodes): `Remove timestamp strings from text.`
+- **Thin community `Community 751`** (1 nodes): `Apply all preprocessing steps to reduce token payload.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (1 nodes): `Replace long base64 strings with placeholder.`
+- **Thin community `Community 752`** (1 nodes): `Extract only error-related sections from log.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (1 nodes): `Remove NPM/pnpm warning lines.`
+- **Thin community `Community 753`** (1 nodes): `Pydantic models for CI Analyzer structured output. QNBS-v3: These models enforce`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (1 nodes): `Remove redundant success messages.`
+- **Thin community `Community 754`** (1 nodes): `Structured CI error for VS Code problem matcher integration.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (1 nodes): `Apply all preprocessing steps to reduce token payload.`
+- **Thin community `Community 755`** (1 nodes): `Vitest JSON test result structure.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (1 nodes): `Extract only error-related sections from log.`
+- **Thin community `Community 756`** (1 nodes): `Full Vitest JSON report structure.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (1 nodes): `Pydantic models for CI Analyzer structured output. QNBS-v3: These models enforce`
+- **Thin community `Community 757`** (1 nodes): `Stryker per-file mutation report.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (1 nodes): `Structured CI error for VS Code problem matcher integration.`
+- **Thin community `Community 758`** (1 nodes): `Full Stryker JSON report structure.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (1 nodes): `Vitest JSON test result structure.`
+- **Thin community `Community 759`** (1 nodes): `Initialize OpenRouter client for Poolside Laguna model.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (1 nodes): `Full Vitest JSON report structure.`
+- **Thin community `Community 760`** (1 nodes): `Analyze Vitest JSON report and raw logs for errors.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (1 nodes): `Stryker per-file mutation report.`
+- **Thin community `Community 761`** (1 nodes): `Analyze Stryker JSON report for surviving mutants.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (1 nodes): `Full Stryker JSON report structure.`
+- **Thin community `Community 762`** (1 nodes): `Send preprocessed errors to LLM for analysis.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (1 nodes): `Initialize OpenRouter client for Poolside Laguna model.`
+- **Thin community `Community 763`** (1 nodes): `Format errors for VS Code problem matcher.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (1 nodes): `Analyze Vitest JSON report and raw logs for errors.`
+- **Thin community `Community 764`** (1 nodes): `Main entry point for CI analyzer.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (1 nodes): `Analyze Stryker JSON report for surviving mutants.`
+- **Thin community `Community 765`** (1 nodes): `Execute gh CLI command and return parsed JSON output.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (1 nodes): `Send preprocessed errors to LLM for analysis.`
+- **Thin community `Community 766`** (1 nodes): `Get the ID of the most recent failed CI run.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (1 nodes): `Format errors for VS Code problem matcher.`
+- **Thin community `Community 767`** (1 nodes): `Download a specific artifact from a workflow run.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (1 nodes): `Main entry point for CI analyzer.`
+- **Thin community `Community 768`** (1 nodes): `Get raw logs from a failed workflow run.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (1 nodes): `Execute gh CLI command and return parsed JSON output.`
+- **Thin community `Community 769`** (1 nodes): `Parse Vitest JSON report for failing tests.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (1 nodes): `Get the ID of the most recent failed CI run.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (1 nodes): `Download a specific artifact from a workflow run.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (1 nodes): `Get raw logs from a failed workflow run.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (1 nodes): `Parse Vitest JSON report for failing tests.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (1 nodes): `Parse Stryker JSON report for surviving mutants.`
+- **Thin community `Community 770`** (1 nodes): `Parse Stryker JSON report for surviving mutants.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `mt()` connect `Community 0` to `Community 1`, `Community 2`, `Community 3`, `Community 5`, `Community 7`, `Community 12`, `Community 13`, `Community 16`, `Community 18`, `Community 22`, `Community 26`, `Community 28`?**
-  _High betweenness centrality (0.075) - this node is a cross-community bridge._
-- **Why does `t()` connect `Community 3` to `Community 0`, `Community 1`, `Community 2`, `Community 4`, `Community 8`, `Community 10`, `Community 12`, `Community 13`, `Community 14`, `Community 18`, `Community 20`, `Community 21`, `Community 27`, `Community 30`?**
-  _High betweenness centrality (0.071) - this node is a cross-community bridge._
-- **Why does `wx()` connect `Community 0` to `Community 1`, `Community 3`, `Community 5`, `Community 6`, `Community 15`, `Community 20`?**
-  _High betweenness centrality (0.048) - this node is a cross-community bridge._
+- **Why does `mt()` connect `Community 1` to `Community 0`, `Community 2`, `Community 4`, `Community 5`, `Community 6`, `Community 8`, `Community 9`, `Community 14`, `Community 15`, `Community 16`, `Community 17`, `Community 21`, `Community 24`?**
+  _High betweenness centrality (0.079) - this node is a cross-community bridge._
+- **Why does `t()` connect `Community 4` to `Community 0`, `Community 1`, `Community 2`, `Community 3`, `Community 6`, `Community 9`, `Community 11`, `Community 12`, `Community 13`, `Community 15`, `Community 26`, `Community 29`?**
+  _High betweenness centrality (0.047) - this node is a cross-community bridge._
+- **Why does `wx()` connect `Community 0` to `Community 1`, `Community 4`, `Community 5`, `Community 6`, `Community 7`, `Community 9`, `Community 14`?**
+  _High betweenness centrality (0.035) - this node is a cross-community bridge._
 - **Are the 87 inferred relationships involving `mt()` (e.g. with `pE()` and `xE()`) actually correct?**
   _`mt()` has 87 INFERRED edges - model-reasoned connections that need verification._
 - **Are the 62 inferred relationships involving `fn()` (e.g. with `makeMediaQuery()` and `MockSpeechRecognition()`) actually correct?**

--- a/hooks/useMicLevel.ts
+++ b/hooks/useMicLevel.ts
@@ -1,45 +1,61 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { logger } from '../services/logger';
 
-// QNBS-v3: PR5 — a self-contained microphone level meter for voice feedback. While `active`, it opens
-// its own getUserMedia stream + AnalyserNode and reports a smoothed 0–1 RMS level via rAF. This works
-// regardless of the STT engine (Web Speech, Whisper, …) because it taps the mic directly rather than
-// relying on the VAD path, which only exists in the WASM/Whisper mode. Feature-detected: returns 0 and
-// does nothing where Web Audio / getUserMedia are unavailable (incl. jsdom). Never records or logs audio.
+// QNBS-v3: PR5 — a self-contained microphone level meter for voice feedback. While any consumer is
+// `active`, ONE shared getUserMedia stream + AnalyserNode is opened and the smoothed 0–1 RMS level is
+// broadcast to every consumer. Sharing (ref-counted) is essential: VoiceIndicator and
+// VoiceControlPanel both meter and are mounted together, so a per-hook stream would open the mic
+// twice. Taps the mic directly (works for any STT engine). Feature-detected — no-ops to 0 where Web
+// Audio / getUserMedia are unavailable (incl. jsdom). Never records or logs audio.
 
-type AudioContextCtor = typeof AudioContext;
+interface WindowWithAudio extends Window {
+  AudioContext?: typeof AudioContext;
+  webkitAudioContext?: typeof AudioContext;
+}
 
-function getAudioContextCtor(): AudioContextCtor | null {
+function getAudioContextCtor(): typeof AudioContext | null {
   if (typeof window === 'undefined') return null;
-  const w = window as unknown as {
-    AudioContext?: AudioContextCtor;
-    webkitAudioContext?: AudioContextCtor;
-  };
+  const w = window as WindowWithAudio;
   return w.AudioContext ?? w.webkitAudioContext ?? null;
 }
 
-/** Returns a smoothed 0–1 microphone input level while `active`; 0 when inactive or unsupported. */
-export function useMicLevel(active: boolean): number {
-  const [level, setLevel] = useState(0);
-  const rafRef = useRef<number | null>(null);
+// ── Shared, ref-counted mic-meter source ─────────────────────────────────────
+const subscribers = new Set<(level: number) => void>();
+let refCount = 0;
+let ctx: AudioContext | null = null;
+let stream: MediaStream | null = null;
+let rafId: number | null = null;
+let currentLevel = 0;
 
-  useEffect(() => {
-    if (!active) return;
-    const AudioCtor = getAudioContextCtor();
-    const media = typeof navigator !== 'undefined' ? navigator.mediaDevices : undefined;
-    if (!AudioCtor || !media?.getUserMedia) return;
+function broadcast(level: number): void {
+  currentLevel = level;
+  for (const cb of subscribers) cb(level);
+}
 
-    let cancelled = false;
-    let ctx: AudioContext | null = null;
-    let stream: MediaStream | null = null;
+function teardown(): void {
+  if (rafId !== null) cancelAnimationFrame(rafId);
+  rafId = null;
+  if (stream) for (const track of stream.getTracks()) track.stop();
+  stream = null;
+  void ctx?.close();
+  ctx = null;
+  broadcast(0);
+}
 
-    media
-      .getUserMedia({ audio: true })
-      .then((s) => {
-        if (cancelled) {
-          for (const track of s.getTracks()) track.stop();
-          return;
-        }
+function start(): void {
+  const AudioCtor = getAudioContextCtor();
+  const media = typeof navigator !== 'undefined' ? navigator.mediaDevices : undefined;
+  if (!AudioCtor || !media?.getUserMedia) return;
+
+  media
+    .getUserMedia({ audio: true })
+    .then((s) => {
+      // Everyone left while we were acquiring the mic — release it immediately.
+      if (refCount === 0) {
+        for (const track of s.getTracks()) track.stop();
+        return;
+      }
+      try {
         stream = s;
         ctx = new AudioCtor();
         const source = ctx.createMediaStreamSource(s);
@@ -57,25 +73,39 @@ export function useMicLevel(active: boolean): number {
           }
           const rms = Math.sqrt(sum / data.length);
           // Smooth toward the new value and clamp; rms ~0.3 is already a loud signal, so scale up.
-          setLevel((prev) => {
-            const next = Math.min(1, rms * 2.2);
-            return prev + (next - prev) * 0.4;
-          });
-          rafRef.current = requestAnimationFrame(tick);
+          const next = currentLevel + (Math.min(1, rms * 2.2) - currentLevel) * 0.4;
+          broadcast(next);
+          rafId = requestAnimationFrame(tick);
         };
-        rafRef.current = requestAnimationFrame(tick);
-      })
-      .catch((err) => {
-        // Permission denied / no device — leave the meter at 0, don't surface an error to the user.
-        logger.warn('useMicLevel: microphone unavailable for metering', { err: String(err) });
-      });
+        rafId = requestAnimationFrame(tick);
+      } catch (err) {
+        // QNBS-v3 (CodeAnt): if setup throws after the stream was acquired, release it + ctx here —
+        // the outer catch only sees rejections, not synchronous setup failures.
+        logger.warn('useMicLevel: audio graph setup failed', { err: String(err) });
+        teardown();
+      }
+    })
+    .catch((err) => {
+      // Permission denied / no device — leave the meter at 0, don't surface an error to the user.
+      logger.warn('useMicLevel: microphone unavailable for metering', { err: String(err) });
+    });
+}
+
+/** Returns a smoothed 0–1 microphone level while `active`; 0 when inactive or unsupported. */
+export function useMicLevel(active: boolean): number {
+  const [level, setLevel] = useState(0);
+
+  useEffect(() => {
+    if (!active) return;
+    const cb = (l: number) => setLevel(l);
+    subscribers.add(cb);
+    refCount += 1;
+    if (refCount === 1) start();
 
     return () => {
-      cancelled = true;
-      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
-      rafRef.current = null;
-      if (stream) for (const track of stream.getTracks()) track.stop();
-      void ctx?.close();
+      subscribers.delete(cb);
+      refCount -= 1;
+      if (refCount === 0) teardown();
       setLevel(0);
     };
   }, [active]);

--- a/hooks/useMicLevel.ts
+++ b/hooks/useMicLevel.ts
@@ -26,6 +26,10 @@ let ctx: AudioContext | null = null;
 let stream: MediaStream | null = null;
 let rafId: number | null = null;
 let currentLevel = 0;
+// QNBS-v3 (CodeAnt): monotonic session token. Each start() and teardown() bumps it; a pending
+// getUserMedia whose token is stale (superseded by a rapid deactivate→reactivate) releases its
+// stream and bails, so overlapping startups can't leak a second pipeline.
+let session = 0;
 
 function broadcast(level: number): void {
   currentLevel = level;
@@ -33,6 +37,7 @@ function broadcast(level: number): void {
 }
 
 function teardown(): void {
+  session += 1;
   if (rafId !== null) cancelAnimationFrame(rafId);
   rafId = null;
   if (stream) for (const track of stream.getTracks()) track.stop();
@@ -47,11 +52,13 @@ function start(): void {
   const media = typeof navigator !== 'undefined' ? navigator.mediaDevices : undefined;
   if (!AudioCtor || !media?.getUserMedia) return;
 
+  session += 1;
+  const mySession = session;
   media
     .getUserMedia({ audio: true })
     .then((s) => {
-      // Everyone left while we were acquiring the mic — release it immediately.
-      if (refCount === 0) {
+      // Superseded by a newer start/teardown, or everyone left while acquiring — release the mic.
+      if (mySession !== session || refCount === 0) {
         for (const track of s.getTracks()) track.stop();
         return;
       }

--- a/hooks/useMicLevel.ts
+++ b/hooks/useMicLevel.ts
@@ -1,0 +1,84 @@
+import { useEffect, useRef, useState } from 'react';
+import { logger } from '../services/logger';
+
+// QNBS-v3: PR5 — a self-contained microphone level meter for voice feedback. While `active`, it opens
+// its own getUserMedia stream + AnalyserNode and reports a smoothed 0–1 RMS level via rAF. This works
+// regardless of the STT engine (Web Speech, Whisper, …) because it taps the mic directly rather than
+// relying on the VAD path, which only exists in the WASM/Whisper mode. Feature-detected: returns 0 and
+// does nothing where Web Audio / getUserMedia are unavailable (incl. jsdom). Never records or logs audio.
+
+type AudioContextCtor = typeof AudioContext;
+
+function getAudioContextCtor(): AudioContextCtor | null {
+  if (typeof window === 'undefined') return null;
+  const w = window as unknown as {
+    AudioContext?: AudioContextCtor;
+    webkitAudioContext?: AudioContextCtor;
+  };
+  return w.AudioContext ?? w.webkitAudioContext ?? null;
+}
+
+/** Returns a smoothed 0–1 microphone input level while `active`; 0 when inactive or unsupported. */
+export function useMicLevel(active: boolean): number {
+  const [level, setLevel] = useState(0);
+  const rafRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!active) return;
+    const AudioCtor = getAudioContextCtor();
+    const media = typeof navigator !== 'undefined' ? navigator.mediaDevices : undefined;
+    if (!AudioCtor || !media?.getUserMedia) return;
+
+    let cancelled = false;
+    let ctx: AudioContext | null = null;
+    let stream: MediaStream | null = null;
+
+    media
+      .getUserMedia({ audio: true })
+      .then((s) => {
+        if (cancelled) {
+          for (const track of s.getTracks()) track.stop();
+          return;
+        }
+        stream = s;
+        ctx = new AudioCtor();
+        const source = ctx.createMediaStreamSource(s);
+        const analyser = ctx.createAnalyser();
+        analyser.fftSize = 512;
+        source.connect(analyser);
+        const data = new Uint8Array(analyser.fftSize);
+
+        const tick = () => {
+          analyser.getByteTimeDomainData(data);
+          let sum = 0;
+          for (const v of data) {
+            const centered = (v - 128) / 128;
+            sum += centered * centered;
+          }
+          const rms = Math.sqrt(sum / data.length);
+          // Smooth toward the new value and clamp; rms ~0.3 is already a loud signal, so scale up.
+          setLevel((prev) => {
+            const next = Math.min(1, rms * 2.2);
+            return prev + (next - prev) * 0.4;
+          });
+          rafRef.current = requestAnimationFrame(tick);
+        };
+        rafRef.current = requestAnimationFrame(tick);
+      })
+      .catch((err) => {
+        // Permission denied / no device — leave the meter at 0, don't surface an error to the user.
+        logger.warn('useMicLevel: microphone unavailable for metering', { err: String(err) });
+      });
+
+    return () => {
+      cancelled = true;
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+      if (stream) for (const track of stream.getTracks()) track.stop();
+      void ctx?.close();
+      setLevel(0);
+    };
+  }, [active]);
+
+  return active ? level : 0;
+}

--- a/hooks/useVoice.ts
+++ b/hooks/useVoice.ts
@@ -11,6 +11,7 @@ import { selectVoiceSettings } from '../features/settings/settingsSlice';
 import {
   resetVoiceState,
   selectDictationActive,
+  selectLastConfidence,
   selectMicrophonePermission,
   selectSttStatus,
   selectTtsStatus,
@@ -78,6 +79,7 @@ export const useVoice = () => {
   const ttsStatus = useAppSelector(selectTtsStatus);
   const microphonePermission = useAppSelector(selectMicrophonePermission);
   const dictationActive = useAppSelector(selectDictationActive);
+  const confidence = useAppSelector(selectLastConfidence);
 
   const startListening = useCallback(async () => {
     if (!voiceSettings.enabled) {
@@ -144,6 +146,7 @@ export const useVoice = () => {
       ttsStatus,
       microphonePermission,
       dictationActive,
+      confidence,
       enabled: voiceSettings.enabled,
       // Actions
       startListening,
@@ -165,6 +168,7 @@ export const useVoice = () => {
       ttsStatus,
       microphonePermission,
       dictationActive,
+      confidence,
       voiceSettings.enabled,
       startListening,
       stopListening,

--- a/locales/ar/common.json
+++ b/locales/ar/common.json
@@ -658,6 +658,7 @@
   "voice.cancelSpeech": "إلغاء النطق",
   "voice.modeChip.commands": "أوامر",
   "voice.modeChip.dictation": "إملاء",
+  "voice.feedback.confidence": "الثقة {{percent}}%",
   "voice.panelLabel": "التحكم الصوتي",
   "voice.permissionDenied": "تم رفض الوصول إلى الميكروفون. يرجى السماح بالوصول إلى الميكروفون في إعدادات متصفّحك لاستخدام الميزات الصوتية.",
   "voice.startDictation": "بدء الإملاء",

--- a/locales/de/common.json
+++ b/locales/de/common.json
@@ -658,6 +658,7 @@
   "voice.cancelSpeech": "Sprache abbrechen",
   "voice.modeChip.commands": "Befehle",
   "voice.modeChip.dictation": "Diktat",
+  "voice.feedback.confidence": "Konfidenz {{percent}}%",
   "voice.panelLabel": "Sprachsteuerung",
   "voice.permissionDenied": "Mikrofonzugriff verweigert. Bitte erlaube den Mikrofonzugriff in deinen Browsereinstellungen.",
   "voice.startDictation": "Diktat starten",

--- a/locales/el/common.json
+++ b/locales/el/common.json
@@ -658,6 +658,7 @@
   "voice.cancelSpeech": "Ακύρωση speech",
   "voice.modeChip.commands": "Εντολές",
   "voice.modeChip.dictation": "Υπαγόρευση",
+  "voice.feedback.confidence": "Βεβαιότητα {{percent}}%",
   "voice.panelLabel": "Φωνητικός έλεγχος",
   "voice.permissionDenied": "Δεν επιτρέπεται η πρόσβαση στο μικρόφωνο. Επιτρέψτε την πρόσβαση στο μικρόφωνο στις ρυθμίσεις του προγράμματος περιήγησής σας για χρήση φωνητικών λειτουργιών.",
   "voice.startDictation": "Έναρξη υπαγόρευσης",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -39,6 +39,7 @@
   "voice.cancelSpeech": "Cancel speech",
   "voice.modeChip.commands": "Commands",
   "voice.modeChip.dictation": "Dictation",
+  "voice.feedback.confidence": "Confidence {{percent}}%",
   "header.openMenu": "Open menu",
   "error.apiErrorTitle": "AI Assistant Error",
   "error.apiErrorDescription": "The AI failed to generate a response. Please check your connection and API key, then try again. If the problem persists, the service may be temporarily unavailable.",

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -658,6 +658,7 @@
   "voice.cancelSpeech": "Cancelar voz",
   "voice.modeChip.commands": "Comandos",
   "voice.modeChip.dictation": "Dictado",
+  "voice.feedback.confidence": "Confianza {{percent}}%",
   "voice.panelLabel": "Control de voz",
   "voice.permissionDenied": "Acceso al micrófono denegado. Permite el acceso al micrófono en la configuración de tu navegador.",
   "voice.startDictation": "Iniciar dictado",

--- a/locales/eu/common.json
+++ b/locales/eu/common.json
@@ -658,6 +658,7 @@
   "voice.cancelSpeech": "Hitzaldia bertan behera utzi",
   "voice.modeChip.commands": "Komandoak",
   "voice.modeChip.dictation": "Diktaketa",
+  "voice.feedback.confidence": "Konfiantza %{{percent}}",
   "voice.panelLabel": "Ahots kontrola",
   "voice.permissionDenied": "Mikrofonorako sarbidea ukatu da. Mesedez, baimendu mikrofonorako sarbidea zure arakatzailearen ezarpenetan ahots-eginbideak erabiltzeko.",
   "voice.startDictation": "Hasi diktaketa",

--- a/locales/fa/common.json
+++ b/locales/fa/common.json
@@ -658,6 +658,7 @@
   "voice.cancelSpeech": "لغو سخنرانی",
   "voice.modeChip.commands": "دستورات",
   "voice.modeChip.dictation": "دیکته",
+  "voice.feedback.confidence": "اطمینان {{percent}}%",
   "voice.panelLabel": "کنترل صدا",
   "voice.permissionDenied": "دسترسی به میکروفون رد شد. برای استفاده از ویژگی‌های صوتی، لطفاً به میکروفون در تنظیمات مرورگر خود اجازه دهید.",
   "voice.startDictation": "دیکته را شروع کنید",

--- a/locales/fi/common.json
+++ b/locales/fi/common.json
@@ -658,6 +658,7 @@
   "voice.cancelSpeech": "Peruuta puhe",
   "voice.modeChip.commands": "Komennot",
   "voice.modeChip.dictation": "Sanelu",
+  "voice.feedback.confidence": "Varmuus {{percent}} %",
   "voice.panelLabel": "Ääniohjaus",
   "voice.permissionDenied": "Mikrofonin käyttö estetty. Salli mikrofonin käyttö selaimesi asetuksista, jotta voit käyttää ääniominaisuuksia.",
   "voice.startDictation": "Aloita sanelu",

--- a/locales/fr/common.json
+++ b/locales/fr/common.json
@@ -658,6 +658,7 @@
   "voice.cancelSpeech": "Annuler la parole",
   "voice.modeChip.commands": "Commandes",
   "voice.modeChip.dictation": "Dictée",
+  "voice.feedback.confidence": "Confiance {{percent}} %",
   "voice.panelLabel": "Contrôle vocal",
   "voice.permissionDenied": "Accès au micro refusé. Veuillez autoriser l’accès au microphone dans les paramètres de votre navigateur.",
   "voice.startDictation": "Commencer la dictée",

--- a/locales/he/common.json
+++ b/locales/he/common.json
@@ -658,6 +658,7 @@
   "voice.cancelSpeech": "ביטול דיבור",
   "voice.modeChip.commands": "פקודות",
   "voice.modeChip.dictation": "הכתבה",
+  "voice.feedback.confidence": "ביטחון {{percent}}%",
   "voice.panelLabel": "בקרה קולית",
   "voice.permissionDenied": "הגישה למיקרופון נדחתה. אנא אפשרו גישה למיקרופון בהגדרות הדפדפן כדי להשתמש בתכונות הקוליות.",
   "voice.startDictation": "התחלת הכתבה",

--- a/locales/hu/common.json
+++ b/locales/hu/common.json
@@ -658,6 +658,7 @@
   "voice.cancelSpeech": "Beszéd megszakítása",
   "voice.modeChip.commands": "Parancsok",
   "voice.modeChip.dictation": "Diktálás",
+  "voice.feedback.confidence": "Megbízhatóság {{percent}}%",
   "voice.panelLabel": "Hangvezérlés",
   "voice.permissionDenied": "Mikrofon hozzáférés megtagadva. A hangfunkciók használatához engedélyezze a mikrofonhoz való hozzáférést a böngésző beállításaiban.",
   "voice.startDictation": "Indítsa el a diktálást",

--- a/locales/is/common.json
+++ b/locales/is/common.json
@@ -658,6 +658,7 @@
   "voice.cancelSpeech": "Hætta við ræðu",
   "voice.modeChip.commands": "Skipanir",
   "voice.modeChip.dictation": "Upplestur",
+  "voice.feedback.confidence": "Vissa {{percent}}%",
   "voice.panelLabel": "Raddstýring",
   "voice.permissionDenied": "Aðgangi hljóðnema hafnað. Vinsamlegast leyfðu aðgang að hljóðnema í stillingum vafrans til að nota raddaðgerðir.",
   "voice.startDictation": "Byrjaðu á einræði",

--- a/locales/it/common.json
+++ b/locales/it/common.json
@@ -658,6 +658,7 @@
   "voice.cancelSpeech": "Annulla voce",
   "voice.modeChip.commands": "Comandi",
   "voice.modeChip.dictation": "Dettatura",
+  "voice.feedback.confidence": "Affidabilità {{percent}}%",
   "voice.panelLabel": "Controllo vocale",
   "voice.permissionDenied": "Accesso al microfono negato. Consenti l’accesso al microfono nelle impostazioni del browser.",
   "voice.startDictation": "Inizia dettatura",

--- a/locales/ja/common.json
+++ b/locales/ja/common.json
@@ -658,6 +658,7 @@
   "voice.cancelSpeech": "キャンセル speech",
   "voice.modeChip.commands": "コマンド",
   "voice.modeChip.dictation": "ディクテーション",
+  "voice.feedback.confidence": "信頼度 {{percent}}%",
   "voice.panelLabel": "音声制御",
   "voice.permissionDenied": "マイクへのアクセスが拒否されました。音声機能を使用するには、ブラウザの設定でマイクへのアクセスを許可してください。",
   "voice.startDictation": "ディクテーションを開始する",

--- a/locales/ko/common.json
+++ b/locales/ko/common.json
@@ -658,6 +658,7 @@
   "voice.cancelSpeech": "음성 취소",
   "voice.modeChip.commands": "명령",
   "voice.modeChip.dictation": "받아쓰기",
+  "voice.feedback.confidence": "신뢰도 {{percent}}%",
   "voice.panelLabel": "음성 제어",
   "voice.permissionDenied": "마이크 액세스가 거부되었습니다. 음성 기능을 사용하려면 브라우저 설정에서 마이크 접근을 허용해주세요.",
   "voice.startDictation": "받아쓰기 시작",

--- a/locales/pt/common.json
+++ b/locales/pt/common.json
@@ -658,6 +658,7 @@
   "voice.cancelSpeech": "Cancelar speech",
   "voice.modeChip.commands": "Comandos",
   "voice.modeChip.dictation": "Ditado",
+  "voice.feedback.confidence": "Confiança {{percent}}%",
   "voice.panelLabel": "Controle de voz",
   "voice.permissionDenied": "Acesso ao microfone negado. Permita o acesso ao microfone nas configurações do seu navegador para usar os recursos de voz.",
   "voice.startDictation": "Iniciar ditado",

--- a/locales/ru/common.json
+++ b/locales/ru/common.json
@@ -658,6 +658,7 @@
   "voice.cancelSpeech": "Отменить речь",
   "voice.modeChip.commands": "Команды",
   "voice.modeChip.dictation": "Диктант",
+  "voice.feedback.confidence": "Уверенность {{percent}}%",
   "voice.panelLabel": "Голосовое управление",
   "voice.permissionDenied": "Доступ к микрофону запрещен. Разрешите доступ к микрофону в настройках браузера, чтобы использовать голосовые функции.",
   "voice.startDictation": "Начать диктовку",

--- a/locales/sv/common.json
+++ b/locales/sv/common.json
@@ -658,6 +658,7 @@
   "voice.cancelSpeech": "Avbryt tal",
   "voice.modeChip.commands": "Kommandon",
   "voice.modeChip.dictation": "Diktering",
+  "voice.feedback.confidence": "Säkerhet {{percent}} %",
   "voice.panelLabel": "Röststyrning",
   "voice.permissionDenied": "Mikrofonåtkomst nekad. Tillåt mikrofonåtkomst i webbläsarinställningarna för att använda röstfunktioner.",
   "voice.startDictation": "Börja diktering",

--- a/locales/zh/common.json
+++ b/locales/zh/common.json
@@ -658,6 +658,7 @@
   "voice.cancelSpeech": "取消 speech",
   "voice.modeChip.commands": "命令",
   "voice.modeChip.dictation": "听写",
+  "voice.feedback.confidence": "置信度 {{percent}}%",
   "voice.panelLabel": "语音控制",
   "voice.permissionDenied": "麦克风访问被拒绝。请在浏览器设置中允许麦克风访问才能使用语音功能。",
   "voice.startDictation": "开始听写",

--- a/public/locales/ar/bundle.json
+++ b/public/locales/ar/bundle.json
@@ -766,6 +766,7 @@
   "voice.cancelSpeech": "إلغاء النطق",
   "voice.modeChip.commands": "أوامر",
   "voice.modeChip.dictation": "إملاء",
+  "voice.feedback.confidence": "الثقة {{percent}}%",
   "voice.panelLabel": "التحكم الصوتي",
   "voice.permissionDenied": "تم رفض الوصول إلى الميكروفون. يرجى السماح بالوصول إلى الميكروفون في إعدادات متصفّحك لاستخدام الميزات الصوتية.",
   "voice.startDictation": "بدء الإملاء",

--- a/public/locales/de/bundle.json
+++ b/public/locales/de/bundle.json
@@ -766,6 +766,7 @@
   "voice.cancelSpeech": "Sprache abbrechen",
   "voice.modeChip.commands": "Befehle",
   "voice.modeChip.dictation": "Diktat",
+  "voice.feedback.confidence": "Konfidenz {{percent}}%",
   "voice.panelLabel": "Sprachsteuerung",
   "voice.permissionDenied": "Mikrofonzugriff verweigert. Bitte erlaube den Mikrofonzugriff in deinen Browsereinstellungen.",
   "voice.startDictation": "Diktat starten",

--- a/public/locales/el/bundle.json
+++ b/public/locales/el/bundle.json
@@ -766,6 +766,7 @@
   "voice.cancelSpeech": "Ακύρωση speech",
   "voice.modeChip.commands": "Εντολές",
   "voice.modeChip.dictation": "Υπαγόρευση",
+  "voice.feedback.confidence": "Βεβαιότητα {{percent}}%",
   "voice.panelLabel": "Φωνητικός έλεγχος",
   "voice.permissionDenied": "Δεν επιτρέπεται η πρόσβαση στο μικρόφωνο. Επιτρέψτε την πρόσβαση στο μικρόφωνο στις ρυθμίσεις του προγράμματος περιήγησής σας για χρήση φωνητικών λειτουργιών.",
   "voice.startDictation": "Έναρξη υπαγόρευσης",

--- a/public/locales/en/bundle.json
+++ b/public/locales/en/bundle.json
@@ -147,6 +147,7 @@
   "voice.cancelSpeech": "Cancel speech",
   "voice.modeChip.commands": "Commands",
   "voice.modeChip.dictation": "Dictation",
+  "voice.feedback.confidence": "Confidence {{percent}}%",
   "header.openMenu": "Open menu",
   "error.apiErrorTitle": "AI Assistant Error",
   "error.apiErrorDescription": "The AI failed to generate a response. Please check your connection and API key, then try again. If the problem persists, the service may be temporarily unavailable.",

--- a/public/locales/es/bundle.json
+++ b/public/locales/es/bundle.json
@@ -766,6 +766,7 @@
   "voice.cancelSpeech": "Cancelar voz",
   "voice.modeChip.commands": "Comandos",
   "voice.modeChip.dictation": "Dictado",
+  "voice.feedback.confidence": "Confianza {{percent}}%",
   "voice.panelLabel": "Control de voz",
   "voice.permissionDenied": "Acceso al micrófono denegado. Permite el acceso al micrófono en la configuración de tu navegador.",
   "voice.startDictation": "Iniciar dictado",

--- a/public/locales/eu/bundle.json
+++ b/public/locales/eu/bundle.json
@@ -766,6 +766,7 @@
   "voice.cancelSpeech": "Hitzaldia bertan behera utzi",
   "voice.modeChip.commands": "Komandoak",
   "voice.modeChip.dictation": "Diktaketa",
+  "voice.feedback.confidence": "Konfiantza %{{percent}}",
   "voice.panelLabel": "Ahots kontrola",
   "voice.permissionDenied": "Mikrofonorako sarbidea ukatu da. Mesedez, baimendu mikrofonorako sarbidea zure arakatzailearen ezarpenetan ahots-eginbideak erabiltzeko.",
   "voice.startDictation": "Hasi diktaketa",

--- a/public/locales/fa/bundle.json
+++ b/public/locales/fa/bundle.json
@@ -766,6 +766,7 @@
   "voice.cancelSpeech": "لغو سخنرانی",
   "voice.modeChip.commands": "دستورات",
   "voice.modeChip.dictation": "دیکته",
+  "voice.feedback.confidence": "اطمینان {{percent}}%",
   "voice.panelLabel": "کنترل صدا",
   "voice.permissionDenied": "دسترسی به میکروفون رد شد. برای استفاده از ویژگی‌های صوتی، لطفاً به میکروفون در تنظیمات مرورگر خود اجازه دهید.",
   "voice.startDictation": "دیکته را شروع کنید",

--- a/public/locales/fi/bundle.json
+++ b/public/locales/fi/bundle.json
@@ -766,6 +766,7 @@
   "voice.cancelSpeech": "Peruuta puhe",
   "voice.modeChip.commands": "Komennot",
   "voice.modeChip.dictation": "Sanelu",
+  "voice.feedback.confidence": "Varmuus {{percent}} %",
   "voice.panelLabel": "Ääniohjaus",
   "voice.permissionDenied": "Mikrofonin käyttö estetty. Salli mikrofonin käyttö selaimesi asetuksista, jotta voit käyttää ääniominaisuuksia.",
   "voice.startDictation": "Aloita sanelu",

--- a/public/locales/fr/bundle.json
+++ b/public/locales/fr/bundle.json
@@ -766,6 +766,7 @@
   "voice.cancelSpeech": "Annuler la parole",
   "voice.modeChip.commands": "Commandes",
   "voice.modeChip.dictation": "Dictée",
+  "voice.feedback.confidence": "Confiance {{percent}} %",
   "voice.panelLabel": "Contrôle vocal",
   "voice.permissionDenied": "Accès au micro refusé. Veuillez autoriser l’accès au microphone dans les paramètres de votre navigateur.",
   "voice.startDictation": "Commencer la dictée",

--- a/public/locales/he/bundle.json
+++ b/public/locales/he/bundle.json
@@ -766,6 +766,7 @@
   "voice.cancelSpeech": "ביטול דיבור",
   "voice.modeChip.commands": "פקודות",
   "voice.modeChip.dictation": "הכתבה",
+  "voice.feedback.confidence": "ביטחון {{percent}}%",
   "voice.panelLabel": "בקרה קולית",
   "voice.permissionDenied": "הגישה למיקרופון נדחתה. אנא אפשרו גישה למיקרופון בהגדרות הדפדפן כדי להשתמש בתכונות הקוליות.",
   "voice.startDictation": "התחלת הכתבה",

--- a/public/locales/hu/bundle.json
+++ b/public/locales/hu/bundle.json
@@ -766,6 +766,7 @@
   "voice.cancelSpeech": "Beszéd megszakítása",
   "voice.modeChip.commands": "Parancsok",
   "voice.modeChip.dictation": "Diktálás",
+  "voice.feedback.confidence": "Megbízhatóság {{percent}}%",
   "voice.panelLabel": "Hangvezérlés",
   "voice.permissionDenied": "Mikrofon hozzáférés megtagadva. A hangfunkciók használatához engedélyezze a mikrofonhoz való hozzáférést a böngésző beállításaiban.",
   "voice.startDictation": "Indítsa el a diktálást",

--- a/public/locales/is/bundle.json
+++ b/public/locales/is/bundle.json
@@ -766,6 +766,7 @@
   "voice.cancelSpeech": "Hætta við ræðu",
   "voice.modeChip.commands": "Skipanir",
   "voice.modeChip.dictation": "Upplestur",
+  "voice.feedback.confidence": "Vissa {{percent}}%",
   "voice.panelLabel": "Raddstýring",
   "voice.permissionDenied": "Aðgangi hljóðnema hafnað. Vinsamlegast leyfðu aðgang að hljóðnema í stillingum vafrans til að nota raddaðgerðir.",
   "voice.startDictation": "Byrjaðu á einræði",

--- a/public/locales/it/bundle.json
+++ b/public/locales/it/bundle.json
@@ -766,6 +766,7 @@
   "voice.cancelSpeech": "Annulla voce",
   "voice.modeChip.commands": "Comandi",
   "voice.modeChip.dictation": "Dettatura",
+  "voice.feedback.confidence": "Affidabilità {{percent}}%",
   "voice.panelLabel": "Controllo vocale",
   "voice.permissionDenied": "Accesso al microfono negato. Consenti l’accesso al microfono nelle impostazioni del browser.",
   "voice.startDictation": "Inizia dettatura",

--- a/public/locales/ja/bundle.json
+++ b/public/locales/ja/bundle.json
@@ -766,6 +766,7 @@
   "voice.cancelSpeech": "キャンセル speech",
   "voice.modeChip.commands": "コマンド",
   "voice.modeChip.dictation": "ディクテーション",
+  "voice.feedback.confidence": "信頼度 {{percent}}%",
   "voice.panelLabel": "音声制御",
   "voice.permissionDenied": "マイクへのアクセスが拒否されました。音声機能を使用するには、ブラウザの設定でマイクへのアクセスを許可してください。",
   "voice.startDictation": "ディクテーションを開始する",

--- a/public/locales/ko/bundle.json
+++ b/public/locales/ko/bundle.json
@@ -766,6 +766,7 @@
   "voice.cancelSpeech": "음성 취소",
   "voice.modeChip.commands": "명령",
   "voice.modeChip.dictation": "받아쓰기",
+  "voice.feedback.confidence": "신뢰도 {{percent}}%",
   "voice.panelLabel": "음성 제어",
   "voice.permissionDenied": "마이크 액세스가 거부되었습니다. 음성 기능을 사용하려면 브라우저 설정에서 마이크 접근을 허용해주세요.",
   "voice.startDictation": "받아쓰기 시작",

--- a/public/locales/pt/bundle.json
+++ b/public/locales/pt/bundle.json
@@ -766,6 +766,7 @@
   "voice.cancelSpeech": "Cancelar speech",
   "voice.modeChip.commands": "Comandos",
   "voice.modeChip.dictation": "Ditado",
+  "voice.feedback.confidence": "Confiança {{percent}}%",
   "voice.panelLabel": "Controle de voz",
   "voice.permissionDenied": "Acesso ao microfone negado. Permita o acesso ao microfone nas configurações do seu navegador para usar os recursos de voz.",
   "voice.startDictation": "Iniciar ditado",

--- a/public/locales/ru/bundle.json
+++ b/public/locales/ru/bundle.json
@@ -766,6 +766,7 @@
   "voice.cancelSpeech": "Отменить речь",
   "voice.modeChip.commands": "Команды",
   "voice.modeChip.dictation": "Диктант",
+  "voice.feedback.confidence": "Уверенность {{percent}}%",
   "voice.panelLabel": "Голосовое управление",
   "voice.permissionDenied": "Доступ к микрофону запрещен. Разрешите доступ к микрофону в настройках браузера, чтобы использовать голосовые функции.",
   "voice.startDictation": "Начать диктовку",

--- a/public/locales/sv/bundle.json
+++ b/public/locales/sv/bundle.json
@@ -766,6 +766,7 @@
   "voice.cancelSpeech": "Avbryt tal",
   "voice.modeChip.commands": "Kommandon",
   "voice.modeChip.dictation": "Diktering",
+  "voice.feedback.confidence": "Säkerhet {{percent}} %",
   "voice.panelLabel": "Röststyrning",
   "voice.permissionDenied": "Mikrofonåtkomst nekad. Tillåt mikrofonåtkomst i webbläsarinställningarna för att använda röstfunktioner.",
   "voice.startDictation": "Börja diktering",

--- a/public/locales/zh/bundle.json
+++ b/public/locales/zh/bundle.json
@@ -766,6 +766,7 @@
   "voice.cancelSpeech": "取消 speech",
   "voice.modeChip.commands": "命令",
   "voice.modeChip.dictation": "听写",
+  "voice.feedback.confidence": "置信度 {{percent}}%",
   "voice.panelLabel": "语音控制",
   "voice.permissionDenied": "麦克风访问被拒绝。请在浏览器设置中允许麦克风访问才能使用语音功能。",
   "voice.startDictation": "开始听写",

--- a/tests/unit/VoiceControlPanel.test.tsx
+++ b/tests/unit/VoiceControlPanel.test.tsx
@@ -22,6 +22,8 @@ let mockMode = 'inactive';
 let mockIsListening = false;
 let mockDictationActive = false;
 let mockMicPermission: 'granted' | 'denied' | 'prompt' = 'prompt';
+let mockTranscript = '';
+let mockConfidence = 0;
 
 vi.mock('../../hooks/useVoice', () => ({
   useVoice: () => ({
@@ -35,6 +37,8 @@ vi.mock('../../hooks/useVoice', () => ({
     stopDictation: mockStopDictation,
     cancelSpeech: mockCancelSpeech,
     microphonePermission: mockMicPermission,
+    transcript: mockTranscript,
+    confidence: mockConfidence,
   }),
 }));
 
@@ -60,6 +64,8 @@ describe('VoiceControlPanel', () => {
     mockIsListening = false;
     mockDictationActive = false;
     mockMicPermission = 'prompt';
+    mockTranscript = '';
+    mockConfidence = 0;
   });
 
   it('renders nothing when voice is not enabled', () => {
@@ -167,5 +173,17 @@ describe('VoiceControlPanel', () => {
     mockDictationActive = true;
     render(<VoiceControlPanel />);
     expect(screen.getByText('voice.modeChip.dictation')).toBeInTheDocument();
+  });
+
+  it('shows the live feedback (meter, interim transcript, confidence) while listening', () => {
+    mockEnabled = true;
+    mockMode = 'listening';
+    mockIsListening = true;
+    mockTranscript = 'open the writer';
+    mockConfidence = 0.8;
+    render(<VoiceControlPanel />);
+    expect(screen.getByTestId('voice-level-meter')).toBeInTheDocument();
+    expect(screen.getByText('open the writer')).toBeInTheDocument();
+    expect(screen.getByText('voice.feedback.confidence')).toBeInTheDocument();
   });
 });

--- a/tests/unit/VoiceIndicator.test.tsx
+++ b/tests/unit/VoiceIndicator.test.tsx
@@ -13,12 +13,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 let mockMode = 'inactive';
 let mockEnabled = false;
 let mockTranscript = '';
+let mockConfidence = 0;
 
 vi.mock('../../hooks/useVoice', () => ({
   useVoice: () => ({
     mode: mockMode,
     enabled: mockEnabled,
     transcript: mockTranscript,
+    confidence: mockConfidence,
   }),
 }));
 
@@ -38,6 +40,7 @@ describe('VoiceIndicator', () => {
     mockMode = 'inactive';
     mockEnabled = false;
     mockTranscript = '';
+    mockConfidence = 0;
   });
 
   it('renders nothing when voice is not enabled', () => {
@@ -71,6 +74,25 @@ describe('VoiceIndicator', () => {
     const { container } = render(<VoiceIndicator />);
     const dot = container.querySelector('.animate-pulse');
     expect(dot).toBeInTheDocument();
+  });
+
+  it('shows the level meter and confidence when active with a confidence score', () => {
+    mockEnabled = true;
+    mockMode = 'listening';
+    mockConfidence = 0.9;
+    render(<VoiceIndicator />);
+    // meter rendered while active …
+    expect(screen.getByTestId('voice-level-meter')).toBeInTheDocument();
+    // … and the confidence label (confidencePct > 0 branch).
+    expect(screen.getByText(/confidence/i)).toBeInTheDocument();
+  });
+
+  it('hides the confidence label when confidence is 0', () => {
+    mockEnabled = true;
+    mockMode = 'listening';
+    mockConfidence = 0;
+    render(<VoiceIndicator />);
+    expect(screen.queryByText(/confidence/i)).not.toBeInTheDocument();
   });
 
   it('indicator dot has no animate-pulse class when processing', () => {

--- a/tests/unit/VoiceIndicator.test.tsx
+++ b/tests/unit/VoiceIndicator.test.tsx
@@ -76,21 +76,32 @@ describe('VoiceIndicator', () => {
     expect(dot).toBeInTheDocument();
   });
 
-  it('shows the level meter and confidence when active with a confidence score', () => {
+  it('shows the level meter and confidence when listening with a current transcript', () => {
     mockEnabled = true;
     mockMode = 'listening';
     mockConfidence = 0.9;
+    mockTranscript = 'open the writer';
     render(<VoiceIndicator />);
     // meter rendered while active …
     expect(screen.getByTestId('voice-level-meter')).toBeInTheDocument();
-    // … and the confidence label (confidencePct > 0 branch).
+    // … and the confidence label (current transcript + confidence > 0).
     expect(screen.getByText(/confidence/i)).toBeInTheDocument();
+  });
+
+  it('hides confidence when there is no current transcript (stale guard)', () => {
+    mockEnabled = true;
+    mockMode = 'listening';
+    mockConfidence = 0.9;
+    mockTranscript = '';
+    render(<VoiceIndicator />);
+    expect(screen.queryByText(/confidence/i)).not.toBeInTheDocument();
   });
 
   it('hides the confidence label when confidence is 0', () => {
     mockEnabled = true;
     mockMode = 'listening';
     mockConfidence = 0;
+    mockTranscript = 'hi';
     render(<VoiceIndicator />);
     expect(screen.queryByText(/confidence/i)).not.toBeInTheDocument();
   });

--- a/tests/unit/VoiceLevelMeter.test.tsx
+++ b/tests/unit/VoiceLevelMeter.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { VoiceLevelMeter } from '../../components/voice/VoiceLevelMeter';
+
+describe('VoiceLevelMeter', () => {
+  it('renders a 5-bar meter', () => {
+    render(<VoiceLevelMeter level={0} />);
+    const meter = screen.getByTestId('voice-level-meter');
+    expect(meter.children).toHaveLength(5);
+  });
+
+  it('fills bars proportionally to the level', () => {
+    const { rerender } = render(<VoiceLevelMeter level={0.6} />);
+    const accentBars = () =>
+      Array.from(screen.getByTestId('voice-level-meter').children).filter((c) =>
+        c.className.includes('--sc-accent'),
+      ).length;
+    expect(accentBars()).toBe(3); // round(0.6 * 5)
+    rerender(<VoiceLevelMeter level={1} />);
+    expect(accentBars()).toBe(5);
+    rerender(<VoiceLevelMeter level={0} />);
+    expect(accentBars()).toBe(0);
+  });
+
+  it('clamps out-of-range levels', () => {
+    render(<VoiceLevelMeter level={5} />);
+    const accent = Array.from(screen.getByTestId('voice-level-meter').children).filter((c) =>
+      c.className.includes('--sc-accent'),
+    ).length;
+    expect(accent).toBe(5);
+  });
+});

--- a/tests/unit/hooks/useMicLevel.test.ts
+++ b/tests/unit/hooks/useMicLevel.test.ts
@@ -1,8 +1,7 @@
-import { renderHook } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useMicLevel } from '../../../hooks/useMicLevel';
 
-// jsdom exposes no Web Audio / getUserMedia, so the hook must feature-detect and no-op to 0.
 describe('useMicLevel', () => {
   it('returns 0 when inactive', () => {
     const { result } = renderHook(() => useMicLevel(false));
@@ -21,5 +20,105 @@ describe('useMicLevel', () => {
     rerender({ active: false });
     expect(result.current).toBe(0);
     expect(() => unmount()).not.toThrow();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Active metering path — Web Audio + getUserMedia mocked (absent in jsdom).
+  // ---------------------------------------------------------------------------
+  describe('with Web Audio available', () => {
+    let stopTrack: ReturnType<typeof vi.fn>;
+    let close: ReturnType<typeof vi.fn>;
+    let getUserMedia: ReturnType<typeof vi.fn>;
+    let rafCbs: FrameRequestCallback[];
+    let origMediaDevices: PropertyDescriptor | undefined;
+
+    beforeEach(() => {
+      stopTrack = vi.fn();
+      close = vi.fn();
+      // A loud signal (samples ≠ 128) → non-zero RMS.
+      const getByteTimeDomainData = vi.fn((arr: Uint8Array) => arr.fill(200));
+      getUserMedia = vi.fn().mockResolvedValue({ getTracks: () => [{ stop: stopTrack }] });
+
+      const source = { connect: vi.fn() };
+      const analyser = { fftSize: 0, getByteTimeDomainData, connect: vi.fn() };
+      class FakeAudioContext {
+        createMediaStreamSource = vi.fn(() => source);
+        createAnalyser = vi.fn(() => analyser);
+        close = close;
+      }
+
+      rafCbs = [];
+      origMediaDevices = Object.getOwnPropertyDescriptor(navigator, 'mediaDevices');
+      Object.defineProperty(navigator, 'mediaDevices', {
+        value: { getUserMedia },
+        configurable: true,
+      });
+      (window as unknown as Record<string, unknown>)['AudioContext'] = FakeAudioContext;
+      vi.stubGlobal(
+        'requestAnimationFrame',
+        vi.fn((cb: FrameRequestCallback) => {
+          rafCbs.push(cb);
+          return rafCbs.length;
+        }),
+      );
+      vi.stubGlobal('cancelAnimationFrame', vi.fn());
+    });
+
+    afterEach(() => {
+      // Restore the original mediaDevices descriptor (or neutralise it when jsdom had none).
+      Object.defineProperty(
+        navigator,
+        'mediaDevices',
+        origMediaDevices ?? { value: undefined, configurable: true },
+      );
+      (window as unknown as Record<string, unknown>)['AudioContext'] = undefined;
+      vi.unstubAllGlobals();
+      vi.restoreAllMocks();
+    });
+
+    it('reports a non-zero level from the mic and tears down on unmount', async () => {
+      const { result, unmount } = renderHook(() => useMicLevel(true));
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(getUserMedia).toHaveBeenCalled();
+
+      await act(async () => {
+        rafCbs[0]?.(0); // run one metering tick
+      });
+      expect(result.current).toBeGreaterThan(0);
+
+      unmount();
+      expect(stopTrack).toHaveBeenCalled();
+      expect(close).toHaveBeenCalled();
+      expect(cancelAnimationFrame).toHaveBeenCalled();
+    });
+
+    it('stops the stream if cancelled before getUserMedia resolves', async () => {
+      let resolveStream: (s: unknown) => void = () => {};
+      getUserMedia.mockReturnValue(
+        new Promise((r) => {
+          resolveStream = r;
+        }),
+      );
+      const { unmount } = renderHook(() => useMicLevel(true));
+      unmount(); // cancelled = true
+      await act(async () => {
+        resolveStream({ getTracks: () => [{ stop: stopTrack }] });
+        await Promise.resolve();
+      });
+      expect(stopTrack).toHaveBeenCalled();
+    });
+
+    it('stays at 0 when getUserMedia is denied', async () => {
+      getUserMedia.mockRejectedValue(new Error('NotAllowedError'));
+      const { result } = renderHook(() => useMicLevel(true));
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(result.current).toBe(0);
+    });
   });
 });

--- a/tests/unit/hooks/useMicLevel.test.ts
+++ b/tests/unit/hooks/useMicLevel.test.ts
@@ -53,7 +53,7 @@ describe('useMicLevel', () => {
         value: { getUserMedia },
         configurable: true,
       });
-      (window as unknown as Record<string, unknown>)['AudioContext'] = FakeAudioContext;
+      vi.stubGlobal('AudioContext', FakeAudioContext);
       vi.stubGlobal(
         'requestAnimationFrame',
         vi.fn((cb: FrameRequestCallback) => {
@@ -71,7 +71,6 @@ describe('useMicLevel', () => {
         'mediaDevices',
         origMediaDevices ?? { value: undefined, configurable: true },
       );
-      (window as unknown as Record<string, unknown>)['AudioContext'] = undefined;
       vi.unstubAllGlobals();
       vi.restoreAllMocks();
     });

--- a/tests/unit/hooks/useMicLevel.test.ts
+++ b/tests/unit/hooks/useMicLevel.test.ts
@@ -65,12 +65,14 @@ describe('useMicLevel', () => {
     });
 
     afterEach(() => {
-      // Restore the original mediaDevices descriptor (or neutralise it when jsdom had none).
-      Object.defineProperty(
-        navigator,
-        'mediaDevices',
-        origMediaDevices ?? { value: undefined, configurable: true },
-      );
+      // QNBS-v3 (CodeAnt): restore the original descriptor, or REMOVE the own property when jsdom had
+      // none — setting an own `undefined` would shadow a prototype-provided mediaDevices for the rest
+      // of the run. Reflect.deleteProperty avoids the `delete`-operator lint.
+      if (origMediaDevices) {
+        Object.defineProperty(navigator, 'mediaDevices', origMediaDevices);
+      } else {
+        Reflect.deleteProperty(navigator, 'mediaDevices');
+      }
       vi.unstubAllGlobals();
       vi.restoreAllMocks();
     });

--- a/tests/unit/hooks/useMicLevel.test.ts
+++ b/tests/unit/hooks/useMicLevel.test.ts
@@ -9,8 +9,19 @@ describe('useMicLevel', () => {
   });
 
   it('returns 0 (does not throw) when Web Audio / getUserMedia are unavailable', () => {
-    const { result } = renderHook(() => useMicLevel(true));
-    expect(result.current).toBe(0);
+    // QNBS-v3 (CodeAnt): explicitly make both APIs unavailable so this asserts the unsupported path
+    // deterministically, rather than relying on jsdom happening to lack them.
+    vi.stubGlobal('AudioContext', undefined);
+    const orig = Object.getOwnPropertyDescriptor(navigator, 'mediaDevices');
+    Object.defineProperty(navigator, 'mediaDevices', { value: undefined, configurable: true });
+    try {
+      const { result } = renderHook(() => useMicLevel(true));
+      expect(result.current).toBe(0);
+    } finally {
+      if (orig) Object.defineProperty(navigator, 'mediaDevices', orig);
+      else Reflect.deleteProperty(navigator, 'mediaDevices');
+      vi.unstubAllGlobals();
+    }
   });
 
   it('cleans up without error when toggled off and unmounted', () => {

--- a/tests/unit/hooks/useMicLevel.test.ts
+++ b/tests/unit/hooks/useMicLevel.test.ts
@@ -1,0 +1,25 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useMicLevel } from '../../../hooks/useMicLevel';
+
+// jsdom exposes no Web Audio / getUserMedia, so the hook must feature-detect and no-op to 0.
+describe('useMicLevel', () => {
+  it('returns 0 when inactive', () => {
+    const { result } = renderHook(() => useMicLevel(false));
+    expect(result.current).toBe(0);
+  });
+
+  it('returns 0 (does not throw) when Web Audio / getUserMedia are unavailable', () => {
+    const { result } = renderHook(() => useMicLevel(true));
+    expect(result.current).toBe(0);
+  });
+
+  it('cleans up without error when toggled off and unmounted', () => {
+    const { result, rerender, unmount } = renderHook(({ active }) => useMicLevel(active), {
+      initialProps: { active: true },
+    });
+    rerender({ active: false });
+    expect(result.current).toBe(0);
+    expect(() => unmount()).not.toThrow();
+  });
+});

--- a/tests/unit/hooks/useVoice.test.ts
+++ b/tests/unit/hooks/useVoice.test.ts
@@ -92,6 +92,7 @@ vi.mock('../../../features/voice/voiceSlice', () => ({
   selectMicrophonePermission: (s: { voice: { microphonePermission: string } }) =>
     s.voice.microphonePermission,
   selectDictationActive: (s: { voice: { dictationActive: boolean } }) => s.voice.dictationActive,
+  selectLastConfidence: (s: { voice: { lastConfidence: number } }) => s.voice.lastConfidence,
 }));
 
 const mockStartListening = vi.fn().mockResolvedValue(undefined);

--- a/tests/unit/hooks/useVoice.test.ts
+++ b/tests/unit/hooks/useVoice.test.ts
@@ -69,6 +69,7 @@ vi.mock('../../../app/hooks', () => ({
         ttsStatus: mockTtsStatus,
         microphonePermission: mockMicPermission,
         dictationActive: mockDictationActive,
+        lastConfidence: 0,
       },
     }),
 }));

--- a/tests/unit/voice/voiceSlice.test.ts
+++ b/tests/unit/voice/voiceSlice.test.ts
@@ -69,6 +69,13 @@ describe('voiceSlice', () => {
     expect(listening.lastConfidence).toBe(0);
   });
 
+  it('resets confidence when dictation starts (setDictationActive)', () => {
+    const withConfidence = voiceSliceReducer(initialState, setLastConfidence(0.9));
+    const dictating = voiceSliceReducer(withConfidence, setDictationActive(true));
+    expect(dictating.lastConfidence).toBe(0);
+    expect(dictating.mode).toBe('dictating');
+  });
+
   it('keeps confidence when staying in the same mode', () => {
     const listening = voiceSliceReducer(initialState, setVoiceMode('listening'));
     const withConfidence = voiceSliceReducer(listening, setLastConfidence(0.8));

--- a/tests/unit/voice/voiceSlice.test.ts
+++ b/tests/unit/voice/voiceSlice.test.ts
@@ -63,6 +63,20 @@ describe('voiceSlice', () => {
     expect(next.lastConfidence).toBe(0.95);
   });
 
+  it('resets confidence when a fresh listening cycle starts', () => {
+    const withConfidence = voiceSliceReducer(initialState, setLastConfidence(0.9));
+    const listening = voiceSliceReducer(withConfidence, setVoiceMode('listening'));
+    expect(listening.lastConfidence).toBe(0);
+  });
+
+  it('keeps confidence when staying in the same mode', () => {
+    const listening = voiceSliceReducer(initialState, setVoiceMode('listening'));
+    const withConfidence = voiceSliceReducer(listening, setLastConfidence(0.8));
+    // Re-dispatching the same mode must not wipe a confidence set mid-session.
+    const same = voiceSliceReducer(withConfidence, setVoiceMode('listening'));
+    expect(same.lastConfidence).toBe(0.8);
+  });
+
   it('sets microphone permission', () => {
     const next = voiceSliceReducer(initialState, setMicrophonePermission('granted'));
     expect(next.microphonePermission).toBe('granted');


### PR DESCRIPTION
## **User description**
## Wave A · PR5 — Voice feedback depth (P1) — final Wave-A PR

Stacked on #211 → #210 → #209 → #208.

Closes the voice-feedback gaps: there was **no audio-level visualizer**, and the tracked confidence score was **never rendered**.

### Changes
- **`useMicLevel`** — a self-contained `AnalyserNode` meter that, while listening, opens its own `getUserMedia` stream and reports a smoothed 0–1 RMS level via rAF. Works across **every** STT engine (Web Speech, Whisper) because it taps the mic directly rather than the VAD path (which only exists in WASM/Whisper mode). Feature-detected → no-ops to 0 without Web Audio / in jsdom. **Never records or logs audio.**
- **`VoiceLevelMeter`** — small reusable 5-bar meter.
- **VoiceIndicator** + **VoiceControlPanel** now show the level meter + transcription **confidence** (`selectLastConfidence` → `useVoice`). VoiceControlPanel also gains the **interim transcript** it never rendered before.

### i18n
`voice.feedback.confidence` across **all 19 locales** + bundles.

### Tests
`useMicLevel` (inactive/unsupported/cleanup), `VoiceLevelMeter` (fill + clamp); existing voice suites updated for the new confidence selector. 45 voice tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Add live voice feedback and prevent stale confidence from showing**

### What Changed
- Voice controls now show a live microphone level meter while listening.
- The voice panel now displays the current transcript and transcription confidence when a new voice result is available.
- Starting a fresh listening or dictation session clears the previous confidence score so an older result does not appear before the next speech is recognized.
- The confidence label is available in all supported languages.
- New and updated tests cover the meter, the confidence display, and the confidence reset behavior.

### Impact
`✅ Clearer voice feedback`
`✅ Fewer stale confidence readings`
`✅ Easier to tell when the microphone is picking up speech`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
