### PR TITLE
feat(settings): consistent maturity badges across Settings sections

### DIFF
--- a/components/settings/FeatureFlagsSection.tsx
+++ b/components/settings/FeatureFlagsSection.tsx
@@ -1,4 +1,4 @@
-import type { FC, ReactNode } from 'react';
+import type { FC } from 'react';
 import { useMemo, useState } from 'react';
 import { useSettingsViewContext } from '../../contexts/SettingsViewContext';
 import {
@@ -12,21 +12,12 @@ import {
 } from '../../features/featureFlags/featureFlagsSlice';
 import { resolveFlagAvailability } from '../../features/featureFlags/flagDependencies';
 import { isTauriRuntime } from '../../services/tauriRuntime';
-import { Badge, type BadgeVariant } from '../ui/Badge';
 import { Button } from '../ui/Button';
 import { Card, CardContent, CardHeader } from '../ui/Card';
 import { Modal } from '../ui/Modal';
 import { useToast } from '../ui/Toast';
+import { MaturityBadge } from './MaturityBadge';
 import { ToggleSwitch } from './SettingsShared';
-
-// QNBS-v3: drive the maturity badge from FEATURE_CATALOG (single source of truth) rather than a
-// hand-maintained list — stub/experimental → "Experimental", beta → "Beta", stable/unlisted → none.
-const MATURITY_TO_BADGE: Record<string, BadgeVariant | undefined> = {
-  experimental: 'experimental',
-  stub: 'experimental',
-  beta: 'beta',
-  stable: undefined,
-};
 
 // QNBS-v3: enableIdbAtRestEncryption is intentionally NOT shown here — toggling it without the
 // passphrase setup flow would lock users out. Its dedicated UI lives in Settings → Privacy
@@ -54,13 +45,6 @@ export const FeatureFlagsSection: FC = () => {
       entries: visible.filter((e) => e.tier === tier),
     })).filter((g) => g.entries.length > 0);
   }, []);
-
-  const renderBadge = (entry: FeatureCatalogEntry): ReactNode => {
-    const variant = MATURITY_TO_BADGE[entry.maturity];
-    if (!variant) return undefined;
-    const label = variant === 'beta' ? t('common.badge.beta') : t('common.badge.experimental');
-    return <Badge variant={variant}>{label}</Badge>;
-  };
 
   // QNBS-v3: compose a localized hint from dependency state + risk level (no English catalog text
   // is shown to users — only i18n strings).
@@ -145,7 +129,7 @@ export const FeatureFlagsSection: FC = () => {
                     <ToggleSwitch
                       key={entry.flagKey}
                       label={t(`settings.featureFlags.${entry.flagKey}`)}
-                      badge={renderBadge(entry)}
+                      badge={<MaturityBadge flagKey={entry.flagKey} decorative />}
                       hint={buildHint(entry)}
                       checked={isOn}
                       disabled={disabled}

--- a/components/settings/FeatureFlagsSection.tsx
+++ b/components/settings/FeatureFlagsSection.tsx
@@ -129,7 +129,7 @@ export const FeatureFlagsSection: FC = () => {
                     <ToggleSwitch
                       key={entry.flagKey}
                       label={t(`settings.featureFlags.${entry.flagKey}`)}
-                      badge={<MaturityBadge flagKey={entry.flagKey} decorative />}
+                      badge={<MaturityBadge flagKey={entry.flagKey} />}
                       hint={buildHint(entry)}
                       checked={isOn}
                       disabled={disabled}

--- a/components/settings/LoraAdapterSection.tsx
+++ b/components/settings/LoraAdapterSection.tsx
@@ -11,6 +11,7 @@ import {
 } from '../../services/loraAdapterService';
 import { Button } from '../ui/Button';
 import { Card, CardContent, CardHeader } from '../ui/Card';
+import { MaturityBadge } from './MaturityBadge';
 
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
@@ -89,9 +90,13 @@ export const LoraAdapterSection: React.FC = () => {
     <div className="space-y-4">
       <Card>
         <CardHeader>
-          <h2 className="text-xl font-semibold text-[var(--sc-text-primary)]">
-            {t('settings.loraAdapters.title')}
-          </h2>
+          {/* QNBS-v3: maturity badge (enableLoraAdapters → Experimental), derived from FEATURE_CATALOG. */}
+          <div className="flex items-center gap-2">
+            <h2 className="text-xl font-semibold text-[var(--sc-text-primary)]">
+              {t('settings.loraAdapters.title')}
+            </h2>
+            <MaturityBadge flagKey="enableLoraAdapters" />
+          </div>
           <p className="text-sm text-[var(--sc-text-muted)] mt-1">
             {t('settings.loraAdapters.description')}
           </p>

--- a/components/settings/LoraAdapterSection.tsx
+++ b/components/settings/LoraAdapterSection.tsx
@@ -73,9 +73,14 @@ export const LoraAdapterSection: React.FC = () => {
     return (
       <Card>
         <CardHeader>
-          <h2 className="text-xl font-semibold text-[var(--sc-text-primary)]">
-            {t('settings.loraAdapters.title')}
-          </h2>
+          {/* QNBS-v3: badge also in the flag-gated header so maturity signalling stays consistent
+              whether or not the feature is enabled. */}
+          <div className="flex items-center gap-2">
+            <h2 className="text-xl font-semibold text-[var(--sc-text-primary)]">
+              {t('settings.loraAdapters.title')}
+            </h2>
+            <MaturityBadge flagKey="enableLoraAdapters" />
+          </div>
         </CardHeader>
         <CardContent>
           <p className="text-sm text-[var(--sc-text-muted)]">

--- a/components/settings/MaturityBadge.tsx
+++ b/components/settings/MaturityBadge.tsx
@@ -1,0 +1,50 @@
+import type { FC } from 'react';
+import { FEATURE_CATALOG } from '../../features/featureCatalog';
+import type { FeatureFlagsState } from '../../features/featureFlags/featureFlagsSlice';
+import { useTranslation } from '../../hooks/useTranslation';
+import { Badge, type BadgeVariant } from '../ui/Badge';
+
+// QNBS-v3: maturity → badge variant, single source for the whole Settings surface. Derived from
+// FEATURE_CATALOG so a section's badge can never drift from the catalog/slice. `stable`/unlisted → no
+// badge (Production needs no pill); `stub`/`experimental` → Experimental; `beta` → Beta.
+const MATURITY_TO_BADGE: Record<string, BadgeVariant | undefined> = {
+  experimental: 'experimental',
+  stub: 'experimental',
+  beta: 'beta',
+  stable: undefined,
+};
+
+/** Returns the badge variant a flag's feature should carry, or `undefined` for stable/unlisted. */
+export function maturityBadgeVariant(flagKey: keyof FeatureFlagsState): BadgeVariant | undefined {
+  const entry = FEATURE_CATALOG.find((e) => e.flagKey === flagKey);
+  return entry ? MATURITY_TO_BADGE[entry.maturity] : undefined;
+}
+
+/**
+ * Inline maturity pill for a Settings section/flag, driven by FEATURE_CATALOG. Renders nothing for
+ * stable/unlisted features. Reused by both the dedicated section headers and the Experimental flags
+ * list, so the maturity signalling is consistent everywhere.
+ */
+export const MaturityBadge: FC<{
+  flagKey: keyof FeatureFlagsState;
+  className?: string;
+  /** When true the pill is decorative (already-labelled context) and hidden from the a11y tree. */
+  decorative?: boolean;
+}> = ({ flagKey, className, decorative }) => {
+  const { t } = useTranslation();
+  const variant = maturityBadgeVariant(flagKey);
+  if (!variant) return null;
+  const label = variant === 'beta' ? t('common.badge.beta') : t('common.badge.experimental');
+  // QNBS-v3: exactOptionalPropertyTypes — only pass optional props when defined (never `undefined`).
+  return (
+    <Badge
+      variant={variant}
+      {...(className !== undefined && { className })}
+      {...(decorative ? { srLabel: '' } : {})}
+    >
+      {label}
+    </Badge>
+  );
+};
+
+MaturityBadge.displayName = 'MaturityBadge';

--- a/components/settings/MaturityBadge.tsx
+++ b/components/settings/MaturityBadge.tsx
@@ -1,17 +1,19 @@
 import type { FC } from 'react';
-import { FEATURE_CATALOG } from '../../features/featureCatalog';
+import { FEATURE_CATALOG, type FeatureMaturity } from '../../features/featureCatalog';
 import type { FeatureFlagsState } from '../../features/featureFlags/featureFlagsSlice';
 import { useTranslation } from '../../hooks/useTranslation';
 import { Badge, type BadgeVariant } from '../ui/Badge';
 
 // QNBS-v3: maturity → badge variant, single source for the whole Settings surface. Derived from
-// FEATURE_CATALOG so a section's badge can never drift from the catalog/slice. `stable`/unlisted → no
-// badge (Production needs no pill); `stub`/`experimental` → Experimental; `beta` → Beta.
-const MATURITY_TO_BADGE: Record<string, BadgeVariant | undefined> = {
+// FEATURE_CATALOG so a section's badge can never drift from the catalog/slice. The strict
+// FeatureMaturity-keyed Record forces every maturity value to be handled (a new one fails to
+// compile). `stable` → no badge (Production needs no pill); `beta` → Beta; everything else → Experimental.
+const MATURITY_TO_BADGE: Record<FeatureMaturity, BadgeVariant | undefined> = {
+  stable: undefined,
+  beta: 'beta',
   experimental: 'experimental',
   stub: 'experimental',
-  beta: 'beta',
-  stable: undefined,
+  ghost: 'experimental',
 };
 
 /** Returns the badge variant a flag's feature should carry, or `undefined` for stable/unlisted. */

--- a/components/settings/MaturityBadge.tsx
+++ b/components/settings/MaturityBadge.tsx
@@ -28,20 +28,16 @@ export function maturityBadgeVariant(flagKey: keyof FeatureFlagsState): BadgeVar
 export const MaturityBadge: FC<{
   flagKey: keyof FeatureFlagsState;
   className?: string;
-  /** When true the pill is decorative (already-labelled context) and hidden from the a11y tree. */
-  decorative?: boolean;
-}> = ({ flagKey, className, decorative }) => {
+}> = ({ flagKey, className }) => {
   const { t } = useTranslation();
   const variant = maturityBadgeVariant(flagKey);
   if (!variant) return null;
   const label = variant === 'beta' ? t('common.badge.beta') : t('common.badge.experimental');
-  // QNBS-v3: exactOptionalPropertyTypes — only pass optional props when defined (never `undefined`).
+  // QNBS-v3: the badge is always announced — "Experimental/Beta" conveys feature readiness (real
+  // status), not decoration, so it must reach screen-reader users. exactOptionalPropertyTypes:
+  // only pass className when defined.
   return (
-    <Badge
-      variant={variant}
-      {...(className !== undefined && { className })}
-      {...(decorative ? { srLabel: '' } : {})}
-    >
+    <Badge variant={variant} {...(className !== undefined && { className })}>
       {label}
     </Badge>
   );

--- a/components/settings/PluginsSection.tsx
+++ b/components/settings/PluginsSection.tsx
@@ -4,6 +4,7 @@ import { useSettingsViewContext } from '../../contexts/SettingsViewContext';
 import { selectEnablePluginSystem } from '../../features/featureFlags/featureFlagsSlice';
 import { pluginRegistry } from '../../services/pluginRegistry';
 import { Card, CardContent, CardHeader } from '../ui/Card';
+import { MaturityBadge } from './MaturityBadge';
 
 const TYPE_BADGE: Record<string, string> = {
   command: 'bg-[var(--sc-interactive-bg)] text-[var(--sc-interactive-fg)]',
@@ -35,9 +36,13 @@ export const PluginsSection: React.FC = () => {
     <div className="space-y-4">
       <Card>
         <CardHeader>
-          <h2 className="text-xl font-semibold text-[var(--sc-text-primary)]">
-            {t('settings.plugins.title')}
-          </h2>
+          {/* QNBS-v3: maturity badge (enablePluginSystem → Beta), derived from FEATURE_CATALOG. */}
+          <div className="flex items-center gap-2">
+            <h2 className="text-xl font-semibold text-[var(--sc-text-primary)]">
+              {t('settings.plugins.title')}
+            </h2>
+            <MaturityBadge flagKey="enablePluginSystem" />
+          </div>
           <p className="text-sm text-[var(--sc-text-muted)] mt-1">
             {t('settings.plugins.description')}
           </p>

--- a/components/settings/PluginsSection.tsx
+++ b/components/settings/PluginsSection.tsx
@@ -21,9 +21,13 @@ export const PluginsSection: React.FC = () => {
     return (
       <Card>
         <CardHeader>
-          <h2 className="text-xl font-semibold text-[var(--sc-text-primary)]">
-            {t('settings.plugins.title')}
-          </h2>
+          {/* QNBS-v3: badge also in the flag-gated header for consistent maturity signalling. */}
+          <div className="flex items-center gap-2">
+            <h2 className="text-xl font-semibold text-[var(--sc-text-primary)]">
+              {t('settings.plugins.title')}
+            </h2>
+            <MaturityBadge flagKey="enablePluginSystem" />
+          </div>
         </CardHeader>
         <CardContent>
           <p className="text-sm text-[var(--sc-text-muted)]">{t('settings.plugins.flagGate')}</p>

--- a/components/settings/VoiceSettingsSection.tsx
+++ b/components/settings/VoiceSettingsSection.tsx
@@ -11,6 +11,7 @@ import { settingsActions } from '../../features/settings/settingsSlice';
 import { Card, CardContent, CardHeader } from '../ui/Card';
 import { Select } from '../ui/Select';
 import { VoiceModelDownloadModal } from '../voice/VoiceModelDownloadModal';
+import { MaturityBadge } from './MaturityBadge';
 import { ToggleSwitch } from './SettingsShared';
 
 export const VoiceSettingsSection: FC = () => {
@@ -44,9 +45,13 @@ export const VoiceSettingsSection: FC = () => {
       {/* ── Master toggle ── */}
       <Card>
         <CardHeader>
-          <h2 className="text-xl font-semibold text-[var(--sc-text-primary)]">
-            {t('settings.voice.title')}
-          </h2>
+          {/* QNBS-v3: maturity badge derived from FEATURE_CATALOG (enableVoiceSupport → Experimental). */}
+          <div className="flex items-center gap-2">
+            <h2 className="text-xl font-semibold text-[var(--sc-text-primary)]">
+              {t('settings.voice.title')}
+            </h2>
+            <MaturityBadge flagKey="enableVoiceSupport" />
+          </div>
           <p className="text-sm text-[var(--sc-text-muted)] mt-2">{t('settings.voice.intro')}</p>
         </CardHeader>
         <CardContent className="space-y-6">

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,12 +1,12 @@
 # Graph Report - StoryCraft-Studio  (2026-06-24)
 
 ## Corpus Check
-- 1164 files · ~1,311,376 words
+- 1166 files · ~1,311,879 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 5047 nodes · 8852 edges · 88 communities detected
-- Extraction: 76% EXTRACTED · 24% INFERRED · 0% AMBIGUOUS · INFERRED: 2166 edges (avg confidence: 0.8)
+- 5049 nodes · 8851 edges · 87 communities detected
+- Extraction: 76% EXTRACTED · 24% INFERRED · 0% AMBIGUOUS · INFERRED: 2165 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Community Hubs (Navigation)
@@ -39,7 +39,7 @@
 - [[_COMMUNITY_Community 26|Community 26]]
 - [[_COMMUNITY_Community 27|Community 27]]
 - [[_COMMUNITY_Community 28|Community 28]]
-- [[_COMMUNITY_Community 29|Community 29]]
+- [[_COMMUNITY_Community 30|Community 30]]
 - [[_COMMUNITY_Community 32|Community 32]]
 - [[_COMMUNITY_Community 33|Community 33]]
 - [[_COMMUNITY_Community 35|Community 35]]
@@ -47,33 +47,31 @@
 - [[_COMMUNITY_Community 38|Community 38]]
 - [[_COMMUNITY_Community 39|Community 39]]
 - [[_COMMUNITY_Community 42|Community 42]]
-- [[_COMMUNITY_Community 43|Community 43]]
+- [[_COMMUNITY_Community 44|Community 44]]
 - [[_COMMUNITY_Community 45|Community 45]]
-- [[_COMMUNITY_Community 46|Community 46]]
+- [[_COMMUNITY_Community 48|Community 48]]
 - [[_COMMUNITY_Community 49|Community 49]]
-- [[_COMMUNITY_Community 50|Community 50]]
-- [[_COMMUNITY_Community 53|Community 53]]
-- [[_COMMUNITY_Community 58|Community 58]]
-- [[_COMMUNITY_Community 61|Community 61]]
+- [[_COMMUNITY_Community 52|Community 52]]
+- [[_COMMUNITY_Community 57|Community 57]]
+- [[_COMMUNITY_Community 60|Community 60]]
+- [[_COMMUNITY_Community 63|Community 63]]
 - [[_COMMUNITY_Community 64|Community 64]]
 - [[_COMMUNITY_Community 65|Community 65]]
 - [[_COMMUNITY_Community 66|Community 66]]
-- [[_COMMUNITY_Community 70|Community 70]]
+- [[_COMMUNITY_Community 71|Community 71]]
 - [[_COMMUNITY_Community 72|Community 72]]
-- [[_COMMUNITY_Community 73|Community 73]]
-- [[_COMMUNITY_Community 78|Community 78]]
-- [[_COMMUNITY_Community 84|Community 84]]
-- [[_COMMUNITY_Community 87|Community 87]]
-- [[_COMMUNITY_Community 91|Community 91]]
-- [[_COMMUNITY_Community 100|Community 100]]
-- [[_COMMUNITY_Community 135|Community 135]]
-- [[_COMMUNITY_Community 146|Community 146]]
-- [[_COMMUNITY_Community 152|Community 152]]
-- [[_COMMUNITY_Community 185|Community 185]]
-- [[_COMMUNITY_Community 233|Community 233]]
+- [[_COMMUNITY_Community 77|Community 77]]
+- [[_COMMUNITY_Community 83|Community 83]]
+- [[_COMMUNITY_Community 86|Community 86]]
+- [[_COMMUNITY_Community 90|Community 90]]
+- [[_COMMUNITY_Community 99|Community 99]]
+- [[_COMMUNITY_Community 134|Community 134]]
+- [[_COMMUNITY_Community 145|Community 145]]
+- [[_COMMUNITY_Community 151|Community 151]]
+- [[_COMMUNITY_Community 184|Community 184]]
+- [[_COMMUNITY_Community 232|Community 232]]
 - [[_COMMUNITY_Community 274|Community 274]]
 - [[_COMMUNITY_Community 279|Community 279]]
-- [[_COMMUNITY_Community 749|Community 749]]
 - [[_COMMUNITY_Community 750|Community 750]]
 - [[_COMMUNITY_Community 751|Community 751]]
 - [[_COMMUNITY_Community 752|Community 752]]
@@ -98,12 +96,13 @@
 - [[_COMMUNITY_Community 771|Community 771]]
 - [[_COMMUNITY_Community 772|Community 772]]
 - [[_COMMUNITY_Community 773|Community 773]]
+- [[_COMMUNITY_Community 774|Community 774]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `mt()` - 104 edges
 2. `Bv` - 74 edges
 3. `fn()` - 63 edges
-4. `t()` - 51 edges
+4. `t()` - 50 edges
 5. `Ze()` - 43 edges
 6. `wx()` - 41 edges
 7. `xA` - 40 edges
@@ -118,100 +117,100 @@
   features/featureFlags/featureFlagsStorage.ts → components/copilot/CopilotPanel.tsx
 - `setItem()` --calls--> `writeMode()`  [INFERRED]
   features/featureFlags/featureFlagsStorage.ts → components/copilot/CopilotPanel.tsx
-- `removeItem()` --calls--> `disableDebugLogging()`  [INFERRED]
-  features/featureFlags/featureFlagsStorage.ts → services/logger.ts
-- `removeItem()` --calls--> `clearBenchmarkResults()`  [INFERRED]
-  features/featureFlags/featureFlagsStorage.ts → services/ai/benchmarkService.ts
+- `Ja()` --calls--> `matches()`  [INFERRED]
+  e2e-deep-report/trace/assets/codeMirrorModule-Ds_H_9Yq.js → tests/unit/ai/localModelStorageService.test.ts
+- `stubDownload()` --calls--> `fn()`  [INFERRED]
+  tests/unit/epubApiService.test.ts → stories/PWAComponents.stories.tsx
 
 ## Communities
 
 ### Community 0 - "Community 0"
 Cohesion: 0.01
-Nodes (347): mt(), md(), flushMicrotasks(), _0, _2(), A0, a2(), aA() (+339 more)
+Nodes (329): md(), flushMicrotasks(), _0, _2(), A0, a2(), aA(), ab() (+321 more)
 
 ### Community 1 - "Community 1"
 Cohesion: 0.01
-Nodes (101): accessibilityPresetDefaults(), normalizeAccessibilitySettings(), applyPreset(), loadAgent(), analyticsPersistenceAllowedNow(), isAnalyticsPersistenceAllowed(), handleRemoveKey(), handleSaveKey() (+93 more)
+Nodes (132): recordLatency(), AiInferenceCacheService, hashKey(), _cleanupPendingRequest(), _clearPendingRequestsForTest(), binderDepth(), collectSubtreeIds(), createCancellationToken() (+124 more)
 
 ### Community 2 - "Community 2"
 Cohesion: 0.01
-Nodes (158): af(), ef(), ff(), Ja(), lf(), nf(), of(), po() (+150 more)
+Nodes (171): af(), ef(), ff(), Ja(), lf(), mt(), nf(), of() (+163 more)
 
 ### Community 3 - "Community 3"
 Cohesion: 0.01
-Nodes (131): recordLatency(), AiInferenceCacheService, hashKey(), assertCloudAiAllowed(), assertCloudAiAllowedSync(), assertLoraLocalOnly(), _cleanupPendingRequest(), _clearPendingRequestsForTest() (+123 more)
+Nodes (98): accessibilityPresetDefaults(), normalizeAccessibilitySettings(), applyPreset(), handleRemoveKey(), handleSaveKey(), handleTestConnection(), CloudSyncBackend, decryptCloudPayload() (+90 more)
 
 ### Community 4 - "Community 4"
-Cohesion: 0.02
-Nodes (102): getActiveAiMode(), getLocalFallbackModel(), getOpenRouterFallbackProvider(), getOpenRouterModel(), isCloudOnlyMode(), isOffline(), shouldRouteLocally(), shouldUseOpenRouter() (+94 more)
+Cohesion: 0.01
+Nodes (80): handleCopyForNotion(), handleDocxImport(), handleExport(), handlePasteImport(), handleBuildLocalRag(), handleWebllmDownload(), isCustomOllamaModel(), analyticsPersistenceAllowedNow() (+72 more)
 
 ### Community 5 - "Community 5"
 Cohesion: 0.02
-Nodes (68): handleCopyForNotion(), handleDocxImport(), handleExport(), handlePasteImport(), handleBuildLocalRag(), handleWebllmDownload(), isCustomOllamaModel(), binderDepth() (+60 more)
+Nodes (92): AdaptiveAiEngine, _clearLatencyHistory(), estimateLatency(), getTaskConfig(), selectModelForBackend(), pipeline(), pipeline(), start() (+84 more)
 
 ### Community 6 - "Community 6"
 Cohesion: 0.03
-Nodes (16): a_(), bh, Dh(), eA(), el(), GE(), Gh(), lv() (+8 more)
+Nodes (17): a_(), bh, Dh(), eA(), el(), GE(), Gh(), lv() (+9 more)
 
 ### Community 7 - "Community 7"
 Cohesion: 0.01
 Nodes (80): categoryFromMessage(), categoryFromStatus(), classificationFor(), classifyAiError(), extractStatus(), getAiErrorMessage(), isOffline(), clampRetryAfter() (+72 more)
 
 ### Community 8 - "Community 8"
-Cohesion: 0.02
-Nodes (64): createCancellationToken(), createAttentionPipeline(), createComputePipeline(), createKvCachePipeline(), createMlpPipeline(), createSimilarityBuffers(), createSimilarityPipeline(), encodeSimilarityUniforms() (+56 more)
+Cohesion: 0.03
+Nodes (69): FsAssetStore, glossaryTranslate(), loadCheckpoint(), loadGlossary(), main(), maskPlaceholders(), parseArgs(), restorePlaceholders() (+61 more)
 
 ### Community 9 - "Community 9"
 Cohesion: 0.02
-Nodes (85): countWords(), enrichProjectIndex(), extractCharacterNames(), getDb(), indexProject(), listIndexedProjects(), removeProjectIndex(), semanticSearchProjects() (+77 more)
+Nodes (70): item(), clearBenchmarkResults(), getLocalUser(), getRandomColor(), handleKeyDown(), sanitizeRoomInput(), stripControlChars(), deleteIdb() (+62 more)
 
 ### Community 10 - "Community 10"
 Cohesion: 0.02
-Nodes (30): isEcoMode(), getFocusable(), onKeyDown(), onPointerUp(), n2(), getFocusable(), handleEsc(), handleTabKey() (+22 more)
+Nodes (35): isEcoMode(), generateMessageId(), getWorker(), send(), EcoModeService, FeedbackService, handleEcoToggle(), KokoroTtsEngine (+27 more)
 
 ### Community 11 - "Community 11"
 Cohesion: 0.02
-Nodes (65): AnalyticsBootstrap(), App(), ViewLoader(), BookPreviewView(), useCommandExecutor(), CopilotLauncher(), Header(), useAppDispatch() (+57 more)
+Nodes (64): AnalyticsBootstrap(), App(), ViewLoader(), BookPreviewView(), useCommandExecutor(), CopilotLauncher(), Header(), useAppDispatch() (+56 more)
 
 ### Community 12 - "Community 12"
-Cohesion: 0.02
-Nodes (60): AdaptiveAiEngine, _clearLatencyHistory(), estimateLatency(), getTaskConfig(), selectModelForBackend(), notifyLocalModelsReady(), start(), clearBenchmarkResults() (+52 more)
+Cohesion: 0.03
+Nodes (97): AiModeIndicator(), getActiveAiMode(), getOpenRouterFallbackProvider(), getOpenRouterModel(), isCloudOnlyMode(), isOffline(), notifyLocalModelsReady(), shouldRouteLocally() (+89 more)
 
 ### Community 13 - "Community 13"
-Cohesion: 0.02
-Nodes (60): item(), getLocalUser(), getRandomColor(), handleKeyDown(), sanitizeRoomInput(), stripControlChars(), deleteIdb(), formatStorageError() (+52 more)
+Cohesion: 0.05
+Nodes (53): getLocalFallbackModel(), generateJson(), attachCause(), cleanPrompt(), sanitizePromptBlock(), stripControlChars(), stripJsonFences(), AnalyticsAgent (+45 more)
 
 ### Community 14 - "Community 14"
-Cohesion: 0.02
-Nodes (65): pipeline(), pipeline(), installDesktopMenu(), installCloseToTray(), installDesktopTray(), buildTimeoutSignal(), createWorldScriptFetch(), resolveTauriFetch() (+57 more)
+Cohesion: 0.03
+Nodes (35): AudioNavigator, getFocusable(), onKeyDown(), onPointerUp(), buildEncodedPayload(), makeCommands(), makeProjectData(), Hb() (+27 more)
 
 ### Community 15 - "Community 15"
 Cohesion: 0.04
-Nodes (70): AiModeIndicator(), generateTextSingleProvider(), isAbortError(), _pendingKey(), streamAiHelpResponse(), streamAnthropic(), streamGrok(), streamOpenAI() (+62 more)
+Nodes (61): countWords(), enrichProjectIndex(), extractCharacterNames(), getDb(), indexProject(), listIndexedProjects(), removeProjectIndex(), semanticSearchProjects() (+53 more)
 
 ### Community 16 - "Community 16"
-Cohesion: 0.03
-Nodes (41): AudioNavigator, buildEncodedPayload(), makeCommands(), makeProjectData(), makeContext(), makeLargeContext(), makeSection(), smallProject() (+33 more)
+Cohesion: 0.04
+Nodes (35): assertNoSeriousViolations(), loadAgent(), bindAbortSignal(), setRetryFeedback(), navigateToCollaborationSettings(), connectSrcTokens(), group1(), tauriCsp() (+27 more)
 
 ### Community 17 - "Community 17"
-Cohesion: 0.09
-Nodes (17): FsAssetStore, FsCodexStore, countProjectWords(), decompressData(), decryptText(), deriveFileSystemCryptoKey(), encryptText(), FsCore (+9 more)
+Cohesion: 0.06
+Nodes (15): bb(), d_, f_, h_, kS(), mc(), ps(), r0() (+7 more)
 
 ### Community 18 - "Community 18"
-Cohesion: 0.05
-Nodes (28): applyPreset(), async(), close(), isSidebar(), onKey(), onPointerDown(), readMode(), writeMode() (+20 more)
+Cohesion: 0.04
+Nodes (39): collect(), buildPaletteCommandModels(), collectAllDefinitions(), resolveTitle(), runCommandById(), DeadLetterQueue, openDlqDb(), storeClear() (+31 more)
 
 ### Community 19 - "Community 19"
-Cohesion: 0.07
-Nodes (10): d_, f_, ps(), r0(), Tr, u_, Ui, wT() (+2 more)
+Cohesion: 0.04
+Nodes (37): createAttentionPipeline(), createComputePipeline(), createKvCachePipeline(), createMlpPipeline(), createSimilarityBuffers(), createSimilarityPipeline(), encodeSimilarityUniforms(), getComputeDevice() (+29 more)
 
 ### Community 20 - "Community 20"
-Cohesion: 0.05
-Nodes (37): collect(), buildPaletteCommandModels(), collectAllDefinitions(), resolveTitle(), runCommandById(), DeadLetterQueue, openDlqDb(), storeClear() (+29 more)
+Cohesion: 0.1
+Nodes (11): bc(), fr(), Go(), jS(), LS, Xd, xn(), aa (+3 more)
 
 ### Community 21 - "Community 21"
-Cohesion: 0.06
-Nodes (25): assertNoSeriousViolations(), navigateToCollaborationSettings(), connectSrcTokens(), group1(), tauriCsp(), webCsp(), clickNavItem(), ensureBlankProject() (+17 more)
+Cohesion: 0.07
+Nodes (32): applyPreset(), async(), close(), isSidebar(), onKey(), onPointerDown(), readMode(), writeMode() (+24 more)
 
 ### Community 22 - "Community 22"
 Cohesion: 0.06
@@ -222,8 +221,8 @@ Cohesion: 0.11
 Nodes (1): StorageManager
 
 ### Community 24 - "Community 24"
-Cohesion: 0.23
-Nodes (3): LS, xn(), aa
+Cohesion: 0.07
+Nodes (16): smallProject(), buildCharacter(), buildLargeManuscript(), buildParagraph(), buildSectionContent(), buildWorld(), countWords(), makeRng() (+8 more)
 
 ### Community 25 - "Community 25"
 Cohesion: 0.14
@@ -239,15 +238,15 @@ Nodes (2): cc, Gb()
 
 ### Community 28 - "Community 28"
 Cohesion: 0.17
-Nodes (8): check(), extractCatalogFlags(), extractHiddenFlags(), extractSectionFlags(), green(), grep(), hasRuntimeConsumption(), red()
-
-### Community 29 - "Community 29"
-Cohesion: 0.17
 Nodes (9): applyTextEdit(), applyReviewEditsToSection(), containsDisallowedControlChar(), isValidRange(), nearestFreeOccurrence(), planAcceptedManuscriptEdits(), validateProposedText(), applyEditsPure() (+1 more)
 
+### Community 30 - "Community 30"
+Cohesion: 0.21
+Nodes (8): classifyDevice(), detectIsMobile(), getBatteryLevel(), getHealthReport(), getMemoryInfo(), getStorageQuotaMb(), classifyVram(), detectWebGpuDetails()
+
 ### Community 32 - "Community 32"
-Cohesion: 0.42
-Nodes (6): emit(), main(), merge(), ProgressCallback, Emits JSON progress events on each training log step., train()
+Cohesion: 0.29
+Nodes (1): PriorityTaskQueue
 
 ### Community 33 - "Community 33"
 Cohesion: 0.25
@@ -270,102 +269,98 @@ Cohesion: 0.7
 Nodes (4): check_cuda_and_vram(), check_package(), check_python_version(), main()
 
 ### Community 42 - "Community 42"
-Cohesion: 0.4
-Nodes (1): O0
-
-### Community 43 - "Community 43"
 Cohesion: 0.5
 Nodes (3): createStorageMock(), setupStorage(), SpeechSynthesisUtteranceMock
 
-### Community 45 - "Community 45"
+### Community 44 - "Community 44"
 Cohesion: 0.4
 Nodes (4): Room, SignalingConn, WebrtcConn, WebrtcProvider
 
-### Community 46 - "Community 46"
+### Community 45 - "Community 45"
 Cohesion: 0.4
 Nodes (2): useDashboardContext(), DashboardHeader()
 
-### Community 49 - "Community 49"
+### Community 48 - "Community 48"
 Cohesion: 0.6
 Nodes (4): applyFormula(), computeReadabilitySnapshot(), estimateSyllables(), getSyllablePattern()
 
-### Community 50 - "Community 50"
+### Community 49 - "Community 49"
 Cohesion: 0.5
 Nodes (1): rc
 
-### Community 53 - "Community 53"
+### Community 52 - "Community 52"
 Cohesion: 0.67
 Nodes (2): makeConfig(), startPipelinePayload()
 
-### Community 58 - "Community 58"
+### Community 57 - "Community 57"
 Cohesion: 0.67
 Nodes (2): make(), noop()
 
-### Community 61 - "Community 61"
+### Community 60 - "Community 60"
 Cohesion: 0.67
 Nodes (2): defaultProject(), setProjectData()
 
-### Community 64 - "Community 64"
+### Community 63 - "Community 63"
 Cohesion: 0.83
 Nodes (3): makeChars(), makeProject(), makeWorlds()
 
-### Community 65 - "Community 65"
+### Community 64 - "Community 64"
 Cohesion: 0.83
 Nodes (3): emptyChars(), emptyWorlds(), makeProject()
+
+### Community 65 - "Community 65"
+Cohesion: 0.5
+Nodes (2): ManuscriptDesktopLayout(), useManuscriptViewContext()
 
 ### Community 66 - "Community 66"
 Cohesion: 0.5
 Nodes (3): AsyncDuckDB, AsyncDuckDBConnection, ConsoleLogger
 
-### Community 70 - "Community 70"
-Cohesion: 0.5
-Nodes (2): ManuscriptDesktopLayout(), useManuscriptViewContext()
-
-### Community 72 - "Community 72"
+### Community 71 - "Community 71"
 Cohesion: 0.67
 Nodes (2): getQuestionsForArchetype(), getTemplateForArchetype()
 
-### Community 73 - "Community 73"
+### Community 72 - "Community 72"
 Cohesion: 0.83
 Nodes (3): esc(), inline(), renderExportMarkdownToHtml()
 
-### Community 78 - "Community 78"
+### Community 77 - "Community 77"
 Cohesion: 0.67
 Nodes (1): makeSection()
 
-### Community 84 - "Community 84"
+### Community 83 - "Community 83"
 Cohesion: 0.67
 Nodes (1): MockGoogleGenAI
 
-### Community 87 - "Community 87"
+### Community 86 - "Community 86"
 Cohesion: 0.67
 Nodes (1): makeDeps()
 
-### Community 91 - "Community 91"
+### Community 90 - "Community 90"
 Cohesion: 0.67
 Nodes (1): FakeAudioContext
 
-### Community 100 - "Community 100"
+### Community 99 - "Community 99"
 Cohesion: 0.67
 Nodes (1): TaskError
 
-### Community 135 - "Community 135"
+### Community 134 - "Community 134"
 Cohesion: 1.0
 Nodes (1): MockIntersectionObserver
 
-### Community 146 - "Community 146"
+### Community 145 - "Community 145"
 Cohesion: 1.0
 Nodes (1): MockWorker
 
-### Community 152 - "Community 152"
+### Community 151 - "Community 151"
 Cohesion: 1.0
 Nodes (1): MockBroadcastChannel
 
-### Community 185 - "Community 185"
+### Community 184 - "Community 184"
 Cohesion: 1.0
 Nodes (1): MockIntersectionObserver
 
-### Community 233 - "Community 233"
+### Community 232 - "Community 232"
 Cohesion: 1.0
 Nodes (1): MockWorker
 
@@ -377,103 +372,103 @@ Nodes (1): FileSystemService
 Cohesion: 1.0
 Nodes (1): IndexedDBService
 
-### Community 749 - "Community 749"
+### Community 750 - "Community 750"
 Cohesion: 1.0
 Nodes (1): Remove ANSI escape codes from text.
 
-### Community 750 - "Community 750"
+### Community 751 - "Community 751"
 Cohesion: 1.0
 Nodes (1): Remove timestamp strings from text.
 
-### Community 751 - "Community 751"
+### Community 752 - "Community 752"
 Cohesion: 1.0
 Nodes (1): Replace long base64 strings with placeholder.
 
-### Community 752 - "Community 752"
+### Community 753 - "Community 753"
 Cohesion: 1.0
 Nodes (1): Remove NPM/pnpm warning lines.
 
-### Community 753 - "Community 753"
+### Community 754 - "Community 754"
 Cohesion: 1.0
 Nodes (1): Remove redundant success messages.
 
-### Community 754 - "Community 754"
+### Community 755 - "Community 755"
 Cohesion: 1.0
 Nodes (1): Apply all preprocessing steps to reduce token payload.
 
-### Community 755 - "Community 755"
+### Community 756 - "Community 756"
 Cohesion: 1.0
 Nodes (1): Extract only error-related sections from log.
 
-### Community 756 - "Community 756"
+### Community 757 - "Community 757"
 Cohesion: 1.0
 Nodes (1): Pydantic models for CI Analyzer structured output. QNBS-v3: These models enforce
 
-### Community 757 - "Community 757"
+### Community 758 - "Community 758"
 Cohesion: 1.0
 Nodes (1): Structured CI error for VS Code problem matcher integration.
 
-### Community 758 - "Community 758"
+### Community 759 - "Community 759"
 Cohesion: 1.0
 Nodes (1): Vitest JSON test result structure.
 
-### Community 759 - "Community 759"
+### Community 760 - "Community 760"
 Cohesion: 1.0
 Nodes (1): Full Vitest JSON report structure.
 
-### Community 760 - "Community 760"
+### Community 761 - "Community 761"
 Cohesion: 1.0
 Nodes (1): Stryker per-file mutation report.
 
-### Community 761 - "Community 761"
+### Community 762 - "Community 762"
 Cohesion: 1.0
 Nodes (1): Full Stryker JSON report structure.
 
-### Community 762 - "Community 762"
+### Community 763 - "Community 763"
 Cohesion: 1.0
 Nodes (1): Initialize OpenRouter client for Poolside Laguna model.
 
-### Community 763 - "Community 763"
+### Community 764 - "Community 764"
 Cohesion: 1.0
 Nodes (1): Analyze Vitest JSON report and raw logs for errors.
 
-### Community 764 - "Community 764"
+### Community 765 - "Community 765"
 Cohesion: 1.0
 Nodes (1): Analyze Stryker JSON report for surviving mutants.
 
-### Community 765 - "Community 765"
+### Community 766 - "Community 766"
 Cohesion: 1.0
 Nodes (1): Send preprocessed errors to LLM for analysis.
 
-### Community 766 - "Community 766"
+### Community 767 - "Community 767"
 Cohesion: 1.0
 Nodes (1): Format errors for VS Code problem matcher.
 
-### Community 767 - "Community 767"
+### Community 768 - "Community 768"
 Cohesion: 1.0
 Nodes (1): Main entry point for CI analyzer.
 
-### Community 768 - "Community 768"
+### Community 769 - "Community 769"
 Cohesion: 1.0
 Nodes (1): Execute gh CLI command and return parsed JSON output.
 
-### Community 769 - "Community 769"
+### Community 770 - "Community 770"
 Cohesion: 1.0
 Nodes (1): Get the ID of the most recent failed CI run.
 
-### Community 770 - "Community 770"
+### Community 771 - "Community 771"
 Cohesion: 1.0
 Nodes (1): Download a specific artifact from a workflow run.
 
-### Community 771 - "Community 771"
+### Community 772 - "Community 772"
 Cohesion: 1.0
 Nodes (1): Get raw logs from a failed workflow run.
 
-### Community 772 - "Community 772"
+### Community 773 - "Community 773"
 Cohesion: 1.0
 Nodes (1): Parse Vitest JSON report for failing tests.
 
-### Community 773 - "Community 773"
+### Community 774 - "Community 774"
 Cohesion: 1.0
 Nodes (1): Parse Stryker JSON report for surviving mutants.
 
@@ -484,111 +479,111 @@ Nodes (1): Parse Stryker JSON report for surviving mutants.
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 27`** (17 nodes): `cc`, `._applyAttribute()`, `._assert()`, `.constructor()`, `._eof()`, `._isWhitespace()`, `._next()`, `.parse()`, `._peek()`, `._readAttributes()`, `._readIdentifier()`, `._readRegex()`, `._readString()`, `._readStringOrRegex()`, `._skipWhitespace()`, `._throwError()`, `Gb()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 42`** (5 nodes): `O0`, `.constructor()`, `.toJSON()`, `.toSource()`, `.toString()`
+- **Thin community `Community 32`** (10 nodes): `taskQueue.ts`, `PriorityTaskQueue`, `.constructor()`, `.dequeue()`, `.effectivePriority()`, `.enqueue()`, `.peek()`, `.promoteStarvedTasks()`, `.stats()`, `.totalDepth()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 46`** (5 nodes): `DashboardHeader.tsx`, `DashboardContext.ts`, `useDashboardContext()`, `Chip()`, `DashboardHeader()`
+- **Thin community `Community 45`** (5 nodes): `DashboardHeader.tsx`, `DashboardContext.ts`, `useDashboardContext()`, `Chip()`, `DashboardHeader()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 50`** (4 nodes): `rc`, `.constructor()`, `.toSource()`, `.toString()`
+- **Thin community `Community 49`** (4 nodes): `rc`, `.constructor()`, `.toSource()`, `.toString()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 53`** (4 nodes): `makeConfig()`, `makeReviewItem()`, `startPipelinePayload()`, `proForgeSlice.test.ts`
+- **Thin community `Community 52`** (4 nodes): `makeConfig()`, `makeReviewItem()`, `startPipelinePayload()`, `proForgeSlice.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 58`** (4 nodes): `make()`, `noop()`, `aiRetry.test.ts`, `aiRetry.test.ts`
+- **Thin community `Community 57`** (4 nodes): `make()`, `noop()`, `aiRetry.test.ts`, `aiRetry.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 61`** (4 nodes): `useDashboard.test.ts`, `defaultProject()`, `defaultSection()`, `setProjectData()`
+- **Thin community `Community 60`** (4 nodes): `useDashboard.test.ts`, `defaultProject()`, `defaultSection()`, `setProjectData()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 70`** (4 nodes): `ManuscriptDesktopLayout.tsx`, `ManuscriptViewContext.ts`, `ManuscriptDesktopLayout()`, `useManuscriptViewContext()`
+- **Thin community `Community 65`** (4 nodes): `ManuscriptDesktopLayout.tsx`, `ManuscriptViewContext.ts`, `ManuscriptDesktopLayout()`, `useManuscriptViewContext()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 72`** (4 nodes): `getAllTemplates()`, `getQuestionsForArchetype()`, `getTemplateForArchetype()`, `characterInterviewTemplates.ts`
+- **Thin community `Community 71`** (4 nodes): `getAllTemplates()`, `getQuestionsForArchetype()`, `getTemplateForArchetype()`, `characterInterviewTemplates.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 78`** (3 nodes): `makeSection()`, `plotBoardService.test.ts`, `plotBoardService.test.ts`
+- **Thin community `Community 77`** (3 nodes): `makeSection()`, `plotBoardService.test.ts`, `plotBoardService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 84`** (3 nodes): `makeStream()`, `MockGoogleGenAI`, `geminiService.test.ts`
+- **Thin community `Community 83`** (3 nodes): `makeStream()`, `MockGoogleGenAI`, `geminiService.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 87`** (3 nodes): `makeDeps()`, `aiSuggestions.test.ts`, `aiSuggestions.test.ts`
+- **Thin community `Community 86`** (3 nodes): `makeDeps()`, `aiSuggestions.test.ts`, `aiSuggestions.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 91`** (3 nodes): `useMicLevel.test.ts`, `FakeAudioContext`, `resolveStream()`
+- **Thin community `Community 90`** (3 nodes): `useMicLevel.test.ts`, `FakeAudioContext`, `resolveStream()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 100`** (3 nodes): `types.ts`, `TaskError`, `.constructor()`
+- **Thin community `Community 99`** (3 nodes): `types.ts`, `TaskError`, `.constructor()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 135`** (2 nodes): `MockIntersectionObserver`, `BookPreviewView.test.tsx`
+- **Thin community `Community 134`** (2 nodes): `MockIntersectionObserver`, `BookPreviewView.test.tsx`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 146`** (2 nodes): `MockWorker`, `duckdbClient.test.ts`
+- **Thin community `Community 145`** (2 nodes): `MockWorker`, `duckdbClient.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 152`** (2 nodes): `MockBroadcastChannel`, `tabLeaderElection.test.ts`
+- **Thin community `Community 151`** (2 nodes): `MockBroadcastChannel`, `tabLeaderElection.test.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 185`** (2 nodes): `useBookPreviewView.test.ts`, `MockIntersectionObserver`
+- **Thin community `Community 184`** (2 nodes): `useBookPreviewView.test.ts`, `MockIntersectionObserver`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 233`** (2 nodes): `workerPool.test.ts`, `MockWorker`
+- **Thin community `Community 232`** (2 nodes): `workerPool.test.ts`, `MockWorker`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 274`** (2 nodes): `FileSystemService`, `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 279`** (2 nodes): `IndexedDBService`, `index.ts`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 749`** (1 nodes): `Remove ANSI escape codes from text.`
+- **Thin community `Community 750`** (1 nodes): `Remove ANSI escape codes from text.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 750`** (1 nodes): `Remove timestamp strings from text.`
+- **Thin community `Community 751`** (1 nodes): `Remove timestamp strings from text.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 751`** (1 nodes): `Replace long base64 strings with placeholder.`
+- **Thin community `Community 752`** (1 nodes): `Replace long base64 strings with placeholder.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 752`** (1 nodes): `Remove NPM/pnpm warning lines.`
+- **Thin community `Community 753`** (1 nodes): `Remove NPM/pnpm warning lines.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 753`** (1 nodes): `Remove redundant success messages.`
+- **Thin community `Community 754`** (1 nodes): `Remove redundant success messages.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 754`** (1 nodes): `Apply all preprocessing steps to reduce token payload.`
+- **Thin community `Community 755`** (1 nodes): `Apply all preprocessing steps to reduce token payload.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 755`** (1 nodes): `Extract only error-related sections from log.`
+- **Thin community `Community 756`** (1 nodes): `Extract only error-related sections from log.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 756`** (1 nodes): `Pydantic models for CI Analyzer structured output. QNBS-v3: These models enforce`
+- **Thin community `Community 757`** (1 nodes): `Pydantic models for CI Analyzer structured output. QNBS-v3: These models enforce`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 757`** (1 nodes): `Structured CI error for VS Code problem matcher integration.`
+- **Thin community `Community 758`** (1 nodes): `Structured CI error for VS Code problem matcher integration.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 758`** (1 nodes): `Vitest JSON test result structure.`
+- **Thin community `Community 759`** (1 nodes): `Vitest JSON test result structure.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 759`** (1 nodes): `Full Vitest JSON report structure.`
+- **Thin community `Community 760`** (1 nodes): `Full Vitest JSON report structure.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 760`** (1 nodes): `Stryker per-file mutation report.`
+- **Thin community `Community 761`** (1 nodes): `Stryker per-file mutation report.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 761`** (1 nodes): `Full Stryker JSON report structure.`
+- **Thin community `Community 762`** (1 nodes): `Full Stryker JSON report structure.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 762`** (1 nodes): `Initialize OpenRouter client for Poolside Laguna model.`
+- **Thin community `Community 763`** (1 nodes): `Initialize OpenRouter client for Poolside Laguna model.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 763`** (1 nodes): `Analyze Vitest JSON report and raw logs for errors.`
+- **Thin community `Community 764`** (1 nodes): `Analyze Vitest JSON report and raw logs for errors.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 764`** (1 nodes): `Analyze Stryker JSON report for surviving mutants.`
+- **Thin community `Community 765`** (1 nodes): `Analyze Stryker JSON report for surviving mutants.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 765`** (1 nodes): `Send preprocessed errors to LLM for analysis.`
+- **Thin community `Community 766`** (1 nodes): `Send preprocessed errors to LLM for analysis.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 766`** (1 nodes): `Format errors for VS Code problem matcher.`
+- **Thin community `Community 767`** (1 nodes): `Format errors for VS Code problem matcher.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 767`** (1 nodes): `Main entry point for CI analyzer.`
+- **Thin community `Community 768`** (1 nodes): `Main entry point for CI analyzer.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 768`** (1 nodes): `Execute gh CLI command and return parsed JSON output.`
+- **Thin community `Community 769`** (1 nodes): `Execute gh CLI command and return parsed JSON output.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 769`** (1 nodes): `Get the ID of the most recent failed CI run.`
+- **Thin community `Community 770`** (1 nodes): `Get the ID of the most recent failed CI run.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 770`** (1 nodes): `Download a specific artifact from a workflow run.`
+- **Thin community `Community 771`** (1 nodes): `Download a specific artifact from a workflow run.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 771`** (1 nodes): `Get raw logs from a failed workflow run.`
+- **Thin community `Community 772`** (1 nodes): `Get raw logs from a failed workflow run.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 772`** (1 nodes): `Parse Vitest JSON report for failing tests.`
+- **Thin community `Community 773`** (1 nodes): `Parse Vitest JSON report for failing tests.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 773`** (1 nodes): `Parse Stryker JSON report for surviving mutants.`
+- **Thin community `Community 774`** (1 nodes): `Parse Stryker JSON report for surviving mutants.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `mt()` connect `Community 0` to `Community 2`, `Community 3`, `Community 5`, `Community 6`, `Community 10`, `Community 12`, `Community 15`, `Community 16`, `Community 18`, `Community 19`, `Community 22`, `Community 24`?**
-  _High betweenness centrality (0.084) - this node is a cross-community bridge._
-- **Why does `fn()` connect `Community 7` to `Community 1`, `Community 3`, `Community 4`, `Community 16`, `Community 17`, `Community 21`, `Community 22`?**
+- **Why does `mt()` connect `Community 2` to `Community 0`, `Community 1`, `Community 4`, `Community 5`, `Community 6`, `Community 10`, `Community 13`, `Community 14`, `Community 17`, `Community 20`, `Community 21`, `Community 22`?**
+  _High betweenness centrality (0.085) - this node is a cross-community bridge._
+- **Why does `fn()` connect `Community 7` to `Community 1`, `Community 3`, `Community 8`, `Community 13`, `Community 14`, `Community 21`, `Community 22`?**
   _High betweenness centrality (0.056) - this node is a cross-community bridge._
-- **Why does `t()` connect `Community 5` to `Community 0`, `Community 1`, `Community 2`, `Community 3`, `Community 7`, `Community 11`, `Community 12`, `Community 13`, `Community 14`, `Community 15`, `Community 18`, `Community 20`, `Community 25`?**
-  _High betweenness centrality (0.043) - this node is a cross-community bridge._
+- **Why does `wx()` connect `Community 0` to `Community 2`, `Community 4`, `Community 8`, `Community 10`, `Community 19`?**
+  _High betweenness centrality (0.042) - this node is a cross-community bridge._
 - **Are the 87 inferred relationships involving `mt()` (e.g. with `pE()` and `xE()`) actually correct?**
   _`mt()` has 87 INFERRED edges - model-reasoned connections that need verification._
 - **Are the 62 inferred relationships involving `fn()` (e.g. with `makeMediaQuery()` and `MockSpeechRecognition()`) actually correct?**
   _`fn()` has 62 INFERRED edges - model-reasoned connections that need verification._
-- **Are the 50 inferred relationships involving `t()` (e.g. with `.flattenForSingleProject()` and `fr()`) actually correct?**
-  _`t()` has 50 INFERRED edges - model-reasoned connections that need verification._
+- **Are the 49 inferred relationships involving `t()` (e.g. with `.flattenForSingleProject()` and `fr()`) actually correct?**
+  _`t()` has 49 INFERRED edges - model-reasoned connections that need verification._
 - **What connects `Emits JSON progress events on each training log step.`, `qb`, `v2` to the rest of the system?**
   _54 weakly-connected nodes found - possible documentation gaps or missing edges._

--- a/tests/unit/settings/LoraAdapterSection.test.tsx
+++ b/tests/unit/settings/LoraAdapterSection.test.tsx
@@ -33,8 +33,11 @@ vi.mock('../../../services/loraAdapterService', () => ({
   deleteAdapter: (...args: unknown[]) => mockDeleteAdapter(...args),
 }));
 
-// selectEnableLoraAdapters is used with useAppSelector
-vi.mock('../../../features/featureFlags/featureFlagsSlice', () => ({
+// selectEnableLoraAdapters is used with useAppSelector. QNBS-v3: keep the real module (so
+// `defaultFeatureFlagsState`, which featureCatalog derives from via the section's MaturityBadge,
+// still exists) and override only the selector.
+vi.mock('../../../features/featureFlags/featureFlagsSlice', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../features/featureFlags/featureFlagsSlice')>()),
   selectEnableLoraAdapters: (s: unknown) => s,
 }));
 

--- a/tests/unit/settings/LoraAdapterSection.test.tsx
+++ b/tests/unit/settings/LoraAdapterSection.test.tsx
@@ -33,13 +33,9 @@ vi.mock('../../../services/loraAdapterService', () => ({
   deleteAdapter: (...args: unknown[]) => mockDeleteAdapter(...args),
 }));
 
-// selectEnableLoraAdapters is used with useAppSelector. QNBS-v3: keep the real module (so
-// `defaultFeatureFlagsState`, which featureCatalog derives from via the section's MaturityBadge,
-// still exists) and override only the selector.
-vi.mock('../../../features/featureFlags/featureFlagsSlice', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('../../../features/featureFlags/featureFlagsSlice')>()),
-  selectEnableLoraAdapters: (s: unknown) => s,
-}));
+// QNBS-v3: featureFlagsSlice is NOT mocked — useAppSelector above is mocked to ignore its selector
+// argument (returns mockIsEnabled), so the real, typed selectEnableLoraAdapters is harmlessly unused,
+// and featureCatalog (loaded via the section's MaturityBadge) keeps its real defaultFeatureFlagsState.
 
 // ---------------------------------------------------------------------------
 // Import after mocks

--- a/tests/unit/settings/LoraAdapterSection.test.tsx
+++ b/tests/unit/settings/LoraAdapterSection.test.tsx
@@ -60,6 +60,12 @@ describe('LoraAdapterSection', () => {
     expect(screen.getByText('settings.loraAdapters.flagGate')).toBeInTheDocument();
   });
 
+  // QNBS-v3: maturity signalling must stay consistent whether the flag is on or off.
+  it('shows the Experimental maturity badge even when the feature is disabled', () => {
+    render(<LoraAdapterSection />);
+    expect(screen.getByText('common.badge.experimental')).toBeInTheDocument();
+  });
+
   it('does not show upload button when feature is disabled', () => {
     render(<LoraAdapterSection />);
     expect(

--- a/tests/unit/settings/MaturityBadge.test.tsx
+++ b/tests/unit/settings/MaturityBadge.test.tsx
@@ -1,0 +1,46 @@
+/**
+ * Tests for components/settings/MaturityBadge.tsx
+ * QNBS-v3: the badge variant is DERIVED from FEATURE_CATALOG maturity (single source of truth), so a
+ * section badge can never drift from the catalog/slice. We assert the experimental + beta paths and
+ * the catalog-derived helper.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../hooks/useTranslation', () => ({
+  useTranslation: () => ({ t: (k: string) => k, language: 'en' }),
+}));
+
+import { MaturityBadge, maturityBadgeVariant } from '../../../components/settings/MaturityBadge';
+
+describe('maturityBadgeVariant', () => {
+  it('maps an experimental feature to the experimental variant', () => {
+    expect(maturityBadgeVariant('enableProForge')).toBe('experimental');
+  });
+
+  it('maps a stub feature to the experimental variant', () => {
+    expect(maturityBadgeVariant('enableRtlLayout')).toBe('experimental');
+  });
+
+  it('maps a beta feature to the beta variant', () => {
+    expect(maturityBadgeVariant('enablePluginSystem')).toBe('beta');
+  });
+});
+
+describe('MaturityBadge', () => {
+  it('renders the Experimental label for an experimental flag', () => {
+    render(<MaturityBadge flagKey="enableVoiceSupport" />);
+    expect(screen.getByText('common.badge.experimental')).toBeInTheDocument();
+  });
+
+  it('renders the Beta label for a beta flag', () => {
+    render(<MaturityBadge flagKey="enablePluginSystem" />);
+    expect(screen.getByText('common.badge.beta')).toBeInTheDocument();
+  });
+
+  it('renders the LoRA (experimental) badge', () => {
+    render(<MaturityBadge flagKey="enableLoraAdapters" />);
+    expect(screen.getByText('common.badge.experimental')).toBeInTheDocument();
+  });
+});

--- a/tests/unit/settings/PluginsSection.test.tsx
+++ b/tests/unit/settings/PluginsSection.test.tsx
@@ -17,7 +17,10 @@ vi.mock('../../../app/hooks', () => ({
   useAppSelector: vi.fn(() => mockIsEnabled),
 }));
 
-vi.mock('../../../features/featureFlags/featureFlagsSlice', () => ({
+// QNBS-v3: keep the real module (so `defaultFeatureFlagsState`, which featureCatalog derives from via
+// the section's MaturityBadge, still exists) and override only the selector.
+vi.mock('../../../features/featureFlags/featureFlagsSlice', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../features/featureFlags/featureFlagsSlice')>()),
   selectEnablePluginSystem: (s: unknown) => s,
 }));
 

--- a/tests/unit/settings/PluginsSection.test.tsx
+++ b/tests/unit/settings/PluginsSection.test.tsx
@@ -17,12 +17,9 @@ vi.mock('../../../app/hooks', () => ({
   useAppSelector: vi.fn(() => mockIsEnabled),
 }));
 
-// QNBS-v3: keep the real module (so `defaultFeatureFlagsState`, which featureCatalog derives from via
-// the section's MaturityBadge, still exists) and override only the selector.
-vi.mock('../../../features/featureFlags/featureFlagsSlice', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('../../../features/featureFlags/featureFlagsSlice')>()),
-  selectEnablePluginSystem: (s: unknown) => s,
-}));
+// QNBS-v3: featureFlagsSlice is NOT mocked — useAppSelector above is mocked to ignore its selector
+// argument (returns mockIsEnabled), so the real, typed selectEnablePluginSystem is harmlessly unused,
+// and featureCatalog (loaded via the section's MaturityBadge) keeps its real defaultFeatureFlagsState.
 
 vi.mock('../../../contexts/SettingsViewContext', () => ({
   useSettingsViewContext: () => ({

--- a/tests/unit/settings/PluginsSection.test.tsx
+++ b/tests/unit/settings/PluginsSection.test.tsx
@@ -57,6 +57,12 @@ describe('PluginsSection', () => {
     expect(screen.getByText('settings.plugins.flagGate')).toBeInTheDocument();
   });
 
+  // QNBS-v3: maturity signalling must stay consistent whether the flag is on or off.
+  it('shows the Beta maturity badge even when the plugin system is disabled', () => {
+    render(<PluginsSection />);
+    expect(screen.getByText('common.badge.beta')).toBeInTheDocument();
+  });
+
   it('shows empty state when feature enabled but no plugins', () => {
     mockIsEnabled = true;
     render(<PluginsSection />);


### PR DESCRIPTION
## **User description**
## PR B — Settings/Help modernization program (P1.1)

Maturity signalling (Experimental/Beta/Production) was shown **only** in the Experimental flags list;
the dedicated section views (Voice, LoRA, Plugins, …) carried none. This adds **consistent maturity
badges** driven by a single source of truth.

### Changes
- **New `components/settings/MaturityBadge.tsx`** (+ `maturityBadgeVariant` helper): derives the badge
  variant from `FEATURE_CATALOG` by `flagKey`, so a section's badge can never drift from the
  catalog/slice. Renders nothing for stable/unlisted features. Reuses the existing
  `common.badge.experimental` / `common.badge.beta` i18n keys — **no new strings, no locale fan-out**.
- Applied to the **Voice** (experimental), **LoRA** (experimental) and **Plugins** (beta) section
  headers.
- **`FeatureFlagsSection`** refactored to consume the shared component, dropping its duplicate
  `MATURITY_TO_BADGE` map + `renderBadge` (DRY; same rendered output).

### Tests
- New `MaturityBadge` unit test (experimental/beta/stub derivation + rendered labels).
- Fixed two section-test `featureFlagsSlice` mocks to keep the real module via `importOriginal`, so
  `featureCatalog`'s `defaultOn` derivation still resolves now that the sections transitively load it
  through `MaturityBadge`.

Local gate green: lint, typecheck, and the 5 affected section suites (48 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Show maturity badges in all Settings feature sections, even when a feature is disabled**

### What Changed
- Voice, LoRA, and Plugins section headers now show their maturity badge in both the enabled and flag-gated views.
- The feature list now uses the same badge source as the section headers, so Experimental and Beta labels stay consistent across Settings while stable features show no badge.
- Users with disabled LoRA or Plugins still see the maturity label before turning the feature on.

### Impact
`✅ Consistent feature readiness labels`
`✅ Clearer disabled feature pages`
`✅ Fewer missing badge signals`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
