### PR TITLE
test(settings): full patch coverage for MaturityBadge

### DIFF
--- a/tests/unit/settings/MaturityBadge.fallback.test.tsx
+++ b/tests/unit/settings/MaturityBadge.fallback.test.tsx
@@ -1,0 +1,27 @@
+/**
+ * Tests for MaturityBadge's defensive "no catalog entry" path.
+ * QNBS-v3: parity guarantees every flag is catalogued today, so the no-variant branch is unreachable
+ * with real data — this file mocks an empty FEATURE_CATALOG to exercise (and document) the guard so
+ * a future stable/uncatalogued flag degrades to "no badge" instead of crashing.
+ */
+
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../features/featureCatalog', () => ({ FEATURE_CATALOG: [] }));
+vi.mock('../../../hooks/useTranslation', () => ({
+  useTranslation: () => ({ t: (k: string) => k, language: 'en' }),
+}));
+
+import { MaturityBadge, maturityBadgeVariant } from '../../../components/settings/MaturityBadge';
+
+describe('MaturityBadge — no catalog entry', () => {
+  it('maturityBadgeVariant returns undefined when the flag is not catalogued', () => {
+    expect(maturityBadgeVariant('enableProForge')).toBeUndefined();
+  });
+
+  it('renders nothing when there is no matching catalog entry', () => {
+    const { container } = render(<MaturityBadge flagKey="enableProForge" />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/tests/unit/settings/MaturityBadge.test.tsx
+++ b/tests/unit/settings/MaturityBadge.test.tsx
@@ -43,4 +43,9 @@ describe('MaturityBadge', () => {
     render(<MaturityBadge flagKey="enableLoraAdapters" />);
     expect(screen.getByText('common.badge.experimental')).toBeInTheDocument();
   });
+
+  it('forwards a custom className to the badge', () => {
+    render(<MaturityBadge flagKey="enableVoiceSupport" className="my-pill" />);
+    expect(screen.getByText('common.badge.experimental')).toHaveClass('my-pill');
+  });
 });


### PR DESCRIPTION
## **User description**
Closes the codecov partial-coverage warning left by #216. `MaturityBadge.tsx` had 3 partially-covered branches (the `className`-forwarding path and two defensive no-catalog-entry guards). This adds a `className` test and an empty-catalog fallback test (parity catalogues every flag today, so the guard is otherwise unreachable — the mock exercises + documents it). No production code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Add test coverage for MaturityBadge styling and missing-flag fallback**

### What Changed
- Verifies that a custom class name is applied to the badge when one is passed in
- Covers the case where a flag is not found in the catalog and the badge renders nothing instead of breaking

### Impact
`✅ Correct badge styling`
`✅ Safer handling for uncatalogued flags`
`✅ Fewer blank badge renders from missing data`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
