### PR TITLE
fix(settings): drop search hints for removed categories

### DIFF
--- a/services/settingsSearchHints.ts
+++ b/services/settingsSearchHints.ts
@@ -43,12 +43,11 @@ export const SETTINGS_CATEGORY_SEARCH_HINTS: Record<string, string[]> = {
     'announcements',
   ],
   privacy: ['analytics', 'encryption', 'data'],
-  performance: ['cache', 'preload', 'offline'],
-  notifications: ['reminder', 'desktop', 'email'],
   collaboration: ['webrtc', 'sharing', 'yjs'],
-  integrations: ['language tool', 'sync', 'notion'],
-  backup: ['snapshot', 'frequency', 'encrypt'],
-  data: ['export', 'import', 'reset', 'json'],
+  // QNBS-v3: Integrations is now LanguageTool-only — the dead sync/import card (Notion/Evernote/etc.)
+  // was removed, so its hints point at the real grammar/spell integration.
+  integrations: ['language tool', 'grammar', 'spell', 'proofread'],
+  data: ['export', 'import', 'reset', 'json', 'backup'],
   about: ['version', 'license', 'credits', 'health', 'diagnostics', 'locale', 'updater', 'tauri'],
   shortcuts: ['keyboard', 'hotkey', 'keybinding', 'ctrl', 'meta'],
   guide: ['overview', 'help', 'map', 'categories', 'leitfaden'],

--- a/tests/unit/settingsSearchHints.test.ts
+++ b/tests/unit/settingsSearchHints.test.ts
@@ -40,4 +40,14 @@ describe('SETTINGS_CATEGORY_SEARCH_HINTS', () => {
       }
     }
   });
+
+  // QNBS-v3: guard against hints for removed settings categories (the dead-toggle audit deleted the
+  // performance/notifications/backup sections) — a stale hint would surface a nav category that no
+  // longer exists.
+  it('has no hints for removed settings categories', () => {
+    const keys = Object.keys(SETTINGS_CATEGORY_SEARCH_HINTS);
+    expect(keys).not.toContain('performance');
+    expect(keys).not.toContain('notifications');
+    expect(keys).not.toContain('backup');
+  });
 });


### PR DESCRIPTION
Follow-up to the dead-toggle audit (#219/#220/#223). `services/settingsSearchHints.ts` still had keywords for the removed **Performance / Notifications / Backup** categories, so searching them surfaced a nav entry that no longer exists. Removed those three; retargeted **Integrations** hints (dropped `sync`/`notion` → `grammar`/`spell`/`proofread`, matching the LanguageTool-only section); moved `backup` to **Data** (where the real one-click backup lives); added a regression guard test. Tiny, code-only, no i18n.

🤖 Generated with [Claude Code](https://claude.com/claude-code)