### PR TITLE
fix(settings): ToggleSwitch for desktop minimize-to-tray (P1.3 a11y)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Desktop settings "minimize to tray" is now a proper switch.** `DesktopSection` used the only raw
+  `<input type="checkbox">` left in Settings, with its hint not programmatically associated. It now
+  renders the design-system `ToggleSwitch` (`role="switch"`, `aria-labelledby` + `aria-describedby`
+  hint, focus-visible ring, RTL-aware), matching every other Settings control — consistent styling and
+  screen-reader behaviour. Added a `DesktopSection` component test (web no-op, accessible switch, state
+  reflection, dispatch on toggle).
 - **Help content truthfulness pass (post-release).** Two stale Help articles were corrected against
   code reality: **Languages** now states the real **19 interface languages** with their Production /
   Near-Production / Beta status tiers + the quality dashboard (was "seven languages — German, English,

--- a/components/settings/DesktopSection.tsx
+++ b/components/settings/DesktopSection.tsx
@@ -4,6 +4,7 @@ import { settingsActions } from '../../features/settings/settingsSlice';
 import { useTranslation } from '../../hooks/useTranslation';
 import { isTauriRuntime } from '../../services/tauriRuntime';
 import { Card, CardContent } from '../ui/Card';
+import { ToggleSwitch } from './SettingsShared';
 
 /**
  * QNBS-v3 (T2): Desktop-only (Tauri) settings. Renders nothing on the web — the toggle drives the
@@ -22,24 +23,16 @@ export const DesktopSection: FC = () => {
         <p className="text-sm font-medium text-[var(--sc-text-primary)]">
           {t('desktop.settings.sectionTitle')}
         </p>
-        <label className="flex items-start gap-3 cursor-pointer">
-          <input
-            type="checkbox"
-            className="mt-1 rounded border-[var(--sc-border-subtle)]"
-            checked={minimizeToTray}
-            onChange={(e) =>
-              dispatch(settingsActions.setDesktopSettings({ minimizeToTray: e.target.checked }))
-            }
-          />
-          <span>
-            <span className="block text-sm text-[var(--sc-text-primary)]">
-              {t('desktop.settings.minimizeToTray')}
-            </span>
-            <span className="block text-xs text-[var(--sc-text-secondary)]">
-              {t('desktop.settings.minimizeToTrayHint')}
-            </span>
-          </span>
-        </label>
+        {/* QNBS-v3 (P1.3): the design-system ToggleSwitch (role=switch + aria-describedby hint)
+            replaces the only raw <input type="checkbox"> left in Settings — a11y + DS consistency. */}
+        <ToggleSwitch
+          label={t('desktop.settings.minimizeToTray')}
+          hint={t('desktop.settings.minimizeToTrayHint')}
+          checked={minimizeToTray}
+          onChange={(checked) =>
+            dispatch(settingsActions.setDesktopSettings({ minimizeToTray: checked }))
+          }
+        />
       </CardContent>
     </Card>
   );

--- a/tests/unit/settings/DesktopSection.test.tsx
+++ b/tests/unit/settings/DesktopSection.test.tsx
@@ -8,6 +8,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { RootState } from '../../../app/store';
 
 // ---------------------------------------------------------------------------
 // Mocks (component uses real Redux hooks + useTranslation + the Tauri gate)
@@ -21,9 +22,12 @@ const { mockDispatch, stateRef, mockIsTauri } = vi.hoisted(() => ({
 
 vi.mock('../../../app/hooks', () => ({
   useAppDispatch: () => mockDispatch,
-  // biome-ignore lint/suspicious/noExplicitAny: test selector mock
-  useAppSelector: (selector: (s: any) => unknown) =>
-    selector({ settings: { desktop: { minimizeToTray: stateRef.minimizeToTray } } }),
+  // QNBS-v3: type the selector against RootState (not `any`) and feed it a minimal slice cast through
+  // `unknown` — keeps the test honest without a lint suppression (the ratchet gate stays at baseline).
+  useAppSelector: (selector: (s: RootState) => unknown) =>
+    selector({
+      settings: { desktop: { minimizeToTray: stateRef.minimizeToTray } },
+    } as unknown as RootState),
 }));
 
 vi.mock('../../../hooks/useTranslation', () => ({

--- a/tests/unit/settings/DesktopSection.test.tsx
+++ b/tests/unit/settings/DesktopSection.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * Tests for components/settings/DesktopSection.tsx
+ * QNBS-v3 (P1.3): the minimize-to-tray control is the design-system ToggleSwitch (role=switch +
+ * aria-describedby hint), Tauri-gated. Verifies the web no-op, accessible switch, state reflection,
+ * and dispatch on toggle.
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks (component uses real Redux hooks + useTranslation + the Tauri gate)
+// ---------------------------------------------------------------------------
+
+const { mockDispatch, stateRef, mockIsTauri } = vi.hoisted(() => ({
+  mockDispatch: vi.fn(),
+  stateRef: { minimizeToTray: false },
+  mockIsTauri: vi.fn(() => true),
+}));
+
+vi.mock('../../../app/hooks', () => ({
+  useAppDispatch: () => mockDispatch,
+  // biome-ignore lint/suspicious/noExplicitAny: test selector mock
+  useAppSelector: (selector: (s: any) => unknown) =>
+    selector({ settings: { desktop: { minimizeToTray: stateRef.minimizeToTray } } }),
+}));
+
+vi.mock('../../../hooks/useTranslation', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+vi.mock('../../../services/tauriRuntime', () => ({
+  isTauriRuntime: () => mockIsTauri(),
+}));
+
+import { DesktopSection } from '../../../components/settings/DesktopSection';
+import { settingsActions } from '../../../features/settings/settingsSlice';
+
+describe('DesktopSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stateRef.minimizeToTray = false;
+    mockIsTauri.mockReturnValue(true);
+  });
+
+  it('renders nothing on the web (non-Tauri runtime)', () => {
+    mockIsTauri.mockReturnValue(false);
+    const { container } = render(<DesktopSection />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the minimize-to-tray switch with an accessible name + described-by hint', () => {
+    render(<DesktopSection />);
+    const sw = screen.getByRole('switch', { name: 'desktop.settings.minimizeToTray' });
+    expect(sw).toHaveAttribute('aria-checked', 'false');
+    expect(sw).toHaveAttribute('aria-describedby');
+  });
+
+  it('reflects the enabled state via aria-checked', () => {
+    stateRef.minimizeToTray = true;
+    render(<DesktopSection />);
+    expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('dispatches setDesktopSettings({ minimizeToTray: true }) when toggled on', async () => {
+    const user = userEvent.setup();
+    render(<DesktopSection />);
+    await user.click(screen.getByRole('switch'));
+    expect(mockDispatch).toHaveBeenCalledWith(
+      settingsActions.setDesktopSettings({ minimizeToTray: true }),
+    );
+  });
+});


### PR DESCRIPTION
## What & why (P1.3 — Settings a11y/DS consistency)

`DesktopSection` held the **only raw `<input type="checkbox">` left in Settings**, and its hint span was not programmatically associated with the control. It now renders the design-system **`ToggleSwitch`** (`role="switch"`, `aria-labelledby` + `aria-describedby` hint, focus-visible ring, RTL-aware), matching every other Settings control.

### Audit scope (P1.3/P1.5)
- Swept all `components/settings/*` for raw form controls → **DesktopSection was the only raw checkbox**; every other section already uses `ToggleSwitch` or an accessible `role="switch"` button.
- `TauriUpdaterBanner` reviewed — already accessible (`role="alert"` w/ reserved height, version copy via interpolation); no change needed.
- The `.tsx.html` files under `components/settings/` are untracked local artifacts (0 git-tracked) — out of scope.

### Tests
- New `tests/unit/settings/DesktopSection.test.tsx`: web no-op (non-Tauri), accessible switch name + described-by hint, `aria-checked` state reflection, dispatch on toggle. **4 passed.**

### Verification
- `pnpm run lint` ✅ · `pnpm run typecheck` ✅ · `vitest DesktopSection` → 4 passed ✅
- 3 files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)