### PR TITLE
fix(eco): isEcoMode direct boolean return (DeepSource JS-W1041) + baseline probe

### DIFF
--- a/services/ai/ecoModeService.ts
+++ b/services/ai/ecoModeService.ts
@@ -39,11 +39,9 @@ class EcoModeService {
 
   isEcoMode(): boolean {
     if (this.explicitEcoMode !== null) return this.explicitEcoMode;
-    // Auto: eco when battery is low
-    if (this.cachedBatteryLevel !== null && this.cachedBatteryLevel < LOW_BATTERY_THRESHOLD) {
-      return true;
-    }
-    return false;
+    // QNBS-v3: Auto — eco when battery is low. Direct boolean return (DeepSource JS-W1041),
+    // mirroring isCriticalBattery() below.
+    return this.cachedBatteryLevel !== null && this.cachedBatteryLevel < LOW_BATTERY_THRESHOLD;
   }
 
   isCriticalBattery(): boolean {


### PR DESCRIPTION
## What
Collapses `if (cond) return true; return false;` → `return cond;` in `EcoModeService.isEcoMode()` (DeepSource **JS-W1041**, the one clear single-condition case; multi-guard cases left as-is — guard clauses read better than a collapsed boolean). Behavior-preserving — 35 ecoModeService tests pass.

## Dual purpose
Also a **DeepSource baseline probe**: touching one file makes DeepSource report that file's still-un-ignored anti-pattern rules as "introduced". Its bot comment / JS status tells us **which rule-ignores still need doing repo-wide** (the authoritative remaining list), validating the triage in `docs/DEEPSOURCE-REMEDIATION-PLAN.md`.

## Verification
- `vitest ecoModeService` → 35 passed ✅
- DeepSource JS may show "introduced" anti-patterns on `ecoModeService.ts` until the noise rules are rule-ignored — that output is the intended signal, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)