### PR TITLE
fix(storybook): wrap story/decorator hooks in components (DeepSource JS-0820)

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -4,13 +4,21 @@ import '../index.css';
 
 const APPEARANCE_CLASSES = ['appearance-sepia', 'appearance-fantasy', 'appearance-romance'];
 
-const withTheme: DecoratorFunction = (Story, context) => {
+// QNBS-v3: the theme effect lives in a component, not the decorator callback (DeepSource JS-0820 /
+// rules-of-hooks). Storybook renders ThemeWrapper as a component, so useEffect is valid here.
+const ThemeWrapper = ({
+  theme,
+  appearance,
+  children,
+}: {
+  theme: string;
+  appearance: string;
+  children: React.ReactNode;
+}) => {
   useEffect(() => {
-    const theme = context.globals.theme ?? 'dark';
     document.body.classList.remove('light-theme', 'dark-theme');
     document.body.classList.add(`${theme}-theme`);
 
-    const appearance = context.globals.appearance ?? 'default';
     document.body.classList.remove(...APPEARANCE_CLASSES);
     if (appearance === 'sepia') document.body.classList.add('appearance-sepia');
     if (appearance === 'fantasy') document.body.classList.add('appearance-fantasy');
@@ -19,14 +27,21 @@ const withTheme: DecoratorFunction = (Story, context) => {
     return () => {
       document.body.classList.remove('light-theme', 'dark-theme', ...APPEARANCE_CLASSES);
     };
-  }, [context.globals.theme, context.globals.appearance]);
+  }, [theme, appearance]);
 
   return (
-    <div className="min-h-screen p-6 bg-sc-surface-base text-sc-text-primary">
-      <Story />
-    </div>
+    <div className="min-h-screen p-6 bg-sc-surface-base text-sc-text-primary">{children}</div>
   );
 };
+
+const withTheme: DecoratorFunction = (Story, context) => (
+  <ThemeWrapper
+    theme={context.globals.theme ?? 'dark'}
+    appearance={context.globals.appearance ?? 'default'}
+  >
+    <Story />
+  </ThemeWrapper>
+);
 
 const preview: Preview = {
   decorators: [withTheme],

--- a/stories/Tabs.stories.tsx
+++ b/stories/Tabs.stories.tsx
@@ -56,34 +56,38 @@ export const Underline: Story = {
   render: () => <TabsDemo variant="underline" />,
 };
 
+// QNBS-v3: hooks belong in a component, not a story render callback (DeepSource JS-0820 /
+// rules-of-hooks). Storybook renders this as a component, so useState is valid here.
+const WithPanelsDemo = () => {
+  const [activeTab, setActiveTab] = useState('outline');
+  const groupId = 'story-tabs';
+  return (
+    <div className="space-y-4">
+      <Tabs
+        tabs={TABS}
+        activeTab={activeTab}
+        onChange={setActiveTab}
+        ariaLabel="Document sections"
+      />
+      <TabPanel tabId="outline" activeTab={activeTab} groupId={groupId}>
+        <div className="p-4 rounded-sc-lg bg-[var(--sc-surface-raised)] text-[var(--sc-text-primary)]">
+          Outline content
+        </div>
+      </TabPanel>
+      <TabPanel tabId="manuscript" activeTab={activeTab} groupId={groupId}>
+        <div className="p-4 rounded-sc-lg bg-[var(--sc-surface-raised)] text-[var(--sc-text-primary)]">
+          Manuscript content
+        </div>
+      </TabPanel>
+      <TabPanel tabId="notes" activeTab={activeTab} groupId={groupId}>
+        <div className="p-4 rounded-sc-lg bg-[var(--sc-surface-raised)] text-[var(--sc-text-primary)]">
+          Notes content
+        </div>
+      </TabPanel>
+    </div>
+  );
+};
+
 export const WithPanels: Story = {
-  render: () => {
-    const [activeTab, setActiveTab] = useState('outline');
-    const groupId = 'story-tabs';
-    return (
-      <div className="space-y-4">
-        <Tabs
-          tabs={TABS}
-          activeTab={activeTab}
-          onChange={setActiveTab}
-          ariaLabel="Document sections"
-        />
-        <TabPanel tabId="outline" activeTab={activeTab} groupId={groupId}>
-          <div className="p-4 rounded-sc-lg bg-[var(--sc-surface-raised)] text-[var(--sc-text-primary)]">
-            Outline content
-          </div>
-        </TabPanel>
-        <TabPanel tabId="manuscript" activeTab={activeTab} groupId={groupId}>
-          <div className="p-4 rounded-sc-lg bg-[var(--sc-surface-raised)] text-[var(--sc-text-primary)]">
-            Manuscript content
-          </div>
-        </TabPanel>
-        <TabPanel tabId="notes" activeTab={activeTab} groupId={groupId}>
-          <div className="p-4 rounded-sc-lg bg-[var(--sc-surface-raised)] text-[var(--sc-text-primary)]">
-            Notes content
-          </div>
-        </TabPanel>
-      </div>
-    );
-  },
+  render: () => <WithPanelsDemo />,
 };


### PR DESCRIPTION
## What
Resolves both **JS-0820** (rules-of-hooks, Major) findings — both in Storybook files, where hooks ran in a story `render` callback / a decorator function. Valid at Storybook runtime, but the react-hooks rule flags them because the enclosing function isn't a capitalized component. **Fixed honestly** (the recommended Storybook pattern), not suppressed:
- `stories/Tabs.stories.tsx`: `useState` → extracted `WithPanelsDemo` component; story renders `<WithPanelsDemo />`.
- `.storybook/preview.tsx`: theme `useEffect` → extracted `ThemeWrapper` component (theme/appearance as props); decorator renders `<ThemeWrapper>…<Story/></ThemeWrapper>`.

Rendered output is unchanged — pure structural refactor so the hook lives in a component.

## Verification
`pnpm run lint` ✅ · `pnpm run typecheck` ✅ · behavior-preserving (same DOM). Storybook test-runner unaffected (same rendered tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)