### PR TITLE
fix(security): sandbox user-PDF iframes (DeepSource JS-D010)

### DIFF
--- a/components/BinderPanel.tsx
+++ b/components/BinderPanel.tsx
@@ -27,14 +27,14 @@ function sortBinderNodes(nodes: BinderNode[]): BinderNode[] {
 
 function binderDepth(node: BinderNode, byId: Map<string, BinderNode>): number {
   if (!node.parentId) return 0;
-  let d = 0;
+  let depth = 0;
   let pid: string | null = node.parentId;
   while (pid) {
-    d++;
-    const p = byId.get(pid);
-    pid = p?.parentId ?? null;
+    depth++;
+    const parent = byId.get(pid);
+    pid = parent?.parentId ?? null;
   }
-  return d;
+  return depth;
 }
 
 function projectStorageId(data: { id?: string } | undefined): string {
@@ -210,9 +210,7 @@ export const BinderPanel: FC = () => {
   const onImportFiles = async (list: FileList | null) => {
     if (!list?.length) return;
     const parent = ensureResearchRoot();
-    for (let i = 0; i < list.length; i++) {
-      const file = list[i];
-      if (!file) continue;
+    for (const file of Array.from(list)) {
       try {
         const newId = await dispatch(importBinderFileThunk({ parentId: parent, file })).unwrap();
         setSelectedId(newId);

--- a/components/BinderPanel.tsx
+++ b/components/BinderPanel.tsx
@@ -124,6 +124,7 @@ const BinderAssetPreview: FC<{
       <iframe
         title={node.title}
         src={url}
+        sandbox="allow-same-origin"
         className="w-full h-48 rounded border border-[var(--sc-border-subtle)] bg-[var(--sc-surface-raised)]"
       />
     );

--- a/components/ManuscriptResearchSplit.tsx
+++ b/components/ManuscriptResearchSplit.tsx
@@ -92,6 +92,7 @@ export const ManuscriptResearchSplit: FC<{
             <iframe
               title={node.title}
               src={blobUrl}
+              sandbox="allow-same-origin"
               className="w-full min-h-[60vh] rounded border border-[var(--sc-border-subtle)] bg-[var(--sc-surface-base)]"
             />
           ) : (

--- a/docs/TODO-IFRAME-SANDBOX.md
+++ b/docs/TODO-IFRAME-SANDBOX.md
@@ -1,0 +1,43 @@
+# TODO — verify the PDF-iframe `sandbox` hardening (DeepSource JS-D010)
+
+> **Status: applied, NOT yet locally verified.** Created 2026-06-24. Owner: maintainer (local check).
+
+## What changed
+
+Added `sandbox="allow-same-origin"` to the two `<iframe>`s that embed **user-imported PDFs** via
+`blob:` URLs (resolves DeepSource **JS-D010** "missing sandbox in iframe"):
+
+- `components/ManuscriptResearchSplit.tsx` (Research split — PDF preview)
+- `components/BinderPanel.tsx` (Binder — PDF preview)
+
+`allow-same-origin` is required so the `blob:` PDF still loads in the browser's **native** PDF viewer;
+**no `allow-scripts`** → embedded JS / forms / top-navigation in a malicious PDF stay blocked. Threat
+model is low (the PDF is the user's own local import and the browser PDF viewer is itself sandboxed),
+so this is defense-in-depth — but it's a real hardening and DeepSource flags its absence.
+
+## ⚠️ Manual verification needed (do locally before relying on it)
+
+`pnpm run dev` → import a PDF, then in **both** surfaces confirm the PDF still **renders** (not blank /
+not forced-download):
+
+1. **Research split** (Manuscript → research panel) — open a PDF node.
+2. **Binder panel** — open a PDF node.
+
+Test in **Chrome/Edge** (Chromium PDFium), **Firefox** (pdf.js), and **Safari** if available — the
+sandboxed-iframe PDF behaviour differs per engine.
+
+## Iterative refinement (only if verification fails)
+
+- **Renders but download/print button dead** → add `allow-downloads` (and/or `allow-popups` for in-PDF
+  links): `sandbox="allow-same-origin allow-downloads allow-popups"`.
+- **Blank in Chrome** (PDFium-in-sandbox quirk) → try adding `allow-downloads`; if still blank,
+  consider an explicit object/embed fallback or a "open in new tab" affordance. **Do NOT** add
+  `allow-scripts` together with `allow-same-origin` — that combination defeats the sandbox and
+  DeepSource will (correctly) re-flag it.
+- **If no safe value renders on a target engine** → document the accepted residual risk here (user's
+  own local PDF, viewer self-sandboxed) and consider a per-engine `sandbox` value.
+
+## Done-when
+
+PDF preview renders in all target browsers with the most restrictive `sandbox` value that works, the
+final value recorded here, and this file deleted (or marked ✅ resolved).

--- a/tests/unit/BinderPanel.test.tsx
+++ b/tests/unit/BinderPanel.test.tsx
@@ -1,12 +1,16 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { BinderPanel } from '../../components/BinderPanel';
+import type { BinderNode } from '../../types';
 
 // ---------------------------------------------------------------------------
 // Mocks
 // ---------------------------------------------------------------------------
 
 const mockDispatch = vi.fn();
+
+// Mutable so individual tests can exercise the node-render path (binderDepth).
+let mockBinderNodes: BinderNode[] = [];
 
 vi.mock('../../app/hooks', () => ({
   useAppDispatch: vi.fn(() => mockDispatch),
@@ -17,7 +21,7 @@ vi.mock('../../app/hooks', () => ({
           data: {
             id: 'proj1',
             title: 'Test Project',
-            binderNodes: [],
+            binderNodes: mockBinderNodes,
             manuscript: [],
             outline: [],
             characters: { ids: [], entities: {} },
@@ -59,6 +63,11 @@ vi.mock('../../features/project/thunks/binderThunks', () => ({
 // ---------------------------------------------------------------------------
 
 describe('BinderPanel', () => {
+  beforeEach(() => {
+    mockBinderNodes = [];
+    mockDispatch.mockReset();
+  });
+
   it('renders without throwing', () => {
     expect(() => render(<BinderPanel />)).not.toThrow();
   });
@@ -78,5 +87,25 @@ describe('BinderPanel', () => {
     // No nodes means the panel should render just buttons and no node items
     const addButtons = screen.getAllByRole('button');
     expect(addButtons.length).toBeGreaterThan(0);
+  });
+
+  it('indents nested nodes by their depth (binderDepth)', () => {
+    // QNBS-v3: covers the binderDepth ancestor-walk + the node-render path —
+    // a root folder, a child, and a grandchild produce increasing paddingLeft.
+    mockBinderNodes = [
+      { id: 'root', parentId: null, type: 'folder', title: 'Root Folder', sortIndex: 0 },
+      { id: 'child', parentId: 'root', type: 'folder', title: 'Child Folder', sortIndex: 0 },
+      { id: 'grand', parentId: 'child', type: 'note', title: 'Grandchild Note', sortIndex: 0 },
+    ];
+    render(<BinderPanel />);
+
+    const root = screen.getByText('Root Folder').closest('button');
+    const child = screen.getByText('Child Folder').closest('button');
+    const grand = screen.getByText('Grandchild Note').closest('button');
+
+    // paddingLeft = 8 + depth * 12 → 8px (depth 0), 20px (depth 1), 32px (depth 2).
+    expect(root?.style.paddingLeft).toBe('8px');
+    expect(child?.style.paddingLeft).toBe('20px');
+    expect(grand?.style.paddingLeft).toBe('32px');
   });
 });


### PR DESCRIPTION
## What
Adds `sandbox="allow-same-origin"` to the two `<iframe>`s embedding user-imported PDFs via `blob:` URLs (`ManuscriptResearchSplit`, `BinderPanel`) — resolves DeepSource **JS-D010** (missing iframe sandbox). `allow-same-origin` keeps the blob rendering in the native PDF viewer; **no `allow-scripts`** → embedded JS/forms/top-nav blocked.

## ⚠️ Needs local verification (tracked)
The sandboxed-PDF render behaviour varies per browser engine. **`docs/TODO-IFRAME-SANDBOX.md`** documents the manual PDF-preview verification + iterative-refinement plan (add `allow-downloads`/`allow-popups` if PDF UI breaks; never `allow-scripts`+`allow-same-origin` together). Per the maintainer's request, the fix ships now and is verified locally later.

## Threat model
Low — the PDF is the user's own local import and the browser PDF viewer is itself sandboxed; this is defense-in-depth.

## Verification
`pnpm run lint` ✅ · `pnpm run typecheck` ✅ (attribute-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)