### PR TITLE
feat(languagetool): 'Check this scene' grammar panel (PR-C1 MVP)

### DIFF
--- a/components/writing/GrammarCheckPanel.tsx
+++ b/components/writing/GrammarCheckPanel.tsx
@@ -9,6 +9,64 @@ import { useTranslation } from '../../hooks/useTranslation';
 import type { LanguageToolMatch } from '../../services/languageToolService';
 import { Button } from '../ui/Button';
 
+const GrammarMatchItem: FC<{
+  match: LanguageToolMatch;
+  onApply: (replacement: string) => void;
+  onIgnore: () => void;
+  onAddToDictionary: () => void;
+}> = ({ match, onApply, onIgnore, onAddToDictionary }) => {
+  const { t } = useTranslation();
+  return (
+    <li className="rounded-sc-md border border-[var(--sc-border-subtle)] bg-[var(--sc-surface-raised)] p-2 space-y-1.5">
+      <div className="flex items-start justify-between gap-2">
+        <span className="text-[10px] uppercase tracking-wide text-[var(--sc-text-muted)]">
+          {match.categoryName || match.category}
+        </span>
+        <code className="text-[11px] text-[var(--sc-danger-fg)] bg-[var(--sc-danger-bg)] px-1 rounded truncate max-w-[50%]">
+          {match.matchedText}
+        </code>
+      </div>
+      <p className="text-xs text-[var(--sc-text-secondary)]">{match.message}</p>
+      <div className="flex flex-wrap items-center gap-1.5">
+        {match.replacements.length > 0 ? (
+          match.replacements.map((replacement) => (
+            <button
+              key={replacement}
+              type="button"
+              onClick={() => onApply(replacement)}
+              className="text-[11px] px-2 py-0.5 rounded-full bg-[var(--sc-accent)]/15 text-[var(--sc-text-primary)] border border-[var(--sc-border-subtle)] hover:bg-[var(--sc-accent)]/25 focus-visible:ring-2 focus-visible:ring-[var(--sc-ring-focus)]"
+            >
+              {replacement}
+            </button>
+          ))
+        ) : (
+          <span className="text-[11px] text-[var(--sc-text-muted)] italic">
+            {t('writer.grammar.noSuggestions')}
+          </span>
+        )}
+      </div>
+      <div className="flex items-center gap-2 pt-0.5">
+        <button
+          type="button"
+          onClick={onIgnore}
+          className="text-[11px] text-[var(--sc-text-muted)] hover:text-[var(--sc-text-secondary)] focus-visible:ring-2 focus-visible:ring-[var(--sc-ring-focus)] rounded"
+        >
+          {t('writer.grammar.ignore')}
+        </button>
+        {match.isSpelling && (
+          <button
+            type="button"
+            onClick={onAddToDictionary}
+            className="text-[11px] text-[var(--sc-text-muted)] hover:text-[var(--sc-text-secondary)] focus-visible:ring-2 focus-visible:ring-[var(--sc-ring-focus)] rounded"
+          >
+            {t('writer.grammar.addToDictionary')}
+          </button>
+        )}
+      </div>
+    </li>
+  );
+};
+
 const GrammarCheckPanel: FC = React.memo(() => {
   const { t } = useTranslation();
   const { selectedSectionId } = useWriterViewContext();
@@ -93,63 +151,5 @@ const GrammarCheckPanel: FC = React.memo(() => {
   );
 });
 GrammarCheckPanel.displayName = 'GrammarCheckPanel';
-
-const GrammarMatchItem: FC<{
-  match: LanguageToolMatch;
-  onApply: (replacement: string) => void;
-  onIgnore: () => void;
-  onAddToDictionary: () => void;
-}> = ({ match, onApply, onIgnore, onAddToDictionary }) => {
-  const { t } = useTranslation();
-  return (
-    <li className="rounded-sc-md border border-[var(--sc-border-subtle)] bg-[var(--sc-surface-raised)] p-2 space-y-1.5">
-      <div className="flex items-start justify-between gap-2">
-        <span className="text-[10px] uppercase tracking-wide text-[var(--sc-text-muted)]">
-          {match.categoryName || match.category}
-        </span>
-        <code className="text-[11px] text-[var(--sc-danger-fg)] bg-[var(--sc-danger-bg)] px-1 rounded truncate max-w-[50%]">
-          {match.matchedText}
-        </code>
-      </div>
-      <p className="text-xs text-[var(--sc-text-secondary)]">{match.message}</p>
-      <div className="flex flex-wrap items-center gap-1.5">
-        {match.replacements.length > 0 ? (
-          match.replacements.map((replacement) => (
-            <button
-              key={replacement}
-              type="button"
-              onClick={() => onApply(replacement)}
-              className="text-[11px] px-2 py-0.5 rounded-full bg-[var(--sc-accent)]/15 text-[var(--sc-text-primary)] border border-[var(--sc-border-subtle)] hover:bg-[var(--sc-accent)]/25 focus-visible:ring-2 focus-visible:ring-[var(--sc-ring-focus)]"
-            >
-              {replacement}
-            </button>
-          ))
-        ) : (
-          <span className="text-[11px] text-[var(--sc-text-muted)] italic">
-            {t('writer.grammar.noSuggestions')}
-          </span>
-        )}
-      </div>
-      <div className="flex items-center gap-2 pt-0.5">
-        <button
-          type="button"
-          onClick={onIgnore}
-          className="text-[11px] text-[var(--sc-text-muted)] hover:text-[var(--sc-text-secondary)] focus-visible:ring-2 focus-visible:ring-[var(--sc-ring-focus)] rounded"
-        >
-          {t('writer.grammar.ignore')}
-        </button>
-        {match.isSpelling && (
-          <button
-            type="button"
-            onClick={onAddToDictionary}
-            className="text-[11px] text-[var(--sc-text-muted)] hover:text-[var(--sc-text-secondary)] focus-visible:ring-2 focus-visible:ring-[var(--sc-ring-focus)] rounded"
-          >
-            {t('writer.grammar.addToDictionary')}
-          </button>
-        )}
-      </div>
-    </li>
-  );
-};
 
 export { GrammarCheckPanel };

--- a/components/writing/GrammarCheckPanel.tsx
+++ b/components/writing/GrammarCheckPanel.tsx
@@ -1,0 +1,155 @@
+// QNBS-v3: PR-C1 — on-demand "Check this scene" LanguageTool panel. Self-hosted grammar/spell check
+// over the active section; offset-safe apply, ignore, and add-to-dictionary. Hidden entirely when the
+// active locale has no LanguageTool coverage (see useLanguageToolCheck).
+import type { FC } from 'react';
+import React from 'react';
+import { useWriterViewContext } from '../../contexts/WriterViewContext';
+import { useLanguageToolCheck } from '../../hooks/useLanguageToolCheck';
+import { useTranslation } from '../../hooks/useTranslation';
+import type { LanguageToolMatch } from '../../services/languageToolService';
+import { Button } from '../ui/Button';
+
+const GrammarCheckPanel: FC = React.memo(() => {
+  const { t } = useTranslation();
+  const { selectedSectionId } = useWriterViewContext();
+  const {
+    available,
+    unsupportedLocale,
+    status,
+    matches,
+    check,
+    applySuggestion,
+    ignore,
+    addToDictionary,
+  } = useLanguageToolCheck();
+
+  // Locale has no LanguageTool support → feature is simply absent (honest, no error).
+  if (unsupportedLocale) {
+    return (
+      <p className="text-xs text-[var(--sc-text-muted)] px-1 py-2">
+        {t('writer.grammar.unsupported')}
+      </p>
+    );
+  }
+
+  const onCheck = () => {
+    if (selectedSectionId) void check(selectedSectionId);
+  };
+
+  return (
+    <section aria-label={t('writer.grammar.title')} className="space-y-3">
+      <div className="flex items-center justify-between gap-2">
+        <h3 className="text-sm font-semibold text-[var(--sc-text-primary)]">
+          {t('writer.grammar.title')}
+        </h3>
+        <Button
+          type="button"
+          size="sm"
+          variant="secondary"
+          onClick={onCheck}
+          disabled={!available || !selectedSectionId || status === 'checking'}
+        >
+          {status === 'checking' ? t('writer.grammar.checking') : t('writer.grammar.checkButton')}
+        </Button>
+      </div>
+
+      {!available && (
+        <p className="text-xs text-[var(--sc-warning-fg)]">{t('writer.grammar.disabled')}</p>
+      )}
+      {!selectedSectionId && available && (
+        <p className="text-xs text-[var(--sc-text-muted)]">{t('writer.grammar.selectScene')}</p>
+      )}
+      {status === 'offline' && (
+        <p className="text-xs text-[var(--sc-danger-fg)]">{t('writer.grammar.offline')}</p>
+      )}
+      {status === 'error' && (
+        <p className="text-xs text-[var(--sc-danger-fg)]">{t('writer.grammar.error')}</p>
+      )}
+      {status === 'ok' && matches.length === 0 && (
+        <p className="text-xs text-[var(--sc-success-fg)]">{t('writer.grammar.noIssues')}</p>
+      )}
+
+      {matches.length > 0 && (
+        <>
+          <p className="text-xs text-[var(--sc-text-muted)]">
+            {t('writer.grammar.issuesFound', { count: matches.length })}
+          </p>
+          <ul className="space-y-2" aria-label={t('writer.grammar.title')}>
+            {matches.map((match) => (
+              <GrammarMatchItem
+                key={`${match.offset}-${match.length}-${match.ruleId}`}
+                match={match}
+                onApply={(replacement) =>
+                  selectedSectionId && applySuggestion(selectedSectionId, match, replacement)
+                }
+                onIgnore={() => ignore(match)}
+                onAddToDictionary={() => addToDictionary(match.matchedText)}
+              />
+            ))}
+          </ul>
+        </>
+      )}
+    </section>
+  );
+});
+GrammarCheckPanel.displayName = 'GrammarCheckPanel';
+
+const GrammarMatchItem: FC<{
+  match: LanguageToolMatch;
+  onApply: (replacement: string) => void;
+  onIgnore: () => void;
+  onAddToDictionary: () => void;
+}> = ({ match, onApply, onIgnore, onAddToDictionary }) => {
+  const { t } = useTranslation();
+  return (
+    <li className="rounded-sc-md border border-[var(--sc-border-subtle)] bg-[var(--sc-surface-raised)] p-2 space-y-1.5">
+      <div className="flex items-start justify-between gap-2">
+        <span className="text-[10px] uppercase tracking-wide text-[var(--sc-text-muted)]">
+          {match.categoryName || match.category}
+        </span>
+        <code className="text-[11px] text-[var(--sc-danger-fg)] bg-[var(--sc-danger-bg)] px-1 rounded truncate max-w-[50%]">
+          {match.matchedText}
+        </code>
+      </div>
+      <p className="text-xs text-[var(--sc-text-secondary)]">{match.message}</p>
+      <div className="flex flex-wrap items-center gap-1.5">
+        {match.replacements.length > 0 ? (
+          match.replacements.map((replacement) => (
+            <button
+              key={replacement}
+              type="button"
+              onClick={() => onApply(replacement)}
+              className="text-[11px] px-2 py-0.5 rounded-full bg-[var(--sc-accent)]/15 text-[var(--sc-text-primary)] border border-[var(--sc-border-subtle)] hover:bg-[var(--sc-accent)]/25 focus-visible:ring-2 focus-visible:ring-[var(--sc-ring-focus)]"
+            >
+              {replacement}
+            </button>
+          ))
+        ) : (
+          <span className="text-[11px] text-[var(--sc-text-muted)] italic">
+            {t('writer.grammar.noSuggestions')}
+          </span>
+        )}
+      </div>
+      <div className="flex items-center gap-2 pt-0.5">
+        <button
+          type="button"
+          onClick={onIgnore}
+          className="text-[11px] text-[var(--sc-text-muted)] hover:text-[var(--sc-text-secondary)] focus-visible:ring-2 focus-visible:ring-[var(--sc-ring-focus)] rounded"
+        >
+          {t('writer.grammar.ignore')}
+        </button>
+        {match.isSpelling && (
+          <button
+            type="button"
+            onClick={onAddToDictionary}
+            className="text-[11px] text-[var(--sc-text-muted)] hover:text-[var(--sc-text-secondary)] focus-visible:ring-2 focus-visible:ring-[var(--sc-ring-focus)] rounded"
+          >
+            {t('writer.grammar.addToDictionary')}
+          </button>
+        )}
+      </div>
+    </li>
+  );
+};
+
+export { GrammarCheckPanel };

--- a/components/writing/ToolsPanel.tsx
+++ b/components/writing/ToolsPanel.tsx
@@ -11,6 +11,7 @@ import { Button } from '../ui/Button';
 import { Card, CardContent, CardHeader } from '../ui/Card';
 import { Icon } from '../ui/Icon';
 import { Select } from '../ui/Select';
+import { GrammarCheckPanel } from './GrammarCheckPanel';
 import { ToolInputs } from './ToolInputs';
 
 const ToolsPanel: FC = React.memo(() => {
@@ -242,6 +243,12 @@ const ToolsPanel: FC = React.memo(() => {
                 {t('common.generate')}
               </Button>
             )}
+          </div>
+
+          {/* QNBS-v3: PR-C1 — deterministic, self-hosted LanguageTool grammar check (no AI tokens),
+              separate from the AI generation flow above. Hidden for LanguageTool-unsupported locales. */}
+          <div className="flex-shrink-0 pt-3 mt-1 border-t border-[var(--sc-border-subtle)]">
+            <GrammarCheckPanel />
           </div>
         </CardContent>
       </Card>

--- a/hooks/useLanguageToolCheck.ts
+++ b/hooks/useLanguageToolCheck.ts
@@ -1,0 +1,172 @@
+/**
+ * QNBS-v3: Orchestrates the on-demand "Check this scene" grammar feature (PR-C1) — the bridge between
+ * the pure `languageToolService` and the editor. Resolves the active locale → LanguageTool code from
+ * the SSOT (`getLanguageToolCode`), enforces the privacy gate (`assertLanguageToolAllowed`), runs the
+ * check on a section's text, and applies/ignores/dictionaries results. Heavy logic lives in the
+ * (tested) service; this hook only wires Redux + settings + abort lifecycle.
+ */
+
+import { useCallback, useRef, useState } from 'react';
+import { useAppDispatch, useAppSelector } from '../app/hooks';
+import { selectManuscript } from '../features/project/projectSelectors';
+import { projectActions } from '../features/project/projectSlice';
+import { settingsActions } from '../features/settings/settingsSlice';
+import { getLanguageToolCode } from '../i18n/locales';
+import { assertLanguageToolAllowed } from '../services/languageToolClient';
+import {
+  applyMatchReplacement,
+  checkText,
+  type LanguageToolMatch,
+} from '../services/languageToolService';
+import { useTranslation } from './useTranslation';
+
+export type LanguageToolUiStatus =
+  | 'idle'
+  | 'checking'
+  | 'ok'
+  | 'offline'
+  | 'error'
+  | 'disabled'
+  | 'unsupported';
+
+export interface UseLanguageToolCheckReturn {
+  /** True when the active locale is LanguageTool-supported AND the integration is enabled. */
+  available: boolean;
+  /** True when the active locale has no LanguageTool coverage (feature hidden, not an error). */
+  unsupportedLocale: boolean;
+  status: LanguageToolUiStatus;
+  matches: LanguageToolMatch[];
+  /** Run a check against the given section's current content. */
+  check: (sectionId: string) => Promise<void>;
+  /** Apply one suggestion offset-safe into the section, then re-check (offsets shift). */
+  applySuggestion: (sectionId: string, match: LanguageToolMatch, replacement: string) => void;
+  /** Dismiss a single match from the current list (does not persist). */
+  ignore: (match: LanguageToolMatch) => void;
+  /** Persist a word to the user dictionary and drop its spelling matches from the list. */
+  addToDictionary: (word: string) => void;
+  /** Reset the panel. */
+  clear: () => void;
+}
+
+/** Stable identity for a match within one result set (offset+rule is unique per check). */
+function matchKey(match: LanguageToolMatch): string {
+  return `${match.offset}:${match.length}:${match.ruleId}`;
+}
+
+export function useLanguageToolCheck(): UseLanguageToolCheckReturn {
+  const dispatch = useAppDispatch();
+  const { language } = useTranslation();
+  const manuscript = useAppSelector(selectManuscript);
+  const settings = useAppSelector((state) => state.settings);
+  const [status, setStatus] = useState<LanguageToolUiStatus>('idle');
+  const [matches, setMatches] = useState<LanguageToolMatch[]>([]);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const ltCode = getLanguageToolCode(language);
+  const unsupportedLocale = ltCode === null;
+  const enabled = settings.integrations.languageToolEnabled;
+  const baseUrl = settings.integrations.languageToolBaseUrl;
+  const dictionary = settings.advancedEditor.customDictionary;
+  const available = !unsupportedLocale && enabled;
+
+  const sectionContent = useCallback(
+    (sectionId: string): string | null => {
+      const section = manuscript.find((s) => s.id === sectionId);
+      return section ? (section.content ?? '') : null;
+    },
+    [manuscript],
+  );
+
+  const check = useCallback(
+    async (sectionId: string) => {
+      if (unsupportedLocale || ltCode === null) {
+        setStatus('unsupported');
+        setMatches([]);
+        return;
+      }
+      try {
+        assertLanguageToolAllowed(settings, baseUrl);
+      } catch {
+        // Disabled in settings, invalid URL, or remote blocked under local-only privacy mode.
+        setStatus('disabled');
+        setMatches([]);
+        return;
+      }
+      const content = sectionContent(sectionId);
+      if (content === null) return;
+
+      // Cancel any in-flight check so a rapid re-trigger never races.
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+      setStatus('checking');
+      try {
+        const result = await checkText(content, ltCode, {
+          baseUrl,
+          signal: controller.signal,
+          dictionary,
+        });
+        if (controller.signal.aborted) return;
+        setMatches(result.matches);
+        setStatus(result.status);
+      } catch {
+        // Aborted (superseded by a newer check) — leave the newer run to set state.
+      }
+    },
+    [unsupportedLocale, ltCode, settings, baseUrl, dictionary, sectionContent],
+  );
+
+  const applySuggestion = useCallback(
+    (sectionId: string, match: LanguageToolMatch, replacement: string) => {
+      const content = sectionContent(sectionId);
+      if (content === null) return;
+      const next = applyMatchReplacement(content, match, replacement);
+      if (next === content) return; // stale anchor — nothing applied
+      dispatch(
+        projectActions.updateManuscriptSection({ id: sectionId, changes: { content: next } }),
+      );
+      // Offsets of the remaining matches are now stale → re-check for a clean list.
+      void check(sectionId);
+    },
+    [sectionContent, dispatch, check],
+  );
+
+  const ignore = useCallback((match: LanguageToolMatch) => {
+    const key = matchKey(match);
+    setMatches((prev) => prev.filter((other) => matchKey(other) !== key));
+  }, []);
+
+  const addToDictionary = useCallback(
+    (word: string) => {
+      const trimmed = word.trim();
+      if (trimmed.length === 0) return;
+      const lower = trimmed.toLowerCase();
+      if (!dictionary.some((existing) => existing.toLowerCase() === lower)) {
+        dispatch(settingsActions.setAdvancedEditor({ customDictionary: [...dictionary, trimmed] }));
+      }
+      // Drop every spelling match for this word from the visible list.
+      setMatches((prev) =>
+        prev.filter((other) => !(other.isSpelling && other.matchedText.toLowerCase() === lower)),
+      );
+    },
+    [dictionary, dispatch],
+  );
+
+  const clear = useCallback(() => {
+    abortRef.current?.abort();
+    setMatches([]);
+    setStatus('idle');
+  }, []);
+
+  return {
+    available,
+    unsupportedLocale,
+    status,
+    matches,
+    check,
+    applySuggestion,
+    ignore,
+    addToDictionary,
+    clear,
+  };
+}

--- a/hooks/useLanguageToolCheck.ts
+++ b/hooks/useLanguageToolCheck.ts
@@ -64,9 +64,11 @@ export function useLanguageToolCheck(): UseLanguageToolCheckReturn {
 
   const ltCode = getLanguageToolCode(language);
   const unsupportedLocale = ltCode === null;
-  const enabled = settings.integrations.languageToolEnabled;
-  const baseUrl = settings.integrations.languageToolBaseUrl;
-  const dictionary = settings.advancedEditor.customDictionary;
+  // QNBS-v3: defensive against partial persisted settings (normalizePersistedSettings can lag a new
+  // nested object) — a component must never crash on a missing settings branch (project convention).
+  const enabled = settings?.integrations?.languageToolEnabled ?? false;
+  const baseUrl = settings?.integrations?.languageToolBaseUrl ?? '';
+  const dictionary = settings?.advancedEditor?.customDictionary ?? [];
   const available = !unsupportedLocale && enabled;
 
   const sectionContent = useCallback(

--- a/locales/ar/writer.json
+++ b/locales/ar/writer.json
@@ -98,5 +98,19 @@
   "writer.tts.start": "قراءة بصوت عالٍ",
   "writer.tts.stop": "إيقاف القراءة",
   "writer.versionControl.label": "الإصدارات",
-  "writer.versionControl.tooltip": "التحكم بالإصدارات (الفروع واللقطات)"
+  "writer.versionControl.tooltip": "التحكم بالإصدارات (الفروع واللقطات)",
+  "writer.grammar.title": "Grammar & Spelling",
+  "writer.grammar.checkButton": "Check this scene",
+  "writer.grammar.checking": "Checking…",
+  "writer.grammar.issuesFound": "{{count}} issues found",
+  "writer.grammar.noIssues": "No issues found.",
+  "writer.grammar.selectScene": "Select a scene to check.",
+  "writer.grammar.unsupported": "Grammar check isn't available for this language.",
+  "writer.grammar.disabled": "Enable LanguageTool in Settings → Connections to check this scene.",
+  "writer.grammar.offline": "Couldn't reach the LanguageTool server. Is it running?",
+  "writer.grammar.error": "The LanguageTool server returned an error.",
+  "writer.grammar.apply": "Apply",
+  "writer.grammar.ignore": "Ignore",
+  "writer.grammar.addToDictionary": "Add to dictionary",
+  "writer.grammar.noSuggestions": "No suggestions"
 }

--- a/locales/de/writer.json
+++ b/locales/de/writer.json
@@ -98,5 +98,19 @@
   "writer.tts.start": "Vorlesen",
   "writer.tts.stop": "Vorlesen stoppen",
   "writer.versionControl.label": "Versionen",
-  "writer.versionControl.tooltip": "Versionskontrolle (Zweige & Schnappschüsse)"
+  "writer.versionControl.tooltip": "Versionskontrolle (Zweige & Schnappschüsse)",
+  "writer.grammar.title": "Grammatik & Rechtschreibung",
+  "writer.grammar.checkButton": "Diese Szene prüfen",
+  "writer.grammar.checking": "Prüfe…",
+  "writer.grammar.issuesFound": "{{count}} Probleme gefunden",
+  "writer.grammar.noIssues": "Keine Probleme gefunden.",
+  "writer.grammar.selectScene": "Wähle eine Szene zum Prüfen.",
+  "writer.grammar.unsupported": "Die Grammatikprüfung ist für diese Sprache nicht verfügbar.",
+  "writer.grammar.disabled": "Aktiviere LanguageTool in Einstellungen → Verbindungen, um diese Szene zu prüfen.",
+  "writer.grammar.offline": "LanguageTool-Server nicht erreichbar. Läuft er?",
+  "writer.grammar.error": "Der LanguageTool-Server hat einen Fehler zurückgegeben.",
+  "writer.grammar.apply": "Übernehmen",
+  "writer.grammar.ignore": "Ignorieren",
+  "writer.grammar.addToDictionary": "Zum Wörterbuch hinzufügen",
+  "writer.grammar.noSuggestions": "Keine Vorschläge"
 }

--- a/locales/el/writer.json
+++ b/locales/el/writer.json
@@ -98,5 +98,19 @@
   "writer.tts.start": "Διαβάστε δυνατά",
   "writer.tts.stop": "Σταμάτα να διαβάζεις",
   "writer.versionControl.label": "εκδόσεις",
-  "writer.versionControl.tooltip": "Έλεγχος έκδοσης (Κλάδοι και στιγμιότυπα)"
+  "writer.versionControl.tooltip": "Έλεγχος έκδοσης (Κλάδοι και στιγμιότυπα)",
+  "writer.grammar.title": "Grammar & Spelling",
+  "writer.grammar.checkButton": "Check this scene",
+  "writer.grammar.checking": "Checking…",
+  "writer.grammar.issuesFound": "{{count}} issues found",
+  "writer.grammar.noIssues": "No issues found.",
+  "writer.grammar.selectScene": "Select a scene to check.",
+  "writer.grammar.unsupported": "Grammar check isn't available for this language.",
+  "writer.grammar.disabled": "Enable LanguageTool in Settings → Connections to check this scene.",
+  "writer.grammar.offline": "Couldn't reach the LanguageTool server. Is it running?",
+  "writer.grammar.error": "The LanguageTool server returned an error.",
+  "writer.grammar.apply": "Apply",
+  "writer.grammar.ignore": "Ignore",
+  "writer.grammar.addToDictionary": "Add to dictionary",
+  "writer.grammar.noSuggestions": "No suggestions"
 }

--- a/locales/en/writer.json
+++ b/locales/en/writer.json
@@ -98,5 +98,19 @@
   "writer.studio.controls.custom": "Custom...",
   "writer.studio.controls.customTonePlaceholder": "e.g., Sarcastic, Melancholic, Fast-paced",
   "writer.versionControl.tooltip": "Version Control (Branches & Snapshots)",
-  "writer.cancelledTag": "Cancelled"
+  "writer.cancelledTag": "Cancelled",
+  "writer.grammar.title": "Grammar & Spelling",
+  "writer.grammar.checkButton": "Check this scene",
+  "writer.grammar.checking": "Checking…",
+  "writer.grammar.issuesFound": "{{count}} issues found",
+  "writer.grammar.noIssues": "No issues found.",
+  "writer.grammar.selectScene": "Select a scene to check.",
+  "writer.grammar.unsupported": "Grammar check isn't available for this language.",
+  "writer.grammar.disabled": "Enable LanguageTool in Settings → Connections to check this scene.",
+  "writer.grammar.offline": "Couldn't reach the LanguageTool server. Is it running?",
+  "writer.grammar.error": "The LanguageTool server returned an error.",
+  "writer.grammar.apply": "Apply",
+  "writer.grammar.ignore": "Ignore",
+  "writer.grammar.addToDictionary": "Add to dictionary",
+  "writer.grammar.noSuggestions": "No suggestions"
 }

--- a/locales/es/writer.json
+++ b/locales/es/writer.json
@@ -98,5 +98,19 @@
   "writer.tts.start": "Leer en voz alta",
   "writer.tts.stop": "Detener lectura",
   "writer.versionControl.label": "Versiones",
-  "writer.versionControl.tooltip": "Control de versiones (ramas e instantáneas)"
+  "writer.versionControl.tooltip": "Control de versiones (ramas e instantáneas)",
+  "writer.grammar.title": "Gramática y ortografía",
+  "writer.grammar.checkButton": "Revisar esta escena",
+  "writer.grammar.checking": "Revisando…",
+  "writer.grammar.issuesFound": "{{count}} problemas encontrados",
+  "writer.grammar.noIssues": "No se encontraron problemas.",
+  "writer.grammar.selectScene": "Selecciona una escena para revisar.",
+  "writer.grammar.unsupported": "La revisión gramatical no está disponible para este idioma.",
+  "writer.grammar.disabled": "Activa LanguageTool en Ajustes → Conexiones para revisar esta escena.",
+  "writer.grammar.offline": "No se pudo conectar con el servidor de LanguageTool. ¿Está en marcha?",
+  "writer.grammar.error": "El servidor de LanguageTool devolvió un error.",
+  "writer.grammar.apply": "Aplicar",
+  "writer.grammar.ignore": "Ignorar",
+  "writer.grammar.addToDictionary": "Añadir al diccionario",
+  "writer.grammar.noSuggestions": "Sin sugerencias"
 }

--- a/locales/eu/writer.json
+++ b/locales/eu/writer.json
@@ -98,5 +98,19 @@
   "writer.tts.start": "Irakurri ozen",
   "writer.tts.stop": "Utzi irakurtzeari",
   "writer.versionControl.label": "Bertsioak",
-  "writer.versionControl.tooltip": "Bertsio-kontrola (adarrak eta argazkiak)"
+  "writer.versionControl.tooltip": "Bertsio-kontrola (adarrak eta argazkiak)",
+  "writer.grammar.title": "Grammar & Spelling",
+  "writer.grammar.checkButton": "Check this scene",
+  "writer.grammar.checking": "Checking…",
+  "writer.grammar.issuesFound": "{{count}} issues found",
+  "writer.grammar.noIssues": "No issues found.",
+  "writer.grammar.selectScene": "Select a scene to check.",
+  "writer.grammar.unsupported": "Grammar check isn't available for this language.",
+  "writer.grammar.disabled": "Enable LanguageTool in Settings → Connections to check this scene.",
+  "writer.grammar.offline": "Couldn't reach the LanguageTool server. Is it running?",
+  "writer.grammar.error": "The LanguageTool server returned an error.",
+  "writer.grammar.apply": "Apply",
+  "writer.grammar.ignore": "Ignore",
+  "writer.grammar.addToDictionary": "Add to dictionary",
+  "writer.grammar.noSuggestions": "No suggestions"
 }

--- a/locales/fa/writer.json
+++ b/locales/fa/writer.json
@@ -98,5 +98,19 @@
   "writer.tts.start": "با صدای بلند بخوانید",
   "writer.tts.stop": "خواندن را متوقف کنید",
   "writer.versionControl.label": "نسخه ها",
-  "writer.versionControl.tooltip": "کنترل نسخه (شاخه ها و عکس های فوری)"
+  "writer.versionControl.tooltip": "کنترل نسخه (شاخه ها و عکس های فوری)",
+  "writer.grammar.title": "Grammar & Spelling",
+  "writer.grammar.checkButton": "Check this scene",
+  "writer.grammar.checking": "Checking…",
+  "writer.grammar.issuesFound": "{{count}} issues found",
+  "writer.grammar.noIssues": "No issues found.",
+  "writer.grammar.selectScene": "Select a scene to check.",
+  "writer.grammar.unsupported": "Grammar check isn't available for this language.",
+  "writer.grammar.disabled": "Enable LanguageTool in Settings → Connections to check this scene.",
+  "writer.grammar.offline": "Couldn't reach the LanguageTool server. Is it running?",
+  "writer.grammar.error": "The LanguageTool server returned an error.",
+  "writer.grammar.apply": "Apply",
+  "writer.grammar.ignore": "Ignore",
+  "writer.grammar.addToDictionary": "Add to dictionary",
+  "writer.grammar.noSuggestions": "No suggestions"
 }

--- a/locales/fi/writer.json
+++ b/locales/fi/writer.json
@@ -98,5 +98,19 @@
   "writer.tts.start": "Lue ääneen",
   "writer.tts.stop": "Lopeta lukeminen",
   "writer.versionControl.label": "Versiot",
-  "writer.versionControl.tooltip": "Versionhallinta (oksat ja tilannekuvat)"
+  "writer.versionControl.tooltip": "Versionhallinta (oksat ja tilannekuvat)",
+  "writer.grammar.title": "Grammar & Spelling",
+  "writer.grammar.checkButton": "Check this scene",
+  "writer.grammar.checking": "Checking…",
+  "writer.grammar.issuesFound": "{{count}} issues found",
+  "writer.grammar.noIssues": "No issues found.",
+  "writer.grammar.selectScene": "Select a scene to check.",
+  "writer.grammar.unsupported": "Grammar check isn't available for this language.",
+  "writer.grammar.disabled": "Enable LanguageTool in Settings → Connections to check this scene.",
+  "writer.grammar.offline": "Couldn't reach the LanguageTool server. Is it running?",
+  "writer.grammar.error": "The LanguageTool server returned an error.",
+  "writer.grammar.apply": "Apply",
+  "writer.grammar.ignore": "Ignore",
+  "writer.grammar.addToDictionary": "Add to dictionary",
+  "writer.grammar.noSuggestions": "No suggestions"
 }

--- a/locales/fr/writer.json
+++ b/locales/fr/writer.json
@@ -98,5 +98,19 @@
   "writer.tts.start": "Lire à haute voix",
   "writer.tts.stop": "Arrêter la lecture",
   "writer.versionControl.label": "Versions",
-  "writer.versionControl.tooltip": "Contrôle de version (branches et instantanés)"
+  "writer.versionControl.tooltip": "Contrôle de version (branches et instantanés)",
+  "writer.grammar.title": "Grammaire et orthographe",
+  "writer.grammar.checkButton": "Vérifier cette scène",
+  "writer.grammar.checking": "Vérification…",
+  "writer.grammar.issuesFound": "{{count}} problèmes détectés",
+  "writer.grammar.noIssues": "Aucun problème détecté.",
+  "writer.grammar.selectScene": "Sélectionnez une scène à vérifier.",
+  "writer.grammar.unsupported": "La vérification grammaticale n'est pas disponible pour cette langue.",
+  "writer.grammar.disabled": "Activez LanguageTool dans Paramètres → Connexions pour vérifier cette scène.",
+  "writer.grammar.offline": "Impossible de joindre le serveur LanguageTool. Est-il démarré ?",
+  "writer.grammar.error": "Le serveur LanguageTool a renvoyé une erreur.",
+  "writer.grammar.apply": "Appliquer",
+  "writer.grammar.ignore": "Ignorer",
+  "writer.grammar.addToDictionary": "Ajouter au dictionnaire",
+  "writer.grammar.noSuggestions": "Aucune suggestion"
 }

--- a/locales/he/writer.json
+++ b/locales/he/writer.json
@@ -98,5 +98,19 @@
   "writer.tts.start": "הקראה בקול",
   "writer.tts.stop": "עצירת הקראה",
   "writer.versionControl.label": "גרסאות",
-  "writer.versionControl.tooltip": "בקרת גרסאות (ענפים ותמונות מצב)"
+  "writer.versionControl.tooltip": "בקרת גרסאות (ענפים ותמונות מצב)",
+  "writer.grammar.title": "Grammar & Spelling",
+  "writer.grammar.checkButton": "Check this scene",
+  "writer.grammar.checking": "Checking…",
+  "writer.grammar.issuesFound": "{{count}} issues found",
+  "writer.grammar.noIssues": "No issues found.",
+  "writer.grammar.selectScene": "Select a scene to check.",
+  "writer.grammar.unsupported": "Grammar check isn't available for this language.",
+  "writer.grammar.disabled": "Enable LanguageTool in Settings → Connections to check this scene.",
+  "writer.grammar.offline": "Couldn't reach the LanguageTool server. Is it running?",
+  "writer.grammar.error": "The LanguageTool server returned an error.",
+  "writer.grammar.apply": "Apply",
+  "writer.grammar.ignore": "Ignore",
+  "writer.grammar.addToDictionary": "Add to dictionary",
+  "writer.grammar.noSuggestions": "No suggestions"
 }

--- a/locales/hu/writer.json
+++ b/locales/hu/writer.json
@@ -98,5 +98,19 @@
   "writer.tts.start": "Olvass fel hangosan",
   "writer.tts.stop": "Hagyd abba az olvasást",
   "writer.versionControl.label": "Verziók",
-  "writer.versionControl.tooltip": "Verzióvezérlés (elágazások és pillanatképek)"
+  "writer.versionControl.tooltip": "Verzióvezérlés (elágazások és pillanatképek)",
+  "writer.grammar.title": "Grammar & Spelling",
+  "writer.grammar.checkButton": "Check this scene",
+  "writer.grammar.checking": "Checking…",
+  "writer.grammar.issuesFound": "{{count}} issues found",
+  "writer.grammar.noIssues": "No issues found.",
+  "writer.grammar.selectScene": "Select a scene to check.",
+  "writer.grammar.unsupported": "Grammar check isn't available for this language.",
+  "writer.grammar.disabled": "Enable LanguageTool in Settings → Connections to check this scene.",
+  "writer.grammar.offline": "Couldn't reach the LanguageTool server. Is it running?",
+  "writer.grammar.error": "The LanguageTool server returned an error.",
+  "writer.grammar.apply": "Apply",
+  "writer.grammar.ignore": "Ignore",
+  "writer.grammar.addToDictionary": "Add to dictionary",
+  "writer.grammar.noSuggestions": "No suggestions"
 }

--- a/locales/is/writer.json
+++ b/locales/is/writer.json
@@ -98,5 +98,19 @@
   "writer.tts.start": "Lestu upphátt",
   "writer.tts.stop": "Hættu að lesa",
   "writer.versionControl.label": "Útgáfur",
-  "writer.versionControl.tooltip": "Útgáfustýring (útibú og skyndimyndir)"
+  "writer.versionControl.tooltip": "Útgáfustýring (útibú og skyndimyndir)",
+  "writer.grammar.title": "Grammar & Spelling",
+  "writer.grammar.checkButton": "Check this scene",
+  "writer.grammar.checking": "Checking…",
+  "writer.grammar.issuesFound": "{{count}} issues found",
+  "writer.grammar.noIssues": "No issues found.",
+  "writer.grammar.selectScene": "Select a scene to check.",
+  "writer.grammar.unsupported": "Grammar check isn't available for this language.",
+  "writer.grammar.disabled": "Enable LanguageTool in Settings → Connections to check this scene.",
+  "writer.grammar.offline": "Couldn't reach the LanguageTool server. Is it running?",
+  "writer.grammar.error": "The LanguageTool server returned an error.",
+  "writer.grammar.apply": "Apply",
+  "writer.grammar.ignore": "Ignore",
+  "writer.grammar.addToDictionary": "Add to dictionary",
+  "writer.grammar.noSuggestions": "No suggestions"
 }

--- a/locales/it/writer.json
+++ b/locales/it/writer.json
@@ -98,5 +98,19 @@
   "writer.tts.start": "Leggi ad alta voce",
   "writer.tts.stop": "Interrompi lettura",
   "writer.versionControl.label": "Versioni",
-  "writer.versionControl.tooltip": "Controllo versione (rami e istantanee)"
+  "writer.versionControl.tooltip": "Controllo versione (rami e istantanee)",
+  "writer.grammar.title": "Grammatica e ortografia",
+  "writer.grammar.checkButton": "Controlla questa scena",
+  "writer.grammar.checking": "Controllo…",
+  "writer.grammar.issuesFound": "{{count}} problemi rilevati",
+  "writer.grammar.noIssues": "Nessun problema rilevato.",
+  "writer.grammar.selectScene": "Seleziona una scena da controllare.",
+  "writer.grammar.unsupported": "Il controllo grammaticale non è disponibile per questa lingua.",
+  "writer.grammar.disabled": "Attiva LanguageTool in Impostazioni → Connessioni per controllare questa scena.",
+  "writer.grammar.offline": "Impossibile raggiungere il server LanguageTool. È in esecuzione?",
+  "writer.grammar.error": "Il server LanguageTool ha restituito un errore.",
+  "writer.grammar.apply": "Applica",
+  "writer.grammar.ignore": "Ignora",
+  "writer.grammar.addToDictionary": "Aggiungi al dizionario",
+  "writer.grammar.noSuggestions": "Nessun suggerimento"
 }

--- a/locales/ja/writer.json
+++ b/locales/ja/writer.json
@@ -98,5 +98,19 @@
   "writer.tts.start": "声に出して読む",
   "writer.tts.stop": "読むのをやめる",
   "writer.versionControl.label": "バージョン",
-  "writer.versionControl.tooltip": "バージョン管理 (ブランチとスナップショット)"
+  "writer.versionControl.tooltip": "バージョン管理 (ブランチとスナップショット)",
+  "writer.grammar.title": "Grammar & Spelling",
+  "writer.grammar.checkButton": "Check this scene",
+  "writer.grammar.checking": "Checking…",
+  "writer.grammar.issuesFound": "{{count}} issues found",
+  "writer.grammar.noIssues": "No issues found.",
+  "writer.grammar.selectScene": "Select a scene to check.",
+  "writer.grammar.unsupported": "Grammar check isn't available for this language.",
+  "writer.grammar.disabled": "Enable LanguageTool in Settings → Connections to check this scene.",
+  "writer.grammar.offline": "Couldn't reach the LanguageTool server. Is it running?",
+  "writer.grammar.error": "The LanguageTool server returned an error.",
+  "writer.grammar.apply": "Apply",
+  "writer.grammar.ignore": "Ignore",
+  "writer.grammar.addToDictionary": "Add to dictionary",
+  "writer.grammar.noSuggestions": "No suggestions"
 }

--- a/locales/ko/writer.json
+++ b/locales/ko/writer.json
@@ -98,5 +98,19 @@
   "writer.tts.start": "소리내어 읽기",
   "writer.tts.stop": "읽기 중지",
   "writer.versionControl.label": "버전",
-  "writer.versionControl.tooltip": "버전 관리(브랜치 및 스냅샷)"
+  "writer.versionControl.tooltip": "버전 관리(브랜치 및 스냅샷)",
+  "writer.grammar.title": "Grammar & Spelling",
+  "writer.grammar.checkButton": "Check this scene",
+  "writer.grammar.checking": "Checking…",
+  "writer.grammar.issuesFound": "{{count}} issues found",
+  "writer.grammar.noIssues": "No issues found.",
+  "writer.grammar.selectScene": "Select a scene to check.",
+  "writer.grammar.unsupported": "Grammar check isn't available for this language.",
+  "writer.grammar.disabled": "Enable LanguageTool in Settings → Connections to check this scene.",
+  "writer.grammar.offline": "Couldn't reach the LanguageTool server. Is it running?",
+  "writer.grammar.error": "The LanguageTool server returned an error.",
+  "writer.grammar.apply": "Apply",
+  "writer.grammar.ignore": "Ignore",
+  "writer.grammar.addToDictionary": "Add to dictionary",
+  "writer.grammar.noSuggestions": "No suggestions"
 }

--- a/locales/pt/writer.json
+++ b/locales/pt/writer.json
@@ -98,5 +98,19 @@
   "writer.tts.start": "Ler em voz alta",
   "writer.tts.stop": "Pare de ler",
   "writer.versionControl.label": "Versões",
-  "writer.versionControl.tooltip": "Controle de versão (ramos e instantâneos)"
+  "writer.versionControl.tooltip": "Controle de versão (ramos e instantâneos)",
+  "writer.grammar.title": "Grammar & Spelling",
+  "writer.grammar.checkButton": "Check this scene",
+  "writer.grammar.checking": "Checking…",
+  "writer.grammar.issuesFound": "{{count}} issues found",
+  "writer.grammar.noIssues": "No issues found.",
+  "writer.grammar.selectScene": "Select a scene to check.",
+  "writer.grammar.unsupported": "Grammar check isn't available for this language.",
+  "writer.grammar.disabled": "Enable LanguageTool in Settings → Connections to check this scene.",
+  "writer.grammar.offline": "Couldn't reach the LanguageTool server. Is it running?",
+  "writer.grammar.error": "The LanguageTool server returned an error.",
+  "writer.grammar.apply": "Apply",
+  "writer.grammar.ignore": "Ignore",
+  "writer.grammar.addToDictionary": "Add to dictionary",
+  "writer.grammar.noSuggestions": "No suggestions"
 }

--- a/locales/ru/writer.json
+++ b/locales/ru/writer.json
@@ -98,5 +98,19 @@
   "writer.tts.start": "Читать вслух",
   "writer.tts.stop": "Хватит читать",
   "writer.versionControl.label": "Версии",
-  "writer.versionControl.tooltip": "Контроль версий (ветви и снимки)"
+  "writer.versionControl.tooltip": "Контроль версий (ветви и снимки)",
+  "writer.grammar.title": "Grammar & Spelling",
+  "writer.grammar.checkButton": "Check this scene",
+  "writer.grammar.checking": "Checking…",
+  "writer.grammar.issuesFound": "{{count}} issues found",
+  "writer.grammar.noIssues": "No issues found.",
+  "writer.grammar.selectScene": "Select a scene to check.",
+  "writer.grammar.unsupported": "Grammar check isn't available for this language.",
+  "writer.grammar.disabled": "Enable LanguageTool in Settings → Connections to check this scene.",
+  "writer.grammar.offline": "Couldn't reach the LanguageTool server. Is it running?",
+  "writer.grammar.error": "The LanguageTool server returned an error.",
+  "writer.grammar.apply": "Apply",
+  "writer.grammar.ignore": "Ignore",
+  "writer.grammar.addToDictionary": "Add to dictionary",
+  "writer.grammar.noSuggestions": "No suggestions"
 }

--- a/locales/sv/writer.json
+++ b/locales/sv/writer.json
@@ -98,5 +98,19 @@
   "writer.tts.start": "Läs högt",
   "writer.tts.stop": "Sluta läsa",
   "writer.versionControl.label": "Versioner",
-  "writer.versionControl.tooltip": "Versionskontroll (grenar och ögonblicksbilder)"
+  "writer.versionControl.tooltip": "Versionskontroll (grenar och ögonblicksbilder)",
+  "writer.grammar.title": "Grammar & Spelling",
+  "writer.grammar.checkButton": "Check this scene",
+  "writer.grammar.checking": "Checking…",
+  "writer.grammar.issuesFound": "{{count}} issues found",
+  "writer.grammar.noIssues": "No issues found.",
+  "writer.grammar.selectScene": "Select a scene to check.",
+  "writer.grammar.unsupported": "Grammar check isn't available for this language.",
+  "writer.grammar.disabled": "Enable LanguageTool in Settings → Connections to check this scene.",
+  "writer.grammar.offline": "Couldn't reach the LanguageTool server. Is it running?",
+  "writer.grammar.error": "The LanguageTool server returned an error.",
+  "writer.grammar.apply": "Apply",
+  "writer.grammar.ignore": "Ignore",
+  "writer.grammar.addToDictionary": "Add to dictionary",
+  "writer.grammar.noSuggestions": "No suggestions"
 }

--- a/locales/zh/writer.json
+++ b/locales/zh/writer.json
@@ -98,5 +98,19 @@
   "writer.tts.start": "大声朗读",
   "writer.tts.stop": "停止阅读",
   "writer.versionControl.label": "版本",
-  "writer.versionControl.tooltip": "版本控制（分支和快照）"
+  "writer.versionControl.tooltip": "版本控制（分支和快照）",
+  "writer.grammar.title": "Grammar & Spelling",
+  "writer.grammar.checkButton": "Check this scene",
+  "writer.grammar.checking": "Checking…",
+  "writer.grammar.issuesFound": "{{count}} issues found",
+  "writer.grammar.noIssues": "No issues found.",
+  "writer.grammar.selectScene": "Select a scene to check.",
+  "writer.grammar.unsupported": "Grammar check isn't available for this language.",
+  "writer.grammar.disabled": "Enable LanguageTool in Settings → Connections to check this scene.",
+  "writer.grammar.offline": "Couldn't reach the LanguageTool server. Is it running?",
+  "writer.grammar.error": "The LanguageTool server returned an error.",
+  "writer.grammar.apply": "Apply",
+  "writer.grammar.ignore": "Ignore",
+  "writer.grammar.addToDictionary": "Add to dictionary",
+  "writer.grammar.noSuggestions": "No suggestions"
 }

--- a/public/locales/ar/bundle.json
+++ b/public/locales/ar/bundle.json
@@ -2764,5 +2764,19 @@
   "writer.tts.start": "قراءة بصوت عالٍ",
   "writer.tts.stop": "إيقاف القراءة",
   "writer.versionControl.label": "الإصدارات",
-  "writer.versionControl.tooltip": "التحكم بالإصدارات (الفروع واللقطات)"
+  "writer.versionControl.tooltip": "التحكم بالإصدارات (الفروع واللقطات)",
+  "writer.grammar.title": "Grammar & Spelling",
+  "writer.grammar.checkButton": "Check this scene",
+  "writer.grammar.checking": "Checking…",
+  "writer.grammar.issuesFound": "{{count}} issues found",
+  "writer.grammar.noIssues": "No issues found.",
+  "writer.grammar.selectScene": "Select a scene to check.",
+  "writer.grammar.unsupported": "Grammar check isn't available for this language.",
+  "writer.grammar.disabled": "Enable LanguageTool in Settings → Connections to check this scene.",
+  "writer.grammar.offline": "Couldn't reach the LanguageTool server. Is it running?",
+  "writer.grammar.error": "The LanguageTool server returned an error.",
+  "writer.grammar.apply": "Apply",
+  "writer.grammar.ignore": "Ignore",
+  "writer.grammar.addToDictionary": "Add to dictionary",
+  "writer.grammar.noSuggestions": "No suggestions"
 }

--- a/public/locales/de/bundle.json
+++ b/public/locales/de/bundle.json
@@ -2764,5 +2764,19 @@
   "writer.tts.start": "Vorlesen",
   "writer.tts.stop": "Vorlesen stoppen",
   "writer.versionControl.label": "Versionen",
-  "writer.versionControl.tooltip": "Versionskontrolle (Zweige & Schnappschüsse)"
+  "writer.versionControl.tooltip": "Versionskontrolle (Zweige & Schnappschüsse)",
+  "writer.grammar.title": "Grammatik & Rechtschreibung",
+  "writer.grammar.checkButton": "Diese Szene prüfen",
+  "writer.grammar.checking": "Prüfe…",
+  "writer.grammar.issuesFound": "{{count}} Probleme gefunden",
+  "writer.grammar.noIssues": "Keine Probleme gefunden.",
+  "writer.grammar.selectScene": "Wähle eine Szene zum Prüfen.",
+  "writer.grammar.unsupported": "Die Grammatikprüfung ist für diese Sprache nicht verfügbar.",
+  "writer.grammar.disabled": "Aktiviere LanguageTool in Einstellungen → Verbindungen, um diese Szene zu prüfen.",
+  "writer.grammar.offline": "LanguageTool-Server nicht erreichbar. Läuft er?",
+  "writer.grammar.error": "Der LanguageTool-Server hat einen Fehler zurückgegeben.",
+  "writer.grammar.apply": "Übernehmen",
+  "writer.grammar.ignore": "Ignorieren",
+  "writer.grammar.addToDictionary": "Zum Wörterbuch hinzufügen",
+  "writer.grammar.noSuggestions": "Keine Vorschläge"
 }

--- a/public/locales/el/bundle.json
+++ b/public/locales/el/bundle.json
@@ -2764,5 +2764,19 @@
   "writer.tts.start": "Διαβάστε δυνατά",
   "writer.tts.stop": "Σταμάτα να διαβάζεις",
   "writer.versionControl.label": "εκδόσεις",
-  "writer.versionControl.tooltip": "Έλεγχος έκδοσης (Κλάδοι και στιγμιότυπα)"
+  "writer.versionControl.tooltip": "Έλεγχος έκδοσης (Κλάδοι και στιγμιότυπα)",
+  "writer.grammar.title": "Grammar & Spelling",
+  "writer.grammar.checkButton": "Check this scene",
+  "writer.grammar.checking": "Checking…",
+  "writer.grammar.issuesFound": "{{count}} issues found",
+  "writer.grammar.noIssues": "No issues found.",
+  "writer.grammar.selectScene": "Select a scene to check.",
+  "writer.grammar.unsupported": "Grammar check isn't available for this language.",
+  "writer.grammar.disabled": "Enable LanguageTool in Settings → Connections to check this scene.",
+  "writer.grammar.offline": "Couldn't reach the LanguageTool server. Is it running?",
+  "writer.grammar.error": "The LanguageTool server returned an error.",
+  "writer.grammar.apply": "Apply",
+  "writer.grammar.ignore": "Ignore",
+  "writer.grammar.addToDictionary": "Add to dictionary",
+  "writer.grammar.noSuggestions": "No suggestions"
 }

--- a/public/locales/en/bundle.json
+++ b/public/locales/en/bundle.json
@@ -2764,5 +2764,19 @@
   "writer.studio.controls.custom": "Custom...",
   "writer.studio.controls.customTonePlaceholder": "e.g., Sarcastic, Melancholic, Fast-paced",
   "writer.versionControl.tooltip": "Version Control (Branches & Snapshots)",
-  "writer.cancelledTag": "Cancelled"
+  "writer.cancelledTag": "Cancelled",
+  "writer.grammar.title": "Grammar & Spelling",
+  "writer.grammar.checkButton": "Check this scene",
+  "writer.grammar.checking": "Checking…",
+  "writer.grammar.issuesFound": "{{count}} issues found",
+  "writer.grammar.noIssues": "No issues found.",
+  "writer.grammar.selectScene": "Select a scene to check.",
+  "writer.grammar.unsupported": "Grammar check isn't available for this language.",
+  "writer.grammar.disabled": "Enable LanguageTool in Settings → Connections to check this scene.",
+  "writer.grammar.offline": "Couldn't reach the LanguageTool server. Is it running?",
+  "writer.grammar.error": "The LanguageTool server returned an error.",
+  "writer.grammar.apply": "Apply",
+  "writer.grammar.ignore": "Ignore",
+  "writer.grammar.addToDictionary": "Add to dictionary",
+  "writer.grammar.noSuggestions": "No suggestions"
 }

--- a/public/locales/es/bundle.json
+++ b/public/locales/es/bundle.json
@@ -2764,5 +2764,19 @@
   "writer.tts.start": "Leer en voz alta",
   "writer.tts.stop": "Detener lectura",
   "writer.versionControl.label": "Versiones",
-  "writer.versionControl.tooltip": "Control de versiones (ramas e instantáneas)"
+  "writer.versionControl.tooltip": "Control de versiones (ramas e instantáneas)",
+  "writer.grammar.title": "Gramática y ortografía",
+  "writer.grammar.checkButton": "Revisar esta escena",
+  "writer.grammar.checking": "Revisando…",
+  "writer.grammar.issuesFound": "{{count}} problemas encontrados",
+  "writer.grammar.noIssues": "No se encontraron problemas.",
+  "writer.grammar.selectScene": "Selecciona una escena para revisar.",
+  "writer.grammar.unsupported": "La revisión gramatical no está disponible para este idioma.",
+  "writer.grammar.disabled": "Activa LanguageTool en Ajustes → Conexiones para revisar esta escena.",
+  "writer.grammar.offline": "No se pudo conectar con el servidor de LanguageTool. ¿Está en marcha?",
+  "writer.grammar.error": "El servidor de LanguageTool devolvió un error.",
+  "writer.grammar.apply": "Aplicar",
+  "writer.grammar.ignore": "Ignorar",
+  "writer.grammar.addToDictionary": "Añadir al diccionario",
+  "writer.grammar.noSuggestions": "Sin sugerencias"
 }

--- a/public/locales/eu/bundle.json
+++ b/public/locales/eu/bundle.json
@@ -2764,5 +2764,19 @@
   "writer.tts.start": "Irakurri ozen",
   "writer.tts.stop": "Utzi irakurtzeari",
   "writer.versionControl.label": "Bertsioak",
-  "writer.versionControl.tooltip": "Bertsio-kontrola (adarrak eta argazkiak)"
+  "writer.versionControl.tooltip": "Bertsio-kontrola (adarrak eta argazkiak)",
+  "writer.grammar.title": "Grammar & Spelling",
+  "writer.grammar.checkButton": "Check this scene",
+  "writer.grammar.checking": "Checking…",
+  "writer.grammar.issuesFound": "{{count}} issues found",
+  "writer.grammar.noIssues": "No issues found.",
+  "writer.grammar.selectScene": "Select a scene to check.",
+  "writer.grammar.unsupported": "Grammar check isn't available for this language.",
+  "writer.grammar.disabled": "Enable LanguageTool in Settings → Connections to check this scene.",
+  "writer.grammar.offline": "Couldn't reach the LanguageTool server. Is it running?",
+  "writer.grammar.error": "The LanguageTool server returned an error.",
+  "writer.grammar.apply": "Apply",
+  "writer.grammar.ignore": "Ignore",
+  "writer.grammar.addToDictionary": "Add to dictionary",
+  "writer.grammar.noSuggestions": "No suggestions"
 }

--- a/public/locales/fa/bundle.json
+++ b/public/locales/fa/bundle.json
@@ -2764,5 +2764,19 @@
   "writer.tts.start": "با صدای بلند بخوانید",
   "writer.tts.stop": "خواندن را متوقف کنید",
   "writer.versionControl.label": "نسخه ها",
-  "writer.versionControl.tooltip": "کنترل نسخه (شاخه ها و عکس های فوری)"
+  "writer.versionControl.tooltip": "کنترل نسخه (شاخه ها و عکس های فوری)",
+  "writer.grammar.title": "Grammar & Spelling",
+  "writer.grammar.checkButton": "Check this scene",
+  "writer.grammar.checking": "Checking…",
+  "writer.grammar.issuesFound": "{{count}} issues found",
+  "writer.grammar.noIssues": "No issues found.",
+  "writer.grammar.selectScene": "Select a scene to check.",
+  "writer.grammar.unsupported": "Grammar check isn't available for this language.",
+  "writer.grammar.disabled": "Enable LanguageTool in Settings → Connections to check this scene.",
+  "writer.grammar.offline": "Couldn't reach the LanguageTool server. Is it running?",
+  "writer.grammar.error": "The LanguageTool server returned an error.",
+  "writer.grammar.apply": "Apply",
+  "writer.grammar.ignore": "Ignore",
+  "writer.grammar.addToDictionary": "Add to dictionary",
+  "writer.grammar.noSuggestions": "No suggestions"
 }

--- a/public/locales/fi/bundle.json
+++ b/public/locales/fi/bundle.json
@@ -2764,5 +2764,19 @@
   "writer.tts.start": "Lue ääneen",
   "writer.tts.stop": "Lopeta lukeminen",
   "writer.versionControl.label": "Versiot",
-  "writer.versionControl.tooltip": "Versionhallinta (oksat ja tilannekuvat)"
+  "writer.versionControl.tooltip": "Versionhallinta (oksat ja tilannekuvat)",
+  "writer.grammar.title": "Grammar & Spelling",
+  "writer.grammar.checkButton": "Check this scene",
+  "writer.grammar.checking": "Checking…",
+  "writer.grammar.issuesFound": "{{count}} issues found",
+  "writer.grammar.noIssues": "No issues found.",
+  "writer.grammar.selectScene": "Select a scene to check.",
+  "writer.grammar.unsupported": "Grammar check isn't available for this language.",
+  "writer.grammar.disabled": "Enable LanguageTool in Settings → Connections to check this scene.",
+  "writer.grammar.offline": "Couldn't reach the LanguageTool server. Is it running?",
+  "writer.grammar.error": "The LanguageTool server returned an error.",
+  "writer.grammar.apply": "Apply",
+  "writer.grammar.ignore": "Ignore",
+  "writer.grammar.addToDictionary": "Add to dictionary",
+  "writer.grammar.noSuggestions": "No suggestions"
 }

--- a/public/locales/fr/bundle.json
+++ b/public/locales/fr/bundle.json
@@ -2764,5 +2764,19 @@
   "writer.tts.start": "Lire à haute voix",
   "writer.tts.stop": "Arrêter la lecture",
   "writer.versionControl.label": "Versions",
-  "writer.versionControl.tooltip": "Contrôle de version (branches et instantanés)"
+  "writer.versionControl.tooltip": "Contrôle de version (branches et instantanés)",
+  "writer.grammar.title": "Grammaire et orthographe",
+  "writer.grammar.checkButton": "Vérifier cette scène",
+  "writer.grammar.checking": "Vérification…",
+  "writer.grammar.issuesFound": "{{count}} problèmes détectés",
+  "writer.grammar.noIssues": "Aucun problème détecté.",
+  "writer.grammar.selectScene": "Sélectionnez une scène à vérifier.",
+  "writer.grammar.unsupported": "La vérification grammaticale n'est pas disponible pour cette langue.",
+  "writer.grammar.disabled": "Activez LanguageTool dans Paramètres → Connexions pour vérifier cette scène.",
+  "writer.grammar.offline": "Impossible de joindre le serveur LanguageTool. Est-il démarré ?",
+  "writer.grammar.error": "Le serveur LanguageTool a renvoyé une erreur.",
+  "writer.grammar.apply": "Appliquer",
+  "writer.grammar.ignore": "Ignorer",
+  "writer.grammar.addToDictionary": "Ajouter au dictionnaire",
+  "writer.grammar.noSuggestions": "Aucune suggestion"
 }

--- a/public/locales/he/bundle.json
+++ b/public/locales/he/bundle.json
@@ -2764,5 +2764,19 @@
   "writer.tts.start": "הקראה בקול",
   "writer.tts.stop": "עצירת הקראה",
   "writer.versionControl.label": "גרסאות",
-  "writer.versionControl.tooltip": "בקרת גרסאות (ענפים ותמונות מצב)"
+  "writer.versionControl.tooltip": "בקרת גרסאות (ענפים ותמונות מצב)",
+  "writer.grammar.title": "Grammar & Spelling",
+  "writer.grammar.checkButton": "Check this scene",
+  "writer.grammar.checking": "Checking…",
+  "writer.grammar.issuesFound": "{{count}} issues found",
+  "writer.grammar.noIssues": "No issues found.",
+  "writer.grammar.selectScene": "Select a scene to check.",
+  "writer.grammar.unsupported": "Grammar check isn't available for this language.",
+  "writer.grammar.disabled": "Enable LanguageTool in Settings → Connections to check this scene.",
+  "writer.grammar.offline": "Couldn't reach the LanguageTool server. Is it running?",
+  "writer.grammar.error": "The LanguageTool server returned an error.",
+  "writer.grammar.apply": "Apply",
+  "writer.grammar.ignore": "Ignore",
+  "writer.grammar.addToDictionary": "Add to dictionary",
+  "writer.grammar.noSuggestions": "No suggestions"
 }

--- a/public/locales/hu/bundle.json
+++ b/public/locales/hu/bundle.json
@@ -2764,5 +2764,19 @@
   "writer.tts.start": "Olvass fel hangosan",
   "writer.tts.stop": "Hagyd abba az olvasást",
   "writer.versionControl.label": "Verziók",
-  "writer.versionControl.tooltip": "Verzióvezérlés (elágazások és pillanatképek)"
+  "writer.versionControl.tooltip": "Verzióvezérlés (elágazások és pillanatképek)",
+  "writer.grammar.title": "Grammar & Spelling",
+  "writer.grammar.checkButton": "Check this scene",
+  "writer.grammar.checking": "Checking…",
+  "writer.grammar.issuesFound": "{{count}} issues found",
+  "writer.grammar.noIssues": "No issues found.",
+  "writer.grammar.selectScene": "Select a scene to check.",
+  "writer.grammar.unsupported": "Grammar check isn't available for this language.",
+  "writer.grammar.disabled": "Enable LanguageTool in Settings → Connections to check this scene.",
+  "writer.grammar.offline": "Couldn't reach the LanguageTool server. Is it running?",
+  "writer.grammar.error": "The LanguageTool server returned an error.",
+  "writer.grammar.apply": "Apply",
+  "writer.grammar.ignore": "Ignore",
+  "writer.grammar.addToDictionary": "Add to dictionary",
+  "writer.grammar.noSuggestions": "No suggestions"
 }

--- a/public/locales/is/bundle.json
+++ b/public/locales/is/bundle.json
@@ -2764,5 +2764,19 @@
   "writer.tts.start": "Lestu upphátt",
   "writer.tts.stop": "Hættu að lesa",
   "writer.versionControl.label": "Útgáfur",
-  "writer.versionControl.tooltip": "Útgáfustýring (útibú og skyndimyndir)"
+  "writer.versionControl.tooltip": "Útgáfustýring (útibú og skyndimyndir)",
+  "writer.grammar.title": "Grammar & Spelling",
+  "writer.grammar.checkButton": "Check this scene",
+  "writer.grammar.checking": "Checking…",
+  "writer.grammar.issuesFound": "{{count}} issues found",
+  "writer.grammar.noIssues": "No issues found.",
+  "writer.grammar.selectScene": "Select a scene to check.",
+  "writer.grammar.unsupported": "Grammar check isn't available for this language.",
+  "writer.grammar.disabled": "Enable LanguageTool in Settings → Connections to check this scene.",
+  "writer.grammar.offline": "Couldn't reach the LanguageTool server. Is it running?",
+  "writer.grammar.error": "The LanguageTool server returned an error.",
+  "writer.grammar.apply": "Apply",
+  "writer.grammar.ignore": "Ignore",
+  "writer.grammar.addToDictionary": "Add to dictionary",
+  "writer.grammar.noSuggestions": "No suggestions"
 }

--- a/public/locales/it/bundle.json
+++ b/public/locales/it/bundle.json
@@ -2764,5 +2764,19 @@
   "writer.tts.start": "Leggi ad alta voce",
   "writer.tts.stop": "Interrompi lettura",
   "writer.versionControl.label": "Versioni",
-  "writer.versionControl.tooltip": "Controllo versione (rami e istantanee)"
+  "writer.versionControl.tooltip": "Controllo versione (rami e istantanee)",
+  "writer.grammar.title": "Grammatica e ortografia",
+  "writer.grammar.checkButton": "Controlla questa scena",
+  "writer.grammar.checking": "Controllo…",
+  "writer.grammar.issuesFound": "{{count}} problemi rilevati",
+  "writer.grammar.noIssues": "Nessun problema rilevato.",
+  "writer.grammar.selectScene": "Seleziona una scena da controllare.",
+  "writer.grammar.unsupported": "Il controllo grammaticale non è disponibile per questa lingua.",
+  "writer.grammar.disabled": "Attiva LanguageTool in Impostazioni → Connessioni per controllare questa scena.",
+  "writer.grammar.offline": "Impossibile raggiungere il server LanguageTool. È in esecuzione?",
+  "writer.grammar.error": "Il server LanguageTool ha restituito un errore.",
+  "writer.grammar.apply": "Applica",
+  "writer.grammar.ignore": "Ignora",
+  "writer.grammar.addToDictionary": "Aggiungi al dizionario",
+  "writer.grammar.noSuggestions": "Nessun suggerimento"
 }

--- a/public/locales/ja/bundle.json
+++ b/public/locales/ja/bundle.json
@@ -2764,5 +2764,19 @@
   "writer.tts.start": "声に出して読む",
   "writer.tts.stop": "読むのをやめる",
   "writer.versionControl.label": "バージョン",
-  "writer.versionControl.tooltip": "バージョン管理 (ブランチとスナップショット)"
+  "writer.versionControl.tooltip": "バージョン管理 (ブランチとスナップショット)",
+  "writer.grammar.title": "Grammar & Spelling",
+  "writer.grammar.checkButton": "Check this scene",
+  "writer.grammar.checking": "Checking…",
+  "writer.grammar.issuesFound": "{{count}} issues found",
+  "writer.grammar.noIssues": "No issues found.",
+  "writer.grammar.selectScene": "Select a scene to check.",
+  "writer.grammar.unsupported": "Grammar check isn't available for this language.",
+  "writer.grammar.disabled": "Enable LanguageTool in Settings → Connections to check this scene.",
+  "writer.grammar.offline": "Couldn't reach the LanguageTool server. Is it running?",
+  "writer.grammar.error": "The LanguageTool server returned an error.",
+  "writer.grammar.apply": "Apply",
+  "writer.grammar.ignore": "Ignore",
+  "writer.grammar.addToDictionary": "Add to dictionary",
+  "writer.grammar.noSuggestions": "No suggestions"
 }

--- a/public/locales/ko/bundle.json
+++ b/public/locales/ko/bundle.json
@@ -2764,5 +2764,19 @@
   "writer.tts.start": "소리내어 읽기",
   "writer.tts.stop": "읽기 중지",
   "writer.versionControl.label": "버전",
-  "writer.versionControl.tooltip": "버전 관리(브랜치 및 스냅샷)"
+  "writer.versionControl.tooltip": "버전 관리(브랜치 및 스냅샷)",
+  "writer.grammar.title": "Grammar & Spelling",
+  "writer.grammar.checkButton": "Check this scene",
+  "writer.grammar.checking": "Checking…",
+  "writer.grammar.issuesFound": "{{count}} issues found",
+  "writer.grammar.noIssues": "No issues found.",
+  "writer.grammar.selectScene": "Select a scene to check.",
+  "writer.grammar.unsupported": "Grammar check isn't available for this language.",
+  "writer.grammar.disabled": "Enable LanguageTool in Settings → Connections to check this scene.",
+  "writer.grammar.offline": "Couldn't reach the LanguageTool server. Is it running?",
+  "writer.grammar.error": "The LanguageTool server returned an error.",
+  "writer.grammar.apply": "Apply",
+  "writer.grammar.ignore": "Ignore",
+  "writer.grammar.addToDictionary": "Add to dictionary",
+  "writer.grammar.noSuggestions": "No suggestions"
 }

--- a/public/locales/pt/bundle.json
+++ b/public/locales/pt/bundle.json
@@ -2764,5 +2764,19 @@
   "writer.tts.start": "Ler em voz alta",
   "writer.tts.stop": "Pare de ler",
   "writer.versionControl.label": "Versões",
-  "writer.versionControl.tooltip": "Controle de versão (ramos e instantâneos)"
+  "writer.versionControl.tooltip": "Controle de versão (ramos e instantâneos)",
+  "writer.grammar.title": "Grammar & Spelling",
+  "writer.grammar.checkButton": "Check this scene",
+  "writer.grammar.checking": "Checking…",
+  "writer.grammar.issuesFound": "{{count}} issues found",
+  "writer.grammar.noIssues": "No issues found.",
+  "writer.grammar.selectScene": "Select a scene to check.",
+  "writer.grammar.unsupported": "Grammar check isn't available for this language.",
+  "writer.grammar.disabled": "Enable LanguageTool in Settings → Connections to check this scene.",
+  "writer.grammar.offline": "Couldn't reach the LanguageTool server. Is it running?",
+  "writer.grammar.error": "The LanguageTool server returned an error.",
+  "writer.grammar.apply": "Apply",
+  "writer.grammar.ignore": "Ignore",
+  "writer.grammar.addToDictionary": "Add to dictionary",
+  "writer.grammar.noSuggestions": "No suggestions"
 }

--- a/public/locales/ru/bundle.json
+++ b/public/locales/ru/bundle.json
@@ -2764,5 +2764,19 @@
   "writer.tts.start": "Читать вслух",
   "writer.tts.stop": "Хватит читать",
   "writer.versionControl.label": "Версии",
-  "writer.versionControl.tooltip": "Контроль версий (ветви и снимки)"
+  "writer.versionControl.tooltip": "Контроль версий (ветви и снимки)",
+  "writer.grammar.title": "Grammar & Spelling",
+  "writer.grammar.checkButton": "Check this scene",
+  "writer.grammar.checking": "Checking…",
+  "writer.grammar.issuesFound": "{{count}} issues found",
+  "writer.grammar.noIssues": "No issues found.",
+  "writer.grammar.selectScene": "Select a scene to check.",
+  "writer.grammar.unsupported": "Grammar check isn't available for this language.",
+  "writer.grammar.disabled": "Enable LanguageTool in Settings → Connections to check this scene.",
+  "writer.grammar.offline": "Couldn't reach the LanguageTool server. Is it running?",
+  "writer.grammar.error": "The LanguageTool server returned an error.",
+  "writer.grammar.apply": "Apply",
+  "writer.grammar.ignore": "Ignore",
+  "writer.grammar.addToDictionary": "Add to dictionary",
+  "writer.grammar.noSuggestions": "No suggestions"
 }

--- a/public/locales/sv/bundle.json
+++ b/public/locales/sv/bundle.json
@@ -2764,5 +2764,19 @@
   "writer.tts.start": "Läs högt",
   "writer.tts.stop": "Sluta läsa",
   "writer.versionControl.label": "Versioner",
-  "writer.versionControl.tooltip": "Versionskontroll (grenar och ögonblicksbilder)"
+  "writer.versionControl.tooltip": "Versionskontroll (grenar och ögonblicksbilder)",
+  "writer.grammar.title": "Grammar & Spelling",
+  "writer.grammar.checkButton": "Check this scene",
+  "writer.grammar.checking": "Checking…",
+  "writer.grammar.issuesFound": "{{count}} issues found",
+  "writer.grammar.noIssues": "No issues found.",
+  "writer.grammar.selectScene": "Select a scene to check.",
+  "writer.grammar.unsupported": "Grammar check isn't available for this language.",
+  "writer.grammar.disabled": "Enable LanguageTool in Settings → Connections to check this scene.",
+  "writer.grammar.offline": "Couldn't reach the LanguageTool server. Is it running?",
+  "writer.grammar.error": "The LanguageTool server returned an error.",
+  "writer.grammar.apply": "Apply",
+  "writer.grammar.ignore": "Ignore",
+  "writer.grammar.addToDictionary": "Add to dictionary",
+  "writer.grammar.noSuggestions": "No suggestions"
 }

--- a/public/locales/zh/bundle.json
+++ b/public/locales/zh/bundle.json
@@ -2764,5 +2764,19 @@
   "writer.tts.start": "大声朗读",
   "writer.tts.stop": "停止阅读",
   "writer.versionControl.label": "版本",
-  "writer.versionControl.tooltip": "版本控制（分支和快照）"
+  "writer.versionControl.tooltip": "版本控制（分支和快照）",
+  "writer.grammar.title": "Grammar & Spelling",
+  "writer.grammar.checkButton": "Check this scene",
+  "writer.grammar.checking": "Checking…",
+  "writer.grammar.issuesFound": "{{count}} issues found",
+  "writer.grammar.noIssues": "No issues found.",
+  "writer.grammar.selectScene": "Select a scene to check.",
+  "writer.grammar.unsupported": "Grammar check isn't available for this language.",
+  "writer.grammar.disabled": "Enable LanguageTool in Settings → Connections to check this scene.",
+  "writer.grammar.offline": "Couldn't reach the LanguageTool server. Is it running?",
+  "writer.grammar.error": "The LanguageTool server returned an error.",
+  "writer.grammar.apply": "Apply",
+  "writer.grammar.ignore": "Ignore",
+  "writer.grammar.addToDictionary": "Add to dictionary",
+  "writer.grammar.noSuggestions": "No suggestions"
 }

--- a/tests/unit/GrammarCheckPanel.test.tsx
+++ b/tests/unit/GrammarCheckPanel.test.tsx
@@ -116,4 +116,36 @@ describe('GrammarCheckPanel', () => {
     render(<GrammarCheckPanel />);
     expect(screen.getByText('writer.grammar.disabled')).toBeTruthy();
   });
+
+  it('shows the no-issues message on a clean check', async () => {
+    mocks.checkText.mockResolvedValue({ matches: [], status: 'ok' });
+    render(<GrammarCheckPanel />);
+    await userEvent.click(screen.getByText('writer.grammar.checkButton'));
+    expect(await screen.findByText('writer.grammar.noIssues')).toBeTruthy();
+  });
+
+  it('shows the offline message when the server is unreachable', async () => {
+    mocks.checkText.mockResolvedValue({ matches: [], status: 'offline' });
+    render(<GrammarCheckPanel />);
+    await userEvent.click(screen.getByText('writer.grammar.checkButton'));
+    expect(await screen.findByText('writer.grammar.offline')).toBeTruthy();
+  });
+
+  it('shows the error message on a server error', async () => {
+    mocks.checkText.mockResolvedValue({ matches: [], status: 'error' });
+    render(<GrammarCheckPanel />);
+    await userEvent.click(screen.getByText('writer.grammar.checkButton'));
+    expect(await screen.findByText('writer.grammar.error')).toBeTruthy();
+  });
+
+  it('offers add-to-dictionary for a spelling match and no-suggestions when empty', async () => {
+    mocks.checkText.mockResolvedValue({
+      matches: [match({ isSpelling: true, replacements: [], matchedText: 'Gandalf' })],
+      status: 'ok',
+    });
+    render(<GrammarCheckPanel />);
+    await userEvent.click(screen.getByText('writer.grammar.checkButton'));
+    expect(await screen.findByText('writer.grammar.addToDictionary')).toBeTruthy();
+    expect(screen.getByText('writer.grammar.noSuggestions')).toBeTruthy();
+  });
 });

--- a/tests/unit/GrammarCheckPanel.test.tsx
+++ b/tests/unit/GrammarCheckPanel.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { LanguageToolMatch } from '../../services/languageToolService';
+
+// Mutable mock state so individual tests vary locale / enabled / dispatch.
+const mocks = vi.hoisted(() => ({
+  language: 'en',
+  enabled: true,
+  dispatch: vi.fn(),
+  checkText: vi.fn(),
+}));
+
+vi.mock('../../app/hooks', () => ({
+  useAppDispatch: () => mocks.dispatch,
+  useAppSelector: (selector: (s: unknown) => unknown) =>
+    selector({
+      settings: {
+        integrations: {
+          languageToolEnabled: mocks.enabled,
+          languageToolBaseUrl: 'http://localhost:8010',
+        },
+        advancedEditor: { customDictionary: [] },
+        privacy: { localStorageOnly: true },
+      },
+      project: { present: { data: { manuscript: [{ id: 'sec1', content: 'She go home.' }] } } },
+    }),
+}));
+
+vi.mock('../../contexts/WriterViewContext', () => ({
+  useWriterViewContext: () => ({ selectedSectionId: 'sec1' }),
+}));
+
+vi.mock('../../hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (k: string, opts?: { count?: number }) => (opts?.count != null ? `${k}:${opts.count}` : k),
+    language: mocks.language,
+  }),
+}));
+
+vi.mock('../../services/languageToolClient', () => ({
+  assertLanguageToolAllowed: vi.fn(),
+}));
+
+vi.mock('../../services/languageToolService', () => ({
+  checkText: mocks.checkText,
+  applyMatchReplacement: vi.fn(() => 'She goes home.'),
+}));
+
+import { GrammarCheckPanel } from '../../components/writing/GrammarCheckPanel';
+
+function match(over: Partial<LanguageToolMatch> = {}): LanguageToolMatch {
+  return {
+    offset: 4,
+    length: 2,
+    message: 'Subject-verb agreement',
+    shortMessage: 'Agreement',
+    replacements: ['goes'],
+    ruleId: 'AGREEMENT',
+    category: 'GRAMMAR',
+    categoryName: 'Grammar',
+    matchedText: 'go',
+    isSpelling: false,
+    ...over,
+  };
+}
+
+describe('GrammarCheckPanel', () => {
+  beforeEach(() => {
+    mocks.language = 'en';
+    mocks.enabled = true;
+    mocks.dispatch.mockReset();
+    mocks.checkText.mockReset();
+    mocks.checkText.mockResolvedValue({ matches: [match()], status: 'ok' });
+  });
+
+  it('runs a check and lists the issue with a suggestion', async () => {
+    render(<GrammarCheckPanel />);
+    await userEvent.click(screen.getByText('writer.grammar.checkButton'));
+
+    await waitFor(() => expect(mocks.checkText).toHaveBeenCalledOnce());
+    expect(await screen.findByText('Subject-verb agreement')).toBeTruthy();
+    expect(screen.getByText('goes')).toBeTruthy();
+    expect(screen.getByText('writer.grammar.issuesFound:1')).toBeTruthy();
+  });
+
+  it('applies a suggestion → dispatches a section update and re-checks', async () => {
+    render(<GrammarCheckPanel />);
+    await userEvent.click(screen.getByText('writer.grammar.checkButton'));
+    await screen.findByText('goes');
+
+    await userEvent.click(screen.getByText('goes'));
+    await waitFor(() => expect(mocks.dispatch).toHaveBeenCalled());
+    // Re-check after apply (offsets shifted): checkText called a second time.
+    await waitFor(() => expect(mocks.checkText).toHaveBeenCalledTimes(2));
+  });
+
+  it('removes an issue from the list when ignored', async () => {
+    render(<GrammarCheckPanel />);
+    await userEvent.click(screen.getByText('writer.grammar.checkButton'));
+    await screen.findByText('Subject-verb agreement');
+
+    await userEvent.click(screen.getByText('writer.grammar.ignore'));
+    await waitFor(() => expect(screen.queryByText('Subject-verb agreement')).toBeNull());
+  });
+
+  it('hides the feature for a LanguageTool-unsupported locale (Korean)', () => {
+    mocks.language = 'ko';
+    render(<GrammarCheckPanel />);
+    expect(screen.getByText('writer.grammar.unsupported')).toBeTruthy();
+    expect(screen.queryByText('writer.grammar.checkButton')).toBeNull();
+  });
+
+  it('shows the enable hint when the integration is disabled', () => {
+    mocks.enabled = false;
+    render(<GrammarCheckPanel />);
+    expect(screen.getByText('writer.grammar.disabled')).toBeTruthy();
+  });
+});

--- a/tests/unit/ToolsPanel.test.tsx
+++ b/tests/unit/ToolsPanel.test.tsx
@@ -54,6 +54,12 @@ vi.mock('../../components/writing/ToolInputs', () => ({
   ToolInputs: () => <div data-testid="tool-inputs" />,
 }));
 
+// QNBS-v3: GrammarCheckPanel pulls in Redux (useLanguageToolCheck) — stub it so ToolsPanel's own
+// behavior is tested in isolation (it has its own test file).
+vi.mock('../../components/writing/GrammarCheckPanel', () => ({
+  GrammarCheckPanel: () => <div data-testid="grammar-check-panel" />,
+}));
+
 vi.mock('../../components/ui/Select', () => ({
   Select: vi.fn(
     ({

--- a/tests/unit/useLanguageToolCheck.test.tsx
+++ b/tests/unit/useLanguageToolCheck.test.tsx
@@ -1,0 +1,208 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { LanguageToolMatch } from '../../services/languageToolService';
+
+const mocks = vi.hoisted(() => ({
+  language: 'en',
+  enabled: true,
+  dictionary: [] as string[],
+  manuscript: [{ id: 'sec1', content: 'She go home.' }] as Array<{ id: string; content: string }>,
+  dispatch: vi.fn(),
+  checkText: vi.fn(),
+  applyMatchReplacement: vi.fn(),
+  assertAllowed: vi.fn(),
+}));
+
+vi.mock('../../app/hooks', () => ({
+  useAppDispatch: () => mocks.dispatch,
+  useAppSelector: (selector: (s: unknown) => unknown) =>
+    selector({
+      settings: {
+        integrations: {
+          languageToolEnabled: mocks.enabled,
+          languageToolBaseUrl: 'http://localhost:8010',
+        },
+        advancedEditor: { customDictionary: mocks.dictionary },
+        privacy: { localStorageOnly: true },
+      },
+      project: { present: { data: { manuscript: mocks.manuscript } } },
+    }),
+}));
+
+vi.mock('../../hooks/useTranslation', () => ({
+  useTranslation: () => ({ t: (k: string) => k, language: mocks.language }),
+}));
+
+vi.mock('../../services/languageToolClient', () => ({
+  assertLanguageToolAllowed: (...args: unknown[]) => mocks.assertAllowed(...args),
+}));
+
+vi.mock('../../services/languageToolService', () => ({
+  checkText: mocks.checkText,
+  applyMatchReplacement: mocks.applyMatchReplacement,
+}));
+
+import { useLanguageToolCheck } from '../../hooks/useLanguageToolCheck';
+
+function ltMatch(over: Partial<LanguageToolMatch> = {}): LanguageToolMatch {
+  return {
+    offset: 4,
+    length: 2,
+    message: 'Agreement',
+    shortMessage: 'Agreement',
+    replacements: ['goes'],
+    ruleId: 'AGREEMENT',
+    category: 'GRAMMAR',
+    categoryName: 'Grammar',
+    matchedText: 'go',
+    isSpelling: false,
+    ...over,
+  };
+}
+
+describe('useLanguageToolCheck', () => {
+  beforeEach(() => {
+    mocks.language = 'en';
+    mocks.enabled = true;
+    mocks.dictionary = [];
+    mocks.manuscript = [{ id: 'sec1', content: 'She go home.' }];
+    mocks.dispatch.mockReset();
+    mocks.checkText.mockReset().mockResolvedValue({ matches: [ltMatch()], status: 'ok' });
+    mocks.applyMatchReplacement.mockReset().mockReturnValue('She goes home.');
+    mocks.assertAllowed.mockReset();
+  });
+
+  it('reports availability from locale + enabled flag', () => {
+    const { result } = renderHook(() => useLanguageToolCheck());
+    expect(result.current.available).toBe(true);
+    expect(result.current.unsupportedLocale).toBe(false);
+  });
+
+  it('flags an unsupported locale and check() short-circuits', async () => {
+    mocks.language = 'ko';
+    const { result } = renderHook(() => useLanguageToolCheck());
+    expect(result.current.unsupportedLocale).toBe(true);
+    await act(async () => {
+      await result.current.check('sec1');
+    });
+    expect(result.current.status).toBe('unsupported');
+    expect(mocks.checkText).not.toHaveBeenCalled();
+  });
+
+  it('sets disabled when the privacy gate rejects', async () => {
+    mocks.assertAllowed.mockImplementation(() => {
+      throw new Error('blocked');
+    });
+    const { result } = renderHook(() => useLanguageToolCheck());
+    await act(async () => {
+      await result.current.check('sec1');
+    });
+    expect(result.current.status).toBe('disabled');
+    expect(mocks.checkText).not.toHaveBeenCalled();
+  });
+
+  it('does nothing for an unknown section id', async () => {
+    const { result } = renderHook(() => useLanguageToolCheck());
+    await act(async () => {
+      await result.current.check('missing');
+    });
+    expect(mocks.checkText).not.toHaveBeenCalled();
+  });
+
+  it('surfaces offline and error statuses from the service', async () => {
+    mocks.checkText.mockResolvedValue({ matches: [], status: 'offline' });
+    const { result } = renderHook(() => useLanguageToolCheck());
+    await act(async () => {
+      await result.current.check('sec1');
+    });
+    expect(result.current.status).toBe('offline');
+
+    mocks.checkText.mockResolvedValue({ matches: [], status: 'error' });
+    await act(async () => {
+      await result.current.check('sec1');
+    });
+    expect(result.current.status).toBe('error');
+  });
+
+  it('stores matches on a successful check', async () => {
+    const { result } = renderHook(() => useLanguageToolCheck());
+    await act(async () => {
+      await result.current.check('sec1');
+    });
+    expect(result.current.status).toBe('ok');
+    expect(result.current.matches).toHaveLength(1);
+  });
+
+  it('applies a suggestion → dispatches an update and re-checks', async () => {
+    const { result } = renderHook(() => useLanguageToolCheck());
+    await act(async () => {
+      await result.current.check('sec1');
+    });
+    mocks.checkText.mockClear();
+    act(() => {
+      result.current.applySuggestion('sec1', ltMatch(), 'goes');
+    });
+    expect(mocks.dispatch).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mocks.checkText).toHaveBeenCalledTimes(1)); // re-check
+  });
+
+  it('does not dispatch when the apply is a no-op (stale anchor)', () => {
+    mocks.applyMatchReplacement.mockReturnValue('She go home.'); // unchanged
+    const { result } = renderHook(() => useLanguageToolCheck());
+    act(() => {
+      result.current.applySuggestion('sec1', ltMatch(), 'goes');
+    });
+    expect(mocks.dispatch).not.toHaveBeenCalled();
+  });
+
+  it('adds a new word to the dictionary and drops its spelling matches', async () => {
+    mocks.checkText.mockResolvedValue({
+      matches: [ltMatch({ matchedText: 'Gandalf', isSpelling: true })],
+      status: 'ok',
+    });
+    const { result } = renderHook(() => useLanguageToolCheck());
+    await act(async () => {
+      await result.current.check('sec1');
+    });
+    act(() => {
+      result.current.addToDictionary('Gandalf');
+    });
+    expect(mocks.dispatch).toHaveBeenCalledTimes(1);
+    expect(result.current.matches).toHaveLength(0);
+  });
+
+  it('does not persist a word already in the dictionary', () => {
+    mocks.dictionary = ['gandalf'];
+    const { result } = renderHook(() => useLanguageToolCheck());
+    act(() => {
+      result.current.addToDictionary('Gandalf');
+    });
+    expect(mocks.dispatch).not.toHaveBeenCalled();
+  });
+
+  it('ignores a blank dictionary word', () => {
+    const { result } = renderHook(() => useLanguageToolCheck());
+    act(() => {
+      result.current.addToDictionary('   ');
+    });
+    expect(mocks.dispatch).not.toHaveBeenCalled();
+  });
+
+  it('ignore() removes a single match; clear() resets', async () => {
+    const { result } = renderHook(() => useLanguageToolCheck());
+    await act(async () => {
+      await result.current.check('sec1');
+    });
+    expect(result.current.matches).toHaveLength(1);
+    act(() => {
+      result.current.ignore(ltMatch());
+    });
+    expect(result.current.matches).toHaveLength(0);
+
+    act(() => {
+      result.current.clear();
+    });
+    expect(result.current.status).toBe('idle');
+    expect(result.current.matches).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

PR-C1 of the LanguageTool program — the on-demand grammar/spell **MVP** wired into the Writer tools sidebar, built on the tested `languageToolService` (#235). Deterministic, self-hosted, **no AI tokens**, separate from the AI generation flow.

### What's new
- **`hooks/useLanguageToolCheck.ts`** — orchestration. Resolves the active locale → LanguageTool code from the SSOT (`getLanguageToolCode`, #234), enforces the privacy gate (`assertLanguageToolAllowed`), runs `checkText` on the active section (abortable; a rapid re-trigger cancels the prior run). Apply is **offset-safe** and re-checks (offsets shift after an edit); **add-to-dictionary** persists to `advancedEditor.customDictionary` (reused — no new settings field) and drops the word's spelling matches; **ignore** dismisses one match.
- **`components/writing/GrammarCheckPanel.tsx`** — "Check this scene" button + diagnostics list (category, message, flagged span, replacement chips → one-click apply, ignore, add-to-dictionary). **Hidden entirely** for LanguageTool-unsupported locales (tr/he/fi/hu/is/eu/ko); shows an enable hint when the integration is off; offline/error degrade quietly so typing is never blocked.
- Wired into `ToolsPanel` below the AI tools (bordered section).
- **i18n**: 14 `writer.grammar.*` keys across all **19 locales** (core-5 hand-translated: en/de/es/fr/it; others English-seeded for parity, bulk-MT later) + rebuilt bundles.
- **Tests** (`GrammarCheckPanel.test.tsx`, 5): check→list, apply→dispatch+re-check, ignore removes, unsupported-locale hidden, disabled hint. Service core covered by #235's 13 tests; gating by `languageToolClient.test`.

## Test plan
- `pnpm run lint` ✅ · `pnpm run typecheck` ✅ · `pnpm run i18n:check` ✅ (+14 keys/bundle, parity OK) · `pnpm run suppressions:check` ✅ (no new suppressions)
- `pnpm exec vitest run tests/unit/GrammarCheckPanel.test.tsx tests/unit/languageToolService.test.ts tests/unit/i18nPlaceholders.test.ts` ✅ (55)

## Verification (manual, later)
Run a local LanguageTool (`docker run -p 8010:8010 erikvl87/languagetool`), enable it in Settings → Connections, then "Check this scene" on a section with a planted error → fix applies offset-safe; add-to-dictionary suppresses a flagged name; server-down degrades silently.

## Next in the stack
PR-C2 — live inline underlines on the ManuscriptEditor overlay + suggestion popover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)