### PR TITLE
feat(languagetool): live inline grammar overlay + popover (PR-C2)

### DIFF
--- a/components/manuscript/ManuscriptEditor.tsx
+++ b/components/manuscript/ManuscriptEditor.tsx
@@ -297,7 +297,9 @@ export const ManuscriptEditor: FC<{ isFocusMode: boolean }> = React.memo(({ isFo
     });
 
     if (lastIndex < text.length) parts.push(text.substring(lastIndex));
-    return <>{parts}</>;
+    // QNBS-v3: return the parts array directly — a single-child fragment is redundant (DeepSource
+    // JS-0424); rendered elements carry keys, bare string segments don't need them.
+    return parts;
   }, [
     deferredContent,
     characters,

--- a/components/manuscript/ManuscriptEditor.tsx
+++ b/components/manuscript/ManuscriptEditor.tsx
@@ -2,8 +2,10 @@ import type { FC, ReactNode } from 'react';
 import React, { useCallback, useDeferredValue, useEffect, useMemo, useState } from 'react';
 import { useAppSelector } from '../../app/hooks';
 import { useManuscriptViewContext } from '../../contexts/ManuscriptViewContext';
+import { useLanguageToolCheck } from '../../hooks/useLanguageToolCheck';
 import { useTranslation } from '../../hooks/useTranslation';
 import { useVoiceDictation } from '../../hooks/useVoiceDictation';
+import type { LanguageToolMatch } from '../../services/languageToolService';
 import { InlineAnnotationLayer } from '../copilot/InlineAnnotationLayer';
 import { DebouncedInput } from '../ui/DebouncedInput';
 import { Icon } from '../ui/Icon';
@@ -79,7 +81,12 @@ export const ManuscriptEditor: FC<{ isFocusMode: boolean }> = React.memo(({ isFo
     x: number;
     y: number;
     word: string;
-    suggestion: string;
+    // QNBS-v3: PR-C2 — `suggestion` is the legacy single fallback (TYPOS); when `match` is set the
+    // popover renders the real LanguageTool message + replacement chips (offset-safe apply).
+    suggestion?: string;
+    message?: string;
+    replacements?: string[];
+    match?: LanguageToolMatch;
   } | null>(null);
   const [selectedMentionIndex, setSelectedMentionIndex] = useState(0);
 
@@ -119,9 +126,48 @@ export const ManuscriptEditor: FC<{ isFocusMode: boolean }> = React.memo(({ isFo
 
   const currentTypos = language === 'de' ? TYPOS_DE : TYPOS_EN;
 
+  // QNBS-v3: PR-C2 — live LanguageTool spell/grammar check feeding the existing overlay. Active only
+  // when the integration is enabled + the locale is LT-supported (lt.available); otherwise the overlay
+  // falls back to the static TYPOS map below. Debounced so typing stays smooth; the service caches by
+  // text hash + degrades silently offline.
+  const lt = useLanguageToolCheck();
+  const ltCheck = lt.check;
+  const ltAvailable = lt.available;
+  const activeSectionId = activeSection?.id;
+  useEffect(() => {
+    // QNBS-v3: re-run on each settled edit; skip empty content (also makes deferredContent a real dep).
+    if (!ltAvailable || !activeSectionId || deferredContent.trim().length === 0) return;
+    const handle = setTimeout(() => {
+      void ltCheck(activeSectionId);
+    }, 700);
+    return () => clearTimeout(handle);
+  }, [deferredContent, activeSectionId, ltAvailable, ltCheck]);
+
+  // QNBS-v3: map single-word LanguageTool matches to their start offset so the word-token overlay can
+  // underline them precisely (multi-word grammar matches are covered by the on-demand panel, PR-C1).
+  const ltMatchByOffset = useMemo(() => {
+    const map = new Map<number, LanguageToolMatch>();
+    if (!ltAvailable) return map;
+    for (const match of lt.matches) {
+      if (/^[\wÀ-ſ']+$/.test(match.matchedText)) map.set(match.offset, match);
+    }
+    return map;
+  }, [ltAvailable, lt.matches]);
+
   const handleSpellErrorClick = useCallback(
-    (e: React.MouseEvent, word: string) => {
+    (e: React.MouseEvent, word: string, ltMatch?: LanguageToolMatch) => {
       e.stopPropagation();
+      if (ltMatch) {
+        setSpellCheckPopover({
+          x: e.clientX,
+          y: e.clientY,
+          word,
+          message: ltMatch.message,
+          replacements: ltMatch.replacements,
+          match: ltMatch,
+        });
+        return;
+      }
       const suggestion = currentTypos[word.toLowerCase()] || '';
       if (suggestion) {
         setSpellCheckPopover({ x: e.clientX, y: e.clientY, word, suggestion });
@@ -131,10 +177,19 @@ export const ManuscriptEditor: FC<{ isFocusMode: boolean }> = React.memo(({ isFo
   );
 
   const applyCorrection = () => {
-    if (spellCheckPopover && activeSection) {
+    if (spellCheckPopover?.suggestion && activeSection) {
       const regex = new RegExp(`\\b${spellCheckPopover.word}\\b`);
       const newContent = activeSection.content.replace(regex, spellCheckPopover.suggestion);
       handleContentChange(activeSection.id, newContent);
+      setSpellCheckPopover(null);
+    }
+  };
+
+  // QNBS-v3: PR-C2 — apply a LanguageTool suggestion offset-safe via the PR-C1 hook (anchor-checked,
+  // redux-undo-wrapped, then re-checks), so the inline popover and the panel share one apply path.
+  const applyLtReplacement = (replacement: string) => {
+    if (spellCheckPopover?.match && activeSectionId) {
+      lt.applySuggestion(activeSectionId, spellCheckPopover.match, replacement);
       setSpellCheckPopover(null);
     }
   };
@@ -203,14 +258,19 @@ export const ManuscriptEditor: FC<{ isFocusMode: boolean }> = React.memo(({ isFo
         }
       } else if (word) {
         const lowerWord = word.toLowerCase();
-        if (Object.hasOwn(currentTypos, lowerWord)) {
+        // QNBS-v3: PR-C2 — prefer a real LanguageTool match at this exact offset; only fall back to the
+        // static TYPOS map when LanguageTool is not active (disabled or unsupported locale).
+        const ltMatch = ltMatchByOffset.get(offset);
+        const isLtFlagged = Boolean(ltMatch && ltMatch.matchedText === word);
+        const matchForClick = isLtFlagged ? ltMatch : undefined;
+        if (isLtFlagged || (!ltAvailable && Object.hasOwn(currentTypos, lowerWord))) {
           parts.push(
             // QNBS-v3: button replaces span[role=button] for native semantics; keyboard path derives position from bounding rect since no clientX/Y on KeyboardEvent.
             <button
               key={offset}
               type="button"
               className="spell-error bg-transparent border-0 p-0 font-[inherit] text-[inherit]"
-              onClick={(e) => handleSpellErrorClick(e, word)}
+              onClick={(e) => handleSpellErrorClick(e, word, matchForClick)}
               onKeyDown={(e) => {
                 if (e.key === 'Enter' || e.key === ' ') {
                   e.preventDefault();
@@ -220,7 +280,7 @@ export const ManuscriptEditor: FC<{ isFocusMode: boolean }> = React.memo(({ isFo
                     clientY: rect.bottom,
                     stopPropagation: () => {},
                   } as React.MouseEvent;
-                  handleSpellErrorClick(synthetic, word);
+                  handleSpellErrorClick(synthetic, word, matchForClick);
                 }
               }}
             >
@@ -238,7 +298,15 @@ export const ManuscriptEditor: FC<{ isFocusMode: boolean }> = React.memo(({ isFo
 
     if (lastIndex < text.length) parts.push(text.substring(lastIndex));
     return <>{parts}</>;
-  }, [deferredContent, characters, worlds, currentTypos, handleSpellErrorClick]);
+  }, [
+    deferredContent,
+    characters,
+    worlds,
+    currentTypos,
+    handleSpellErrorClick,
+    ltMatchByOffset,
+    ltAvailable,
+  ]);
 
   if (!activeSection) {
     return (
@@ -384,16 +452,46 @@ export const ManuscriptEditor: FC<{ isFocusMode: boolean }> = React.memo(({ isFo
           onClick={(e) => e.stopPropagation()}
           onKeyDown={(e) => e.stopPropagation()}
         >
-          <p className="text-xs text-[var(--sc-text-muted)] mb-1 uppercase tracking-wide px-2">
-            {t('manuscript.spellcheck.didYouMean')}
-          </p>
-          <button
-            type="button"
-            onClick={applyCorrection}
-            className="block w-full text-left px-3 py-2 min-h-[44px] rounded hover:bg-[var(--sc-accent)] hover:text-[var(--sc-text-on-accent)] text-[var(--sc-text-primary)] font-medium flex items-center"
-          >
-            {spellCheckPopover.suggestion}
-          </button>
+          {spellCheckPopover.match ? (
+            <>
+              {/* QNBS-v3: PR-C2 — real LanguageTool finding: message + replacement chips. */}
+              <p className="text-xs text-[var(--sc-text-secondary)] mb-1.5 px-2 max-w-[260px]">
+                {spellCheckPopover.message}
+              </p>
+              {spellCheckPopover.replacements && spellCheckPopover.replacements.length > 0 ? (
+                <ul className="space-y-0.5">
+                  {spellCheckPopover.replacements.slice(0, 5).map((replacement) => (
+                    <li key={replacement}>
+                      <button
+                        type="button"
+                        onClick={() => applyLtReplacement(replacement)}
+                        className="block w-full text-left px-3 py-2 min-h-[44px] rounded hover:bg-[var(--sc-accent)] hover:text-[var(--sc-text-on-accent)] text-[var(--sc-text-primary)] font-medium flex items-center"
+                      >
+                        {replacement}
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="text-xs text-[var(--sc-text-muted)] italic px-2 py-1">
+                  {t('writer.grammar.noSuggestions')}
+                </p>
+              )}
+            </>
+          ) : (
+            <>
+              <p className="text-xs text-[var(--sc-text-muted)] mb-1 uppercase tracking-wide px-2">
+                {t('manuscript.spellcheck.didYouMean')}
+              </p>
+              <button
+                type="button"
+                onClick={applyCorrection}
+                className="block w-full text-left px-3 py-2 min-h-[44px] rounded hover:bg-[var(--sc-accent)] hover:text-[var(--sc-text-on-accent)] text-[var(--sc-text-primary)] font-medium flex items-center"
+              >
+                {spellCheckPopover.suggestion}
+              </button>
+            </>
+          )}
         </div>
       )}
     </div>

--- a/tests/unit/manuscript/ManuscriptEditor.test.tsx
+++ b/tests/unit/manuscript/ManuscriptEditor.test.tsx
@@ -53,6 +53,28 @@ vi.mock('../../../hooks/useVoiceDictation', () => ({
   useVoiceDictation: vi.fn(),
 }));
 
+// QNBS-v3: stub the LanguageTool hook (it pulls Redux selectors). Mutable so the default tests stay on
+// the static TYPOS fallback (available:false) while the PR-C2 block drives the live LanguageTool path.
+const ltMock = vi.hoisted(() => ({
+  available: false,
+  matches: [] as Array<Record<string, unknown>>,
+  applySuggestion: vi.fn(),
+}));
+
+vi.mock('../../../hooks/useLanguageToolCheck', () => ({
+  useLanguageToolCheck: () => ({
+    available: ltMock.available,
+    unsupportedLocale: false,
+    status: 'idle',
+    matches: ltMock.matches,
+    check: vi.fn(),
+    applySuggestion: ltMock.applySuggestion,
+    ignore: vi.fn(),
+    addToDictionary: vi.fn(),
+    clear: vi.fn(),
+  }),
+}));
+
 vi.mock('../../../app/hooks', () => ({
   useAppSelector: vi.fn(() => ({
     editorFont: 'Georgia',
@@ -134,6 +156,9 @@ describe('ManuscriptEditor', () => {
     };
     mockMentions = [];
     mockMentionPosition = null;
+    ltMock.available = false;
+    ltMock.matches = [];
+    ltMock.applySuggestion.mockReset();
   });
 
   it('shows empty state when no section is selected', () => {
@@ -212,5 +237,47 @@ describe('ManuscriptEditor', () => {
     render(<ManuscriptEditor isFocusMode={false} />);
     const textarea = screen.getByTestId('editor-textarea');
     expect(textarea).toHaveAttribute('placeholder', 'Write about adventure');
+  });
+
+  describe('PR-C2 live LanguageTool overlay', () => {
+    // "Hello world teh quick brown fox" — "teh" starts at offset 12.
+    const tehMatch = {
+      offset: 12,
+      length: 3,
+      message: 'Possible spelling mistake',
+      shortMessage: '',
+      replacements: ['the'],
+      ruleId: 'MORFOLOGIK',
+      category: 'TYPOS',
+      categoryName: 'Typos',
+      matchedText: 'teh',
+      isSpelling: true,
+    };
+
+    it('underlines a LanguageTool-flagged word and applies its replacement offset-safe', async () => {
+      ltMock.available = true;
+      ltMock.matches = [tehMatch];
+      // The overlay is aria-hidden, so query the spell-error button by class via the container.
+      const { container } = render(<ManuscriptEditor isFocusMode={false} />);
+
+      const flagged = container.querySelector('.spell-error');
+      expect(flagged?.textContent).toBe('teh');
+      await userEvent.click(flagged as Element);
+
+      // Popover (role=dialog, not hidden) shows the LanguageTool message + the replacement chip.
+      expect(await screen.findByText('Possible spelling mistake')).toBeTruthy();
+      await userEvent.click(screen.getByRole('button', { name: 'the' }));
+
+      // Applies via the hook (offset-safe), not the legacy regex path.
+      expect(ltMock.applySuggestion).toHaveBeenCalledWith('sec-1', tehMatch, 'the');
+    });
+
+    it('does not use the static TYPOS fallback when LanguageTool is active', () => {
+      ltMock.available = true;
+      ltMock.matches = []; // LT active but found nothing → no underline at all
+      const { container } = render(<ManuscriptEditor isFocusMode={false} />);
+      // "teh" is in the static TYPOS map but must NOT be flagged while LT is the source of truth.
+      expect(container.querySelector('.spell-error')).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
## Summary

PR-C2 — the **live inline** half of the LanguageTool feature, built on the PR-C1 service+hook. Feeds real LanguageTool matches into the ManuscriptEditor's **existing** aligned spell-check overlay (the one that previously underlined hardcoded `TYPOS_EN/DE` fake typos).

- **Live, debounced** check (700ms) on each settled edit via `useLanguageToolCheck`, gated by `languageToolEnabled` + a LT-supported locale. When LT is active it is the source of truth; when it's off/unsupported the static `TYPOS` map stays as the zero-network fallback.
- **Inline underline**: single-word matches underline at their exact offset (reusing the overlay's word-token renderer). Multi-word grammar matches stay covered by the on-demand "Check this scene" panel (PR-C1).
- **Popover**: click / keyboard on a flagged word shows the real LT **message + replacement chips**, applied **offset-safe** through the shared hook (`applySuggestion` → anchor-checked, redux-undo-wrapped, then re-checks). One apply path for panel + inline.
- Degrades silently offline; never logs text; no new feature flag (the existing integration toggle gates it).

## Test plan
- `pnpm run lint` ✅ · `pnpm run typecheck` ✅ · `pnpm run suppressions:check` ✅ (no new suppressions; the Biome `useExhaustiveDependencies` on the debounce was resolved with a real empty-content guard, not an ignore)
- `pnpm exec vitest run tests/unit/manuscript/ManuscriptEditor.test.tsx` ✅ (13, incl. 2 PR-C2 cases) + related manuscript tests (72) ✅

## Verification (manual, later)
Run a local LanguageTool (`docker run -p 8010:8010 erikvl87/languagetool`), enable it in Settings → Connections, type a misspelling → it underlines live; clicking it offers the LT suggestion and applies offset-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)