### PR TITLE
docs(languagetool): feature guide + ADR 0010 + CHANGELOG + README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Real LanguageTool grammar & spelling integration (self-hosted, privacy-first).** Replaces the
+  hardcoded fake-typo list with a real, multilingual proofreader running on the user's own machine.
+  Two surfaces share one offset-safe apply path (`hooks/useLanguageToolCheck.ts`): an on-demand
+  **"Check this scene"** panel in the Writer tools sidebar (findings list → apply / ignore /
+  add-to-dictionary) and a **live inline overlay** in the manuscript editor (debounced underline +
+  suggestion popover, reusing the existing aligned-overlay infrastructure). New
+  `services/languageToolService.ts` (`checkText` → parse `matches[]`, text-hash cache, abortable,
+  silent offline degrade, never logs text); the privacy gate (`assertLanguageToolAllowed`) keeps cloud
+  servers blocked under local-only mode. Locale coverage is encoded in the SSOT `i18n/locales.ts`
+  (`languageToolSupport` + `languageToolCode`, verified against dev.languagetool.org) and the feature
+  is hidden for unsupported locales (tr/he/fi/hu/is/eu/ko). Opt-in via Settings → Connections; run a
+  server with `docker run -p 8010:8010 erikvl87/languagetool`. See [`docs/LANGUAGETOOL.md`](docs/LANGUAGETOOL.md)
+  and [ADR 0010](docs/adr/0010-languagetool-self-hosted.md).
 - **Native Intel-Mac (x86_64) desktop builds.** `tauri-build.yml` now builds on `macos-13` (Intel) in
   addition to `macos-latest` (Apple Silicon), so Intel Macs get a native bundle and in-app updates.
   The `latest.json` updater manifest already mapped `*_x64.app.tar.gz` → `darwin-x86_64`, so the Intel

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Everything is computed locally without sending manuscript text to the cloud.
 
 ### ✍️ Three-Panel Manuscript Editor
 
-A focused, distraction-free writing environment. The central editor is flanked by a draggable chapter **Navigator** and a project **Inspector**. An advanced overlay provides real-time highlighting and linking for `@character` and `#world` mentions, turning your manuscript into a living document. Includes **Zen Mode** for full-screen distraction-free writing, **spell-check with suggestions**, and **grammar & style hints**.
+A focused, distraction-free writing environment. The central editor is flanked by a draggable chapter **Navigator** and a project **Inspector**. An advanced overlay provides real-time highlighting and linking for `@character` and `#world` mentions, turning your manuscript into a living document. Includes **Zen Mode** for full-screen distraction-free writing and real **grammar & spell checking** via an optional **self-hosted [LanguageTool](https://languagetool.org)** server — live inline underlines plus an on-demand "Check this scene" panel, with one-click offset-safe corrections and a personal dictionary. Privacy-first (manuscript text never leaves your machine); off by default. See [`docs/LANGUAGETOOL.md`](docs/LANGUAGETOOL.md).
 
 ### 🎬 Plot-Board v2 _(Visual Story Planning)_
 
@@ -738,6 +738,7 @@ See **[`CONTRIBUTING.md`](CONTRIBUTING.md)** for the full dev setup, Biome / Vit
 | [`docs/COPILOT.md`](docs/COPILOT.md) | Global AI Copilot v2 — panel modes, heuristics, Apply-to-chapter, ProForge integration |
 | [`docs/LOCAL-AI.md`](docs/LOCAL-AI.md) | Local AI setup & troubleshooting — WebGPU/WASM requirements, model downloads, storage management, fallback chain |
 | [`docs/HEURISTIC-RULES.md`](docs/HEURISTIC-RULES.md) | Heuristic Rules Reference — 8 built-in manuscript analysis rules, how-to-satisfy guidance |
+| [`docs/LANGUAGETOOL.md`](docs/LANGUAGETOOL.md) | LanguageTool grammar/spell integration — self-hosted setup, privacy model, locale coverage, architecture |
 | [`docs/PROFORGE-PIPELINE.md`](docs/PROFORGE-PIPELINE.md) | ProForge Ultimate Author Pipeline — 8-stage agentic editing system architecture |
 | [`docs/history/sprints/SPRINT-HANDOFF-2026-05-27.md`](docs/history/sprints/SPRINT-HANDOFF-2026-05-27.md) | Sprint handoff: v1.18.0/v1.18.1 ProForge Humanization & Refinement + TypeScript strict-mode sweep |
 | [`docs/history/sprints/SPRINT-HANDOFF-2026-05-28.md`](docs/history/sprints/SPRINT-HANDOFF-2026-05-28.md) | Sprint handoff: v1.19.0 Phase 2 — B-1..B-8 security, voice WASM, collab-transport, a11y gate, RTL |

--- a/docs/LANGUAGETOOL.md
+++ b/docs/LANGUAGETOOL.md
@@ -1,0 +1,93 @@
+# LanguageTool grammar & spelling integration
+
+A **privacy-first, self-hosted** grammar/spell checker wired directly into the manuscript editor.
+It uses [LanguageTool](https://languagetool.org) — an open-source proofreading engine — running on
+**your own machine**, so manuscript text never leaves the device. This replaced the earlier hardcoded
+fake-typo list with a real, multilingual checker.
+
+> **TL;DR** — install a local LanguageTool server, point Settings → Connections at it, and the editor
+> gains a live "underline + suggestion" layer plus an on-demand "Check this scene" panel. If you don't
+> run a server, the feature stays hidden and nothing changes.
+
+## 1. What you get
+
+| Surface | Where | Behaviour |
+|---------|-------|-----------|
+| **"Check this scene" panel** | Writer tools sidebar (below the AI tools) | On-demand check of the active section → a list of findings (category, message, suggestion) with **one-click apply**, **ignore**, and **add-to-dictionary**. |
+| **Live inline overlay** | Manuscript editor | Debounced live check as you type; single-word findings **underline in place**; click/keyboard opens a popover with the LanguageTool message + replacement chips. |
+
+Both apply edits **offset-safe** through one shared path (`hooks/useLanguageToolCheck.ts` →
+`applyMatchReplacement`) so corrections are anchor-checked and natively undoable (the project slice is
+`redux-undo`-wrapped). The user dictionary is persisted in `settings.advancedEditor.customDictionary`
+and suppresses matching spelling findings everywhere.
+
+## 2. Privacy model (why self-hosted only)
+
+- The integration is **opt-in** and **off by default** (`settings.integrations.languageToolEnabled`).
+- `services/languageToolClient.ts#assertLanguageToolAllowed` is the gate: when
+  `settings.privacy.localStorageOnly` is on, any **non-`localhost`/`127.0.0.1`** base URL is **blocked**
+  — so a cloud LanguageTool can never silently receive your prose. The documented default base URL is
+  `http://localhost:8010`.
+- `services/languageToolService.ts` **never logs manuscript text** (only match counts), and any
+  network/HTTP failure **degrades silently** to an empty result so typing is never blocked.
+
+## 3. Setup — run a local server
+
+The quickest path is the community Docker image:
+
+```bash
+docker run --rm -p 8010:8010 erikvl87/languagetool
+```
+
+Then in the app: **Settings → Connections → LanguageTool** → enable it and set the base URL to
+`http://localhost:8010`. (Native installs and the official `languagetool.org` JAR work too — point the
+base URL at whatever host/port the server listens on.)
+
+## 4. Language coverage
+
+LanguageTool does **not** support every locale the app ships. Coverage is encoded in the locale SSOT
+(`i18n/locales.ts`) as `languageToolSupport: 'strong' | 'partial' | 'none'` + `languageToolCode`, and
+the feature is **simply hidden** for unsupported locales — no fake promise. Verified against
+[dev.languagetool.org/languages](https://dev.languagetool.org/languages) (2026-06-24):
+
+- **strong** — en, de, fr, es, pt, nl, pl, uk (large rule set + spell check)
+- **partial** — it, ru, ja, zh, el, ar, fa, sv, ro (supported but limited rules and/or no spell check)
+- **none** — **tr**, he, fi, hu, is, eu, ko (not supported by LanguageTool → feature absent)
+
+`getLanguageToolCode(locale)` / `hasLanguageToolSupport(locale)` (`i18n/locales.ts`) are the single
+source the editor gates on.
+
+## 5. Architecture
+
+```
+i18n/locales.ts              SSOT: languageToolSupport + languageToolCode (+ helpers)
+        │
+services/languageToolClient.ts   assertLanguageToolAllowed() — privacy gate (cloud blocked in local-only)
+services/languageToolService.ts  checkText() → POST /v2/check, parse matches[], text-hash cache,
+        │                        abortable (AbortSignal.any), graceful offline/error degrade,
+        │                        applyMatchReplacement() — offset-safe single-edit apply (anchor check)
+        ▼
+hooks/useLanguageToolCheck.ts    orchestration: locale→code, gate, run, apply→re-check,
+        │                        ignore, add-to-dictionary (→ advancedEditor.customDictionary)
+        ├──────────────► components/writing/GrammarCheckPanel.tsx   "Check this scene" (PR-C1)
+        └──────────────► components/manuscript/ManuscriptEditor.tsx  live inline overlay (PR-C2)
+```
+
+- The **service** is pure and fully unit-tested (`tests/unit/languageToolService.test.ts`); the
+  **hook** and **panel** have their own tests. The inline overlay reuses the editor's existing
+  aligned-overlay + popover infrastructure rather than introducing a new rendering layer.
+- **Caching**: results are keyed by a text hash; the user dictionary is applied *after* the cache read,
+  so adding a word never forces a re-fetch. The request is abortable so rapid typing cancels in-flight
+  checks.
+- **Scope of the inline layer**: only single-word matches underline in place (mapped to their exact
+  offset in the word-token overlay). Multi-word grammar findings are surfaced by the on-demand panel.
+
+See [ADR 0010](adr/0010-languagetool-self-hosted.md) for the design rationale.
+
+## 6. Limitations & future work
+
+- **No bundled server.** This is intentional (privacy + bundle size); the user runs LanguageTool.
+- **Inline = single-word only.** Phrase-level grammar shows in the panel, not as inline underlines.
+- **Cloud LanguageTool** is deliberately gated off under local-only privacy mode.
+- New UI locales whose LanguageTool support is `none` (e.g. Turkish) get the editor but not the grammar
+  layer — this is documented per-locale, not a bug.

--- a/docs/adr/0010-languagetool-self-hosted.md
+++ b/docs/adr/0010-languagetool-self-hosted.md
@@ -1,0 +1,67 @@
+# ADR 0010 — Self-hosted LanguageTool grammar checking via the editor overlay
+
+- **Status:** Accepted (PR-C1 on-demand panel + PR-C2 live inline overlay shipped; new-locale rollout staged)
+- **Date:** 2026-06-25
+- **Deciders:** Maintainer + Claude Code
+- **Context tags:** editor, i18n, privacy, grammar, languagetool
+
+## Context
+
+The manuscript editor advertised "spell-check with suggestions" and "grammar & style hints", but the
+implementation was a **hardcoded list of ~16 English + ~16 German typos** (`TYPOS_EN`/`TYPOS_DE` in
+`ManuscriptEditor.tsx`) — not a real checker, no other languages, no grammar. Separately,
+`services/languageToolClient.ts` existed only as a **connectivity ping** (a gate +
+`POST /v2/check` with `language=en-US`), never parsing results; and the Writer "grammar check" tool is
+an **AI/Gemini prompt**, unrelated and token-costly.
+
+The app is **offline-first and privacy-first**: API keys live only in the browser, analytics are gated,
+and manuscript text must not leave the device without explicit consent. Any real grammar feature has to
+respect that. We also ship **19 locales** of widely varying maturity, and the proofreading engine we
+pick does not support all of them.
+
+## Decision
+
+Adopt **LanguageTool** as the real grammar/spell engine, **self-hosted only**, integrated through the
+editor's **existing overlay + popover** rather than a new rendering layer.
+
+1. **Self-hosted, privacy-gated.** Keep `assertLanguageToolAllowed` as the gate: under
+   `privacy.localStorageOnly`, only `localhost`/`127.0.0.1` base URLs are allowed — a cloud
+   LanguageTool can never silently receive prose. Off by default; the user runs the server
+   (`docker run -p 8010:8010 erikvl87/languagetool`). The service never logs text and degrades silently
+   on any failure.
+2. **One service, one apply path.** `services/languageToolService.ts` does the real work (`checkText`
+   → parse `matches[]`, text-hash cache, abortable, offset-safe `applyMatchReplacement` with an anchor
+   check). `hooks/useLanguageToolCheck.ts` orchestrates both surfaces so the on-demand panel and the
+   live overlay share gating, apply, ignore, and dictionary logic.
+3. **Locale support in the SSOT.** `i18n/locales.ts` carries `languageToolSupport` +
+   `languageToolCode`; the feature is **hidden** for unsupported locales (`none`) — verified data, no
+   fake promise (notably Turkish, Hebrew, Finnish, Hungarian, Icelandic, Basque, Korean are unsupported).
+4. **Reuse the editor overlay.** The editor already renders an aligned, font-matched overlay with
+   clickable spell-error spans + a suggestion popover. Live underlines map LanguageTool single-word
+   matches to their exact offset in that overlay; multi-word grammar findings are surfaced by the
+   on-demand panel instead of inventing a measured-span overlay.
+
+## Alternatives considered
+
+- **Cloud LanguageTool / a paid proofreading API** — rejected: sends manuscript text off-device,
+  violates the privacy model, adds cost and a network dependency.
+- **Bundle a WASM/JS grammar engine** — rejected for now: large download, narrower language coverage
+  than LanguageTool's server, and duplicates the heavy-model concerns we already manage for voice/RAG.
+- **Keep using the AI `grammarCheck` prompt for everything** — rejected as the *primary* path:
+  non-deterministic, token-costly, and not a real per-token diagnostics layer (it stays available as a
+  separate creative tool).
+- **A new offset-driven underline overlay (full phrase underlines)** — deferred: a larger, riskier
+  rewrite of a core editor file; the single-word overlay + panel covers the common case now.
+
+## Consequences
+
+- **Positive:** real multilingual spell/grammar checking; deterministic and free (no tokens);
+  privacy-preserving by construction; minimal new UI surface (reuses overlay + popover); offset-safe,
+  undoable corrections shared across both entry points.
+- **Negative / trade-offs:** requires the user to run a local server (no bundled engine); inline
+  underlines are single-word only (phrase grammar lives in the panel); coverage is uneven across
+  locales and absent for several.
+- **Follow-ups:** roll out new high-coverage UI locales (pl/nl/tr/uk/ro) — tracked separately; a future
+  ADR could revisit a full offset-driven inline layer if phrase-level underlines are wanted.
+
+See [`docs/LANGUAGETOOL.md`](../LANGUAGETOOL.md) for the feature guide and setup.

--- a/docs/i18n/LANGUAGETOOL-LOCALE-ROLLOUT-TODO.md
+++ b/docs/i18n/LANGUAGETOOL-LOCALE-ROLLOUT-TODO.md
@@ -1,0 +1,112 @@
+# TODO — LanguageTool program: new-locale rollout + closing items
+
+> **Status: NOT STARTED — deferred for later execution.** This is the remaining tail of the
+> "i18n hardening + 5 new locales + real LanguageTool" program. The LanguageTool *engine* work is
+> **done and merged** (see below); what remains is the **language curation / addition** half plus the
+> locale-dependent closing docs. Pick this up after the other planned work — do **not** start it
+> inline. This file is self-contained; the original execution plan file may be overwritten in the
+> meantime, so everything needed is captured here.
+
+## 0. What is already DONE (merged to `main`, 2026-06-24/25)
+
+| PR | Scope |
+|----|-------|
+| #234 | Phase-0 report (`ADAPTIVE_CURRENT_STATE_REPORT_v3.md`) + Workstream B: SSOT `i18n/locales.ts` enriched with `languageToolSupport` + `languageToolCode` (all 19 locales) + helpers; Review & Elevation Log seeded in `TRANSLATION_STATUS.md` |
+| #235 | `services/languageToolService.ts` — real `checkText` + offset-safe `applyMatchReplacement` (13 tests) |
+| #236 | PR-C1 MVP: `useLanguageToolCheck` hook + `GrammarCheckPanel` ("Check this scene") + 14 `writer.grammar.*` i18n keys ×19 locales |
+| #237 | DeepSource runbook updated (inline resolvable threads) |
+| #238 | PR-C2: live inline grammar overlay + popover in `ManuscriptEditor` |
+| #239 | Docs: `docs/LANGUAGETOOL.md`, ADR 0010, CHANGELOG, README |
+
+**Net:** real self-hosted LanguageTool grammar/spell checking is live for all currently-supported
+locales. The remaining work below is **purely the 5 new UI locales + the locale-dependent closing
+docs**. Nothing in the engine needs changing.
+
+## 1. Workstream A — add 5 new UI locales (one stacked PR each)
+
+Add **pl, nl, tr, uk, ro** — high creative-writing demand. Of these, LanguageTool supports
+**pl/nl/uk = strong, ro = partial, tr = none** (verified; see `ADAPTIVE_CURRENT_STATE_REPORT_v3.md §5`).
+Turkish still gets the UI locale; its grammar feature is simply absent (`languageToolSupport: 'none'`),
+exactly like he/fi/hu/is/eu/ko.
+
+### Per-locale recipe (reuse the existing pipeline — do NOT hand-roll)
+
+Follow [`ADDING_A_NEW_LANGUAGE.md`](./ADDING_A_NEW_LANGUAGE.md). For each locale `<xx>`:
+
+1. **SSOT** — add a `LocaleDescriptor` to `i18n/locales.ts` with `status: 'beta'`, correct
+   `nativeName` (endonym), `englishName`, `flag`, `dir: 'ltr'`, `script: 'latin'` (all 5 are Latin),
+   `helpFallback: true`, **and the LanguageTool metadata**:
+   - `pl` → `languageToolSupport: 'strong'`, `languageToolCode: 'pl-PL'`
+   - `nl` → `languageToolSupport: 'strong'`, `languageToolCode: 'nl'`
+   - `uk` → `languageToolSupport: 'strong'`, `languageToolCode: 'uk-UA'`
+   - `ro` → `languageToolSupport: 'partial'`, `languageToolCode: 'ro-RO'`
+   - `tr` → `languageToolSupport: 'none'` (no `languageToolCode`)
+2. **Locale folder** — create `locales/<xx>/` with all module JSON files. Seed high-traffic chrome by
+   hand (common/sidebar/portal/onboarding) + the `i18nBootstrap` native strings; then run
+   `scripts/bulk-translate-locales.mjs` (glossary-anchored, placeholder-masked) for the rest. `help.json`
+   stays **English fallback** (tag-dense HTML isn't safely machine-translatable — matches policy;
+   `helpFallback: true`).
+3. **Script lists** — add `<xx>` wherever the `.mjs` scripts derive their locale list from the
+   filesystem if needed (`scripts/check-i18n-keys.mjs`, `build-i18n.mjs`, `i18n-locales.mjs`); the
+   registry-integrity test (`tests/unit/i18n/localesRegistry.test.ts`) asserts SSOT ↔ folders match.
+4. **Exonym** — add `portal.language.names.<xx>` (the in-UI exonym) to all locales; keep the native
+   endonym in `i18n/locales.ts` hardcoded.
+5. **Fonts** — all 5 are Latin → no CDN/`:lang()` font wiring needed (Inter/Merriweather cover them).
+6. **Bundles** — `pnpm run i18n:bundle`; verify `pnpm run i18n:check` (parity) + the
+   `i18nPlaceholders` test (no single-brace `{x}`, no translated/dropped placeholder names).
+7. **Elevation log** — append a row to the Review & Elevation Log in `TRANSLATION_STATUS.md` (status
+   `beta`, basis = MT + parity, no native review yet — honest tiering).
+8. **Per-PR gate** (one heavy shell at a time): `pnpm run lint && pnpm run typecheck && pnpm run i18n:check`
+   + `pnpm exec vitest run tests/unit/i18n/localesRegistry.test.ts tests/unit/i18nPlaceholders.test.ts`.
+
+### Glossary
+Before bulk-MT, extend [`../I18N-GLOSSARY.md`](../I18N-GLOSSARY.md) with anchor terms for each new
+locale (the canonical Manuscript/Outline/Snapshot/Co-Pilot/etc. translations) so `bulk-translate` stays
+consistent.
+
+### PR sequencing
+One **stacked** PR per locale (D–H): `pl` → `nl` → `tr` → `uk` → `ro`. i18n fan-out is the heaviest of
+the program (each locale = ~20 module JSON + rebuilt bundles), so **one locale per PR** keeps each diff
+reviewable and under the ~100-file limit that the review bot needs. Run the **DeepSource correction
+loop** on each (fix status-red findings, resolve inline `deepsource-io` threads — see
+[`../DEEPSOURCE-REVIEW-LOOP.md`](../DEEPSOURCE-REVIEW-LOOP.md)).
+
+### Deferred (do NOT add now → ROADMAP only)
+`pt-BR` and additional Chinese variants — add to `ROADMAP.md` as future locale work, not this program.
+
+## 2. Closing / locale-dependent docs (after the 5 locales land)
+
+These were intentionally **left out** of the LanguageTool docs PR (#239) because they depend on the
+locale count changing from 19 → 24:
+
+- **README** — update the i18n badge/line and the "Quality tiers" section from **19 → 24 locales**;
+  add pl/nl/tr/uk/ro to the Beta tier list. (Metrics badges auto-sync via `sync-readme-metrics.mjs` —
+  do not hand-edit the generated numbers; only the prose locale list.)
+- **`TRANSLATION_STATUS.md`** — add the 5 new per-locale rows + their elevation-log entries.
+- **`docs/LANGUAGE-EXPANSION-2026.md`** — note the pl/nl/tr/uk/ro addition.
+- **`docs/LANGUAGETOOL.md` §4** — the coverage lists already include pl/nl/tr/uk/ro (written ahead);
+  re-verify they match the shipped `i18n/locales.ts` once the locales are in.
+- **Final handover report** — write `docs/i18n/FINAL_IMPLEMENTATION_AND_HANDOVER_REPORT.md`
+  summarizing the whole program (engine + locales), the self-assessment, and residual debt (native
+  review of Beta locales, single-word inline limitation, no bundled LT server).
+
+## 3. Verification (whole tail)
+
+- Each new locale: `i18n:check` parity green + `i18nPlaceholders` green; switch the UI to the locale →
+  chrome renders translated, no raw keys, LTR direction correct.
+- LanguageTool: for pl/nl/uk/ro, with a local server running (`docker run -p 8010:8010
+  erikvl87/languagetool`) and the locale active, "Check this scene" returns findings and applies them;
+  for **tr**, the grammar UI is **absent** (panel hidden) — confirm no console errors.
+- Full DeepSource loop quiescent + codecov/patch green + all CI green before each merge.
+
+## 4. Gotchas (learned this program — apply on resume)
+
+- **DeepSource analyzes `tests/`** and posts **inline resolvable threads**; rename short `const`/`let`
+  (JS-C1002), declare-before-use (JS-0357), avoid single-child fragments (JS-0424); resolve every
+  `deepsource-io` thread. (Full loop: `../DEEPSOURCE-REVIEW-LOOP.md`.)
+- **Flat, insertion-ordered locale JSON** — do **not** run `check-i18n-keys.mjs --fix` (it re-sorts →
+  churn); inject new keys in place (a small Python `OrderedDict` script worked well this program).
+- **Placeholders are double-brace** `{{count}}`; the `i18nPlaceholders` guard rejects single-brace.
+- **`codecov/patch`** needs the diff's branches tested — but pure locale PRs add no JS branches, so
+  codecov should be a non-issue for Workstream A.
+- **Low-end hardware:** one heavy shell per turn; `typecheck` needs a long timeout (~300s).


### PR DESCRIPTION
Documents the shipped LanguageTool grammar/spell integration (PRs #234–#236, #238). Docs-only.

- **`docs/LANGUAGETOOL.md`** — feature guide: self-hosted setup (`docker run -p 8010:8010 erikvl87/languagetool`), privacy model, verified per-locale coverage, architecture diagram, limitations.
- **`docs/adr/0010-languagetool-self-hosted.md`** — design rationale (self-hosted + privacy gate, one service/apply path, SSOT locale support, overlay reuse) + alternatives considered.
- **CHANGELOG** `[Unreleased]` Added entry.
- **README** — manuscript feature line rewritten (real LanguageTool, not fake typos) + Documentation Hub row.

The new-locale rollout (pl/nl/tr/uk/ro) is intentionally **not** covered here — it's tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)