### PR TITLE
fix(ci): exclude woff/woff2 from build-provenance attestation subjects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,12 +224,19 @@ jobs:
           retention-days: 3
 
       # QNBS-v3: SLSA provenance attestation — ties the dist artifact to this exact
-      # workflow run and commit SHA; verifiable with `gh attestation verify`.
+      # workflow run and commit SHA; verifiable with `gh attestation verify`. Excludes
+      # woff/woff2 — self-hosted CJK fonts (@fontsource noto-sans-jp/kr/sc) ship ~2.2k
+      # unicode-range subset files, pushing dist past the action's 1024-subject cap.
+      # Fonts are vendored static assets, not application code, so attesting the app
+      # bundle (JS/CSS/HTML/JSON/wasm/etc.) without them still covers what matters.
       - name: Attest build provenance
         if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
         with:
-          subject-path: ./dist
+          subject-path: |
+            dist/**
+            !dist/**/*.woff
+            !dist/**/*.woff2
 
       - name: Setup Pages
         if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'


### PR DESCRIPTION
## Summary

`main`'s post-merge CI is currently failing (push-triggered run, not the PR's own checks): the "Attest build provenance" step in `.github/workflows/ci.yml` errors with `Too many subjects specified (>1024)`. This step only runs on `push` to `main` (not `pull_request`), so PR #278's own checks looked fully green and this only surfaced after merge.

**Root cause:** PR #278 self-hosts CJK fonts (`@fontsource/noto-sans-jp/kr/sc`) to fix a broken Google Fonts request. Those packages ship one small `.woff2` per Unicode-range subset for efficient lazy-loading — 2278 font files in `dist/` (2150 Noto-branded) vs. 195 everything else, blowing past `actions/attest-build-provenance`'s 1024-subject cap.

**Fix:** exclude `woff`/`woff2` from the attestation `subject-path` glob. Fonts are vendored static assets, not application code needing per-file SLSA provenance — every JS/CSS/HTML/JSON/wasm file that actually makes up the deployed app is still attested.

## Test plan
- [x] Verified locally: `find dist -type f | wc -l` → 2473; `find dist -type f -iname '*.woff*' | wc -l` → 2278; non-font files → 195 (comfortably under 1024)
- [x] `pnpm run build` succeeds, `dist/` structure unaffected
- [ ] CI on this PR (this step is push-only, so it won't run here — verify via the next push to `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build provenance attestation to cover distributable artifacts while excluding font files.
  * Added documentation clarifying attestation artifact selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->