### PR TITLE
chore: reconcile stale TODO.md entry + add Renovate storybook grouping

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -47,7 +47,7 @@ Status: 🔄 in progress | ⬜ open | ✅ done
 - ✅ **ProForge → opt-in** — flipped `enableProForge` default to `false` (experimental, token-heavy); now 17 on / 6 off. Slice + tests + `FEATURE-PARITY.md` + `CLAUDE.md` updated in lockstep.
 - ✅ **Feature catalog reconciled** — `featureCatalog.ts` covers all 23 flags; `defaultOn` derived from the slice (drift now impossible, guarded by `tests/unit/featureCatalog.test.ts`); added risk/desktop/dependency metadata.
 - ✅ **Grouped Settings UI** — Experimental flags grouped by category with risk hints, dependency-aware disabling (Voice WASM ⇠ Voice Support), "Desktop only" note (Rust Compute), and Reset-to-defaults.
-- ⬜ **WebNN flag decision** — `enableWebnnInference` is a ghost/stub (no runtime gate reads it). Either wire `selectEnableWebnnInference` into the ONNX RT WebNN provider selection, or retire the flag.
+- ✅ **WebNN flag decision** — the ghost/stub `enableWebnnInference` toggle was retired (removed from `featureFlagsSlice.ts`'s 22 flags); see `tests/unit/featureFlagsSlice.test.ts:96` ("WebNN flag (a ghost/no-op toggle) was removed → 22 flags"). This line was stale — reconciled 2026-07-29.
 - ⬜ **CII Best Practices badge** — removed from `README.md` (was a literal `projects/XXXX` placeholder — broken image, dead link). Register the project at <https://bestpractices.coreinfrastructure.org/> (external, interactive signup — maintainer-only action), then re-add the badge with the real project ID.
 
 

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,10 @@
       "automergeType": "pr",
       "platformAutomerge": true,
       "matchPackageNames": ["*"]
+    },
+    {
+      "groupName": "storybook",
+      "matchPackageNames": ["@storybook/**"]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- `TODO.md`: mark the WebNN ghost-flag item ✅ — it was already resolved (flag retired from `featureFlagsSlice.ts`'s 22 flags; confirmed via `tests/unit/featureFlagsSlice.test.ts:96`) but still listed as open.
- `renovate.json`: add a `storybook` group (`@storybook/**`) so those bumps land atomically instead of as separate PRs — carried-forward backlog item from the v1.24.1 Dependabot batch cleanup.

Also verified (no code change needed, documented here for context):
- CII Best Practices registration, Intel-Mac CI runner replacement, and the manual smoke-signoff matrix remain open — all genuinely maintainer/human/external-only actions.
- pnpm override housekeeping (removing the `joi` override) and the `audit-level` `high`→`moderate` bump stay blocked — `pnpm-lock.yaml` still resolves `jest-process-manager@0.4.0`, not the `1.x` the fix depends on.

Separately (outside this PR, no file diff): cleaned up the mis-tagged `v1.5.0` GitHub Release by removing 6 mismatched `StoryCraft.Studio-1.20.0-*` binary assets that were mistakenly attached during a documentation backfill. Tag/title/body were already correct and untouched.

## Test plan
- [x] Pre-commit Biome hook passed on the staged files
- [x] `renovate.json` validated as well-formed JSON
- [ ] CI quality gate green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)