### PR TITLE
chore(release): bump version to 1.24.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.24.3] — 2026-07-30
+
 > Worker-generation consolidation sprint: the v1/WorkerBus-v2 duplication [ADR-0014](docs/adr/0014-worker-generation-duplication.md)
-> deferred is now closed out. Executed as 4 stacked PRs (#286–288, #290); see
-> [ADR-0015](docs/adr/0015-worker-generation-consolidation.md) for the full decision record.
+> deferred is now closed out. Executed as 5 stacked PRs (#286–288, #290–291), plus the independent
+> #289 (Vercel auto-deploy pause); see
+> [ADR-0015](docs/adr/0015-worker-generation-consolidation.md) for the full decision record. This
+> release also recovers a merge queue interrupted mid-session by a local editor crash — all five
+> PRs required a fresh sync-merge conflict resolution against the accumulated fixes below before
+> landing; see `docs/audit/` for the run log.
 
 ### Changed
 
@@ -23,6 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The shared `inference` WorkerBus pool's `maxWorkers` capped at 2 (was 4) — each replica
   independently loads its own transformers.js pipeline with no cross-replica cache sharing, so 4
   concurrent workers under a burst could mean 4x the model memory footprint.
+- **Vercel auto-deploy paused mid-term** after 2 consecutive preview-deployment failures with only a
+  generic "Deployment has failed" message and no reproducing local failure — GitHub Pages and
+  Cloudflare Pages remain live and unaffected while the platform-side cause is investigated.
 
 ### Fixed
 
@@ -44,6 +53,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `tsgo` typecheck. Root-caused by reproducing Vercel's *exact* build command
   (`pnpm run build:edge`, which differs from the plain `pnpm run build` used for an earlier,
   misleading local repro attempt) and fixed by adding the missing function.
+- **A reused `AbortSignal` leaked one `'abort'` listener per call** in `duckdbClient.ts`'s `send()`
+  — `{once: true}` only self-removes once the signal actually fires, so a caller reusing one signal
+  across many non-aborted queries (a common hook/thunk pattern) accumulated listeners for the
+  signal's whole lifetime. Fixed with an explicit `finally`-block `removeEventListener`.
+- **`ensureDuckDbPool()`/`ensureInferencePool()` could reject instead of degrading gracefully** —
+  their pool re-registration helpers awaited a lazy import and called `registerPool()` without a
+  catch, so a re-registration failure after the bus was already live broke the documented "returns
+  null only if init failed" contract. Both now log the failure and return the live bus instead of
+  propagating the rejection.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <img src="https://img.shields.io/badge/TypeScript-7.x_(tsgo)-3178C6?logo=typescript&logoColor=white" alt="TypeScript 7 (tsgo)">
   <img src="https://img.shields.io/badge/AI-Gemini_%7C_OpenAI_%7C_OpenRouter_%7C_Ollama_%7C_WebLLM-4285F4?logo=google" alt="Gemini · OpenAI · OpenRouter · Ollama · WebLLM">
   <img src="https://img.shields.io/badge/Local_AI-WebGPU_%7C_ONNX_%7C_Transformers.js-8B5CF6" alt="WebGPU · ONNX · Transformers.js">
-  <img src="https://img.shields.io/badge/Version-v1.24.2-6366F1" alt="v1.24.2">
+  <img src="https://img.shields.io/badge/Version-v1.24.3-6366F1" alt="v1.24.3">
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2849_keys-0EA5E9" alt="i18n 19 locales — 2849 keys">

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "worldscript-studio",
   "private": true,
-  "version": "1.24.2",
+  "version": "1.24.3",
   "description": "WorldScript Studio — offline-first, AI-powered creative writing application.",
   "author": "QNBS",
   "keywords": [

--- a/public/sw.js
+++ b/public/sw.js
@@ -6,7 +6,7 @@
 // ============================================================
 
 // QNBS-v3 (CodeRabbit): version bump auto-synced from package.json by scripts/sync-sw-version.mjs — every CACHE_STATIC/CACHE_DYNAMIC name changes too, so this alone invalidates all prior caches on next activate.
-const APP_VERSION   = '1.24.2';
+const APP_VERSION   = '1.24.3';
 const CACHE_STATIC  = `worldscript-static-v${APP_VERSION}`;
 const CACHE_DYNAMIC = `worldscript-dynamic-v${APP_VERSION}`;
 const CACHE_IMAGES  = `worldscript-images-v${APP_VERSION}`;

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6593,7 +6593,7 @@ dependencies = [
 
 [[package]]
 name = "worldscript-studio"
-version = "1.24.1"
+version = "1.24.3"
 dependencies = [
  "base64 0.22.1",
  "candle-core",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "worldscript-studio"
-version = "1.24.2"
+version = "1.24.3"
 description = "AI-powered creative writing and world-building application"
 authors = ["QNBS"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "WorldScript Studio",
-  "version": "1.24.2",
+  "version": "1.24.3",
   "identifier": "com.worldscript.studio",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

- Finalizes the `[Unreleased]` → `[1.24.3]` CHANGELOG.md entry for the worker-generation consolidation sprint (ADR-0014 → ADR-0015), correcting the stacked-PR count to 5 (#286–288, #290–291) and folding in independent #289 (Vercel auto-deploy pause)
- Adds 2 additional Fixed entries from this session's merge-queue recovery that weren't yet documented: the `AbortSignal` listener leak in `duckdbClient.ts`, and the pool re-registration failure guards in `workerBusManager.ts`
- Bumps version 1.24.2 → 1.24.3 across `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock` (workspace-member entry only, no checksum), `public/sw.js` (`APP_VERSION`), and the README badge

## Test plan

- [x] `pnpm run lint` — clean
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run docs:check` — OK (7 files match actual state)
- [ ] CI quality gate (Node 22/24, Security Audit, Build) — required checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Updated the application to version **1.24.3** across web, desktop, and service-worker components.
  - Refreshed cached assets during service-worker activation to ensure the latest version is delivered.

- **Bug Fixes**
  - Improved resilience when database or inference services are re-registered.
  - Fixed an issue that could leave cancellation-event listeners behind during database operations.

- **Documentation**
  - Added expanded 1.24.3 release notes and updated the README version badge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->