### PR TITLE
fix(docs): close doc-metrics gate's blind spot for open bullets (F-1)

### DIFF
--- a/scripts/check-doc-metrics.mjs
+++ b/scripts/check-doc-metrics.mjs
@@ -39,6 +39,11 @@ const ANY_HEADING = /^#{1,6}\s+/;
 const HISTORICAL_MARKER =
   /(✅|\bRELEASED\b|\bDELIVERED\b|\bCompleted\b|\[\d+\.\d+\.\d+\]|\(\d{4}-\d{2}-\d{2})/i;
 const DONE_BULLET = /^\s*-\s*✅/;
+// QNBS-v3: mirrors DONE_BULLET's "always present-tense regardless of section" rule for the
+// opposite polarity — an open `- ⬜` bullet describes something NOT yet done, so it must survive
+// stripping even inside a dated/historical section (that's exactly how a stale ⬜ line escaped
+// this gate in a same-day doc edit — see the OPEN_BULLET_VERSION check in scanForDrift below).
+const OPEN_BULLET = /^\s*-\s*⬜/;
 // QNBS-v3: how many lines below a heading to look for a "**Status:** ✅ Released …" marker that
 // applies to the whole section (this repo puts it on its own line, not in the heading text).
 const STATUS_LOOKAHEAD = 5;
@@ -65,7 +70,12 @@ export function stripHistoricalSections(markdown) {
     }
   }
 
-  return lines.map((line, i) => (historical[i] || DONE_BULLET.test(line) ? '' : line)).join('\n');
+  return lines
+    .map((line, i) => {
+      if (OPEN_BULLET.test(line)) return line; // never strip — see OPEN_BULLET comment above
+      return historical[i] || DONE_BULLET.test(line) ? '' : line;
+    })
+    .join('\n');
 }
 
 /** Actual locale count = directories under locales/ (translation-glossary.json is a file, not a locale). */
@@ -185,6 +195,19 @@ export function scanForDrift(content, filePath, { localeCount, keyCount, latestV
           findings.push(
             `${filePath}:${i + 1} — "v${mentioned} … PLANNED" but v${mentioned} <= latest released v${latestVersion}: "${line.trim()}"`,
           );
+        }
+      }
+      // QNBS-v3: catches a stale "⬜ Tag/Release/publish vX.Y.Z" bullet that should have flipped to
+      // ✅ once that version actually shipped — the exact class of drift that escaped the gate when
+      // stripHistoricalSections() had no OPEN_BULLET exemption (see comment above its definition).
+      if (OPEN_BULLET.test(line) && /\b(?:tag|release|publish)\b/i.test(line)) {
+        for (const m of line.matchAll(/v(\d+\.\d+\.\d+)/gi)) {
+          const mentioned = m[1];
+          if (semverLte(mentioned, latestVersion)) {
+            findings.push(
+              `${filePath}:${i + 1} — open "⬜" bullet mentions tag/release/publish of v${mentioned}, but v${mentioned} <= latest released v${latestVersion}: "${line.trim()}"`,
+            );
+          }
         }
       }
     }

--- a/scripts/check-doc-metrics.mjs
+++ b/scripts/check-doc-metrics.mjs
@@ -39,10 +39,7 @@ const ANY_HEADING = /^#{1,6}\s+/;
 const HISTORICAL_MARKER =
   /(✅|\bRELEASED\b|\bDELIVERED\b|\bCompleted\b|\[\d+\.\d+\.\d+\]|\(\d{4}-\d{2}-\d{2})/i;
 const DONE_BULLET = /^\s*-\s*✅/;
-// QNBS-v3: mirrors DONE_BULLET's "always present-tense regardless of section" rule for the
-// opposite polarity — an open `- ⬜` bullet describes something NOT yet done, so it must survive
-// stripping even inside a dated/historical section (that's exactly how a stale ⬜ line escaped
-// this gate in a same-day doc edit — see the OPEN_BULLET_VERSION check in scanForDrift below).
+// QNBS-v3: mirrors DONE_BULLET's "always present-tense regardless of section" rule for open bullets, so a stale ⬜ can't hide in a historical section
 const OPEN_BULLET = /^\s*-\s*⬜/;
 // QNBS-v3: how many lines below a heading to look for a "**Status:** ✅ Released …" marker that
 // applies to the whole section (this repo puts it on its own line, not in the heading text).
@@ -197,10 +194,11 @@ export function scanForDrift(content, filePath, { localeCount, keyCount, latestV
           );
         }
       }
-      // QNBS-v3: catches a stale "⬜ Tag/Release/publish vX.Y.Z" bullet that should have flipped to
-      // ✅ once that version actually shipped — the exact class of drift that escaped the gate when
-      // stripHistoricalSections() had no OPEN_BULLET exemption (see comment above its definition).
-      if (OPEN_BULLET.test(line) && /\b(?:tag|release|publish)\b/i.test(line)) {
+      // QNBS-v3: catches a stale "⬜ Tag/Release/publish vX.Y.Z" bullet that should have flipped to ✅ once that version shipped
+      if (
+        OPEN_BULLET.test(line) &&
+        /\b(?:tag|tagging|release|releasing|publish|publishing)\b/i.test(line)
+      ) {
         for (const m of line.matchAll(/v(\d+\.\d+\.\d+)/gi)) {
           const mentioned = m[1];
           if (semverLte(mentioned, latestVersion)) {

--- a/tests/unit/checkDocMetrics.test.ts
+++ b/tests/unit/checkDocMetrics.test.ts
@@ -63,9 +63,7 @@ describe('stripHistoricalSections', () => {
     expect(stripped).toContain('Present: 17 locales.');
   });
 
-  // QNBS-v3 (F-1): regression guard for the dc14bc0-shaped drift — a stale `- ⬜` bullet sitting
-  // inside a dated/historical section was invisible to the gate because DONE_BULLET had no mirror
-  // for the open-bullet polarity.
+  // QNBS-v3: regression guard for the dc14bc0-shaped drift — a stale open bullet was invisible to the gate inside a historical section
   it('preserves an open "⬜" bullet even inside a dated/historical section', () => {
     const md = [
       '## v1.24.2 — CSP/crypto/doc-truth hardening (2026-07-29)',
@@ -124,13 +122,21 @@ describe('scanForDrift', () => {
     expect(findings).toHaveLength(0);
   });
 
-  // QNBS-v3 (F-1): the OPEN_BULLET_VERSION check — a stale "⬜ Tag/Release vX.Y.Z" bullet for an
-  // already-released version must be flagged now that stripHistoricalSections() preserves it.
+  // QNBS-v3: the OPEN_BULLET_VERSION check — a stale open tag/release bullet for an already-released version must be flagged
   it('flags an open "⬜" bullet for tagging/releasing a version <= the latest release', () => {
     const content = '- ⬜ **Tag `v1.24.1` + publish the GitHub Release** — maintainer action.';
     const findings = scanForDrift(content, 'FAKE.md', actual);
     expect(findings.some((f) => f.includes('v1.24.1'))).toBe(true);
   });
+
+  it.each(['Tagging', 'Releasing', 'Publishing'])(
+    'flags an open "⬜" bullet using the inflected form "%s"',
+    (verb) => {
+      const content = `- ⬜ **${verb} \`v1.24.1\`** — maintainer action.`;
+      const findings = scanForDrift(content, 'FAKE.md', actual);
+      expect(findings.some((f) => f.includes('v1.24.1'))).toBe(true);
+    },
+  );
 
   it('does not flag an open "⬜" bullet for tagging a version newer than the latest release', () => {
     const content = '- ⬜ **Tag `v1.25.0` + publish the GitHub Release** — maintainer action.';

--- a/tests/unit/checkDocMetrics.test.ts
+++ b/tests/unit/checkDocMetrics.test.ts
@@ -62,6 +62,27 @@ describe('stripHistoricalSections', () => {
     expect(stripped).not.toMatch(/Historical/);
     expect(stripped).toContain('Present: 17 locales.');
   });
+
+  // QNBS-v3 (F-1): regression guard for the dc14bc0-shaped drift — a stale `- ⬜` bullet sitting
+  // inside a dated/historical section was invisible to the gate because DONE_BULLET had no mirror
+  // for the open-bullet polarity.
+  it('preserves an open "⬜" bullet even inside a dated/historical section', () => {
+    const md = [
+      '## v1.24.2 — CSP/crypto/doc-truth hardening (2026-07-29)',
+      '',
+      '- ⬜ **Tag `v1.24.2` + publish the GitHub Release** — maintainer action.',
+    ].join('\n');
+    const stripped = stripHistoricalSections(md);
+    expect(stripped).toContain('⬜ **Tag `v1.24.2`');
+  });
+
+  it('still blanks a "✅" bullet even inside a live, non-historical section', () => {
+    const md = ['## Current status', '', '- ✅ Already-done item that should not be scanned.'].join(
+      '\n',
+    );
+    const stripped = stripHistoricalSections(md);
+    expect(stripped).not.toContain('Already-done item');
+  });
 });
 
 describe('scanForDrift', () => {
@@ -100,6 +121,29 @@ describe('scanForDrift', () => {
   it('does not flag a PLANNED marker for a version newer than the latest release', () => {
     const content = '## Upcoming — v2.0 (PLANNED)';
     const findings = scanForDrift(content, 'FAKE.md', actual);
+    expect(findings).toHaveLength(0);
+  });
+
+  // QNBS-v3 (F-1): the OPEN_BULLET_VERSION check — a stale "⬜ Tag/Release vX.Y.Z" bullet for an
+  // already-released version must be flagged now that stripHistoricalSections() preserves it.
+  it('flags an open "⬜" bullet for tagging/releasing a version <= the latest release', () => {
+    const content = '- ⬜ **Tag `v1.24.1` + publish the GitHub Release** — maintainer action.';
+    const findings = scanForDrift(content, 'FAKE.md', actual);
+    expect(findings.some((f) => f.includes('v1.24.1'))).toBe(true);
+  });
+
+  it('does not flag an open "⬜" bullet for tagging a version newer than the latest release', () => {
+    const content = '- ⬜ **Tag `v1.25.0` + publish the GitHub Release** — maintainer action.';
+    const findings = scanForDrift(content, 'FAKE.md', actual);
+    expect(findings).toHaveLength(0);
+  });
+
+  it('does not flag any version-based drift when latestVersion is null (shallow/tagless checkout)', () => {
+    const content = [
+      '- ⬜ **Tag `v1.24.1` + publish the GitHub Release** — maintainer action.',
+      '## Upcoming — v1.0 (PLANNED)',
+    ].join('\n');
+    const findings = scanForDrift(content, 'FAKE.md', { ...actual, latestVersion: null });
     expect(findings).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

**WS-1** of the post-recovery audit (per the governing `PROMPT-WSS-v1.24.x` prompt).

- `stripHistoricalSections()` blanked every line in a dated/historical section, including
  genuinely still-open `- ⬜` bullets — exactly how a stale "Tag v1.24.2" bullet escaped the gate
  in a same-day doc edit (`dc14bc0`). `DONE_BULLET` already had the mirror rule for the opposite
  polarity (a `- ✅` bullet is historical regardless of section); `OPEN_BULLET` now gets the same
  "always present-tense" treatment.
- `scanForDrift()` gains a matching check: a surviving open bullet mentioning tag/release/publish
  of a version `<=` the latest git tag is now a drift finding.
- 6 new unit tests, including proof the repaired gate actually catches the original defect
  (temporarily reverted TODO.md's already-fixed bullet, confirmed old logic passed / new logic
  fails with the exact finding, then restored it).

## Test plan

- [x] `pnpm run lint` — clean
- [x] `pnpm run typecheck` — clean
- [x] `pnpm exec vitest run tests/unit/checkDocMetrics.test.ts` — 26/26 pass
- [x] `pnpm run docs:check` — OK
- [x] Manually proved the repaired gate catches the original defect (see commit message)
- [ ] CI quality gate (Node 22/24, Security Audit, Build) — required checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve open checklist items (unchecked bullets) related to tagging, releasing, or publishing within historical sections.
  * Detect and flag stale open checklist items that reference an already released version (including tagging/releasing/publishing variants).

* **Tests**
  * Added regression coverage for historical stripping behavior and version-based drift detection, including cases for older, newer, and missing latest versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->