### PR TITLE
docs(changelog): back-fill Unreleased section for everything merged since v1.24.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   mentioning tag/release/publish (including inflected forms — "Tagging"/"Releasing"/"Publishing")
   of a version `<=` the latest git tag is now flagged as drift. (#293)
 
+### Docs
+
+- **`CLAUDE.md` codifies three merge-discipline lessons** learned during the PROMPT-WSS-v1.24.x
+  recovery sprint: never commit directly to `main` (always branch + PR, even for a single-file
+  change); wait for the **full** CI suite — including non-required/advisory jobs like E2E,
+  Storybook, Lighthouse, and Visual Regression — to go green before merging, not just the
+  branch-protection-required checks; and group related small workstreams into the fewest
+  reviewable PRs by natural/documented boundaries rather than one PR per tiny item, while keeping
+  one commit per logical concern. Also adds a "Known merge-gate quirks" section distinguishing
+  GitHub's real pending-check block from this repo's own stricter wait-for-pass policy and the
+  mergeable-state cache-lag symptom, plus documents the stacked-PR auto-close-on-squash-merge
+  side effect and its recovery steps; and strengthens the CodeAnt Correction Loop policy to
+  explicitly cover CodeRabbit's collapsed nitpick and outside-diff-range comment sections. (#294)
+
 ## [1.24.3] — 2026-07-30
 
 > Worker-generation consolidation sprint: the v1/WorkerBus-v2 duplication [ADR-0014](docs/adr/0014-worker-generation-duplication.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Doc-drift gate (`scripts/check-doc-metrics.mjs`) had a blind spot for still-open checklist
+  bullets inside dated/historical sections**: `stripHistoricalSections()` blanked every line in a
+  historical section indiscriminately, including a genuinely still-open `- ⬜` bullet — exactly how
+  a stale "Tag `v1.24.2`" bullet escaped the gate in a same-day doc edit (`dc14bc0`). `OPEN_BULLET`
+  now gets the same "always present-tense, never stripped" treatment `DONE_BULLET` already had for
+  the opposite polarity. `scanForDrift()` also gains a new check: a surviving open bullet
+  mentioning tag/release/publish (including inflected forms — "Tagging"/"Releasing"/"Publishing")
+  of a version `<=` the latest git tag is now flagged as drift. (#293)
+
 ## [1.24.3] — 2026-07-30
 
 > Worker-generation consolidation sprint: the v1/WorkerBus-v2 duplication [ADR-0014](docs/adr/0014-worker-generation-duplication.md)


### PR DESCRIPTION
## Summary

The `[Unreleased]` section of `CHANGELOG.md` was empty even though two PRs have already merged
into `main` since the `v1.24.3` release tag. Back-fills it so the changelog stays a complete,
accurate record of what's actually on `main` — not just the last tagged release.

- **#293** (WS-1): `check-doc-metrics.mjs`'s `stripHistoricalSections()` blind spot for still-open
  `- ⬜` checklist bullets inside dated/historical sections, plus the matching `scanForDrift()`
  check for stale open tag/release/publish bullets.
- **#294**: `CLAUDE.md` codifies three merge-discipline lessons from the recovery sprint (never
  commit directly to `main`; wait for the full CI suite including advisory jobs; group related
  workstreams into fewer PRs), a new "Known merge-gate quirks" section (cache-lag vs. this repo's
  wait-for-pass policy, stacked-PR auto-close-on-squash-merge), and a strengthened CodeAnt
  Correction Loop policy covering CodeRabbit's nitpick/outside-diff-range sections.

Verified via `git log v1.24.3..origin/main` and a full `git diff --stat` against the release tag
that these two PRs are the *entire* delta — nothing else is undocumented.

## Test plan

- [x] `git diff v1.24.3..origin/main --stat` cross-checked against the two changelog bullets — exact match
- [ ] CI quality gate (Node 22/24, Security Audit, Build) — required checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved documentation checks to preserve open historical checklist items and flag outdated release or publishing references.

- **Documentation**
  - Updated contributor guidance with merge-discipline lessons and a new section covering known merge-gate quirks.
  - Expanded guidance for the CodeAnt Correction Loop policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->