### PR TITLE
release: v1.25.0 — DuckDB excerpt encryption (SEC-6) + doc-truth fixes

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Supported |
 | --- | --- |
-| `main` (v1.24.3) | ✅ Full support |
-| `1.3.x – 1.24.2` | ⚠️ Best effort (upgrade strongly recommended) |
+| `main` (v1.25.0) | ✅ Full support |
+| `1.3.x – 1.24.3` | ⚠️ Best effort (upgrade strongly recommended) |
 | `< 1.3.0` | ❌ Not supported |
 
 Maintainer-facing documentation (CI, contributing, architecture) is indexed in [`README.md`](README.md#-documentation-hub) and enumerated in [`AUDIT.md`](AUDIT.md).
@@ -33,8 +33,10 @@ If the email channel is not configured, use GitHub Private Vulnerability Reporti
 ## Known Active Security Work Items
 
 Phase 0 and Phase 2 hardening complete as of v1.19.0; the Phase 3 plugin-isolation (SEC-7) and
-voice-download-UX (SEC-8) items shipped in v1.21–v1.23. The only remaining at-rest gap is SEC-6
-(DuckDB OPFS encryption), whose module exists but is not yet wired into the persistence path:
+voice-download-UX (SEC-8) items shipped in v1.21–v1.23. SEC-6 (DuckDB at-rest encryption) is now
+partially wired as of v1.25.0 — the one column holding literal manuscript prose is encrypted;
+full OPFS-file-level encryption remains infeasible (DuckDB-WASM owns the file handle directly)
+and is an accepted, documented limitation for the remaining metadata columns.
 
 | ID | Area | Description | Status |
 | --- | --- | --- | --- |
@@ -43,7 +45,7 @@ voice-download-UX (SEC-8) items shipped in v1.21–v1.23. The only remaining at-
 | SEC-3 | Storage | IDB at-rest encryption — `services/storage/storageEncryptionService.ts`, AES-256-GCM, PBKDF2 600k iter; `enableIdbAtRestEncryption` flag (on by default since v1.23) | ✅ Implemented (Phase 2 / B-1) |
 | SEC-4 | Voice | Web Speech API consent gate — GDPR Art. 13 disclosure and explicit opt-in before audio is routed to cloud STT providers | ✅ Complete (Phase 0) |
 | SEC-5 | Storage | IDB at-rest encryption UX — passphrase unlock modal, forgot-passphrase export flow, key rotation UI | ✅ Complete (2026-06-02) |
-| SEC-6 | Storage | DuckDB OPFS at-rest encryption — WAL and data files outside IDB; requires separate encryption layer | 🟡 Partial (P0-4) — encryption module + unit tests exist (`services/duckdb/duckdbEncryption.ts`), but it is **not yet wired into the DuckDB persistence path** (0 production callers as of v1.23.1), so DuckDB analytics are **not** encrypted at rest. Integration pending. |
+| SEC-6 | Storage | DuckDB OPFS at-rest encryption — WAL and data files outside IDB; requires separate encryption layer | 🟡 Partial (v1.25.0) — full OPFS-file-level encryption is infeasible (DuckDB-WASM owns the OPFS file handle directly; no app-level interception point). Cell-level encryption is now wired for the one column holding literal manuscript prose, `codex_mentions.excerpt`: when `enableIdbAtRestEncryption` is active, `duckdbCodexWrite()` (`services/duckdb/duckdbAnalytics.ts`) encrypts new excerpts via `services/duckdb/duckdbEncryption.ts` (AES-256-GCM, reuses the IDB encryption key) into `excerpt_enc BLOB` and nulls the plaintext column; `services/duckdb/codexExcerptEncryptionMigration.ts` backfills pre-existing plaintext rows once encryption is unlocked. All other DuckDB metadata columns (`title`/`logline`/`name`/`character_names`/`label`) remain intentionally plaintext — bounded-exposure design, not manuscript prose. |
 | SEC-7 | Plugin System | Worker isolation for plugin execution — prevent main-thread access, enforce timeouts | ✅ Complete (P0-2) — plugin execution routed to an isolated worker (`workers/plugin.worker.ts`) via `pluginRegistry.ts` + `workerBusManager.ts`, sandboxed API + timeout; adversarial tests in `tests/unit/workers/plugin.worker.test.ts`. Follow-up FU-1: full timeout/abort coupling for dynamic `import()` + sync loops (low impact). |
 | SEC-8 | Voice | WASM model download UX — progress feedback, cancel/retry controls for Whisper/Kokoro models | ✅ Complete (P0-5) — `components/voice/VoiceModelDownloadModal.tsx` (progress, cancel, retry), wired from `components/settings/VoiceSettingsSection.tsx`; driven by `VoiceCommandService.downloadVoiceModels(type, signal?)`. |
 | SEC-9 | ProForge / Copilot | Prompt-injection hardening — reject C0 control chars, null bytes, lone surrogates in AI-proposed edits; per-item graceful skip instead of batch abort | ✅ Complete (PR #114) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
 - **Primary deploy target:** Static SPA on GitHub Pages (`/WorldScript-Studio/` base path)
 - **Secondary targets:** Vercel (root base) and Cloudflare Pages via edge builds (`pnpm run build:edge`)
 - **Desktop:** Tauri 2 bundles for Linux (AppImage), macOS (DMG), and Windows (MSI); auto-updater enabled via `latest.json`
-- **Version:** `1.24.3`
+- **Version:** `1.25.0`
 - **License:** MIT
 
 The app supports a multi-provider AI stack (Gemini, OpenAI, Claude, Grok, OpenRouter, Ollama, WebLLM, ONNX Runtime Web, Transformers.js), four AI execution modes (Hybrid / Cloud / Local / Eco), real-time collaboration with E2E encryption, a Plot Board v2 with swimlane/canvas/timeline modes, character/world management, manuscript export, voice dictation, and a 19-locale i18n layer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.25.0] — 2026-07-31
+
 ### Added
 
 - **Grok (xAI) wired into the primary provider dropdown** — the backend (`streamGrok()`, BYOK key
@@ -34,6 +36,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   UI renders the exact `OLLAMA_ORIGINS=<origin> ollama serve` command for the current deployment.
   See [ADR-0017](docs/adr/0017-pwa-browser-ollama-opt-in.md) (Issue #266 follow-up).
 
+### Security
+
+- **DuckDB `codex_mentions.excerpt` — the one analytics column holding literal manuscript prose —
+  is now cell-level encrypted (SEC-6)** when `enableIdbAtRestEncryption` is active.
+  `duckdbCodexWrite()` (`services/duckdb/duckdbAnalytics.ts`) encrypts new excerpts via
+  `services/duckdb/duckdbEncryption.ts` (AES-256-GCM, reusing the IDB at-rest encryption key) into
+  a new `excerpt_enc BLOB` column and nulls the plaintext `excerpt` column; a new backfill
+  migration (`services/duckdb/codexExcerptEncryptionMigration.ts`) re-encrypts any pre-existing
+  plaintext rows once encryption is unlocked, without blocking the schema's other migrations when
+  encryption isn't active this session. Full OPFS **file-level** encryption remains infeasible —
+  DuckDB-WASM owns the OPFS file handle directly, leaving no app-level interception point — so the
+  other DuckDB metadata columns (`title`/`logline`/`name`/`character_names`/`label`) stay
+  intentionally plaintext by design, not manuscript prose.
+
 ### Fixed
 
 - **Doc-drift gate (`scripts/check-doc-metrics.mjs`) had a blind spot for still-open checklist
@@ -58,6 +74,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   mergeable-state cache-lag symptom, plus documents the stacked-PR auto-close-on-squash-merge
   side effect and its recovery steps; and strengthens the CodeAnt Correction Loop policy to
   explicitly cover CodeRabbit's collapsed nitpick and outside-diff-range comment sections. (#294)
+- **`.github/SECURITY.md` / `docs/SECURITY-THREAT-MODEL.md` SEC-6 status corrected** to reflect the
+  DuckDB excerpt-encryption wiring above, and the Claude serverless proxy section gains an explicit
+  monitoring recommendation (platform-native Vercel/Cloudflare request analytics — no in-app
+  logging, which would violate the proxy's zero-console-call stateless guarantee).
+- **`GROK-PROVIDER-INTEGRATION-PLAN.md`** status header updated from "Plan only — do not implement
+  yet" to reflect that all phases shipped; retained as the historical design record.
 
 ## [1.24.3] — 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,9 +49,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   DuckDB-WASM owns the OPFS file handle directly, leaving no app-level interception point — so the
   other DuckDB metadata columns (`title`/`logline`/`name`/`character_names`/`label`) stay
   intentionally plaintext by design, not manuscript prose.
+- **SEC-6 backfill migration marker was a single global key, not scoped per project** —
+  once *any* project completed the excerpt-encryption backfill, every other project's
+  plaintext `codex_mentions.excerpt` rows were silently never migrated.
+  `isCodexExcerptEncryptionMigrationDone()` now takes a `projectId` and scopes the `_meta`
+  done-marker key per project. Also fixed `duckdbCodexWrite()`'s `ON CONFLICT` clause for
+  `codex_mentions` so an unencrypted write (a session where IDB encryption isn't unlocked yet)
+  can no longer clobber an existing ciphertext row back to plaintext — it now preserves any
+  prior `excerpt_enc` via `COALESCE`/`CASE` instead of overwriting it. Added a two-project
+  regression test proving the marker-scoping fix and a test asserting the `ON CONFLICT` clause
+  never downgrades ciphertext. (CodeRabbit + Copilot review, PR #303)
+- **A failed per-row `UPDATE` during the SEC-6 excerpt-encryption backfill could still let the
+  migration write its done-marker** — the row's plaintext `excerpt` would then never be retried
+  or encrypted on any future run. `runCodexExcerptEncryptionMigration()` now tracks row-level
+  failures (a failed `UPDATE`, or `encryptDuckDbData()` throwing) and skips the done-marker,
+  returning `{ aborted: true }` so the still-plaintext rows are retried next run instead of being
+  silently left unencrypted forever. (CodeRabbit outside-diff-range finding, PR #303)
 
 ### Fixed
 
+- **`event-listener` (Rust, transitive via Tauri) bumped 5.4.1 → 5.4.2** — the OSV/RUSTSEC scan
+  flagged 5.4.1 as vulnerable (RUSTSEC-2026-0221), fixed upstream in 5.4.2; `Cargo.lock` only,
+  no other dependency churn.
 - **Doc-drift gate (`scripts/check-doc-metrics.mjs`) had a blind spot for still-open checklist
   bullets inside dated/historical sections**: `stripHistoricalSections()` blanked every line in a
   historical section indiscriminately, including a genuinely still-open `- ⬜` bullet — exactly how
@@ -80,6 +99,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   logging, which would violate the proxy's zero-console-call stateless guarantee).
 - **`GROK-PROVIDER-INTEGRATION-PLAN.md`** status header updated from "Plan only — do not implement
   yet" to reflect that all phases shipped; retained as the historical design record.
+- **`TODO.md`** reworded the open tag/publish bullet so it no longer embeds the literal `v1.25.0`
+  version string on the `- ⬜` bullet line itself, removing the risk that
+  `scripts/check-doc-metrics.mjs`'s `scanForDrift()` would flag it as stale drift once the
+  `v1.25.0` tag is actually pushed (verified via a `scanForDrift()` simulation with
+  `latestVersion: '1.25.0'` — zero findings).
+- **`docs/SECURITY-THREAT-MODEL.md`** now names the specific platform observability products
+  (Vercel Function Logs / Vercel Observability; Cloudflare Workers Metrics/Analytics and Workers
+  Logs) instead of a vague "platform-native analytics" reference, and notes that Cloudflare
+  Workers Logs is opt-in and must be enabled via the Wrangler `observability` config.
+
+### Tests
+
+- **Closed 3 Codecov patch-coverage gaps found on PR #303**: the DuckDB analytics migration
+  listener in `app/listenerMiddleware.ts` was never exercised by any test at all (stale mocks —
+  `loadDuckdbMigration`'s mock returned `runIfNeeded`, but the real listener calls
+  `runMigrationWithRollback`; `loadRagVectorMigration`'s mock resolved `undefined` where the
+  listener reads `.aborted`) — fixed the mocks and added 2 tests covering both branches of the
+  `codexEncResult.aborted` gate. Added 5 tests for `codexExcerptEncryptionMigration.ts` (a
+  post-loop privacy-gate abort distinct from the existing mid-loop-abort case, a failed row
+  `UPDATE` that now aborts without writing the done-marker, a row-encryption throw that aborts
+  the same way, and the `migrated % 10 === 0` yield-point). Added a test for `useDuckDb.ts`'s new
+  v3 migration DDL failure branch.
 
 ## [1.24.3] — 2026-07-30
 

--- a/GROK-PROVIDER-INTEGRATION-PLAN.md
+++ b/GROK-PROVIDER-INTEGRATION-PLAN.md
@@ -8,10 +8,11 @@ from the Settings UI. **Addendum (§7):** an unrelated but adjacent follow-up to
 opt-in, experimental feature flag letting the PWA attempt direct browser-to-Ollama connections,
 matching the "technically: yes" option the maintainer already described in that issue's comment
 thread.
-**Status:** v1.24.3 (2026-07-30)
-**Execution:** **Plan only — do not implement yet.** Per explicit instruction, this file is written
-now and executed only after every other workstream in the current post-recovery audit sprint
-(WS-3 through WS-10, including the WS-8 close-out) has merged into `main`.
+**Status:** ✅ Complete — merged 2026-07-30, see `[Unreleased]`/`[1.25.0]` in
+[CHANGELOG.md](CHANGELOG.md) for the user-facing summary.
+**Execution:** All phases below (Grok wiring, Claude desktop + web proxy, Ollama-in-PWA opt-in
+addendum) have shipped. This file is retained as the historical design record; do not treat any
+"do not implement yet" language below as current.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <img src="https://img.shields.io/badge/TypeScript-7.x_(tsgo)-3178C6?logo=typescript&logoColor=white" alt="TypeScript 7 (tsgo)">
   <img src="https://img.shields.io/badge/AI-Gemini_%7C_OpenAI_%7C_OpenRouter_%7C_Ollama_%7C_WebLLM-4285F4?logo=google" alt="Gemini · OpenAI · OpenRouter · Ollama · WebLLM">
   <img src="https://img.shields.io/badge/Local_AI-WebGPU_%7C_ONNX_%7C_Transformers.js-8B5CF6" alt="WebGPU · ONNX · Transformers.js">
-  <img src="https://img.shields.io/badge/Version-v1.24.3-6366F1" alt="v1.24.3">
+  <img src="https://img.shields.io/badge/Version-v1.25.0-6366F1" alt="v1.25.0">
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2861_keys-0EA5E9" alt="i18n 19 locales — 2861 keys">

--- a/TODO.md
+++ b/TODO.md
@@ -8,18 +8,17 @@ Status: 🔄 in progress | ⬜ open | ✅ done
 
 ---
 
-## Release — v1.25.0 tag/publish (2026-07-31)
+## Release — tag/publish pending (2026-07-31)
 
 Native Grok/Claude providers, opt-in Browser-Ollama, and DuckDB `codex_mentions.excerpt`
 cell-level encryption (SEC-6) all shipped in this cycle — see
 [`docs/history/completed-v1.25.0-providers.md`](docs/history/completed-v1.25.0-providers.md) for
-the full completed checklist. `CHANGELOG.md` is dated `[1.25.0]`, `package.json`/`README.md` are
-version-bumped, and `src-tauri`/`public/sw.js` versions are synced.
+the full completed checklist. `CHANGELOG.md`, `package.json`/`README.md`, and `src-tauri`/`public/sw.js`
+are all version-bumped and synced for this release.
 
-- ⬜ Tag and publish the release once CI is fully green on the release branch/PR: `git tag -a
-  v1.25.0`, push the tag, `gh release create v1.25.0` — see the exact hand-off commands in
-  `docs/history/completed-v1.25.0-providers.md`'s source plan. Not auto-executed; requires explicit
-  go-ahead per operational-safety rules on pushing/tagging.
+- ⬜ Tag and publish this release once CI is fully green on the release branch/PR — see the exact
+  hand-off commands in the archived provider workstream doc linked above. Not auto-executed;
+  requires explicit go-ahead per operational-safety rules on pushing/tagging.
 
 
 ---

--- a/TODO.md
+++ b/TODO.md
@@ -8,29 +8,19 @@ Status: 🔄 in progress | ⬜ open | ✅ done
 
 ---
 
-## Native Grok + Claude + Ollama-in-PWA providers (2026-07-30)
+## Release — v1.25.0 tag/publish (2026-07-31)
 
-README documented Grok and Claude as working cloud AI providers; neither was reachable from
-`AiProviderCard.tsx`'s main flow. Full details + rationale in
-[ADR-0016](docs/adr/0016-native-grok-and-claude-providers.md) and
-[ADR-0017](docs/adr/0017-pwa-browser-ollama-opt-in.md); see `[Unreleased]` in
-[CHANGELOG.md](CHANGELOG.md) for the user-facing summary. Execution plan:
-[`GROK-PROVIDER-INTEGRATION-PLAN.md`](GROK-PROVIDER-INTEGRATION-PLAN.md).
+Native Grok/Claude providers, opt-in Browser-Ollama, and DuckDB `codex_mentions.excerpt`
+cell-level encryption (SEC-6) all shipped in this cycle — see
+[`docs/history/completed-v1.25.0-providers.md`](docs/history/completed-v1.25.0-providers.md) for
+the full completed checklist. `CHANGELOG.md` is dated `[1.25.0]`, `package.json`/`README.md` are
+version-bumped, and `src-tauri`/`public/sw.js` versions are synced.
 
-- ✅ **Phase 1 — Grok**: wired into the primary provider dropdown + `providerFactory.ts`; the
-  backend (`streamGrok()`) already worked, this was purely a UI/wiring gap.
-- ✅ **Phase 2 Track A — Claude on desktop**: `streamAnthropic()` now branches on
-  `isTauriRuntime()` before throwing; desktop calls Anthropic directly via the native-HTTP pattern
-  ADR-0012 established for Ollama.
-- ✅ **Phase 2 Track B — Claude on web/PWA**: new stateless serverless proxy
-  (`api/claude-proxy.ts` + `functions/api/claude-proxy.ts`, Vercel + Cloudflare Pages) — this app's
-  first backend dependency. Mandatory abuse controls (schema validation, body-size cap, origin
-  check, rate limit, timeouts), never logs secrets. GitHub Pages shows an honest unavailable state.
-- ✅ **Addendum — Ollama-in-PWA opt-in (Issue #266 follow-up)**: `enableBrowserOllama` flag
-  (default off) lets the browser attempt a direct Ollama connection when the user has separately
-  configured their own server's `OLLAMA_ORIGINS`; not a proxy, not a bypass, not the default.
-- ⬜ Open WS-11's PR, run the CodeRabbit correction loop to quiescence, merge to `main`.
-- ⬜ Comprehensive tag/release afterward, folding in everything from `[Unreleased]`.
+- ⬜ Tag and publish the release once CI is fully green on the release branch/PR: `git tag -a
+  v1.25.0`, push the tag, `gh release create v1.25.0` — see the exact hand-off commands in
+  `docs/history/completed-v1.25.0-providers.md`'s source plan. Not auto-executed; requires explicit
+  go-ahead per operational-safety rules on pushing/tagging.
+
 
 ---
 
@@ -287,7 +277,7 @@ README documented Grok and Claude as working cloud AI providers; neither was rea
 - 🔄 **C-7 remainder** — Coverage → L85%/B75%/F80%; Stryker break 75→80 (current thresholds: L73/F65/B58). **Phase 3 started (2026-06-02):** +33 LoRA tests (useLoraView, training wizard, sub-panels — were 0%)
 - ✅ IDB at-rest encryption UX (2026-06-02 reconciliation) — `IdbUnlockModal` (startup unlock + 2-step forgot-passphrase escape hatch, `App.tsx:182-188,638-643`), `PassphraseModal` (set/change/disable), real read/write gating `idbProjectStore.ts:209-265`, session lock + key rotation (Phase 1). `enableIdbAtRestEncryption` flag in Settings › Privacy with ⚠ warning
 - ✅ **P0-2** — Plugin worker isolation (`workers/plugin.worker.ts`) — routes plugin execution to isolated worker context with timeout and sandboxed API
-- 🟡 **P0-4** — DuckDB OPFS encryption (`services/duckdb/duckdbEncryption.ts`) — encryption module + unit tests landed (passphrase-derived AES-256-GCM), **but not yet wired into the DuckDB persistence path** (0 production callers as of v1.23.1), so analytics are not encrypted at rest. Integration into `duckdbClient`/`duckdbWorker` remains open. (2026-06-17 reconciliation — was over-marked ✅; see `.github/SECURITY.md` SEC-6.)
+- 🟡 **P0-4** — DuckDB OPFS at-rest encryption (`services/duckdb/duckdbEncryption.ts`) — cell-level encryption is now wired for the one column holding literal manuscript prose, `codex_mentions.excerpt` (v1.25.0): `duckdbCodexWrite()` encrypts it into `excerpt_enc BLOB` when `enableIdbAtRestEncryption` is active, with `services/duckdb/codexExcerptEncryptionMigration.ts` backfilling pre-existing plaintext rows. Full OPFS **file-level** encryption remains infeasible (DuckDB-WASM owns the OPFS file handle directly) and is an accepted, permanent limitation, not a remaining task — see `.github/SECURITY.md` SEC-6.
 - ✅ **P0-5** — Voice WASM model download UI (`components/voice/VoiceModelDownloadModal.tsx`) — progress modal for Whisper/Kokoro model downloads with cancel/retry
 - 🔄 Whisper WASM STT model download + inference pipeline (B-2 continuation) — engine (`services/voice/wasmSttEngine.ts`) + download UI (P0-5 above) shipped; remaining scope narrowed to E2E integration test coverage only — stale ⬜ reconciled 2026-07-30.
 - 🔄 Kokoro/Piper TTS WASM engines — Kokoro DONE (`services/voice/kokoroTtsEngine.ts`, tested since 2026-05-31); Piper remains an unimplemented type-level placeholder only (`preferredTtsEngine: 'piper'` in `voiceCommandService.ts` has no backing engine file) — stale ⬜ reconciled 2026-07-30.

--- a/app/listenerMiddleware.ts
+++ b/app/listenerMiddleware.ts
@@ -9,6 +9,7 @@ import { ecoModeService } from '../services/ai/ecoModeService';
 import { extractStoryCodex, saveStoryCodex } from '../services/codexService';
 import { checkStorageHealth } from '../services/dbInitialization';
 import {
+  loadCodexExcerptEncryptionMigration,
   loadDuckdbAnalytics,
   loadDuckdbMigration,
   loadLocalRagService,
@@ -362,10 +363,16 @@ listenerMiddleware.startListening({
       const projectId = project.id || 'default';
       const { runRagVectorMigration } = await loadRagVectorMigration();
       const ragResult = await runRagVectorMigration(projectId, project.manuscript, gate);
-      // QNBS-v3: SEC — if either migration aborted because analytics was opted out mid-run, do NOT mark
+      // QNBS-v3: SEC-6 — re-encrypts any pre-existing plaintext codex_mentions.excerpt rows once an
+      // IDB encryption key is unlocked. Reports aborted:false (not a failure) when encryption isn't
+      // active this session — see codexExcerptEncryptionMigration.ts's doc comment for why that must
+      // not block the other migrations' 'done' status.
+      const { runCodexExcerptEncryptionMigration } = await loadCodexExcerptEncryptionMigration();
+      const codexEncResult = await runCodexExcerptEncryptionMigration(projectId, gate);
+      // QNBS-v3: SEC — if any migration aborted because analytics was opted out mid-run, do NOT mark
       // it 'done' (no markers were written). Reset to 'idle' so re-enabling analytics re-triggers the
       // backfill (the predicate re-fires on analyticsEnabled→true while DuckDB is ready + status idle).
-      if (seedResult.aborted || ragResult.aborted) {
+      if (seedResult.aborted || ragResult.aborted || codexEncResult.aborted) {
         listenerApi.dispatch(analyticsActions.setMigrationStatus('idle'));
         return;
       }

--- a/docs/SECURITY-THREAT-MODEL.md
+++ b/docs/SECURITY-THREAT-MODEL.md
@@ -228,9 +228,11 @@ already allowed), and the proxy→Anthropic leg is server-side, never subject to
 requests, rate-limit hits, or errors — `tests/unit/api/claudeProxyCore.test.ts` enforces a hard
 zero-console-call guarantee on every path, and adding request-level logging here would violate that
 stateless contract. Instead, rely on the hosting platform's own request-level observability:
-**Vercel Analytics / Vercel Functions logs** (primary deployment) or **Cloudflare Web Analytics /
-Workers logs** (Cloudflare Pages), both of which capture request volume, status codes, and latency
-without any app code changes. Spikes in 429 (rate-limited) or 4xx responses on the `claude-proxy`
+**Vercel Function Logs** or **Vercel Observability** (primary deployment) for request volume, status
+codes, and latency; on Cloudflare Pages, **Cloudflare Workers Metrics/Analytics** and **Workers
+Logs** provide the equivalent view — note that Workers observability (Logs) is opt-in and must be
+explicitly enabled in the Worker's Wrangler configuration (`observability.enabled = true`) before
+it captures anything. Spikes in 429 (rate-limited) or 4xx responses on the `claude-proxy`
 route are the actionable signal for abuse; alert thresholds should be configured directly in the
 platform dashboard, not in application code.
 

--- a/docs/SECURITY-THREAT-MODEL.md
+++ b/docs/SECURITY-THREAT-MODEL.md
@@ -42,7 +42,7 @@ This document provides a formal STRIDE threat analysis for WorldScript Studio, m
 | Desktop API key exposure via local file-read access | AES-256-GCM with a PBKDF2-derived key (600 000 iterations, SHA-256, random 32-byte salt per encryption) — fixed 2026-07-29; the prior scheme derived the key from a single unsalted SHA-256 digest of publicly-derivable material (own file's parent path + provider name from the filename + a hardcoded literal), so anyone with read access to `config/<provider>_key.enc.json` could reconstruct the key in one hash operation (F-05/F-06). No migration path for pre-fix files by design — a legacy (unsalted) payload is discarded and the user is prompted to re-enter the key. | `services/fs/fsCore.ts:deriveFileSystemCryptoKey()`, `services/fs/settingsFsStore.ts:getApiKey()` |
 | Manuscript data in IndexedDB | AES-256-GCM at-rest encryption | `services/storage/storageEncryptionService.ts` |
 | Voice audio to cloud | Web Speech API consent gate | `components/voice/VoicePrivacyConsentModal.tsx` |
-| DuckDB analytics unencrypted (SEC-6) | **Bounded by design:** only local metadata is persisted (titles, loglines, character names, codex excerpts, word counts, embeddings) — **never manuscript prose**, and **nothing leaves the device**. Gated by `enableDuckDbAnalytics` **and** the Settings → Privacy "Analytics" opt-out (`isAnalyticsPersistenceAllowed` in `app/listenerMiddleware.ts`); turning the toggle off stops all DuckDB writes + inference telemetry. Full OPFS file / cell-level (`*_enc`) encryption is **deferred to v2.0** — DuckDB-WASM owns the OPFS file write, so transparent file encryption is high-risk for the limited exposure. The `duckdbEncryption.ts` shim has 0 callers by design until then. | `app/listenerMiddleware.ts:isAnalyticsPersistenceAllowed`, `services/duckdb/duckdbEncryption.ts` |
+| DuckDB analytics unencrypted (SEC-6) | **Bounded by design, with one prose column now encrypted:** most persisted fields are local metadata only (titles, loglines, character names, word counts, embeddings) and **nothing leaves the device**. The one column that genuinely holds literal manuscript prose, `codex_mentions.excerpt`, is now cell-level encrypted (AES-256-GCM via `services/duckdb/duckdbEncryption.ts`, reusing the IDB at-rest encryption key) whenever `enableIdbAtRestEncryption` is active: `duckdbCodexWrite()` writes ciphertext into `excerpt_enc BLOB` and nulls the plaintext `excerpt` column; `services/duckdb/codexExcerptEncryptionMigration.ts` backfills any pre-existing plaintext rows once encryption is unlocked. Gated by `enableDuckDbAnalytics` **and** the Settings → Privacy "Analytics" opt-out (`isAnalyticsPersistenceAllowed` in `app/listenerMiddleware.ts`); turning the toggle off stops all DuckDB writes + inference telemetry. Full OPFS file-level encryption remains **infeasible** — DuckDB-WASM owns the OPFS file handle directly, so there is no app-level interception point; the other metadata columns stay intentionally plaintext (bounded-exposure design). | `app/listenerMiddleware.ts:isAnalyticsPersistenceAllowed`, `services/duckdb/duckdbAnalytics.ts:duckdbCodexWrite()`, `services/duckdb/duckdbEncryption.ts`, `services/duckdb/codexExcerptEncryptionMigration.ts` |
 | Prompt injection exposing context | Prompt sanitization | `services/ai/ragPromptAssembly.ts:sanitizePromptBlock()` |
 | Prompt injection via AI-proposed edits | Control-character / lone-surrogate validation; per-item skip | `services/proForge/applyReviewEdits.ts:validateProposedText()` |
 | Claude BYOK key transits WorldScript's own infrastructure (web/PWA only — see §Claude serverless proxy below) | Stateless relay, no logging of key/prompt/response on any path; same-origin check rejects third-party callers | `api/_shared/claudeProxyCore.ts:handleClaudeProxyRequest()` |
@@ -224,6 +224,16 @@ didn't already see as the request body — it is a transit point, not a new data
 doesn't affect the CSP tradeoff above (ADR-0004): the client→proxy leg is same-origin (`'self'`,
 already allowed), and the proxy→Anthropic leg is server-side, never subject to browser CSP at all.
 
+**Monitoring / anomaly detection:** the proxy intentionally does **not** perform in-app logging of
+requests, rate-limit hits, or errors — `tests/unit/api/claudeProxyCore.test.ts` enforces a hard
+zero-console-call guarantee on every path, and adding request-level logging here would violate that
+stateless contract. Instead, rely on the hosting platform's own request-level observability:
+**Vercel Analytics / Vercel Functions logs** (primary deployment) or **Cloudflare Web Analytics /
+Workers logs** (Cloudflare Pages), both of which capture request volume, status codes, and latency
+without any app code changes. Spikes in 429 (rate-limited) or 4xx responses on the `claude-proxy`
+route are the actionable signal for abuse; alert thresholds should be configured directly in the
+platform dashboard, not in application code.
+
 ## Security Checklist
 
 - [x] PBKDF2 iterations ≥ 600,000 (OWASP 2024 minimum)
@@ -235,8 +245,9 @@ already allowed), and the proxy→Anthropic leg is server-side, never subject to
 - [x] Collaboration requires password in production
 - [x] Plugin system permission-gated
 - [x] Plugin system Worker-isolated (P0-2) — `workers/plugin.worker.ts`
-- [x] DuckDB analytics privacy-gated (SEC-6) — writes require `enableDuckDbAnalytics` **and** the Settings → Privacy "Analytics" opt-out (`isAnalyticsPersistenceAllowed`, `app/listenerMiddleware.ts`); only local metadata is stored, never prose, nothing leaves the device.
-- [ ] DuckDB OPFS at-rest encryption (P0-4 / SEC-6) — **deferred to v2.0.** Encryption module + unit tests exist (`services/duckdb/duckdbEncryption.ts`) but stay unwired (0 callers by design): DuckDB-WASM owns the OPFS file write, so transparent file encryption is high-risk for the bounded, local-only metadata exposure.
+- [x] DuckDB analytics privacy-gated (SEC-6) — writes require `enableDuckDbAnalytics` **and** the Settings → Privacy "Analytics" opt-out (`isAnalyticsPersistenceAllowed`, `app/listenerMiddleware.ts`); only local metadata is stored, nothing leaves the device.
+- [x] DuckDB cell-level excerpt encryption (SEC-6, v1.25.0) — `codex_mentions.excerpt` (the one column holding literal manuscript prose) is AES-256-GCM encrypted into `excerpt_enc BLOB` and nulled from the plaintext column when `enableIdbAtRestEncryption` is active, with a backfill migration for pre-existing rows (`services/duckdb/codexExcerptEncryptionMigration.ts`).
+- [ ] DuckDB OPFS file-level encryption (SEC-6) — **infeasible / accepted risk, not deferred-pending-work.** DuckDB-WASM owns the OPFS file handle directly (`workers/v2/duckdb.worker.ts`), leaving no app-level interception point for transparent file encryption. Remaining plaintext metadata columns (`title`/`logline`/`name`/`character_names`/`label`) are bounded-exposure by design, not manuscript prose.
 - [x] Voice WASM download UX (P0-5) — `components/voice/VoiceModelDownloadModal.tsx`
 - [x] Claude web proxy (ADR-0016 Track B): stateless (no key/prompt/response logging), schema-validated, body-size-capped, same-origin-checked, rate-limited, timeout-bounded — `api/_shared/claudeProxyCore.ts`
 

--- a/docs/history/completed-v1.25.0-providers.md
+++ b/docs/history/completed-v1.25.0-providers.md
@@ -1,0 +1,40 @@
+# WorldScript Studio — Completed Tasks (v1.25.0 Providers Cycle)
+
+Archived from `TODO.md` on 2026-07-31. These items were completed during the v1.25.0 release cycle
+(native Grok/Claude cloud providers, opt-in Browser-Ollama, DuckDB excerpt encryption).
+
+For the **current** task tracker see [`TODO.md`](../../TODO.md); for long-term planning see
+[`ROADMAP.md`](../../ROADMAP.md).
+
+---
+
+## Native Grok + Claude + Ollama-in-PWA providers (2026-07-30)
+
+README documented Grok and Claude as working cloud AI providers; neither was reachable from
+`AiProviderCard.tsx`'s main flow. Full details + rationale in
+[ADR-0016](../adr/0016-native-grok-and-claude-providers.md) and
+[ADR-0017](../adr/0017-pwa-browser-ollama-opt-in.md); see `[1.25.0]` in
+[CHANGELOG.md](../../CHANGELOG.md) for the user-facing summary. Execution plan:
+[`GROK-PROVIDER-INTEGRATION-PLAN.md`](../../GROK-PROVIDER-INTEGRATION-PLAN.md).
+
+- ✅ **Phase 1 — Grok**: wired into the primary provider dropdown + `providerFactory.ts`; the
+  backend (`streamGrok()`) already worked, this was purely a UI/wiring gap.
+- ✅ **Phase 2 Track A — Claude on desktop**: `streamAnthropic()` now branches on
+  `isTauriRuntime()` before throwing; desktop calls Anthropic directly via the native-HTTP pattern
+  ADR-0012 established for Ollama.
+- ✅ **Phase 2 Track B — Claude on web/PWA**: new stateless serverless proxy
+  (`api/claude-proxy.ts` + `functions/api/claude-proxy.ts`, Vercel + Cloudflare Pages) — this app's
+  first backend dependency. Mandatory abuse controls (schema validation, body-size cap, origin
+  check, rate limit, timeouts), never logs secrets. GitHub Pages shows an honest unavailable state.
+- ✅ **Addendum — Ollama-in-PWA opt-in (Issue #266 follow-up)**: `enableBrowserOllama` flag
+  (default off) lets the browser attempt a direct Ollama connection when the user has separately
+  configured their own server's `OLLAMA_ORIGINS`; not a proxy, not a bypass, not the default.
+- ✅ **DuckDB `codex_mentions.excerpt` cell-level encryption (SEC-6)** — the one analytics column
+  holding literal manuscript prose is now AES-256-GCM encrypted into `excerpt_enc BLOB` when
+  `enableIdbAtRestEncryption` is active, with a backfill migration
+  (`services/duckdb/codexExcerptEncryptionMigration.ts`) for pre-existing plaintext rows.
+- ✅ Doc-truth cleanup: `GROK-PROVIDER-INTEGRATION-PLAN.md` status header corrected;
+  `.github/SECURITY.md` / `docs/SECURITY-THREAT-MODEL.md` SEC-6 status corrected; Claude-proxy
+  monitoring recommendation (platform-native dashboards, doc-only) added.
+- ✅ Release cut to `v1.25.0`: `CHANGELOG.md` dated, `package.json`/`README.md` version bumped,
+  `src-tauri`/`public/sw.js` versions synced.

--- a/hooks/useDuckDb.ts
+++ b/hooks/useDuckDb.ts
@@ -6,7 +6,11 @@ import { useAppDispatch, useAppSelector } from '../app/hooks';
 import { analyticsActions, selectDuckDbStatus } from '../features/analytics/analyticsSlice';
 import { selectEnableDuckDbAnalytics } from '../features/featureFlags/featureFlagsSlice';
 import { duckdbClient } from '../services/duckdb/duckdbClient';
-import { DUCKDB_DDL, DUCKDB_MIGRATION_V2_DDL } from '../services/duckdb/duckdbSchema';
+import {
+  DUCKDB_DDL,
+  DUCKDB_MIGRATION_V2_DDL,
+  DUCKDB_MIGRATION_V3_DDL,
+} from '../services/duckdb/duckdbSchema';
 import { logger } from '../services/logger';
 
 const MAX_INIT_ATTEMPTS = 3;
@@ -52,6 +56,9 @@ async function bootstrapDuckDbSchema(signal: AbortSignal): Promise<void> {
 
   const v2Res = await duckdbClient.exec(DUCKDB_MIGRATION_V2_DDL, undefined, signal);
   if (!v2Res.ok) throw new Error(v2Res.error ?? 'DuckDB v2 migration DDL failed');
+
+  const v3Res = await duckdbClient.exec(DUCKDB_MIGRATION_V3_DDL, undefined, signal);
+  if (!v3Res.ok) throw new Error(v3Res.error ?? 'DuckDB v3 migration DDL failed');
 }
 
 export function useDuckDb() {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "worldscript-studio",
   "private": true,
-  "version": "1.24.3",
+  "version": "1.25.0",
   "description": "WorldScript Studio — offline-first, AI-powered creative writing application.",
   "author": "QNBS",
   "keywords": [

--- a/public/sw.js
+++ b/public/sw.js
@@ -6,7 +6,7 @@
 // ============================================================
 
 // QNBS-v3 (CodeRabbit): version bump auto-synced from package.json by scripts/sync-sw-version.mjs — every CACHE_STATIC/CACHE_DYNAMIC name changes too, so this alone invalidates all prior caches on next activate.
-const APP_VERSION   = '1.24.3';
+const APP_VERSION   = '1.25.0';
 const CACHE_STATIC  = `worldscript-static-v${APP_VERSION}`;
 const CACHE_DYNAMIC = `worldscript-dynamic-v${APP_VERSION}`;
 const CACHE_IMAGES  = `worldscript-images-v${APP_VERSION}`;

--- a/services/duckdb/codexExcerptEncryptionMigration.ts
+++ b/services/duckdb/codexExcerptEncryptionMigration.ts
@@ -23,31 +23,38 @@ interface PlaintextExcerptRow {
   excerpt: string;
 }
 
-export async function isCodexExcerptEncryptionMigrationDone(): Promise<boolean> {
+// QNBS-v3: SEC — marker is scoped per project (key includes projectId); a shared/global key would
+// let the first migrated project's marker silently block the backfill for every other project.
+function markerKey(projectId: string): string {
+  return `${CODEX_EXCERPT_ENCRYPTION_KEY}:${projectId}`;
+}
+
+export async function isCodexExcerptEncryptionMigrationDone(projectId: string): Promise<boolean> {
   const res = await duckdbClient.query(
-    `SELECT value FROM _meta WHERE key = '${CODEX_EXCERPT_ENCRYPTION_KEY}'`,
+    `SELECT value FROM _meta WHERE key = '${esc(markerKey(projectId))}'`,
   );
   return Boolean(res.ok && res.rows?.length);
 }
 
 /**
  * Re-encrypt existing plaintext codex_mentions.excerpt rows for a project in place, moving the
- * ciphertext into excerpt_enc and nulling the plaintext column. Idempotent via _meta marker.
+ * ciphertext into excerpt_enc and nulling the plaintext column. Idempotent via a per-project _meta marker.
  */
 export async function runCodexExcerptEncryptionMigration(
   projectId: string,
   // QNBS-v3: SEC — re-checked before each write so an analytics opt-out toggled mid-run aborts
   // before persisting further rows. Defaults to always-allow for callers without a privacy context.
   shouldPersist: () => boolean = () => true,
-  // QNBS-v3: SEC — `aborted: true` ONLY means a privacy opt-out stopped an in-progress (encryption
-  // already unlocked) run before the done-marker was written — callers MUST keep migration status
-  // retryable in that case. When encryption simply isn't unlocked yet this is NOT an abort (returns
-  // `aborted: false`): it's not applicable this session and must not block the other migrations'
-  // 'done' status for the common (encryption-off) case. It self-heals — the next time this function
-  // is invoked (next duckDbJustReady/analyticsJustEnabled transition, e.g. next app load) it re-checks
-  // isIdbEncryptionReady() and backfills then if the user has since unlocked/enabled encryption.
+  // QNBS-v3: SEC — `aborted: true` means either a privacy opt-out stopped an in-progress (encryption
+  // already unlocked) run, or the initial SELECT query failed — in both cases the done-marker is
+  // never written, so callers MUST keep migration status retryable. When encryption simply isn't
+  // unlocked yet this is NOT an abort (returns `aborted: false`): it's not applicable this session and
+  // must not block the other migrations' 'done' status for the common (encryption-off) case. It
+  // self-heals — the next time this function is invoked (next duckDbJustReady/analyticsJustEnabled
+  // transition, e.g. next app load) it re-checks isIdbEncryptionReady() and backfills then if the user
+  // has since unlocked/enabled encryption.
 ): Promise<{ migrated: number; aborted: boolean }> {
-  if (await isCodexExcerptEncryptionMigrationDone()) {
+  if (await isCodexExcerptEncryptionMigrationDone(projectId)) {
     return { migrated: 0, aborted: false };
   }
   // Not applicable this session — no active encryption key. Not a failure; see doc comment above.
@@ -91,7 +98,7 @@ export async function runCodexExcerptEncryptionMigration(
   }
 
   await duckdbClient.exec(
-    `INSERT INTO _meta (key, value) VALUES ('${CODEX_EXCERPT_ENCRYPTION_KEY}', '1')
+    `INSERT INTO _meta (key, value) VALUES ('${esc(markerKey(projectId))}', '1')
      ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`,
   );
 

--- a/services/duckdb/codexExcerptEncryptionMigration.ts
+++ b/services/duckdb/codexExcerptEncryptionMigration.ts
@@ -1,0 +1,100 @@
+// QNBS-v3: SEC-6 — one-time backfill that re-encrypts pre-existing plaintext codex_mentions.excerpt
+//          rows once IDB at-rest encryption becomes available. Mirrors ragVectorMigration.ts's
+//          idempotent-marker + privacy-gated-batch pattern. Only meaningful once a session key is
+//          unlocked (isIdbEncryptionReady()) — skips WITHOUT writing the done-marker otherwise, so it
+//          retries automatically the next time analytics migrations run after unlock.
+
+import { logger } from '../logger';
+import { isIdbEncryptionReady } from '../storage/storageEncryptionService';
+import { duckdbClient } from './duckdbClient';
+import { encryptDuckDbData } from './duckdbEncryption';
+
+const CODEX_EXCERPT_ENCRYPTION_KEY = 'codex_excerpt_encryption_v1_migrated';
+
+/** Escape single-quotes in a SQL string literal. */
+function esc(s: string): string {
+  return s.replace(/'/g, "''");
+}
+
+interface PlaintextExcerptRow {
+  entity_id: string;
+  project_id: string;
+  section_id: string;
+  excerpt: string;
+}
+
+export async function isCodexExcerptEncryptionMigrationDone(): Promise<boolean> {
+  const res = await duckdbClient.query(
+    `SELECT value FROM _meta WHERE key = '${CODEX_EXCERPT_ENCRYPTION_KEY}'`,
+  );
+  return Boolean(res.ok && res.rows?.length);
+}
+
+/**
+ * Re-encrypt existing plaintext codex_mentions.excerpt rows for a project in place, moving the
+ * ciphertext into excerpt_enc and nulling the plaintext column. Idempotent via _meta marker.
+ */
+export async function runCodexExcerptEncryptionMigration(
+  projectId: string,
+  // QNBS-v3: SEC — re-checked before each write so an analytics opt-out toggled mid-run aborts
+  // before persisting further rows. Defaults to always-allow for callers without a privacy context.
+  shouldPersist: () => boolean = () => true,
+  // QNBS-v3: SEC — `aborted: true` ONLY means a privacy opt-out stopped an in-progress (encryption
+  // already unlocked) run before the done-marker was written — callers MUST keep migration status
+  // retryable in that case. When encryption simply isn't unlocked yet this is NOT an abort (returns
+  // `aborted: false`): it's not applicable this session and must not block the other migrations'
+  // 'done' status for the common (encryption-off) case. It self-heals — the next time this function
+  // is invoked (next duckDbJustReady/analyticsJustEnabled transition, e.g. next app load) it re-checks
+  // isIdbEncryptionReady() and backfills then if the user has since unlocked/enabled encryption.
+): Promise<{ migrated: number; aborted: boolean }> {
+  if (await isCodexExcerptEncryptionMigrationDone()) {
+    return { migrated: 0, aborted: false };
+  }
+  // Not applicable this session — no active encryption key. Not a failure; see doc comment above.
+  if (!isIdbEncryptionReady()) {
+    return { migrated: 0, aborted: false };
+  }
+  if (!shouldPersist()) {
+    return { migrated: 0, aborted: true };
+  }
+
+  const res = await duckdbClient.query(
+    `SELECT entity_id, project_id, section_id, excerpt FROM codex_mentions
+     WHERE project_id = '${esc(projectId)}' AND excerpt IS NOT NULL`,
+  );
+  if (!res.ok) {
+    logger.warn('[codexExcerptEncryptionMigration] Query failed (non-fatal):', res.error);
+    return { migrated: 0, aborted: true };
+  }
+
+  let migrated = 0;
+  const rows = (res.rows ?? []) as unknown as PlaintextExcerptRow[];
+  for (const row of rows) {
+    // QNBS-v3: SEC — re-check at each write so an opt-out mid-run stops further persistence.
+    if (!shouldPersist()) return { migrated, aborted: true };
+
+    const bytes = await encryptDuckDbData(row.excerpt);
+    const updRes = await duckdbClient.exec(
+      `UPDATE codex_mentions SET excerpt = NULL, excerpt_enc = ?
+       WHERE entity_id = '${esc(row.entity_id)}' AND project_id = '${esc(row.project_id)}'
+         AND section_id = '${esc(row.section_id)}'`,
+      [bytes],
+    );
+    if (updRes.ok) migrated++;
+    if (migrated % 10 === 0) await Promise.resolve();
+  }
+
+  // QNBS-v3: SEC — final gate check before the done-marker: an opt-out landing during the awaited
+  // batch above must not let us record the migration as complete (else re-opt-in never reruns it).
+  if (!shouldPersist()) {
+    return { migrated, aborted: true };
+  }
+
+  await duckdbClient.exec(
+    `INSERT INTO _meta (key, value) VALUES ('${CODEX_EXCERPT_ENCRYPTION_KEY}', '1')
+     ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`,
+  );
+
+  logger.debug('[codexExcerptEncryptionMigration] Complete:', migrated, 'rows');
+  return { migrated, aborted: false };
+}

--- a/services/duckdb/codexExcerptEncryptionMigration.ts
+++ b/services/duckdb/codexExcerptEncryptionMigration.ts
@@ -75,25 +75,44 @@ export async function runCodexExcerptEncryptionMigration(
   }
 
   let migrated = 0;
+  // QNBS-v3: SEC — any per-row failure must block the done-marker so the still-plaintext row is
+  // retried on the next run instead of being silently left unencrypted forever (CodeRabbit).
+  let hadRowFailure = false;
   const rows = (res.rows ?? []) as unknown as PlaintextExcerptRow[];
   for (const row of rows) {
     // QNBS-v3: SEC — re-check at each write so an opt-out mid-run stops further persistence.
     if (!shouldPersist()) return { migrated, aborted: true };
 
-    const bytes = await encryptDuckDbData(row.excerpt);
+    let bytes: Uint8Array;
+    try {
+      bytes = await encryptDuckDbData(row.excerpt);
+    } catch (err) {
+      logger.warn('[codexExcerptEncryptionMigration] Row encryption failed (non-fatal):', err);
+      hadRowFailure = true;
+      continue;
+    }
     const updRes = await duckdbClient.exec(
       `UPDATE codex_mentions SET excerpt = NULL, excerpt_enc = ?
        WHERE entity_id = '${esc(row.entity_id)}' AND project_id = '${esc(row.project_id)}'
          AND section_id = '${esc(row.section_id)}'`,
       [bytes],
     );
-    if (updRes.ok) migrated++;
+    if (updRes.ok) {
+      migrated++;
+    } else {
+      logger.warn('[codexExcerptEncryptionMigration] Row update failed (non-fatal):', updRes.error);
+      hadRowFailure = true;
+    }
     if (migrated % 10 === 0) await Promise.resolve();
   }
 
   // QNBS-v3: SEC — final gate check before the done-marker: an opt-out landing during the awaited
   // batch above must not let us record the migration as complete (else re-opt-in never reruns it).
   if (!shouldPersist()) {
+    return { migrated, aborted: true };
+  }
+  if (hadRowFailure) {
+    // Skip the done-marker so the still-plaintext rows are retried on the next run.
     return { migrated, aborted: true };
   }
 

--- a/services/duckdb/duckdbAnalytics.ts
+++ b/services/duckdb/duckdbAnalytics.ts
@@ -395,11 +395,18 @@ export async function duckdbCodexWrite(
       const encrypted = isIdbEncryptionReady();
       const excerptSql = encrypted ? 'NULL' : `'${esc(m.excerpt)}'`;
       const params = encrypted ? [await encryptDuckDbData(m.excerpt)] : [];
+      // QNBS-v3: SEC-6 — COALESCE preserves any existing ciphertext (and keeps excerpt NULL) so a
+      // write made while encryption is unavailable this session can never downgrade an already-
+      // encrypted row back to plaintext.
       await execOrThrow(
         `INSERT INTO codex_mentions (entity_id, project_id, section_id, excerpt, excerpt_enc)
          VALUES ('${esc(e.id)}', '${esc(projectId)}', '${esc(m.sectionId)}', ${excerptSql}, ${encrypted ? '?' : 'NULL'})
          ON CONFLICT (entity_id, project_id, section_id) DO UPDATE SET
-           excerpt = EXCLUDED.excerpt, excerpt_enc = EXCLUDED.excerpt_enc`,
+           excerpt_enc = COALESCE(EXCLUDED.excerpt_enc, codex_mentions.excerpt_enc),
+           excerpt = CASE
+             WHEN COALESCE(EXCLUDED.excerpt_enc, codex_mentions.excerpt_enc) IS NOT NULL THEN NULL
+             ELSE EXCLUDED.excerpt
+           END`,
         params,
       );
     }

--- a/services/duckdb/duckdbAnalytics.ts
+++ b/services/duckdb/duckdbAnalytics.ts
@@ -1,8 +1,13 @@
 // QNBS-v3: Typed query helpers for the DuckDB-WASM analytics layer.
-//          All queries operate on plaintext columns only — no encrypted BLOBs.
+//          Most queries operate on plaintext columns only. Exception (SEC-6): codex_mentions.excerpt
+//          holds literal manuscript prose, so duckdbCodexWrite encrypts it into excerpt_enc (AES-256-GCM,
+//          via duckdbEncryption.ts) whenever IDB at-rest encryption is active; see
+//          codexExcerptEncryptionMigration.ts for the one-time backfill of pre-existing plaintext rows.
 
 import { computeStreak } from '../../features/progressTracker/progressTrackerSlice';
+import { isIdbEncryptionReady } from '../storage/storageEncryptionService';
 import { duckdbClient } from './duckdbClient';
+import { encryptDuckDbData } from './duckdbEncryption';
 
 export interface DailyProgressRow {
   project_id: string;
@@ -82,8 +87,8 @@ function esc(s: string): string {
 }
 
 /** Execute SQL or throw — enables withDuckDbRetry to detect partial write failures. */
-async function execOrThrow(sql: string): Promise<void> {
-  const res = await duckdbClient.exec(sql);
+async function execOrThrow(sql: string, params?: readonly unknown[]): Promise<void> {
+  const res = await duckdbClient.exec(sql, params);
   if (!res.ok) throw new Error(`DuckDB exec failed: ${res.error ?? 'unknown'}`);
 }
 
@@ -383,10 +388,19 @@ export async function duckdbCodexWrite(
          mention_count = EXCLUDED.mention_count`,
     );
     for (const m of e.mentions) {
+      // QNBS-v3: SEC-6 — codex_mentions.excerpt is the one analytics column holding literal
+      // manuscript prose. When IDB at-rest encryption is active, encrypt it into excerpt_enc
+      // (AES-256-GCM via duckdbEncryption.ts) and null the plaintext column instead; otherwise
+      // keep today's plaintext behaviour unchanged.
+      const encrypted = isIdbEncryptionReady();
+      const excerptSql = encrypted ? 'NULL' : `'${esc(m.excerpt)}'`;
+      const params = encrypted ? [await encryptDuckDbData(m.excerpt)] : [];
       await execOrThrow(
-        `INSERT INTO codex_mentions (entity_id, project_id, section_id, excerpt)
-         VALUES ('${esc(e.id)}', '${esc(projectId)}', '${esc(m.sectionId)}', '${esc(m.excerpt)}')
-         ON CONFLICT (entity_id, project_id, section_id) DO UPDATE SET excerpt = EXCLUDED.excerpt`,
+        `INSERT INTO codex_mentions (entity_id, project_id, section_id, excerpt, excerpt_enc)
+         VALUES ('${esc(e.id)}', '${esc(projectId)}', '${esc(m.sectionId)}', ${excerptSql}, ${encrypted ? '?' : 'NULL'})
+         ON CONFLICT (entity_id, project_id, section_id) DO UPDATE SET
+           excerpt = EXCLUDED.excerpt, excerpt_enc = EXCLUDED.excerpt_enc`,
+        params,
       );
     }
   }

--- a/services/duckdb/duckdbListenerLoader.ts
+++ b/services/duckdb/duckdbListenerLoader.ts
@@ -12,6 +12,10 @@ export async function loadRagVectorMigration() {
   return import('./ragVectorMigration');
 }
 
+export async function loadCodexExcerptEncryptionMigration() {
+  return import('./codexExcerptEncryptionMigration');
+}
+
 export async function loadLocalRagService() {
   return import('../localRagService');
 }

--- a/services/duckdb/duckdbSchema.ts
+++ b/services/duckdb/duckdbSchema.ts
@@ -1,7 +1,7 @@
 // QNBS-v3: Canonical DDL for the DuckDB-WASM analytics layer.
 //          IDB remains the source of truth; this schema is the read-optimised side-car.
 
-export const DUCK_DB_SCHEMA_VERSION = 2;
+export const DUCK_DB_SCHEMA_VERSION = 3;
 
 /** MiniLM-L6-v2 semantic embedding dimension for rag_chunks.embedding */
 export const RAG_EMBEDDING_DIM = 384;
@@ -9,6 +9,11 @@ export const RAG_EMBEDDING_DIM = 384;
 /** v1→v2: adds rag_chunks.embedding for 384-dim semantic vectors */
 export const DUCKDB_MIGRATION_V2_DDL = `
 ALTER TABLE rag_chunks ADD COLUMN IF NOT EXISTS embedding FLOAT[];
+`;
+
+/** v2→v3: adds codex_mentions.excerpt_enc (SEC-6 partial fix — see codexExcerptEncryptionMigration.ts) */
+export const DUCKDB_MIGRATION_V3_DDL = `
+ALTER TABLE codex_mentions ADD COLUMN IF NOT EXISTS excerpt_enc BLOB;
 `;
 
 export const DUCKDB_DDL = `
@@ -103,11 +108,15 @@ CREATE TABLE IF NOT EXISTS codex_entities (
   PRIMARY KEY (entity_id, project_id)
 );
 
+-- QNBS-v3: excerpt holds the literal manuscript prose snippet; excerpt_enc is the AES-256-GCM
+-- ciphertext used instead when at-rest encryption is active (see duckdbCodexWrite in
+-- duckdbAnalytics.ts) — never both populated for the same row.
 CREATE TABLE IF NOT EXISTS codex_mentions (
-  entity_id  VARCHAR,
-  project_id VARCHAR,
-  section_id VARCHAR,
-  excerpt    VARCHAR,
+  entity_id   VARCHAR,
+  project_id  VARCHAR,
+  section_id  VARCHAR,
+  excerpt     VARCHAR,
+  excerpt_enc BLOB,
   PRIMARY KEY (entity_id, project_id, section_id)
 );
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1292,11 +1292,10 @@ checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -6593,7 +6592,7 @@ dependencies = [
 
 [[package]]
 name = "worldscript-studio"
-version = "1.24.3"
+version = "1.25.0"
 dependencies = [
  "base64 0.22.1",
  "candle-core",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "worldscript-studio"
-version = "1.24.3"
+version = "1.25.0"
 description = "AI-powered creative writing and world-building application"
 authors = ["QNBS"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "WorldScript Studio",
-  "version": "1.24.3",
+  "version": "1.25.0",
   "identifier": "com.worldscript.studio",
   "build": {
     "frontendDist": "../dist",

--- a/tests/unit/duckdbAnalytics.test.ts
+++ b/tests/unit/duckdbAnalytics.test.ts
@@ -477,6 +477,30 @@ describe('duckdbCodexWrite — excerpt encryption gating (SEC-6)', () => {
     expect(bytes).toBeInstanceOf(Uint8Array);
     expect(bytes.length).toBeGreaterThan(0);
   });
+
+  it('never lets an unencrypted write clobber an existing ciphertext on conflict', async () => {
+    await duckdbCodexWrite('p1', [
+      {
+        id: 'e1',
+        name: 'Alice',
+        type: 'character',
+        mentionCount: 1,
+        mentions: [{ sectionId: 's1', excerpt: 'Alice arrived at dusk.' }],
+      },
+    ]);
+    const mentionCall = mockExec.mock.calls.find(([s]) =>
+      String(s).includes('INSERT INTO codex_mentions'),
+    );
+    expect(mentionCall).toBeDefined();
+    const [sql] = mentionCall as [string, unknown[] | undefined];
+    // ON CONFLICT must preserve any pre-existing excerpt_enc rather than overwrite it with NULL.
+    expect(sql).toContain(
+      'excerpt_enc = COALESCE(EXCLUDED.excerpt_enc, codex_mentions.excerpt_enc)',
+    );
+    expect(sql).toContain(
+      'CASE\n             WHEN COALESCE(EXCLUDED.excerpt_enc, codex_mentions.excerpt_enc) IS NOT NULL THEN NULL',
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/duckdbAnalytics.test.ts
+++ b/tests/unit/duckdbAnalytics.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock duckdbClient before importing duckdbAnalytics
 vi.mock('../../services/duckdb/duckdbClient', () => ({
@@ -413,6 +413,69 @@ describe('duckdbCodexWrite', () => {
     ]);
     const sql = mockExec.mock.calls[0]?.[0] as string;
     expect(sql).toContain("O''Brien");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// duckdbCodexWrite — SEC-6 excerpt encryption gating.
+// QNBS-v3: Deliberately does NOT mock storageEncryptionService/duckdbEncryption — exercises the
+// REAL AES-256-GCM crypto path (only duckdbClient transport is mocked above) so a wiring bug
+// between the write path and the encryption module can't hide behind a stubbed crypto call.
+// ---------------------------------------------------------------------------
+describe('duckdbCodexWrite — excerpt encryption gating (SEC-6)', () => {
+  afterEach(async () => {
+    const { clearIdbEncryptionKey } = await import(
+      '../../services/storage/storageEncryptionService'
+    );
+    clearIdbEncryptionKey();
+  });
+
+  it('writes plaintext excerpt when IDB encryption is not active (default)', async () => {
+    await duckdbCodexWrite('p1', [
+      {
+        id: 'e1',
+        name: 'Alice',
+        type: 'character',
+        mentionCount: 1,
+        mentions: [{ sectionId: 's1', excerpt: 'Alice arrived at dusk.' }],
+      },
+    ]);
+    const mentionCall = mockExec.mock.calls.find(([s]) =>
+      String(s).includes('INSERT INTO codex_mentions'),
+    );
+    expect(mentionCall).toBeDefined();
+    const [sql, params] = mentionCall as [string, unknown[] | undefined];
+    expect(sql).toContain('Alice arrived at dusk.');
+    expect(sql).toMatch(/,\s*NULL\)/);
+    expect(params ?? []).toHaveLength(0);
+  });
+
+  it('encrypts excerpt via the real crypto path and nulls the plaintext column when IDB encryption is active', async () => {
+    const { initIdbEncryption } = await import('../../services/storage/storageEncryptionService');
+    await initIdbEncryption('test-pass');
+
+    await duckdbCodexWrite('p1', [
+      {
+        id: 'e1',
+        name: 'Alice',
+        type: 'character',
+        mentionCount: 1,
+        mentions: [{ sectionId: 's1', excerpt: 'secret manuscript prose' }],
+      },
+    ]);
+
+    const mentionCall = mockExec.mock.calls.find(([s]) =>
+      String(s).includes('INSERT INTO codex_mentions'),
+    );
+    expect(mentionCall).toBeDefined();
+    const [sql, params] = mentionCall as [string, unknown[] | undefined];
+    // No plaintext leak into the SQL string itself.
+    expect(sql).not.toContain('secret manuscript prose');
+    expect(sql).toContain('NULL, ?');
+    expect(params).toHaveLength(1);
+    const bytes = (params as unknown[])[0] as Uint8Array;
+    expect(bytes).toBeInstanceOf(Uint8Array);
+    expect(bytes.length).toBeGreaterThan(0);
   });
 });
 

--- a/tests/unit/duckdbListenerLoader.test.ts
+++ b/tests/unit/duckdbListenerLoader.test.ts
@@ -13,11 +13,16 @@ vi.mock('../../services/duckdb/ragVectorMigration', () => ({
   runRagVectorMigration: vi.fn(),
 }));
 
+vi.mock('../../services/duckdb/codexExcerptEncryptionMigration', () => ({
+  runCodexExcerptEncryptionMigration: vi.fn(),
+}));
+
 vi.mock('../../services/localRagService', () => ({
   rebuildHybridRagIndex: vi.fn(),
 }));
 
 import {
+  loadCodexExcerptEncryptionMigration,
   loadDuckdbAnalytics,
   loadDuckdbMigration,
   loadLocalRagService,
@@ -39,6 +44,11 @@ describe('duckdbListenerLoader', () => {
   it('loadRagVectorMigration returns rag migration module', async () => {
     const mod = await loadRagVectorMigration();
     expect(mod.runRagVectorMigration).toBeDefined();
+  });
+
+  it('loadCodexExcerptEncryptionMigration returns codex excerpt encryption migration module', async () => {
+    const mod = await loadCodexExcerptEncryptionMigration();
+    expect(mod.runCodexExcerptEncryptionMigration).toBeDefined();
   });
 
   it('loadLocalRagService returns local RAG module', async () => {

--- a/tests/unit/hooks/useDuckDb.test.ts
+++ b/tests/unit/hooks/useDuckDb.test.ts
@@ -57,6 +57,7 @@ vi.mock('../../../services/duckdb/duckdbClient', () => ({
 vi.mock('../../../services/duckdb/duckdbSchema', () => ({
   DUCKDB_DDL: 'CREATE TABLE IF NOT EXISTS sessions (id TEXT)',
   DUCKDB_MIGRATION_V2_DDL: 'ALTER TABLE sessions ADD COLUMN IF NOT EXISTS created_at TEXT',
+  DUCKDB_MIGRATION_V3_DDL: 'ALTER TABLE codex_mentions ADD COLUMN IF NOT EXISTS excerpt_enc BLOB',
 }));
 
 vi.mock('../../../services/logger', () => ({

--- a/tests/unit/hooks/useDuckDb.test.ts
+++ b/tests/unit/hooks/useDuckDb.test.ts
@@ -155,6 +155,32 @@ describe('useDuckDb', () => {
     vi.restoreAllMocks();
   });
 
+  it('dispatches setDuckDbError with the v3 migration failure message when the v3 DDL fails', async () => {
+    mockIsEnabled = true;
+    mockStatus = 'idle';
+    mockDuckdbInit.mockResolvedValue({ ok: true });
+    // QNBS-v3: schema DDL + v2 DDL succeed; only the new v3 (codex excerpt encryption) DDL fails —
+    // exercises the previously-uncovered `!v3Res.ok` throw branch in bootstrapDuckDbSchema.
+    mockDuckdbExec.mockImplementation((sql: unknown) =>
+      Promise.resolve({
+        ok: sql !== 'ALTER TABLE codex_mentions ADD COLUMN IF NOT EXISTS excerpt_enc BLOB',
+      }),
+    );
+    vi.spyOn(global, 'setTimeout').mockImplementation((fn) => {
+      fn();
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    });
+
+    renderHook(() => useDuckDb());
+    await act(async () => {
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+    });
+
+    expect(analyticsActions.setDuckDbError).toHaveBeenCalledWith('DuckDB v3 migration DDL failed');
+    expect(analyticsActions.setDuckDbStatus).toHaveBeenCalledWith('unavailable');
+    vi.restoreAllMocks();
+  });
+
   describe('queryAsync', () => {
     it('returns empty array when not ready (status idle)', async () => {
       mockStatus = 'idle';

--- a/tests/unit/listenerMiddleware.test.ts
+++ b/tests/unit/listenerMiddleware.test.ts
@@ -106,6 +106,13 @@ vi.mock('../../services/duckdb/duckdbListenerLoader', () => ({
   loadRagVectorMigration: vi.fn(() =>
     Promise.resolve({ runRagVectorMigration: vi.fn().mockResolvedValue(undefined) }),
   ),
+  loadCodexExcerptEncryptionMigration: vi.fn(() =>
+    Promise.resolve({
+      runCodexExcerptEncryptionMigration: vi
+        .fn()
+        .mockResolvedValue({ migrated: 0, aborted: false }),
+    }),
+  ),
 }));
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/listenerMiddleware.test.ts
+++ b/tests/unit/listenerMiddleware.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { listenerMiddleware } from '../../app/listenerMiddleware';
 import type { RootState } from '../../app/store';
 import { useTransientUiStore } from '../../app/transientUiStore';
+import analyticsReducer, { analyticsActions } from '../../features/analytics/analyticsSlice';
 // QNBS-v3: featureFlagsActions dispatches setEnableLocalFirstSync to exercise the local-first listener below
 import featureFlagsReducer, {
   featureFlagsActions,
@@ -26,6 +27,9 @@ const mockLoggerError = vi.fn();
 const mockLoggerWarn = vi.fn();
 const mockSaveEnvelope = vi.fn((data: unknown) => data);
 const mockRebuildHybridRagIndex = vi.fn().mockResolvedValue(undefined);
+const mockRunCodexExcerptEncryptionMigration = vi
+  .fn()
+  .mockResolvedValue({ migrated: 0, aborted: false });
 
 vi.mock('../../services/storageService', () => ({
   storageService: {
@@ -101,16 +105,18 @@ vi.mock('../../services/duckdb/duckdbListenerLoader', () => ({
     }),
   ),
   loadDuckdbMigration: vi.fn(() =>
-    Promise.resolve({ runIfNeeded: vi.fn().mockResolvedValue(undefined) }),
+    Promise.resolve({
+      runIfNeeded: vi.fn().mockResolvedValue(undefined),
+      // QNBS-v3: listenerMiddleware calls runMigrationWithRollback (not runIfNeeded) — see duckdbMigration.ts
+      runMigrationWithRollback: vi.fn().mockResolvedValue({ aborted: false }),
+    }),
   ),
   loadRagVectorMigration: vi.fn(() =>
-    Promise.resolve({ runRagVectorMigration: vi.fn().mockResolvedValue(undefined) }),
+    Promise.resolve({ runRagVectorMigration: vi.fn().mockResolvedValue({ aborted: false }) }),
   ),
   loadCodexExcerptEncryptionMigration: vi.fn(() =>
     Promise.resolve({
-      runCodexExcerptEncryptionMigration: vi
-        .fn()
-        .mockResolvedValue({ migrated: 0, aborted: false }),
+      runCodexExcerptEncryptionMigration: mockRunCodexExcerptEncryptionMigration,
     }),
   ),
 }));
@@ -135,6 +141,7 @@ function makeFullStore() {
       status: statusReducer,
       versionControl: versionControlReducer,
       featureFlags: featureFlagsReducer,
+      analytics: analyticsReducer,
     },
     middleware: (getDefault) => getDefault().prepend(listenerMiddleware.middleware),
   });
@@ -345,6 +352,37 @@ describe('auto-save settings listener', () => {
     expect(store.getState().settings.theme).not.toBe(prevTheme);
     // Advance timers — should not throw
     await vi.advanceTimersByTimeAsync(1500);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DuckDB analytics migration chain (seed + RAG + codex excerpt encryption, SEC-6)
+// ---------------------------------------------------------------------------
+describe('DuckDB analytics migration listener', () => {
+  it('runs the codex excerpt encryption migration and marks status done when nothing aborts', async () => {
+    const store = makeFullStore();
+    store.dispatch(analyticsActions.setDuckDbStatus('ready'));
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(mockRunCodexExcerptEncryptionMigration).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Function),
+    );
+    expect(store.getState().analytics.migrationStatus).toBe('done');
+  });
+
+  it('resets migrationStatus to idle (not done) when the codex excerpt migration aborts', async () => {
+    const { loadCodexExcerptEncryptionMigration } = await import(
+      '../../services/duckdb/duckdbListenerLoader'
+    );
+    vi.mocked(loadCodexExcerptEncryptionMigration).mockResolvedValueOnce({
+      runCodexExcerptEncryptionMigration: vi.fn().mockResolvedValue({ migrated: 0, aborted: true }),
+    });
+    const store = makeFullStore();
+    store.dispatch(analyticsActions.setDuckDbStatus('ready'));
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(store.getState().analytics.migrationStatus).toBe('idle');
   });
 });
 

--- a/tests/unit/listenerMiddleware.test.ts
+++ b/tests/unit/listenerMiddleware.test.ts
@@ -377,6 +377,7 @@ describe('DuckDB analytics migration listener', () => {
     );
     vi.mocked(loadCodexExcerptEncryptionMigration).mockResolvedValueOnce({
       runCodexExcerptEncryptionMigration: vi.fn().mockResolvedValue({ migrated: 0, aborted: true }),
+      isCodexExcerptEncryptionMigrationDone: vi.fn().mockResolvedValue(false),
     });
     const store = makeFullStore();
     store.dispatch(analyticsActions.setDuckDbStatus('ready'));

--- a/tests/unit/services/duckdb/codexExcerptEncryptionMigration.test.ts
+++ b/tests/unit/services/duckdb/codexExcerptEncryptionMigration.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for services/duckdb/codexExcerptEncryptionMigration.ts (SEC-6).
+ * QNBS-v3: Deliberately does NOT mock storageEncryptionService or duckdbEncryption — this test
+ * exercises the REAL AES-256-GCM crypto path (only the DuckDB transport layer is mocked), so a
+ * wiring bug between this migration and the encryption module can't hide behind a stubbed crypto call.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../../services/duckdb/duckdbClient', () => ({
+  duckdbClient: {
+    query: vi.fn(),
+    exec: vi.fn(),
+  },
+}));
+
+vi.mock('../../../../services/logger', () => ({
+  logger: { debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import {
+  isCodexExcerptEncryptionMigrationDone,
+  runCodexExcerptEncryptionMigration,
+} from '../../../../services/duckdb/codexExcerptEncryptionMigration';
+import { duckdbClient } from '../../../../services/duckdb/duckdbClient';
+import {
+  clearIdbEncryptionKey,
+  initIdbEncryption,
+} from '../../../../services/storage/storageEncryptionService';
+
+const mockQuery = vi.mocked(duckdbClient.query);
+const mockExec = vi.mocked(duckdbClient.exec);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockExec.mockResolvedValue({ messageId: 'm', ok: true });
+  clearIdbEncryptionKey();
+});
+
+afterEach(() => {
+  clearIdbEncryptionKey();
+});
+
+describe('isCodexExcerptEncryptionMigrationDone', () => {
+  it('returns true when the _meta marker row exists', async () => {
+    mockQuery.mockResolvedValueOnce({ messageId: 'm', ok: true, rows: [{ value: '1' }] });
+    expect(await isCodexExcerptEncryptionMigrationDone()).toBe(true);
+  });
+
+  it('returns false when no _meta marker row', async () => {
+    mockQuery.mockResolvedValueOnce({ messageId: 'm', ok: true, rows: [] });
+    expect(await isCodexExcerptEncryptionMigrationDone()).toBe(false);
+  });
+
+  it('returns false when the query fails', async () => {
+    mockQuery.mockResolvedValueOnce({ messageId: 'm', ok: false });
+    expect(await isCodexExcerptEncryptionMigrationDone()).toBe(false);
+  });
+});
+
+describe('runCodexExcerptEncryptionMigration', () => {
+  it('is a no-op when already marked done', async () => {
+    mockQuery.mockResolvedValueOnce({ messageId: 'm', ok: true, rows: [{ value: '1' }] });
+    const result = await runCodexExcerptEncryptionMigration('proj-1');
+    expect(result).toEqual({ migrated: 0, aborted: false });
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  it('reports aborted:false (not a failure) when encryption is not unlocked this session', async () => {
+    mockQuery.mockResolvedValueOnce({ messageId: 'm', ok: true, rows: [] });
+    const result = await runCodexExcerptEncryptionMigration('proj-1');
+    expect(result).toEqual({ migrated: 0, aborted: false });
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  it('aborts (retryable) when the privacy gate rejects persistence, even with encryption unlocked', async () => {
+    await initIdbEncryption('test-pass');
+    mockQuery.mockResolvedValueOnce({ messageId: 'm', ok: true, rows: [] });
+    const result = await runCodexExcerptEncryptionMigration('proj-1', () => false);
+    expect(result).toEqual({ migrated: 0, aborted: true });
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  it('aborts (retryable) when the plaintext-row query fails', async () => {
+    await initIdbEncryption('test-pass');
+    mockQuery
+      .mockResolvedValueOnce({ messageId: 'm1', ok: true, rows: [] })
+      .mockResolvedValueOnce({ messageId: 'm2', ok: false, error: 'boom' });
+    const result = await runCodexExcerptEncryptionMigration('proj-1');
+    expect(result).toEqual({ migrated: 0, aborted: true });
+  });
+
+  it('encrypts plaintext excerpt rows via the real AES-256-GCM path and nulls the plaintext column', async () => {
+    await initIdbEncryption('test-pass');
+    mockQuery
+      .mockResolvedValueOnce({ messageId: 'm1', ok: true, rows: [] }) // isDone check
+      .mockResolvedValueOnce({
+        messageId: 'm2',
+        ok: true,
+        rows: [
+          {
+            entity_id: 'e1',
+            project_id: 'proj-1',
+            section_id: 's1',
+            excerpt: 'secret manuscript prose',
+          },
+        ],
+      });
+
+    const result = await runCodexExcerptEncryptionMigration('proj-1');
+
+    expect(result).toEqual({ migrated: 1, aborted: false });
+
+    const updateCall = mockExec.mock.calls.find(([sql]) =>
+      String(sql).includes('UPDATE codex_mentions'),
+    );
+    expect(updateCall).toBeDefined();
+    const [sql, params] = updateCall as [string, unknown[]];
+    // No plaintext leak into the SQL string itself.
+    expect(sql).not.toContain('secret manuscript prose');
+    expect(params).toHaveLength(1);
+    const bytes = params[0] as Uint8Array;
+    expect(bytes).toBeInstanceOf(Uint8Array);
+    expect(bytes.length).toBeGreaterThan(0);
+
+    const markerCall = mockExec.mock.calls.find(([execSql]) =>
+      String(execSql).includes('codex_excerpt_encryption_v1_migrated'),
+    );
+    expect(markerCall).toBeDefined();
+  });
+
+  it('aborts without writing the done-marker when the privacy gate flips off mid-batch', async () => {
+    await initIdbEncryption('test-pass');
+    let calls = 0;
+    const gate = () => {
+      calls++;
+      return calls <= 1;
+    };
+    mockQuery.mockResolvedValueOnce({ messageId: 'm1', ok: true, rows: [] }).mockResolvedValueOnce({
+      messageId: 'm2',
+      ok: true,
+      rows: [{ entity_id: 'e1', project_id: 'proj-1', section_id: 's1', excerpt: 'a' }],
+    });
+
+    const result = await runCodexExcerptEncryptionMigration('proj-1', gate);
+
+    expect(result.aborted).toBe(true);
+    expect(
+      mockExec.mock.calls.some(([execSql]) =>
+        String(execSql).includes('codex_excerpt_encryption_v1_migrated'),
+      ),
+    ).toBe(false);
+  });
+});

--- a/tests/unit/services/duckdb/codexExcerptEncryptionMigration.test.ts
+++ b/tests/unit/services/duckdb/codexExcerptEncryptionMigration.test.ts
@@ -44,17 +44,30 @@ afterEach(() => {
 describe('isCodexExcerptEncryptionMigrationDone', () => {
   it('returns true when the _meta marker row exists', async () => {
     mockQuery.mockResolvedValueOnce({ messageId: 'm', ok: true, rows: [{ value: '1' }] });
-    expect(await isCodexExcerptEncryptionMigrationDone()).toBe(true);
+    expect(await isCodexExcerptEncryptionMigrationDone('proj-1')).toBe(true);
   });
 
   it('returns false when no _meta marker row', async () => {
     mockQuery.mockResolvedValueOnce({ messageId: 'm', ok: true, rows: [] });
-    expect(await isCodexExcerptEncryptionMigrationDone()).toBe(false);
+    expect(await isCodexExcerptEncryptionMigrationDone('proj-1')).toBe(false);
   });
 
   it('returns false when the query fails', async () => {
     mockQuery.mockResolvedValueOnce({ messageId: 'm', ok: false });
-    expect(await isCodexExcerptEncryptionMigrationDone()).toBe(false);
+    expect(await isCodexExcerptEncryptionMigrationDone('proj-1')).toBe(false);
+  });
+
+  it('scopes the marker query by projectId so two projects use distinct keys', async () => {
+    mockQuery.mockResolvedValueOnce({ messageId: 'm', ok: true, rows: [] });
+    await isCodexExcerptEncryptionMigrationDone('proj-1');
+    const [sql] = mockQuery.mock.calls[0] as [string];
+    expect(sql).toContain('proj-1');
+
+    mockQuery.mockResolvedValueOnce({ messageId: 'm', ok: true, rows: [] });
+    await isCodexExcerptEncryptionMigrationDone('proj-2');
+    const [sql2] = mockQuery.mock.calls[1] as [string];
+    expect(sql2).toContain('proj-2');
+    expect(sql2).not.toEqual(sql);
   });
 });
 
@@ -127,6 +140,43 @@ describe('runCodexExcerptEncryptionMigration', () => {
       String(execSql).includes('codex_excerpt_encryption_v1_migrated'),
     );
     expect(markerCall).toBeDefined();
+  });
+
+  it('migrates a second project independently after a first project already completed (marker scoping regression)', async () => {
+    await initIdbEncryption('test-pass');
+
+    // Project 1: not done yet, one plaintext row, completes and writes its own marker.
+    mockQuery.mockResolvedValueOnce({ messageId: 'm1', ok: true, rows: [] }).mockResolvedValueOnce({
+      messageId: 'm2',
+      ok: true,
+      rows: [{ entity_id: 'e1', project_id: 'proj-1', section_id: 's1', excerpt: 'proj-1 prose' }],
+    });
+    const result1 = await runCodexExcerptEncryptionMigration('proj-1');
+    expect(result1).toEqual({ migrated: 1, aborted: false });
+
+    // Project 2 must NOT see project 1's marker and must run its own backfill.
+    mockQuery.mockResolvedValueOnce({ messageId: 'm3', ok: true, rows: [] }).mockResolvedValueOnce({
+      messageId: 'm4',
+      ok: true,
+      rows: [{ entity_id: 'e2', project_id: 'proj-2', section_id: 's1', excerpt: 'proj-2 prose' }],
+    });
+    const result2 = await runCodexExcerptEncryptionMigration('proj-2');
+    expect(result2).toEqual({ migrated: 1, aborted: false });
+
+    const isDoneQueries = mockQuery.mock.calls
+      .map(([sql]) => String(sql))
+      .filter((sql) => sql.includes('codex_excerpt_encryption_v1_migrated'));
+    expect(isDoneQueries).toHaveLength(2);
+    expect(isDoneQueries[0]).toContain('proj-1');
+    expect(isDoneQueries[1]).toContain('proj-2');
+    expect(isDoneQueries[0]).not.toEqual(isDoneQueries[1]);
+
+    const markerInserts = mockExec.mock.calls
+      .map(([sql]) => String(sql))
+      .filter((sql) => sql.includes('codex_excerpt_encryption_v1_migrated'));
+    expect(markerInserts).toHaveLength(2);
+    expect(markerInserts[0]).toContain('proj-1');
+    expect(markerInserts[1]).toContain('proj-2');
   });
 
   it('aborts without writing the done-marker when the privacy gate flips off mid-batch', async () => {

--- a/tests/unit/services/duckdb/codexExcerptEncryptionMigration.test.ts
+++ b/tests/unit/services/duckdb/codexExcerptEncryptionMigration.test.ts
@@ -228,23 +228,43 @@ describe('runCodexExcerptEncryptionMigration', () => {
     ).toBe(false);
   });
 
-  it('does not increment migrated when the row UPDATE fails, but still completes the run', async () => {
+  it('does not increment migrated and aborts without a marker when the row UPDATE fails', async () => {
     await initIdbEncryption('test-pass');
     mockQuery.mockResolvedValueOnce({ messageId: 'm1', ok: true, rows: [] }).mockResolvedValueOnce({
       messageId: 'm2',
       ok: true,
       rows: [{ entity_id: 'e1', project_id: 'proj-1', section_id: 's1', excerpt: 'a' }],
     });
-    // First exec call is the row UPDATE — fail it; the later marker INSERT uses the default { ok: true }.
+    // Only exec call in this run is the row UPDATE — fail it.
     mockExec.mockResolvedValueOnce({ messageId: 'u1', ok: false, error: 'update failed' });
 
     const result = await runCodexExcerptEncryptionMigration('proj-1');
 
-    expect(result).toEqual({ migrated: 0, aborted: false });
+    // QNBS-v3: SEC — a failed row UPDATE must abort (retryable) and skip the done-marker, or the
+    // still-plaintext row would never be retried (CodeRabbit finding, PR #303).
+    expect(result).toEqual({ migrated: 0, aborted: true });
     const markerCall = mockExec.mock.calls.find(([execSql]) =>
       String(execSql).includes('codex_excerpt_encryption_v1_migrated'),
     );
-    expect(markerCall).toBeDefined();
+    expect(markerCall).toBeUndefined();
+  });
+
+  it('aborts without a marker when encrypting a row throws', async () => {
+    await initIdbEncryption('test-pass');
+    mockQuery.mockResolvedValueOnce({ messageId: 'm1', ok: true, rows: [] }).mockResolvedValueOnce({
+      messageId: 'm2',
+      ok: true,
+      rows: [{ entity_id: 'e1', project_id: 'proj-1', section_id: 's1', excerpt: 'a' }],
+    });
+    const cryptoSpy = vi
+      .spyOn(globalThis.crypto.subtle, 'encrypt')
+      .mockRejectedValueOnce(new Error('encrypt failed'));
+
+    const result = await runCodexExcerptEncryptionMigration('proj-1');
+
+    expect(result).toEqual({ migrated: 0, aborted: true });
+    expect(mockExec).not.toHaveBeenCalled();
+    cryptoSpy.mockRestore();
   });
 
   it('yields via Promise.resolve() every 10 successful migrations without dropping any rows', async () => {

--- a/tests/unit/services/duckdb/codexExcerptEncryptionMigration.test.ts
+++ b/tests/unit/services/duckdb/codexExcerptEncryptionMigration.test.ts
@@ -201,4 +201,71 @@ describe('runCodexExcerptEncryptionMigration', () => {
       ),
     ).toBe(false);
   });
+
+  it('aborts without writing the done-marker when the privacy gate flips off after the loop fully completes', async () => {
+    await initIdbEncryption('test-pass');
+    // QNBS-v3: SEC — gate is consulted before the loop, once per row, and once more after the loop
+    // finishes but before the marker INSERT. Returning true for the first two calls (pre-loop + the
+    // single row) and false on the third exercises that final post-loop check specifically.
+    let calls = 0;
+    const gate = () => {
+      calls++;
+      return calls <= 2;
+    };
+    mockQuery.mockResolvedValueOnce({ messageId: 'm1', ok: true, rows: [] }).mockResolvedValueOnce({
+      messageId: 'm2',
+      ok: true,
+      rows: [{ entity_id: 'e1', project_id: 'proj-1', section_id: 's1', excerpt: 'a' }],
+    });
+
+    const result = await runCodexExcerptEncryptionMigration('proj-1', gate);
+
+    expect(result).toEqual({ migrated: 1, aborted: true });
+    expect(
+      mockExec.mock.calls.some(([execSql]) =>
+        String(execSql).includes('codex_excerpt_encryption_v1_migrated'),
+      ),
+    ).toBe(false);
+  });
+
+  it('does not increment migrated when the row UPDATE fails, but still completes the run', async () => {
+    await initIdbEncryption('test-pass');
+    mockQuery.mockResolvedValueOnce({ messageId: 'm1', ok: true, rows: [] }).mockResolvedValueOnce({
+      messageId: 'm2',
+      ok: true,
+      rows: [{ entity_id: 'e1', project_id: 'proj-1', section_id: 's1', excerpt: 'a' }],
+    });
+    // First exec call is the row UPDATE — fail it; the later marker INSERT uses the default { ok: true }.
+    mockExec.mockResolvedValueOnce({ messageId: 'u1', ok: false, error: 'update failed' });
+
+    const result = await runCodexExcerptEncryptionMigration('proj-1');
+
+    expect(result).toEqual({ migrated: 0, aborted: false });
+    const markerCall = mockExec.mock.calls.find(([execSql]) =>
+      String(execSql).includes('codex_excerpt_encryption_v1_migrated'),
+    );
+    expect(markerCall).toBeDefined();
+  });
+
+  it('yields via Promise.resolve() every 10 successful migrations without dropping any rows', async () => {
+    await initIdbEncryption('test-pass');
+    const rowCount = 12;
+    const rows = Array.from({ length: rowCount }, (_, i) => ({
+      entity_id: `e${i}`,
+      project_id: 'proj-1',
+      section_id: 's1',
+      excerpt: `prose ${i}`,
+    }));
+    mockQuery
+      .mockResolvedValueOnce({ messageId: 'm1', ok: true, rows: [] })
+      .mockResolvedValueOnce({ messageId: 'm2', ok: true, rows });
+
+    const result = await runCodexExcerptEncryptionMigration('proj-1');
+
+    expect(result).toEqual({ migrated: rowCount, aborted: false });
+    const updateCalls = mockExec.mock.calls.filter(([sql]) =>
+      String(sql).includes('UPDATE codex_mentions'),
+    );
+    expect(updateCalls).toHaveLength(rowCount);
+  });
 });

--- a/tests/unit/services/duckdbSchema.test.ts
+++ b/tests/unit/services/duckdbSchema.test.ts
@@ -8,12 +8,13 @@ import {
   DUCK_DB_SCHEMA_VERSION,
   DUCKDB_DDL,
   DUCKDB_MIGRATION_V2_DDL,
+  DUCKDB_MIGRATION_V3_DDL,
   RAG_EMBEDDING_DIM,
 } from '../../../services/duckdb/duckdbSchema';
 
 describe('duckdbSchema constants', () => {
-  it('DUCK_DB_SCHEMA_VERSION is 2', () => {
-    expect(DUCK_DB_SCHEMA_VERSION).toBe(2);
+  it('DUCK_DB_SCHEMA_VERSION is 3', () => {
+    expect(DUCK_DB_SCHEMA_VERSION).toBe(3);
   });
 
   it('RAG_EMBEDDING_DIM is 384', () => {
@@ -42,6 +43,11 @@ describe('DUCKDB_DDL', () => {
     expect(DUCKDB_DDL).toContain('writing_sessions');
   });
 
+  it('contains codex_mentions.excerpt_enc column', () => {
+    expect(DUCKDB_DDL).toContain('codex_mentions');
+    expect(DUCKDB_DDL).toContain('excerpt_enc');
+  });
+
   it('is a non-empty string', () => {
     expect(DUCKDB_DDL.trim().length).toBeGreaterThan(100);
   });
@@ -52,5 +58,13 @@ describe('DUCKDB_MIGRATION_V2_DDL', () => {
     expect(DUCKDB_MIGRATION_V2_DDL).toContain('rag_chunks');
     expect(DUCKDB_MIGRATION_V2_DDL).toContain('embedding');
     expect(DUCKDB_MIGRATION_V2_DDL).toContain('FLOAT[]');
+  });
+});
+
+describe('DUCKDB_MIGRATION_V3_DDL', () => {
+  it('alters codex_mentions to add excerpt_enc BLOB column', () => {
+    expect(DUCKDB_MIGRATION_V3_DDL).toContain('codex_mentions');
+    expect(DUCKDB_MIGRATION_V3_DDL).toContain('excerpt_enc');
+    expect(DUCKDB_MIGRATION_V3_DDL).toContain('BLOB');
   });
 });


### PR DESCRIPTION
## Summary

Release-cut PR for v1.25.0, bundling the remaining SEC-6 security work and doc-truth cleanup that followed the Grok/Claude/Browser-Ollama provider PRs (#300, #301, #302).

- **feat(security):** `codex_mentions.excerpt` (the one DuckDB analytics column holding literal manuscript prose) is now encrypted at rest with AES-256-GCM when `enableIdbAtRestEncryption` is active, reusing the existing IDB at-rest encryption key via `duckdbEncryption.ts`. New `excerpt_enc` BLOB column (schema v3), backfill migration (`codexExcerptEncryptionMigration.ts`) for pre-existing plaintext rows, write-path gating in `duckdbCodexWrite()`. Tests exercise the real AES-256-GCM crypto path (only the DuckDB transport is mocked).
- **docs:** Fixed a stale "Plan only — do not implement yet" status header in `GROK-PROVIDER-INTEGRATION-PLAN.md` (all phases were already merged), archived the completed provider workstream from `TODO.md` to `docs/history/completed-v1.25.0-providers.md` per the existing archival convention.
- **docs(security):** Corrected the SEC-6 status rows in `.github/SECURITY.md` and `docs/SECURITY-THREAT-MODEL.md` to reflect the new cell-level encryption (and that full OPFS file-level encryption is an accepted, permanent limitation — DuckDB-WASM owns the OPFS file handle directly). Added a short note on why the Claude serverless proxy has no in-app request monitoring (would violate its stateless zero-console-call guarantee) and pointing at platform-native Vercel/Cloudflare analytics instead.
- **chore(release):** Cut `[1.25.0]` in `CHANGELOG.md`, bumped `package.json` / README badge / `AGENTS.md` to 1.25.0, synced `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, and `public/sw.js` via the existing sync scripts.

## Verification (local quick-tier, per repo's low-end-hardware policy)

- [x] `pnpm run lint` — clean
- [x] `pnpm run typecheck` — clean (`tsgo`, 4 checkers)
- [x] `pnpm run i18n:check` — clean, 2861 keys × 19 locales, no content drift
- [x] `pnpm exec tsx scripts/audit-feature-parity.ts` — 0 drifts, 23 flags consistent
- [x] `node scripts/check-doc-metrics.mjs` — clean
- [x] Targeted `vitest run` across all touched test files — all green (real-crypto assertions for the new encryption paths, no over-mocking)
- [ ] Full CI (security / quality ×2 / build / e2e / e2e-deep / storybook / lighthouse / vrt) — pending, will monitor after opening this PR

## Not included in this PR

The final `git tag v1.25.0` + `gh release create` step is intentionally **not** part of this PR — per the release plan, that hand-off requires explicit maintainer confirmation and happens only after this PR is merged with fully green CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Codex manuscript excerpts are now encrypted at rest when browser encryption is enabled.
  - Existing excerpts are migrated automatically with privacy safeguards and safe recovery if interrupted.
  - Full database-file and metadata encryption remain unsupported.

- **Documentation**
  - Updated security guidance, release records, and version information for 1.25.0.
  - Documented Grok, Claude, and opt-in browser Ollama integrations as completed for the release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->