### PR TITLE
feat(cef): real worldscript_host — build, dist/, repeated launch/close proof

### DIFF
--- a/.github/workflows/cef-learning-harness.yml
+++ b/.github/workflows/cef-learning-harness.yml
@@ -105,6 +105,9 @@ jobs:
           cmake -S "$BUILD_SRC_DIR" -B build -DCMAKE_BUILD_TYPE=Release
           cmake --build build --target worldscript_host --parallel "$(nproc)"
 
+      - name: List worldscript_host output directory (diagnostic)
+        run: ls -la build/worldscript_host/
+
       - name: Serve production bundle + repeated launch/close proof
         run: |
           python3 -m http.server 8080 --directory dist &

--- a/.github/workflows/cef-learning-harness.yml
+++ b/.github/workflows/cef-learning-harness.yml
@@ -16,6 +16,14 @@
 #
 # Advisory only: not part of the required `ci-success` aggregator. Wave 2 is still
 # in progress; this harness informs it rather than gating unrelated PRs on it.
+#
+# Trigger scope is deliberately asymmetric: `pull_request` stays path-scoped to
+# CEF-specific files, so this ~30-minute, ~300MB-download job doesn't tax every
+# unrelated content/feature PR. `push` to main has NO path filter — it runs the
+# real production bundle through worldscript_host on every merge, so a
+# CEF-rendering regression introduced by an unrelated app-source PR is still
+# caught promptly (informationally, non-blocking), not silently missed until
+# someone next happens to touch a CEF-specific path.
 # ============================================================
 
 name: 🧪 CEF Learning Harness
@@ -30,11 +38,6 @@ on:
       - '.github/workflows/cef-learning-harness.yml'
   push:
     branches: [main]
-    paths:
-      - 'apps/desktop-cef/**'
-      - 'scripts/cef/**'
-      - 'docs/cef/**'
-      - '.github/workflows/cef-learning-harness.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/cef-learning-harness.yml
+++ b/.github/workflows/cef-learning-harness.yml
@@ -5,13 +5,14 @@
 # (CEF binding choice — the Wave 2 spike this harness formalizes into a real,
 # repo-committed, CI-run check per §61.1.4's evidence-link discipline).
 #
-# Scope of this first increment: fetch + verify the pinned CEF SDK, report a
-# clean-machine Linux runtime-dependency inventory (before any apt-get — a genuinely
-# new data point vs. the spike's already-configured dev machine), and print real
-# version diagnostics parsed from the fetched SDK itself. The actual CEF host
-# build/run/shutdown proof (§4.11.3's "isolated learning harness") is deliberately
-# NOT part of this increment — see ADR-0020's Consequences for why that needs its
-# own CMake/Cargo bootstrap PR.
+# Two increments live here:
+# 1. Fetch + verify the pinned CEF SDK, report a clean-machine Linux runtime-
+#    dependency inventory (before any apt-get), and print real version diagnostics.
+# 2. Build apps/desktop-cef's worldscript_host against that SDK, serve the real
+#    production bundle (pnpm run build's dist/), and run repeated start/close
+#    cycles against it under Xvfb — the roadmap's literal "isolated learning
+#    harness" / "safe repeated startup/shutdown" / "existing dist/" deliverables,
+#    plus the FFI boundary proven from inside the real host, not just in isolation.
 #
 # Advisory only: not part of the required `ci-success` aggregator. Wave 2 is still
 # in progress; this harness informs it rather than gating unrelated PRs on it.
@@ -23,12 +24,14 @@ on:
   pull_request:
     branches: [main]
     paths:
+      - 'apps/desktop-cef/**'
       - 'scripts/cef/**'
       - 'docs/cef/**'
       - '.github/workflows/cef-learning-harness.yml'
   push:
     branches: [main]
     paths:
+      - 'apps/desktop-cef/**'
       - 'scripts/cef/**'
       - 'docs/cef/**'
       - '.github/workflows/cef-learning-harness.yml'
@@ -43,9 +46,9 @@ concurrency:
 
 jobs:
   harness:
-    name: 🧪 Fetch CEF SDK + dependency inventory + version diagnostics
+    name: 🧪 CEF host build, dependency inventory, launch-cycle proof
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:
@@ -76,11 +79,44 @@ jobs:
       - name: Print CEF version diagnostics
         run: node scripts/cef/print-cef-version-diagnostics.mjs "$CEF_DIR"
 
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+
+      - name: Install worldscript_host build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake build-essential libx11-dev xvfb
+
+      - uses: ./.github/actions/setup
+
+      - name: Build WorldScript Studio production bundle
+        run: pnpm run build
+        env:
+          NODE_ENV: production
+
+      - name: Configure + build worldscript_host
+        run: |
+          set -o pipefail
+          BUILD_SRC_DIR=$(node scripts/cef/prepare-cef-build.mjs "$CEF_DIR" build | tail -1)
+          cmake -S "$BUILD_SRC_DIR" -B build -DCMAKE_BUILD_TYPE=Release
+          cmake --build build --target worldscript_host --parallel "$(nproc)"
+
+      - name: Serve production bundle + repeated launch/close proof
+        run: |
+          python3 -m http.server 8080 --directory dist &
+          SERVER_PID=$!
+          sleep 1
+          xvfb-run -a node scripts/cef/run-launch-cycle-proof.mjs \
+            "$(pwd)/build/worldscript_host/worldscript_host" \
+            "http://localhost:8080/" --cycles 3
+          kill "$SERVER_PID"
+
       - name: Summary
         run: |
           echo "## 🧪 CEF Learning Harness" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "- Pinned SDK: \`$(node -e "console.log(require('./scripts/cef/cef-version.json').cefVersion)")\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Cache hit: \`${{ steps.cef-cache.outputs.cache-hit }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Scope: fetch/verify + clean-machine dependency inventory + version diagnostics only." >> "$GITHUB_STEP_SUMMARY"
-          echo "- Not yet in scope: CEF host build/run/shutdown proof (see ADR-0020 Consequences)." >> "$GITHUB_STEP_SUMMARY"
+          echo "- worldscript_host built and repeated launch/close cycles proven against the real production bundle (dist/), under Xvfb." >> "$GITHUB_STEP_SUMMARY"
+          echo "- Not yet in scope: X11/Wayland matrix beyond this one runner, sandbox posture, accessibility smoke, crash-reporting proof." >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,9 +278,11 @@ On any non-trivial code change add a single-line comment explaining **why**, not
 | TS / JS | `// QNBS-v3: <reason / impact>` |
 | TSX / JSX | `// QNBS-v3: …` above the changed line; `{/* QNBS-v3: … */}` only when needed inside JSX |
 | CSS | `/* QNBS-v3: … */` |
-| Pure config (JSON, YAML) | No inline comment — explain in the commit message |
+| C++ / Rust (`apps/desktop-cef/`) | `// QNBS-v3: <reason / impact>` |
+| CMake (`CMakeLists.txt`) | `# QNBS-v3: <reason / impact>` |
+| Pure config (JSON, YAML, TOML — e.g. `package.json`, workflow `.yml`, `Cargo.toml`) | No inline comment — explain in the commit message |
 
-**Hard rule — one physical line, never wrapped:** a `// QNBS-v3: …` comment MUST fit on a single line, however long. Never split it across two `//` lines (`// QNBS-v3: foo\n// bar`) — CodeRabbit flags this as a nitpick on every PR that does it. If the reason doesn't fit on one line, shorten it; don't wrap it.
+**Hard rule — one physical line, never wrapped, in every syntax above:** a `QNBS-v3: …` comment MUST fit on a single physical line, however long, regardless of which comment syntax (`//`, `#`, `/* */`) the language uses. Never split it across two lines (`// QNBS-v3: foo\n// bar`) — CodeRabbit and Qodo both flag this as a nitpick on every PR that does it, and it has recurred across TS/JS, YAML, and C++ files in this repo's history. If the reason doesn't fit on one line, shorten it; don't wrap it. This applies the first time a new language/file type is touched too — don't wait for a review bot to point out that the language wasn't in the table yet before applying the same one-line discipline.
 
 Skip for pure formatting, lockfile updates, or generated artefacts.
 

--- a/apps/desktop-cef/CMakeLists.txt
+++ b/apps/desktop-cef/CMakeLists.txt
@@ -25,6 +25,8 @@ corrosion_import_crate(MANIFEST_PATH "${CMAKE_CURRENT_SOURCE_DIR}/rust-core/Carg
 
 set(WORLDSCRIPT_HOST_SRCS
   src/main.cpp
+  src/shutdown_signal.h
+  src/shutdown_signal.cpp
   src/worldscript_app.h
   src/worldscript_app.cpp
   src/worldscript_handler.h

--- a/apps/desktop-cef/CMakeLists.txt
+++ b/apps/desktop-cef/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Wave 2 CEF host (ADR-0020, Option B: thin C++ host + Rust core).
+# QNBS-v3: subdirectory CMakeLists.txt reusing CEF's own proven CMake macros rather than reinventing its platform bootstrap (ADR-0020, Option B).
 #
 # This file is a SUBDIRECTORY CMakeLists.txt, added via add_subdirectory() from
 # a *copy* of CEF's own root CMakeLists.txt at build time (see
@@ -12,6 +12,7 @@
 # macros already being defined by that parent scope by the time this runs — exactly
 # what CEF's own bundled sample targets (cefsimple, cefclient) rely on too.
 
+# QNBS-v3: fetched via CMake FetchContent (small, MIT-licensed CMake module, not a binary) rather than vendored — replaces the ADR-0020 spike's hardcoded .a path with real Cargo<->CMake integration.
 include(FetchContent)
 FetchContent_Declare(
   Corrosion

--- a/apps/desktop-cef/CMakeLists.txt
+++ b/apps/desktop-cef/CMakeLists.txt
@@ -1,0 +1,56 @@
+# Wave 2 CEF host (ADR-0020, Option B: thin C++ host + Rust core).
+#
+# This file is a SUBDIRECTORY CMakeLists.txt, added via add_subdirectory() from
+# a *copy* of CEF's own root CMakeLists.txt at build time (see
+# .github/workflows/cef-learning-harness.yml and scripts/cef/prepare-cef-build.mjs)
+# — never invoked directly with `cmake -S apps/desktop-cef`. This mirrors the
+# ADR-0020 spike's proven mechanism exactly, rather than reinventing CEF's own
+# platform bootstrap (compiler/linker flags, OS_LINUX detection, PROJECT_ARCH)
+# from scratch: it relies on CEF_STANDARD_LIBS, CEF_LIB_DEBUG/CEF_LIB_RELEASE,
+# CEF_BINARY_FILES, CEF_RESOURCE_FILES, CEF_BINARY_DIR, CEF_RESOURCE_DIR, and the
+# ADD_LOGICAL_TARGET/COPY_FILES/SET_EXECUTABLE_TARGET_PROPERTIES/FIND_LINUX_LIBRARIES
+# macros already being defined by that parent scope by the time this runs — exactly
+# what CEF's own bundled sample targets (cefsimple, cefclient) rely on too.
+
+include(FetchContent)
+FetchContent_Declare(
+  Corrosion
+  GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
+  GIT_TAG v0.5.1
+)
+FetchContent_MakeAvailable(Corrosion)
+
+corrosion_import_crate(MANIFEST_PATH "${CMAKE_CURRENT_SOURCE_DIR}/rust-core/Cargo.toml")
+
+set(WORLDSCRIPT_HOST_SRCS
+  src/main.cpp
+  src/worldscript_app.h
+  src/worldscript_app.cpp
+  src/worldscript_handler.h
+  src/worldscript_handler.cpp
+)
+
+add_executable(worldscript_host ${WORLDSCRIPT_HOST_SRCS})
+add_dependencies(worldscript_host libcef_dll_wrapper)
+
+ADD_LOGICAL_TARGET("libcef_lib" "${CEF_LIB_DEBUG}" "${CEF_LIB_RELEASE}")
+
+target_link_libraries(worldscript_host
+  libcef_lib
+  libcef_dll_wrapper
+  worldscript_rust_core
+  ${CEF_STANDARD_LIBS}
+)
+
+set_target_properties(worldscript_host PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+)
+
+SET_EXECUTABLE_TARGET_PROPERTIES(worldscript_host)
+
+COPY_FILES("worldscript_host" "${CEF_BINARY_FILES}" "${CEF_BINARY_DIR}" "${CMAKE_CURRENT_BINARY_DIR}")
+COPY_FILES("worldscript_host" "${CEF_RESOURCE_FILES}" "${CEF_RESOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}")
+
+if(OS_LINUX)
+  FIND_LINUX_LIBRARIES("x11")
+endif()

--- a/apps/desktop-cef/rust-core/Cargo.toml
+++ b/apps/desktop-cef/rust-core/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "worldscript_rust_core"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["staticlib"]
+
+[profile.release]
+panic = "abort"

--- a/apps/desktop-cef/rust-core/src/lib.rs
+++ b/apps/desktop-cef/rust-core/src/lib.rs
@@ -1,0 +1,13 @@
+//! Minimal FFI boundary proof for the Wave 2 CEF host (ADR-0020, Option B).
+//!
+//! Rule from the roadmap (§10): C++ owns CEF integration only; Rust owns WorldScript's
+//! actual logic. This crate is not yet real business logic — it proves the boundary a
+//! future migration will build on, called from a real CEF callback (see
+//! `apps/desktop-cef/src/worldscript_handler.cpp`), not just a decoupled test binary.
+
+#[no_mangle]
+pub extern "C" fn worldscript_rust_ping() -> i32 {
+    // Arbitrary non-trivial sentinel so a stub or miscompiled stand-in can't accidentally
+    // match by coincidence (e.g. a default-zeroed return would read as success).
+    424242
+}

--- a/apps/desktop-cef/rust-core/src/lib.rs
+++ b/apps/desktop-cef/rust-core/src/lib.rs
@@ -7,7 +7,6 @@
 
 #[no_mangle]
 pub extern "C" fn worldscript_rust_ping() -> i32 {
-    // Arbitrary non-trivial sentinel so a stub or miscompiled stand-in can't accidentally
-    // match by coincidence (e.g. a default-zeroed return would read as success).
+    // QNBS-v3: non-trivial sentinel so a stub/miscompiled stand-in can't accidentally match by coincidence (e.g. a default-zeroed return reading as success).
     424242
 }

--- a/apps/desktop-cef/src/main.cpp
+++ b/apps/desktop-cef/src/main.cpp
@@ -3,6 +3,7 @@
 
 #include "include/cef_app.h"
 
+#include "shutdown_signal.h"
 #include "worldscript_app.h"
 
 namespace {
@@ -31,6 +32,9 @@ int main(int argc, char* argv[]) {
   if (exit_code >= 0) {
     return exit_code;
   }
+
+  // QNBS-v3: installed only in the real browser process (past the subprocess check above) — CodeRabbit review finding on PR #388: a raw, unhandled SIGTERM bypassed OnBeforeClose/CefQuitMessageLoop/CefShutdown entirely.
+  InstallShutdownSignalHandlers();
 
   CefSettings settings;
   settings.no_sandbox = true;  // ADR-0020: sandbox posture deliberately deferred (roadmap §12).

--- a/apps/desktop-cef/src/main.cpp
+++ b/apps/desktop-cef/src/main.cpp
@@ -1,0 +1,46 @@
+#include <string>
+
+#include "include/cef_app.h"
+
+#include "worldscript_app.h"
+
+namespace {
+
+// Defaults to about:blank so a bare invocation (e.g. a subprocess re-exec) never
+// depends on --url being present; the real harness always passes it explicitly.
+std::string ParseStartUrl(int argc, char* argv[]) {
+  const std::string prefix = "--url=";
+  for (int i = 1; i < argc; ++i) {
+    const std::string arg = argv[i];
+    if (arg.rfind(prefix, 0) == 0) {
+      return arg.substr(prefix.size());
+    }
+  }
+  return "about:blank";
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) {
+  CefMainArgs main_args(argc, argv);
+
+  CefRefPtr<WorldScriptApp> app(new WorldScriptApp(ParseStartUrl(argc, argv)));
+
+  // Every CEF host re-executes itself for renderer/GPU/utility subprocesses; this
+  // must run before CefInitialize (ADR-0020's documented multi-process architecture
+  // note). A non-negative return means this invocation *was* one of those
+  // subprocesses, already run to completion.
+  int exit_code = CefExecuteProcess(main_args, app.get(), nullptr);
+  if (exit_code >= 0) {
+    return exit_code;
+  }
+
+  CefSettings settings;
+  settings.no_sandbox = true;  // ADR-0020: sandbox posture deliberately deferred (roadmap §12).
+
+  CefInitialize(main_args, settings, app.get(), nullptr);
+  CefRunMessageLoop();
+  CefShutdown();
+
+  return 0;
+}

--- a/apps/desktop-cef/src/main.cpp
+++ b/apps/desktop-cef/src/main.cpp
@@ -1,3 +1,4 @@
+#include <cstdio>
 #include <string>
 
 #include "include/cef_app.h"
@@ -6,8 +7,7 @@
 
 namespace {
 
-// Defaults to about:blank so a bare invocation (e.g. a subprocess re-exec) never
-// depends on --url being present; the real harness always passes it explicitly.
+// QNBS-v3: defaults to about:blank so a bare invocation (e.g. a subprocess re-exec) never depends on --url being present.
 std::string ParseStartUrl(int argc, char* argv[]) {
   const std::string prefix = "--url=";
   for (int i = 1; i < argc; ++i) {
@@ -26,10 +26,7 @@ int main(int argc, char* argv[]) {
 
   CefRefPtr<WorldScriptApp> app(new WorldScriptApp(ParseStartUrl(argc, argv)));
 
-  // Every CEF host re-executes itself for renderer/GPU/utility subprocesses; this
-  // must run before CefInitialize (ADR-0020's documented multi-process architecture
-  // note). A non-negative return means this invocation *was* one of those
-  // subprocesses, already run to completion.
+  // QNBS-v3: every CEF host re-executes itself for renderer/GPU/utility subprocesses — must run before CefInitialize; non-negative return means this invocation *was* one of those, already run to completion.
   int exit_code = CefExecuteProcess(main_args, app.get(), nullptr);
   if (exit_code >= 0) {
     return exit_code;
@@ -38,7 +35,12 @@ int main(int argc, char* argv[]) {
   CefSettings settings;
   settings.no_sandbox = true;  // ADR-0020: sandbox posture deliberately deferred (roadmap §12).
 
-  CefInitialize(main_args, settings, app.get(), nullptr);
+  // QNBS-v3: CefInitialize's return value was previously ignored, masking init failure (missing display/resources) as a normal exit — CodeAnt review finding on PR #388.
+  if (!CefInitialize(main_args, settings, app.get(), nullptr)) {
+    fprintf(stderr, "[worldscript_host] CefInitialize failed\n");
+    return 1;
+  }
+
   CefRunMessageLoop();
   CefShutdown();
 

--- a/apps/desktop-cef/src/shutdown_signal.cpp
+++ b/apps/desktop-cef/src/shutdown_signal.cpp
@@ -1,0 +1,24 @@
+#include "shutdown_signal.h"
+
+// QNBS-v3: sigaction/sigemptyset are POSIX, not standard C++ — <csignal> alone doesn't guarantee them; this file is Linux-only per the app's own OS_LINUX scoping.
+#include <signal.h>
+
+volatile std::sig_atomic_t g_worldscript_shutdown_requested = 0;
+
+namespace {
+
+void HandleShutdownSignal(int /*signum*/) {
+  g_worldscript_shutdown_requested = 1;
+}
+
+}  // namespace
+
+void InstallShutdownSignalHandlers() {
+  struct sigaction action = {};
+  action.sa_handler = HandleShutdownSignal;
+  sigemptyset(&action.sa_mask);
+  action.sa_flags = 0;
+  // QNBS-v3: SIGINT alongside SIGTERM — a dev running the host interactively expects Ctrl+C to trigger the same graceful path, not the OS default abrupt kill.
+  sigaction(SIGTERM, &action, nullptr);
+  sigaction(SIGINT, &action, nullptr);
+}

--- a/apps/desktop-cef/src/shutdown_signal.h
+++ b/apps/desktop-cef/src/shutdown_signal.h
@@ -1,0 +1,11 @@
+#ifndef WORLDSCRIPT_DESKTOP_CEF_SHUTDOWN_SIGNAL_H_
+#define WORLDSCRIPT_DESKTOP_CEF_SHUTDOWN_SIGNAL_H_
+
+#include <csignal>
+
+// QNBS-v3: CEF APIs are not async-signal-safe (CodeRabbit review finding on PR #388) — the signal handler only sets this flag; the actual CloseBrowser/CefQuitMessageLoop/CefShutdown sequence runs from a normal UI-thread task that polls it.
+extern volatile std::sig_atomic_t g_worldscript_shutdown_requested;
+
+void InstallShutdownSignalHandlers();
+
+#endif  // WORLDSCRIPT_DESKTOP_CEF_SHUTDOWN_SIGNAL_H_

--- a/apps/desktop-cef/src/worldscript_app.cpp
+++ b/apps/desktop-cef/src/worldscript_app.cpp
@@ -11,7 +11,7 @@
 
 namespace {
 
-// QNBS-v3: window-close policy only (cefsimple convention) — CanClose triggers the real browser close as a side effect, then always returns true rather than re-deriving the answer.
+// QNBS-v3: window-close policy only (cefsimple convention) — CanClose returns TryCloseBrowser's own result, not an unconditional true.
 class WorldScriptWindowDelegate : public CefWindowDelegate {
  public:
   explicit WorldScriptWindowDelegate(CefRefPtr<CefBrowserView> browser_view)
@@ -26,9 +26,10 @@ class WorldScriptWindowDelegate : public CefWindowDelegate {
   void OnWindowDestroyed(CefRefPtr<CefWindow> window) override { browser_view_ = nullptr; }
 
   bool CanClose(CefRefPtr<CefWindow> window) override {
+    // QNBS-v3: TryCloseBrowser (not CloseBrowser(false) + unconditional true) — an unconditional true let the window close before CEF's own unload-handler sequence finished, matching cefsimple's real pattern (CodeRabbit review finding on PR #388).
     CefRefPtr<CefBrowser> browser = browser_view_ ? browser_view_->GetBrowser() : nullptr;
     if (browser) {
-      browser->GetHost()->CloseBrowser(false);
+      return browser->GetHost()->TryCloseBrowser();
     }
     return true;
   }

--- a/apps/desktop-cef/src/worldscript_app.cpp
+++ b/apps/desktop-cef/src/worldscript_app.cpp
@@ -11,9 +11,7 @@
 
 namespace {
 
-// Window-close policy only (cefsimple convention): request the browser close,
-// then always allow the window itself to close — CanClose is not a place to
-// re-derive that answer, it just triggers the real close and lets it proceed.
+// QNBS-v3: window-close policy only (cefsimple convention) — CanClose triggers the real browser close as a side effect, then always returns true rather than re-deriving the answer.
 class WorldScriptWindowDelegate : public CefWindowDelegate {
  public:
   explicit WorldScriptWindowDelegate(CefRefPtr<CefBrowserView> browser_view)

--- a/apps/desktop-cef/src/worldscript_app.cpp
+++ b/apps/desktop-cef/src/worldscript_app.cpp
@@ -1,0 +1,71 @@
+#include "worldscript_app.h"
+
+#include <utility>
+
+#include "include/cef_browser.h"
+#include "include/views/cef_browser_view.h"
+#include "include/views/cef_window.h"
+#include "include/wrapper/cef_helpers.h"
+
+#include "worldscript_handler.h"
+
+namespace {
+
+// Window-close policy only (cefsimple convention): request the browser close,
+// then always allow the window itself to close — CanClose is not a place to
+// re-derive that answer, it just triggers the real close and lets it proceed.
+class WorldScriptWindowDelegate : public CefWindowDelegate {
+ public:
+  explicit WorldScriptWindowDelegate(CefRefPtr<CefBrowserView> browser_view)
+      : browser_view_(browser_view) {}
+
+  void OnWindowCreated(CefRefPtr<CefWindow> window) override {
+    window->AddChildView(browser_view_);
+    window->Show();
+    browser_view_->RequestFocus();
+  }
+
+  void OnWindowDestroyed(CefRefPtr<CefWindow> window) override { browser_view_ = nullptr; }
+
+  bool CanClose(CefRefPtr<CefWindow> window) override {
+    CefRefPtr<CefBrowser> browser = browser_view_ ? browser_view_->GetBrowser() : nullptr;
+    if (browser) {
+      browser->GetHost()->CloseBrowser(false);
+    }
+    return true;
+  }
+
+  CefSize GetPreferredSize(CefRefPtr<CefView> view) override { return CefSize(1024, 768); }
+
+ private:
+  CefRefPtr<CefBrowserView> browser_view_;
+
+  IMPLEMENT_REFCOUNTING(WorldScriptWindowDelegate);
+  DISALLOW_COPY_AND_ASSIGN(WorldScriptWindowDelegate);
+};
+
+class WorldScriptBrowserViewDelegate : public CefBrowserViewDelegate {
+ public:
+  WorldScriptBrowserViewDelegate() = default;
+
+ private:
+  IMPLEMENT_REFCOUNTING(WorldScriptBrowserViewDelegate);
+  DISALLOW_COPY_AND_ASSIGN(WorldScriptBrowserViewDelegate);
+};
+
+}  // namespace
+
+WorldScriptApp::WorldScriptApp(std::string start_url) : start_url_(std::move(start_url)) {}
+
+void WorldScriptApp::OnContextInitialized() {
+  CEF_REQUIRE_UI_THREAD();
+
+  CefRefPtr<WorldScriptHandler> handler(new WorldScriptHandler());
+  CefBrowserSettings browser_settings;
+
+  CefRefPtr<CefBrowserViewDelegate> browser_view_delegate = new WorldScriptBrowserViewDelegate();
+  CefRefPtr<CefBrowserView> browser_view = CefBrowserView::CreateBrowserView(
+      handler, start_url_, browser_settings, nullptr, nullptr, browser_view_delegate);
+
+  CefWindow::CreateTopLevelWindow(new WorldScriptWindowDelegate(browser_view));
+}

--- a/apps/desktop-cef/src/worldscript_app.h
+++ b/apps/desktop-cef/src/worldscript_app.h
@@ -5,10 +5,7 @@
 
 #include "include/cef_app.h"
 
-// WorldScriptApp: bootstraps a single top-level window via CEF's Views framework
-// (cross-platform window toolkit — avoids raw X11/GTK window code, matching the
-// modern cefsimple convention). C++ owns CEF integration only (ADR-0020); no
-// WorldScript business logic belongs here.
+// QNBS-v3: bootstraps a single top-level window via CEF's Views framework (avoids raw X11/GTK code, matching cefsimple) — C++ owns CEF integration only (ADR-0020), no WorldScript logic here.
 class WorldScriptApp : public CefApp, public CefBrowserProcessHandler {
  public:
   explicit WorldScriptApp(std::string start_url);

--- a/apps/desktop-cef/src/worldscript_app.h
+++ b/apps/desktop-cef/src/worldscript_app.h
@@ -1,0 +1,27 @@
+#ifndef WORLDSCRIPT_DESKTOP_CEF_WORLDSCRIPT_APP_H_
+#define WORLDSCRIPT_DESKTOP_CEF_WORLDSCRIPT_APP_H_
+
+#include <string>
+
+#include "include/cef_app.h"
+
+// WorldScriptApp: bootstraps a single top-level window via CEF's Views framework
+// (cross-platform window toolkit — avoids raw X11/GTK window code, matching the
+// modern cefsimple convention). C++ owns CEF integration only (ADR-0020); no
+// WorldScript business logic belongs here.
+class WorldScriptApp : public CefApp, public CefBrowserProcessHandler {
+ public:
+  explicit WorldScriptApp(std::string start_url);
+
+  CefRefPtr<CefBrowserProcessHandler> GetBrowserProcessHandler() override { return this; }
+
+  void OnContextInitialized() override;
+
+ private:
+  std::string start_url_;
+
+  IMPLEMENT_REFCOUNTING(WorldScriptApp);
+  DISALLOW_COPY_AND_ASSIGN(WorldScriptApp);
+};
+
+#endif  // WORLDSCRIPT_DESKTOP_CEF_WORLDSCRIPT_APP_H_

--- a/apps/desktop-cef/src/worldscript_handler.cpp
+++ b/apps/desktop-cef/src/worldscript_handler.cpp
@@ -5,30 +5,29 @@
 #include "include/cef_app.h"
 #include "include/wrapper/cef_helpers.h"
 
-// Declared, not defined, here — implemented in rust-core and linked in by
-// CMake (Corrosion). This is the whole FFI boundary ADR-0020 proves: C++ never
-// implements WorldScript logic itself, only calls into Rust for it.
+// QNBS-v3: declared not defined — implemented in rust-core, linked in by Corrosion; this is the whole FFI boundary ADR-0020 proves (C++ never implements WorldScript logic itself).
 extern "C" int worldscript_rust_ping();
 
 WorldScriptHandler::WorldScriptHandler() = default;
 
 void WorldScriptHandler::OnTitleChange(CefRefPtr<CefBrowser> browser, const CefString& title) {
   CEF_REQUIRE_UI_THREAD();
-  // ADR-0020's proof point, exercised from inside a real CEF callback (not a
-  // decoupled test binary) — CI greps this exact line for FFI-boundary evidence.
-  printf("[worldscript_host] rust_core ping = %d\n", worldscript_rust_ping());
+  // QNBS-v3: reports the actual title text (not just "a title fired") so the harness can require the specific "WorldScript Studio" title — a CEF error page would not produce it — CodeRabbit/Qodo review finding on PR #388.
+  printf("[worldscript_host] title = %s\n", title.ToString().c_str());
   fflush(stdout);
 }
 
 void WorldScriptHandler::OnAfterCreated(CefRefPtr<CefBrowser> browser) {
   CEF_REQUIRE_UI_THREAD();
   browser_list_.push_back(browser);
+  // QNBS-v3: moved here from OnTitleChange (Qodo review finding on PR #388) — this fires deterministically once per browser regardless of page content, so the FFI-boundary proof no longer depends on the loaded page setting/changing a title.
+  printf("[worldscript_host] rust_core ping = %d\n", worldscript_rust_ping());
+  fflush(stdout);
 }
 
 bool WorldScriptHandler::DoClose(CefRefPtr<CefBrowser> browser) {
   CEF_REQUIRE_UI_THREAD();
-  // No save-coordinator/state to flush yet — that protocol step is Wave 5+ scope
-  // (docs/cef/knowledge/subprocess-and-shutdown.md). Allow the close to proceed.
+  // QNBS-v3: no save-coordinator/state to flush yet (Wave 5+ scope, docs/cef/knowledge/subprocess-and-shutdown.md) — allow the close to proceed.
   return false;
 }
 
@@ -41,8 +40,7 @@ void WorldScriptHandler::OnBeforeClose(CefRefPtr<CefBrowser> browser) {
     }
   }
   if (browser_list_.empty()) {
-    // The literal mechanism the Wave 2 spike proved (ADR-0020): this is what
-    // makes CefRunMessageLoop() in main() return, the signal to call CefShutdown().
+    // QNBS-v3: the literal mechanism the Wave 2 spike proved (ADR-0020) — makes CefRunMessageLoop() in main() return, the signal to call CefShutdown().
     CefQuitMessageLoop();
   }
 }

--- a/apps/desktop-cef/src/worldscript_handler.cpp
+++ b/apps/desktop-cef/src/worldscript_handler.cpp
@@ -31,7 +31,8 @@ void WorldScriptHandler::OnAfterCreated(CefRefPtr<CefBrowser> browser) {
   printf("[worldscript_host] rust_core ping = %d\n", worldscript_rust_ping());
   fflush(stdout);
 
-  CefPostDelayedTask(TID_UI, base::BindOnce(&WorldScriptHandler::PollShutdownFlag, this),
+  CefPostDelayedTask(TID_UI,
+                     base::BindOnce(&WorldScriptHandler::PollShutdownFlag, base::Unretained(this)),
                      kShutdownPollIntervalMs);
 }
 
@@ -45,7 +46,8 @@ void WorldScriptHandler::PollShutdownFlag() {
     return;  // Closing now — no need to keep polling.
   }
   if (!browser_list_.empty()) {
-    CefPostDelayedTask(TID_UI, base::BindOnce(&WorldScriptHandler::PollShutdownFlag, this),
+    CefPostDelayedTask(TID_UI,
+                       base::BindOnce(&WorldScriptHandler::PollShutdownFlag, base::Unretained(this)),
                        kShutdownPollIntervalMs);
   }
 }

--- a/apps/desktop-cef/src/worldscript_handler.cpp
+++ b/apps/desktop-cef/src/worldscript_handler.cpp
@@ -3,7 +3,7 @@
 #include <cstdio>
 
 #include "include/cef_app.h"
-#include "include/wrapper/cef_closure_task.h"
+#include "include/cef_task.h"
 #include "include/wrapper/cef_helpers.h"
 
 #include "shutdown_signal.h"
@@ -12,7 +12,22 @@
 extern "C" int worldscript_rust_ping();
 
 namespace {
+
 constexpr int kShutdownPollIntervalMs = 100;
+
+// QNBS-v3: plain CefTask subclass instead of base::BindOnce — CEF's own ref-counting scheme hit real base::Bind template/header issues (caught by CI, not locally); this is simpler and avoids that machinery entirely.
+class PollShutdownTask : public CefTask {
+ public:
+  explicit PollShutdownTask(CefRefPtr<WorldScriptHandler> handler) : handler_(handler) {}
+  void Execute() override { handler_->PollShutdownFlag(); }
+
+ private:
+  CefRefPtr<WorldScriptHandler> handler_;
+
+  IMPLEMENT_REFCOUNTING(PollShutdownTask);
+  DISALLOW_COPY_AND_ASSIGN(PollShutdownTask);
+};
+
 }  // namespace
 
 WorldScriptHandler::WorldScriptHandler() = default;
@@ -31,9 +46,7 @@ void WorldScriptHandler::OnAfterCreated(CefRefPtr<CefBrowser> browser) {
   printf("[worldscript_host] rust_core ping = %d\n", worldscript_rust_ping());
   fflush(stdout);
 
-  CefPostDelayedTask(TID_UI,
-                     base::BindOnce(&WorldScriptHandler::PollShutdownFlag, base::Unretained(this)),
-                     kShutdownPollIntervalMs);
+  CefPostDelayedTask(TID_UI, new PollShutdownTask(this), kShutdownPollIntervalMs);
 }
 
 void WorldScriptHandler::PollShutdownFlag() {
@@ -46,9 +59,7 @@ void WorldScriptHandler::PollShutdownFlag() {
     return;  // Closing now — no need to keep polling.
   }
   if (!browser_list_.empty()) {
-    CefPostDelayedTask(TID_UI,
-                       base::BindOnce(&WorldScriptHandler::PollShutdownFlag, base::Unretained(this)),
-                       kShutdownPollIntervalMs);
+    CefPostDelayedTask(TID_UI, new PollShutdownTask(this), kShutdownPollIntervalMs);
   }
 }
 

--- a/apps/desktop-cef/src/worldscript_handler.cpp
+++ b/apps/desktop-cef/src/worldscript_handler.cpp
@@ -1,0 +1,48 @@
+#include "worldscript_handler.h"
+
+#include <cstdio>
+
+#include "include/cef_app.h"
+#include "include/wrapper/cef_helpers.h"
+
+// Declared, not defined, here — implemented in rust-core and linked in by
+// CMake (Corrosion). This is the whole FFI boundary ADR-0020 proves: C++ never
+// implements WorldScript logic itself, only calls into Rust for it.
+extern "C" int worldscript_rust_ping();
+
+WorldScriptHandler::WorldScriptHandler() = default;
+
+void WorldScriptHandler::OnTitleChange(CefRefPtr<CefBrowser> browser, const CefString& title) {
+  CEF_REQUIRE_UI_THREAD();
+  // ADR-0020's proof point, exercised from inside a real CEF callback (not a
+  // decoupled test binary) — CI greps this exact line for FFI-boundary evidence.
+  printf("[worldscript_host] rust_core ping = %d\n", worldscript_rust_ping());
+  fflush(stdout);
+}
+
+void WorldScriptHandler::OnAfterCreated(CefRefPtr<CefBrowser> browser) {
+  CEF_REQUIRE_UI_THREAD();
+  browser_list_.push_back(browser);
+}
+
+bool WorldScriptHandler::DoClose(CefRefPtr<CefBrowser> browser) {
+  CEF_REQUIRE_UI_THREAD();
+  // No save-coordinator/state to flush yet — that protocol step is Wave 5+ scope
+  // (docs/cef/knowledge/subprocess-and-shutdown.md). Allow the close to proceed.
+  return false;
+}
+
+void WorldScriptHandler::OnBeforeClose(CefRefPtr<CefBrowser> browser) {
+  CEF_REQUIRE_UI_THREAD();
+  for (auto it = browser_list_.begin(); it != browser_list_.end(); ++it) {
+    if ((*it)->IsSame(browser)) {
+      browser_list_.erase(it);
+      break;
+    }
+  }
+  if (browser_list_.empty()) {
+    // The literal mechanism the Wave 2 spike proved (ADR-0020): this is what
+    // makes CefRunMessageLoop() in main() return, the signal to call CefShutdown().
+    CefQuitMessageLoop();
+  }
+}

--- a/apps/desktop-cef/src/worldscript_handler.cpp
+++ b/apps/desktop-cef/src/worldscript_handler.cpp
@@ -3,10 +3,17 @@
 #include <cstdio>
 
 #include "include/cef_app.h"
+#include "include/wrapper/cef_closure_task.h"
 #include "include/wrapper/cef_helpers.h"
+
+#include "shutdown_signal.h"
 
 // QNBS-v3: declared not defined — implemented in rust-core, linked in by Corrosion; this is the whole FFI boundary ADR-0020 proves (C++ never implements WorldScript logic itself).
 extern "C" int worldscript_rust_ping();
+
+namespace {
+constexpr int kShutdownPollIntervalMs = 100;
+}  // namespace
 
 WorldScriptHandler::WorldScriptHandler() = default;
 
@@ -23,6 +30,24 @@ void WorldScriptHandler::OnAfterCreated(CefRefPtr<CefBrowser> browser) {
   // QNBS-v3: moved here from OnTitleChange (Qodo review finding on PR #388) — this fires deterministically once per browser regardless of page content, so the FFI-boundary proof no longer depends on the loaded page setting/changing a title.
   printf("[worldscript_host] rust_core ping = %d\n", worldscript_rust_ping());
   fflush(stdout);
+
+  CefPostDelayedTask(TID_UI, base::BindOnce(&WorldScriptHandler::PollShutdownFlag, this),
+                     kShutdownPollIntervalMs);
+}
+
+void WorldScriptHandler::PollShutdownFlag() {
+  CEF_REQUIRE_UI_THREAD();
+  if (g_worldscript_shutdown_requested) {
+    // QNBS-v3: TryCloseBrowser (not CloseBrowser(false) directly) — it respects unload handlers and re-signals CanClose once ready, matching cefsimple's real close protocol (CodeRabbit review finding on PR #388).
+    for (const auto& browser : browser_list_) {
+      browser->GetHost()->TryCloseBrowser();
+    }
+    return;  // Closing now — no need to keep polling.
+  }
+  if (!browser_list_.empty()) {
+    CefPostDelayedTask(TID_UI, base::BindOnce(&WorldScriptHandler::PollShutdownFlag, this),
+                       kShutdownPollIntervalMs);
+  }
 }
 
 bool WorldScriptHandler::DoClose(CefRefPtr<CefBrowser> browser) {

--- a/apps/desktop-cef/src/worldscript_handler.h
+++ b/apps/desktop-cef/src/worldscript_handler.h
@@ -1,0 +1,33 @@
+#ifndef WORLDSCRIPT_DESKTOP_CEF_WORLDSCRIPT_HANDLER_H_
+#define WORLDSCRIPT_DESKTOP_CEF_WORLDSCRIPT_HANDLER_H_
+
+#include <list>
+
+#include "include/cef_client.h"
+
+// WorldScriptHandler: browser-process lifecycle/display callbacks only (ADR-0020
+// scorecard — "browser-process handlers exercised"; renderer-process-specific
+// handlers like CefRenderProcessHandler are explicitly out of scope for this proof).
+class WorldScriptHandler : public CefClient,
+                            public CefLifeSpanHandler,
+                            public CefDisplayHandler {
+ public:
+  WorldScriptHandler();
+
+  CefRefPtr<CefLifeSpanHandler> GetLifeSpanHandler() override { return this; }
+  CefRefPtr<CefDisplayHandler> GetDisplayHandler() override { return this; }
+
+  void OnTitleChange(CefRefPtr<CefBrowser> browser, const CefString& title) override;
+
+  void OnAfterCreated(CefRefPtr<CefBrowser> browser) override;
+  bool DoClose(CefRefPtr<CefBrowser> browser) override;
+  void OnBeforeClose(CefRefPtr<CefBrowser> browser) override;
+
+ private:
+  std::list<CefRefPtr<CefBrowser>> browser_list_;
+
+  IMPLEMENT_REFCOUNTING(WorldScriptHandler);
+  DISALLOW_COPY_AND_ASSIGN(WorldScriptHandler);
+};
+
+#endif  // WORLDSCRIPT_DESKTOP_CEF_WORLDSCRIPT_HANDLER_H_

--- a/apps/desktop-cef/src/worldscript_handler.h
+++ b/apps/desktop-cef/src/worldscript_handler.h
@@ -22,6 +22,9 @@ class WorldScriptHandler : public CefClient,
   void OnBeforeClose(CefRefPtr<CefBrowser> browser) override;
 
  private:
+  // QNBS-v3: polls g_worldscript_shutdown_requested from the UI thread (never from the signal handler itself) and, when set, requests a graceful close on every tracked browser via TryCloseBrowser.
+  void PollShutdownFlag();
+
   std::list<CefRefPtr<CefBrowser>> browser_list_;
 
   IMPLEMENT_REFCOUNTING(WorldScriptHandler);

--- a/apps/desktop-cef/src/worldscript_handler.h
+++ b/apps/desktop-cef/src/worldscript_handler.h
@@ -21,10 +21,10 @@ class WorldScriptHandler : public CefClient,
   bool DoClose(CefRefPtr<CefBrowser> browser) override;
   void OnBeforeClose(CefRefPtr<CefBrowser> browser) override;
 
- private:
-  // QNBS-v3: polls g_worldscript_shutdown_requested from the UI thread (never from the signal handler itself) and, when set, requests a graceful close on every tracked browser via TryCloseBrowser.
+  // QNBS-v3: public (not private) — called from PollShutdownTask::Execute(), an unrelated class in worldscript_handler.cpp's anonymous namespace; polls g_worldscript_shutdown_requested from the UI thread and requests a graceful close via TryCloseBrowser when set.
   void PollShutdownFlag();
 
+ private:
   std::list<CefRefPtr<CefBrowser>> browser_list_;
 
   IMPLEMENT_REFCOUNTING(WorldScriptHandler);

--- a/apps/desktop-cef/src/worldscript_handler.h
+++ b/apps/desktop-cef/src/worldscript_handler.h
@@ -5,9 +5,7 @@
 
 #include "include/cef_client.h"
 
-// WorldScriptHandler: browser-process lifecycle/display callbacks only (ADR-0020
-// scorecard — "browser-process handlers exercised"; renderer-process-specific
-// handlers like CefRenderProcessHandler are explicitly out of scope for this proof).
+// QNBS-v3: browser-process lifecycle/display callbacks only (ADR-0020 scorecard) — renderer-process-specific handlers (CefRenderProcessHandler) are explicitly out of scope for this proof.
 class WorldScriptHandler : public CefClient,
                             public CefLifeSpanHandler,
                             public CefDisplayHandler {

--- a/scripts/cef/prepare-cef-build.mjs
+++ b/scripts/cef/prepare-cef-build.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/**
+ * Wires apps/desktop-cef into a fetched CEF SDK's own build, by appending an
+ * add_subdirectory() call to a *copy* of the SDK's root CMakeLists.txt — the exact
+ * mechanism ADR-0020's spike proved works, reused here instead of reinventing CEF's
+ * platform bootstrap (compiler/linker flags, OS_LINUX/PROJECT_ARCH detection) from a
+ * from-scratch top-level CMakeLists.txt in this repo.
+ *
+ * Never mutates the fetched SDK in place — copies its root CMakeLists.txt into the
+ * build directory first, so re-running scripts/cef/fetch-cef-sdk.mjs's cache-hit path
+ * always sees the SDK exactly as extracted.
+ *
+ * Run: node scripts/cef/prepare-cef-build.mjs <extracted-cef-dir> <build-dir>
+ * Prints the patched CMakeLists.txt's directory (the -S argument for `cmake`).
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.join(__dirname, '..', '..');
+
+const [cefDir, buildDir] = process.argv.slice(2);
+if (!cefDir || !buildDir) {
+  console.error(
+    '[prepare-cef-build] Usage: node scripts/cef/prepare-cef-build.mjs <extracted-cef-dir> <build-dir>',
+  );
+  process.exit(1);
+}
+
+const sourceCMakeListsPath = path.join(cefDir, 'CMakeLists.txt');
+if (!fs.existsSync(sourceCMakeListsPath)) {
+  console.error(`[prepare-cef-build] Not found: ${sourceCMakeListsPath}`);
+  process.exit(1);
+}
+
+const cmakeSourceDir = path.join(buildDir, 'cmake-src');
+fs.mkdirSync(cmakeSourceDir, { recursive: true });
+
+// QNBS-v3: copies the whole extracted SDK's top level via symlinks for CEF's own subdirs, keeping only CMakeLists.txt as a real (patchable) file.
+for (const entry of fs.readdirSync(cefDir, { withFileTypes: true })) {
+  if (entry.name === 'CMakeLists.txt') continue;
+  const target = path.join(cmakeSourceDir, entry.name);
+  if (!fs.existsSync(target)) {
+    fs.symlinkSync(path.join(cefDir, entry.name), target);
+  }
+}
+
+const desktopCefAbsPath = path.join(repoRoot, 'apps', 'desktop-cef');
+const originalCMakeLists = fs.readFileSync(sourceCMakeListsPath, 'utf8');
+const patchedCMakeLists = `${originalCMakeLists}\nadd_subdirectory("${desktopCefAbsPath}" "\${CMAKE_BINARY_DIR}/worldscript_host")\n`;
+fs.writeFileSync(path.join(cmakeSourceDir, 'CMakeLists.txt'), patchedCMakeLists);
+
+console.log(`[prepare-cef-build] Patched CMakeLists.txt ready at ${cmakeSourceDir}`);
+console.log(cmakeSourceDir);

--- a/scripts/cef/prepare-cef-build.mjs
+++ b/scripts/cef/prepare-cef-build.mjs
@@ -41,9 +41,14 @@ fs.mkdirSync(cmakeSourceDir, { recursive: true });
 for (const entry of fs.readdirSync(cefDir, { withFileTypes: true })) {
   if (entry.name === 'CMakeLists.txt') continue;
   const target = path.join(cmakeSourceDir, entry.name);
-  if (!fs.existsSync(target)) {
-    fs.symlinkSync(path.join(cefDir, entry.name), target);
+  // QNBS-v3: existsSync follows symlinks, so a dangling link from an earlier run (stale target) reads as absent and symlinkSync then throws EEXIST — lstatSync + remove first makes this idempotent (CodeRabbit review finding on PR #388).
+  try {
+    fs.lstatSync(target);
+    fs.rmSync(target, { recursive: true, force: true });
+  } catch {
+    // No existing entry — nothing to remove.
   }
+  fs.symlinkSync(path.join(cefDir, entry.name), target);
 }
 
 const desktopCefAbsPath = path.join(repoRoot, 'apps', 'desktop-cef');

--- a/scripts/cef/run-launch-cycle-proof.mjs
+++ b/scripts/cef/run-launch-cycle-proof.mjs
@@ -33,6 +33,8 @@ const cycles = cyclesArgIdx === -1 ? 3 : Number(cyclesArg);
 
 const STARTUP_GRACE_MS = 4000;
 const SHUTDOWN_GRACE_MS = 6000;
+// QNBS-v3: extra buffer after the main process exits — a renderer/GPU subprocess can take a moment longer to actually be reaped than its parent (docs/cef/knowledge/subprocess-and-shutdown.md's own "not instantaneous" finding applies to the whole tree, not just the browser process).
+const ORPHAN_CHECK_GRACE_MS = 3000;
 const FFI_PROOF_LINE = 'rust_core ping = 424242';
 const EXPECTED_TITLE_LINE = 'title = WorldScript Studio';
 
@@ -123,6 +125,7 @@ async function runCycle(index) {
     );
   }
 
+  await sleep(ORPHAN_CHECK_GRACE_MS);
   if (processTreeAlive()) {
     logStderr(index, stderr);
     throw new Error(`Cycle ${index + 1}: orphaned worldscript_host process(es) still running.`);

--- a/scripts/cef/run-launch-cycle-proof.mjs
+++ b/scripts/cef/run-launch-cycle-proof.mjs
@@ -9,26 +9,42 @@
  * (docs/cef/knowledge/subprocess-and-shutdown.md): an immediate post-signal check is
  * a false positive, not evidence of a hang.
  *
- * Also greps captured stdout for the Rust FFI boundary's proof line
- * (see apps/desktop-cef/src/worldscript_handler.cpp), so a single CI run proves both
- * "starts/stops cleanly" and "the FFI boundary works inside the real host" — not just
- * in the spike's decoupled isolation test.
+ * Each cycle must independently show two proofs, not just "at least one cycle across
+ * the whole run" (a real review finding — masking a later cycle's failure behind an
+ * earlier success would make the proof meaningless):
+ *   - FFI boundary: apps/desktop-cef/src/worldscript_handler.cpp's OnAfterCreated
+ *     calls into rust-core deterministically, regardless of page content.
+ *   - Real rendering: the page's title must be exactly "WorldScript Studio" — a CEF
+ *     error page (bad bundle, load failure) would not produce that specific title,
+ *     so this catches "CEF started but the app didn't actually render" failures the
+ *     FFI proof alone cannot.
  *
  * Run: node scripts/cef/run-launch-cycle-proof.mjs <binary-path> <url> [--cycles N]
  */
 import { execFileSync, spawn } from 'node:child_process';
 
 const [binaryPath, url] = process.argv.slice(2);
+
 const cyclesArgIdx = process.argv.indexOf('--cycles');
-const cycles = cyclesArgIdx !== -1 ? Number(process.argv[cyclesArgIdx + 1]) : 3;
+// QNBS-v3: distinguishes "flag absent" (default 3) from "flag present but no value" (e.g. trailing --cycles) — a naive undefined-check would silently default the latter too, same footgun class as fetch-cef-sdk.mjs's --cache-dir.
+const cyclesArg = cyclesArgIdx !== -1 ? process.argv[cyclesArgIdx + 1] : undefined;
+const cycles = cyclesArgIdx === -1 ? 3 : Number(cyclesArg);
 
 const STARTUP_GRACE_MS = 4000;
 const SHUTDOWN_GRACE_MS = 6000;
+const FFI_PROOF_LINE = 'rust_core ping = 424242';
+const EXPECTED_TITLE_LINE = 'title = WorldScript Studio';
 
 if (!binaryPath || !url) {
   console.error(
     '[launch-cycle-proof] Usage: node scripts/cef/run-launch-cycle-proof.mjs <binary-path> <url> [--cycles N]',
   );
+  process.exit(1);
+}
+
+// QNBS-v3: Number() accepts Infinity/NaN/fractional/non-positive values unvalidated — CodeAnt review finding on PR #388 (an unbounded or skipped loop from a malformed --cycles).
+if (!Number.isInteger(cycles) || cycles <= 0) {
+  console.error(`[launch-cycle-proof] --cycles must be a positive integer, got: ${cyclesArg}`);
   process.exit(1);
 }
 
@@ -55,6 +71,10 @@ function processTreeAlive() {
   }
 }
 
+function logStderr(index, stderr) {
+  if (stderr) console.error(`[launch-cycle-proof] Cycle ${index + 1} stderr:\n${stderr}`);
+}
+
 async function runCycle(index) {
   console.log(`[launch-cycle-proof] Cycle ${index + 1}/${cycles}: launching…`);
   const child = spawn(binaryPath, [`--url=${url}`], { stdio: ['ignore', 'pipe', 'pipe'] });
@@ -72,47 +92,60 @@ async function runCycle(index) {
     child.once('exit', (code, signal) => resolve({ code, signal })),
   );
 
-  await sleep(STARTUP_GRACE_MS);
-
-  if (stdout.includes('rust_core ping = 424242')) {
-    console.log("[launch-cycle-proof]   FFI boundary proof found in this cycle's output.");
+  // QNBS-v3: races against the startup grace period so an immediate crash is caught here, distinct from a deliberate SIGTERM-driven exit later — Qodo review finding on PR #388 ("crashed cycles count clean").
+  const earlyExit = await Promise.race([exited, sleep(STARTUP_GRACE_MS).then(() => null)]);
+  if (earlyExit) {
+    logStderr(index, stderr);
+    throw new Error(
+      `Cycle ${index + 1}: exited during startup (code=${earlyExit.code}, signal=${earlyExit.signal}) instead of staying up — likely a crash, not a deliberate shutdown.`,
+    );
   }
 
   child.kill('SIGTERM');
-  await sleep(SHUTDOWN_GRACE_MS);
-
-  const result = await Promise.race([exited, sleep(1000).then(() => null)]);
-  if (!result) {
-    if (stderr) console.error(`[launch-cycle-proof] Cycle ${index + 1} stderr:\n${stderr}`);
+  const shutdownResult = await Promise.race([exited, sleep(SHUTDOWN_GRACE_MS).then(() => null)]);
+  if (!shutdownResult) {
+    logStderr(index, stderr);
     throw new Error(`Cycle ${index + 1}: process did not exit within the shutdown grace period.`);
   }
 
+  // QNBS-v3: accepts either "died from the SIGTERM we sent" or "exited 0 on its own" as clean — anything else (e.g. SIGSEGV) is a real crash during shutdown, not evidence this proof should accept.
+  const cleanShutdown = shutdownResult.signal === 'SIGTERM' || shutdownResult.code === 0;
+  if (!cleanShutdown) {
+    logStderr(index, stderr);
+    throw new Error(
+      `Cycle ${index + 1}: abnormal exit during shutdown (code=${shutdownResult.code}, signal=${shutdownResult.signal}).`,
+    );
+  }
+
   if (processTreeAlive()) {
-    if (stderr) console.error(`[launch-cycle-proof] Cycle ${index + 1} stderr:\n${stderr}`);
+    logStderr(index, stderr);
     throw new Error(`Cycle ${index + 1}: orphaned worldscript_host process(es) still running.`);
   }
 
-  console.log(
-    `[launch-cycle-proof] Cycle ${index + 1}/${cycles}: clean exit (signal=${result.signal}).`,
-  );
-  return stdout;
-}
-
-async function main() {
-  let sawFfiProof = false;
-  for (let i = 0; i < cycles; i++) {
-    const stdout = await runCycle(i);
-    if (stdout.includes('rust_core ping = 424242')) sawFfiProof = true;
+  // QNBS-v3: required per cycle, not aggregated across the whole run — Qodo review finding on PR #388 ("FFI proof is not repeated"); one cycle's success must never mask another cycle's failure.
+  if (!stdout.includes(FFI_PROOF_LINE)) {
+    logStderr(index, stderr);
+    throw new Error(`Cycle ${index + 1}: no FFI boundary proof ("${FFI_PROOF_LINE}") observed.`);
   }
-
-  if (!sawFfiProof) {
+  if (!stdout.includes(EXPECTED_TITLE_LINE)) {
+    logStderr(index, stderr);
     throw new Error(
-      'No cycle produced the expected FFI boundary output ("rust_core ping = 424242") — the page may not have set a title, or the callback did not fire.',
+      `Cycle ${index + 1}: expected "${EXPECTED_TITLE_LINE}" not observed — the production bundle may not have rendered (a CEF error page would not produce this specific title).`,
     );
   }
 
   console.log(
-    `[launch-cycle-proof] OK — ${cycles}/${cycles} repeated start/close cycles clean, FFI boundary proven inside the real host.`,
+    `[launch-cycle-proof] Cycle ${index + 1}/${cycles}: clean exit (signal=${shutdownResult.signal}), FFI + rendering proofs both present.`,
+  );
+}
+
+async function main() {
+  for (let i = 0; i < cycles; i++) {
+    await runCycle(i);
+  }
+
+  console.log(
+    `[launch-cycle-proof] OK — ${cycles}/${cycles} repeated start/close cycles clean, FFI boundary and real rendering both proven in every cycle.`,
   );
 }
 

--- a/scripts/cef/run-launch-cycle-proof.mjs
+++ b/scripts/cef/run-launch-cycle-proof.mjs
@@ -77,7 +77,10 @@ function logStderr(index, stderr) {
 
 async function runCycle(index) {
   console.log(`[launch-cycle-proof] Cycle ${index + 1}/${cycles}: launching…`);
-  const child = spawn(binaryPath, [`--url=${url}`], { stdio: ['ignore', 'pipe', 'pipe'] });
+  // QNBS-v3: verbose CEF/Chromium logging to stderr — an early crash otherwise produces zero diagnostic output, making root-causing it impossible from this harness's own log.
+  const child = spawn(binaryPath, [`--url=${url}`, '--enable-logging=stderr', '--v=1'], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
 
   let stdout = '';
   let stderr = '';

--- a/scripts/cef/run-launch-cycle-proof.mjs
+++ b/scripts/cef/run-launch-cycle-proof.mjs
@@ -22,6 +22,7 @@
  * Run: node scripts/cef/run-launch-cycle-proof.mjs <binary-path> <url> [--cycles N]
  */
 import { execFileSync, spawn } from 'node:child_process';
+import path from 'node:path';
 
 const [binaryPath, url] = process.argv.slice(2);
 
@@ -77,8 +78,10 @@ function logStderr(index, stderr) {
 
 async function runCycle(index) {
   console.log(`[launch-cycle-proof] Cycle ${index + 1}/${cycles}: launching…`);
+  // QNBS-v3: cwd set to the binary's own directory — Chromium resolves several resource paths (icudtl.dat et al.) relative to cwd, not the executable's location; without this, "Invalid file descriptor to ICU data received" crashes it on startup even though every file is correctly present.
   // QNBS-v3: verbose CEF/Chromium logging to stderr — an early crash otherwise produces zero diagnostic output, making root-causing it impossible from this harness's own log.
   const child = spawn(binaryPath, [`--url=${url}`, '--enable-logging=stderr', '--v=1'], {
+    cwd: path.dirname(binaryPath),
     stdio: ['ignore', 'pipe', 'pipe'],
   });
 

--- a/scripts/cef/run-launch-cycle-proof.mjs
+++ b/scripts/cef/run-launch-cycle-proof.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+/**
+ * Repeated start/close cycle proof for the Wave 2 CEF host (ADR-0020, roadmap
+ * §3142/§61.1.1 CI-enforceable harness checks).
+ *
+ * Launches the built worldscript_host N times against a real URL, sends SIGTERM
+ * after a startup grace period, and verifies a clean process tree after a shutdown
+ * grace period — per the documented finding that CEF's shutdown is not instantaneous
+ * (docs/cef/knowledge/subprocess-and-shutdown.md): an immediate post-signal check is
+ * a false positive, not evidence of a hang.
+ *
+ * Also greps captured stdout for the Rust FFI boundary's proof line
+ * (see apps/desktop-cef/src/worldscript_handler.cpp), so a single CI run proves both
+ * "starts/stops cleanly" and "the FFI boundary works inside the real host" — not just
+ * in the spike's decoupled isolation test.
+ *
+ * Run: node scripts/cef/run-launch-cycle-proof.mjs <binary-path> <url> [--cycles N]
+ */
+import { execFileSync, spawn } from 'node:child_process';
+
+const [binaryPath, url] = process.argv.slice(2);
+const cyclesArgIdx = process.argv.indexOf('--cycles');
+const cycles = cyclesArgIdx !== -1 ? Number(process.argv[cyclesArgIdx + 1]) : 3;
+
+const STARTUP_GRACE_MS = 4000;
+const SHUTDOWN_GRACE_MS = 6000;
+
+if (!binaryPath || !url) {
+  console.error(
+    '[launch-cycle-proof] Usage: node scripts/cef/run-launch-cycle-proof.mjs <binary-path> <url> [--cycles N]',
+  );
+  process.exit(1);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function processTreeAlive() {
+  try {
+    // QNBS-v3: excludes this Node process's own PID — it received binaryPath as a CLI arg, so a naive `pgrep -f` match on that string would always match itself.
+    const out = execFileSync('pgrep', ['-f', binaryPath], { stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString()
+      .trim();
+    const remaining = out
+      .split('\n')
+      .filter(Boolean)
+      .map(Number)
+      .filter((pid) => pid !== process.pid);
+    return remaining.length > 0;
+  } catch {
+    return false; // pgrep exits 1 when nothing matches — that's the clean state.
+  }
+}
+
+async function runCycle(index) {
+  console.log(`[launch-cycle-proof] Cycle ${index + 1}/${cycles}: launching…`);
+  const child = spawn(binaryPath, [`--url=${url}`], { stdio: ['ignore', 'pipe', 'pipe'] });
+
+  let stdout = '';
+  child.stdout.on('data', (chunk) => {
+    stdout += chunk.toString();
+  });
+  child.stderr.on('data', () => {}); // GPU-fallback warnings etc. — not this proof's concern.
+
+  const exited = new Promise((resolve) =>
+    child.once('exit', (code, signal) => resolve({ code, signal })),
+  );
+
+  await sleep(STARTUP_GRACE_MS);
+
+  if (stdout.includes('rust_core ping = 424242')) {
+    console.log("[launch-cycle-proof]   FFI boundary proof found in this cycle's output.");
+  }
+
+  child.kill('SIGTERM');
+  await sleep(SHUTDOWN_GRACE_MS);
+
+  const result = await Promise.race([exited, sleep(1000).then(() => null)]);
+  if (!result) {
+    throw new Error(`Cycle ${index + 1}: process did not exit within the shutdown grace period.`);
+  }
+
+  if (processTreeAlive()) {
+    throw new Error(`Cycle ${index + 1}: orphaned worldscript_host process(es) still running.`);
+  }
+
+  console.log(
+    `[launch-cycle-proof] Cycle ${index + 1}/${cycles}: clean exit (signal=${result.signal}).`,
+  );
+  return stdout;
+}
+
+async function main() {
+  let sawFfiProof = false;
+  for (let i = 0; i < cycles; i++) {
+    const stdout = await runCycle(i);
+    if (stdout.includes('rust_core ping = 424242')) sawFfiProof = true;
+  }
+
+  if (!sawFfiProof) {
+    throw new Error(
+      'No cycle produced the expected FFI boundary output ("rust_core ping = 424242") — the page may not have set a title, or the callback did not fire.',
+    );
+  }
+
+  console.log(
+    `[launch-cycle-proof] OK — ${cycles}/${cycles} repeated start/close cycles clean, FFI boundary proven inside the real host.`,
+  );
+}
+
+main().catch((err) => {
+  console.error(`[launch-cycle-proof] FAIL — ${err.message}`);
+  process.exit(1);
+});

--- a/scripts/cef/run-launch-cycle-proof.mjs
+++ b/scripts/cef/run-launch-cycle-proof.mjs
@@ -38,8 +38,10 @@ function sleep(ms) {
 
 function processTreeAlive() {
   try {
-    // QNBS-v3: excludes this Node process's own PID — it received binaryPath as a CLI arg, so a naive `pgrep -f` match on that string would always match itself.
-    const out = execFileSync('pgrep', ['-f', binaryPath], { stdio: ['ignore', 'pipe', 'ignore'] })
+    // QNBS-v3: anchored to the start of the command line — xvfb-run's own wrapper process also carries binaryPath as an argument it forwards, so an unanchored match false-flags it as a leaked worldscript_host.
+    const out = execFileSync('pgrep', ['-f', `^${binaryPath}`], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
       .toString()
       .trim();
     const remaining = out
@@ -58,10 +60,13 @@ async function runCycle(index) {
   const child = spawn(binaryPath, [`--url=${url}`], { stdio: ['ignore', 'pipe', 'pipe'] });
 
   let stdout = '';
+  let stderr = '';
   child.stdout.on('data', (chunk) => {
     stdout += chunk.toString();
   });
-  child.stderr.on('data', () => {}); // GPU-fallback warnings etc. — not this proof's concern.
+  child.stderr.on('data', (chunk) => {
+    stderr += chunk.toString();
+  });
 
   const exited = new Promise((resolve) =>
     child.once('exit', (code, signal) => resolve({ code, signal })),
@@ -78,10 +83,12 @@ async function runCycle(index) {
 
   const result = await Promise.race([exited, sleep(1000).then(() => null)]);
   if (!result) {
+    if (stderr) console.error(`[launch-cycle-proof] Cycle ${index + 1} stderr:\n${stderr}`);
     throw new Error(`Cycle ${index + 1}: process did not exit within the shutdown grace period.`);
   }
 
   if (processTreeAlive()) {
+    if (stderr) console.error(`[launch-cycle-proof] Cycle ${index + 1} stderr:\n${stderr}`);
     throw new Error(`Cycle ${index + 1}: orphaned worldscript_host process(es) still running.`);
   }
 


### PR DESCRIPTION
## **User description**
## Summary

Recreates ADR-0020's spike code **inside the repository** per its own Consequences section, and extends the `🧪 CEF Learning Harness` CI job (#387) to actually build and exercise it — the roadmap's real Wave 2 "isolated learning harness" deliverable (§3142/§4.11.3), not just the fetch/verify/diagnostics increment that already landed.

- **`apps/desktop-cef/`** — the thin C++ host (ADR-0020, Option B): `WorldScriptApp` (Views-framework single window) + `WorldScriptHandler` (lifecycle/display callbacks), matching the spike's proven `cefsimple`-with-Views pattern. `rust-core/` is the same minimal FFI-boundary proof, now linked via **Corrosion** (Cargo↔CMake) instead of the spike's hardcoded `.a` path.
- **`CMakeLists.txt`** is a *subdirectory* file, wired in via `add_subdirectory()` from a patched copy of CEF's own root `CMakeLists.txt` (`scripts/cef/prepare-cef-build.mjs`) — reuses the exact mechanism the spike already proved works rather than reinventing CEF's platform bootstrap from scratch.
- **`scripts/cef/run-launch-cycle-proof.mjs`** — the actual "safe repeated startup/shutdown" test: launches the built host 3× against a real URL, sends SIGTERM, and only checks the process tree after the documented shutdown grace period (an immediate check is a known false positive). Also greps captured stdout for the FFI boundary's proof line, so this proves the boundary from *inside* the real host, not just the spike's decoupled isolation test.
- **CI now builds the real production bundle** (`pnpm run build`) and points `worldscript_host` at it via a local HTTP server — the roadmap's "existing dist/" deliverable and the actual Wave 2 exit criterion ("WorldScript renders reliably under CEF"), not a blank page.

Doc updates (native-readiness.md, OWNERSHIP.yaml, knowledge docs, competency manifest) are deliberately **not** part of this PR — they land in a follow-up once this CI job is observed green, so committed docs never claim "proven" ahead of real evidence (§61.1.4 evidence-link discipline).

## Risk / expectations

This is real CMake/C++/Rust/CEF integration written without local access to the ~1.5GB CEF SDK (disk constraints on this dev machine, per ADR-0020) — validated by careful review against known CEF/cefsimple conventions, but the CI run itself is the actual first compile/link/run attempt. Expect this may need one or more follow-up fix commits based on real CI failures — that's the intended CI-first workflow, not a sign of a rushed PR.

## Test plan

- [x] YAML validated (`python3 -c "import yaml; ..."`)
- [x] New `.mjs` scripts linted clean (`biome check`)
- [x] C++ header/include hygiene reviewed manually (no local compiler available)
- [ ] `🧪 CEF Learning Harness` CI job: SDK fetch/diagnostics (already proven in #387) + new build/launch-cycle steps
- [ ] Main quality gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build and exercise the repository’s real WorldScript CEF host against the production bundle with repeated startup and shutdown validation.

New Features:
- Add a CEF desktop host that displays the production WorldScript bundle in a Views-based window and connects browser lifecycle callbacks to the Rust core.
- Add an automated repeated launch and shutdown proof covering real rendering, Rust FFI execution, clean exits, and orphan-process detection.

Enhancements:
- Integrate the CEF host build with the repository through CMake and Corrosion while reusing the fetched CEF build configuration.
- Extend the CEF learning harness to build the production bundle, compile the host, serve the bundle, and exercise three launch cycles under Xvfb.
- Run the CEF harness on every main-branch push while retaining path-scoped pull-request execution.

Build:
- Add the CMake and Rust-core build configuration required to produce the worldscript_host executable.

CI:
- Expand the CEF learning harness with production-bundle build, host compilation, local serving, and repeated launch/close validation steps.

Tests:
- Add a launch-cycle validation script that verifies rendering, FFI output, graceful termination, and absence of orphaned host processes on every cycle.

Chores:
- Update contribution guidance for QNBS-v3 comments in C++, Rust, and CMake files.


___

## **CodeAnt-AI Description**
Build and validate the real WorldScript CEF desktop host

### What Changed
- Added a CEF desktop host that opens the production WorldScript bundle in a window and supports clean startup and shutdown.
- Connected the running host to the Rust core and verifies the boundary from a real browser callback.
- CI now builds the production bundle, compiles the host, serves the bundle locally, and runs three launch/close cycles under a virtual display.
- Added checks for clean process exit and detection of orphaned host processes.

### Impact
`✅ Reliable repeated CEF startup and shutdown`
`✅ WorldScript production bundle runs in the desktop host`
`✅ Fewer orphaned desktop processes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CEF-based desktop host that opens web experiences in a native window.
  * Added Rust runtime integration and startup validation.
  * Added tooling to prepare CEF builds and verify repeated launch and shutdown cycles.

* **Tests**
  * Expanded automated validation to build the desktop host and run three launch/close cycles.
  * Added checks for successful startup, clean shutdown, runtime communication, and absence of orphaned processes.
  * Enabled validation for desktop-app changes in pull requests and pushes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->