### PR TITLE
docs(cef): fill 3 remaining knowledge-doc skeletons from real PR #388 evidence

### DIFF
--- a/docs/cef/OWNERSHIP.yaml
+++ b/docs/cef/OWNERSHIP.yaml
@@ -97,35 +97,41 @@ documents:
     tier: A
     owner_role: cef-runtime
     backup_role: rust-core
-    last_verified: null
+    last_verified:
+      worldscript: "v1.27.1"
+      cef: "151.3.18+gbeff58d+chromium-151.0.7922.138"
     review_days: 90
     related_ci:
       - cef-learning-harness
     driftCheckTool: "planned — not implemented, see Wave 1"
-    note: "Skeleton only — Status: Not started"
+    note: "Real evidence from PR #388 for process model, message loop, subprocess packaging. Sandbox config and a directly-observed process-tree snapshot remain open."
 
   - path: docs/cef/knowledge/cef-rust-binding-cookbook.md
     tier: A
     owner_role: rust-core
     backup_role: cef-runtime
-    last_verified: null
+    last_verified:
+      worldscript: "v1.27.1"
+      cef: "151.3.18+gbeff58d+chromium-151.0.7922.138"
     review_days: 90
     related_ci:
       - cef-learning-harness
     driftCheckTool: "planned — not implemented, see Wave 1"
-    note: "Skeleton only — Status: Not started"
+    note: "Real evidence from apps/desktop-cef/rust-core/ (PR #388) — but the FFI surface is one trivial function, not representative of real API coverage."
 
   - path: docs/cef/knowledge/threading-and-lifetimes.md
     tier: A
     owner_role: cef-runtime
     backup_role: rust-core
-    last_verified: null
+    last_verified:
+      worldscript: "v1.27.1"
+      cef: "151.3.18+gbeff58d+chromium-151.0.7922.138"
     review_days: 90
     related_ci:
       - cef-learning-harness
       # cef-competency-gate: no such CI workflow/job exists yet — planned, not implemented (CodeRabbit review finding on PR #389). Re-add once it's a real job.
     driftCheckTool: "planned — not implemented, see Wave 1"
-    note: "Skeleton only — Status: Not started"
+    note: "Real evidence from PR #388 for UI-thread callback discipline and CEF ref-counting/callback-lifetime patterns. IO-thread and render-process-side rules untouched; full dual-review (§4.11.4) not yet done."
 
   - path: docs/cef/knowledge/subprocess-and-shutdown.md
     tier: A

--- a/docs/cef/knowledge/cef-architecture-primer.md
+++ b/docs/cef/knowledge/cef-architecture-primer.md
@@ -1,19 +1,47 @@
 # CEF Architecture Primer
 
-**Status:** Not started — no CEF integration exists yet in this repository.
-**Scope:** How CEF's multi-process architecture (browser process, renderer process, GPU/utility processes; browser/frame/client ownership; message-loop integration; subprocess launch and packaging; sandbox model) maps onto WorldScript Studio's specific host and build, written from our actual integration once it exists — not a generic CEF tutorial.
+**Status:** Real evidence from `apps/desktop-cef/` (PR #388) for process model, message loop, and subprocess packaging. Sandbox configuration and a directly-observed full process-tree snapshot remain open.
+**Scope:** How CEF's multi-process architecture (browser process, renderer process, GPU/utility processes; browser/frame/client ownership; message-loop integration; subprocess launch and packaging; sandbox model) maps onto WorldScript Studio's specific host and build, written from our actual integration — not a generic CEF tutorial.
 **Tier:** A (release/security-critical) — see [`../OWNERSHIP.yaml`](../OWNERSHIP.yaml).
 **Roadmap context:** [`../ROADMAP-CEF-DESKTOP-MIGRATION.md`](../ROADMAP-CEF-DESKTOP-MIGRATION.md) §4.11.1 ("CEF architecture" domain), §4.11.2, Wave 2.
 
-## Outline (to be filled in during Wave 2)
+## Process model, as implemented (`apps/desktop-cef/src/main.cpp`)
 
-- Process model as implemented in WorldScript's host (which processes exist, what each owns)
-- Browser/frame/client object ownership in our integration
-- Message-loop choice and why
-- Subprocess launch and packaging specifics for our build
-- Sandbox configuration as shipped
-- Diagram: our actual process tree (not the generic CEF one)
+`worldscript_host` is a single executable re-executed by CEF itself for every process role — there is no separate subprocess binary. `main()` calls `CefExecuteProcess(main_args, app.get(), nullptr)` *before* anything else; a non-negative return means *this invocation* is a subprocess (renderer/GPU/utility) that has already run to completion, and `main()` returns immediately. Only when that call returns `-1` (this is the actual browser process) does the code proceed to install the shutdown-signal handler, call `CefInitialize`, and enter the message loop.
 
-## Do not fill this in speculatively
+This single-binary-multi-role design is directly why `scripts/cef/run-launch-cycle-proof.mjs`'s orphan check anchors its `pgrep` pattern to the *start* of the binary's own path (`^${binaryPath}`) — every subprocess CEF spawns re-execs that exact same path with different flags (e.g. `--type=renderer`), so they're all catchable by one pattern, and nothing else on the system should share that literal path prefix.
 
-This document should describe **our real, built integration** once Wave 2 exists. Until then, leave sections empty rather than guessing — a wrong architecture primer is worse than a missing one (see risk register R-10, documentation drift).
+**Directly observed evidence a renderer process exists and runs the real page**: the CI log for a real production-bundle load shows a `[INFO:CONSOLE:95]` line — a JavaScript console message relayed from the renderer process back to the browser process via CEF's own IPC, not something the browser process could produce itself. **GPU process**: not directly observed by name (no `ps`/`--type=gpu-process` capture was taken), but the build output includes `libvk_swiftshader.so`/`libvulkan.so.1` (Vulkan software rendering) and the ADR-0020 spike separately observed real GPU-fallback warnings (`Bay Trail Vulkan support is incomplete`) — consistent with a GPU process existing and falling back to software rendering, not confirmed as a distinct observed process in this specific proof.
+
+## Browser/frame/client ownership, as implemented
+
+- `WorldScriptApp::OnContextInitialized` creates exactly **one** `CefBrowserView` (`CefBrowserView::CreateBrowserView`) wrapped in exactly one top-level `CefWindow` (`CefWindow::CreateTopLevelWindow`) — single-window, single-browser, by design; nothing in this host creates additional windows or popups.
+- `WorldScriptHandler` is the `CefClient` implementation and the sole owner of browser-lifecycle bookkeeping: a `std::list<CefRefPtr<CefBrowser>> browser_list_`, appended to in `OnAfterCreated` and pruned in `OnBeforeClose`. The list shape supports more than one browser in principle, but only one is ever created today.
+- Frame-level ownership (multiple frames per browser, cross-frame navigation) has not been touched at all — the production bundle loads as a single top-level document.
+
+## Message-loop choice and why
+
+`CefRunMessageLoop()` (the blocking, OS-native-integrated variant) — not `CefDoMessageLoopWork()` in a manual polling loop — matching the standard `cefsimple` convention and avoiding a busy-poll CPU cost. `WorldScriptHandler::OnBeforeClose` calls `CefQuitMessageLoop()` only once `browser_list_` becomes empty, which is the actual mechanism that makes `CefRunMessageLoop()` in `main()` return — the real, CI-proven signal that it's safe to call `CefShutdown()`. See `docs/cef/knowledge/subprocess-and-shutdown.md` for the full shutdown sequence.
+
+## Subprocess launch and packaging, as implemented
+
+`apps/desktop-cef/CMakeLists.txt` runs two `COPY_FILES` calls (`CEF_BINARY_FILES`, `CEF_RESOURCE_FILES`) that land everything the runtime needs next to the executable — confirmed via a real `ls -la` in CI (PR #388), not just assumed from the macro's documented behavior: `libcef.so`, `icudtl.dat`, `resources.pak`, `chrome_100_percent.pak`, `chrome_200_percent.pak`, `v8_context_snapshot.bin`, `locales/`, `libEGL.so`, `libGLESv2.so`, `libvk_swiftshader.so`, `libvulkan.so.1`, and `chrome-sandbox`. **This is CEF's own unpackaged build-output layout** (`cmake --build` output, run in place) — not a real installer's layout, which is separate, later, unproven scope.
+
+A real launch-path bug was found and fixed here too: Chromium resolves several of these resource paths relative to the process's *working directory*, not the executable's own location — launching the binary from a different cwd produced an ICU-init crash despite every file being correctly present. See `docs/cef/knowledge/linux-runtime-notes.md` for the full finding.
+
+## Sandbox configuration, as shipped
+
+`chrome-sandbox` is present in the output directory (copied automatically as part of `CEF_BINARY_FILES`) but is **not used** — `main.cpp` sets `CefSettings.no_sandbox = true` unconditionally. Zero evidence exists on real sandbox posture; this is explicitly tracked as "Not yet attempted" in `docs/architecture/native-readiness.md` and `false` in the competency manifest.
+
+## Process tree — what we can honestly claim
+
+```text
+worldscript_host (browser process, no_sandbox=true)
+└── worldscript_host --type=renderer ... (confirmed indirectly: console-log IPC observed;
+    not directly captured by ps/process-name in this proof)
+└── (likely) worldscript_host --type=gpu-process ... (consistent with SwiftShader/Vulkan
+    files present and GPU-fallback warnings from the ADR-0020 spike; not directly observed
+    by process name in PR #388's own CI run)
+```
+
+Not a diagram of the generic CEF process model — this is what PR #388's evidence actually supports, with each claim's confidence level stated rather than assumed. A real `ps`/process-tree capture during a live run would upgrade the two `(likely)`/"not directly observed" lines to confirmed evidence; that capture has not been taken yet.

--- a/docs/cef/knowledge/cef-rust-binding-cookbook.md
+++ b/docs/cef/knowledge/cef-rust-binding-cookbook.md
@@ -1,18 +1,38 @@
 # CEF Rust Binding Cookbook
 
-**Status:** Not started — no CEF integration exists yet in this repository. No binding crate has been selected.
-**Scope:** Practical recipes for the exact Rust CEF-binding crate/version WorldScript adopts (Wave 2 decision, roadmap §10/Appendix H) — unsafe/FFI boundary patterns, wrapper ownership idioms, API coverage gaps we've hit, and workarounds, written against our real usage.
+**Status:** Real evidence from `apps/desktop-cef/rust-core/` (PR #388) — but the FFI surface it documents is currently one trivial function, not representative of real API coverage. Treat this as "the pattern is proven," not "the binding is complete."
+**Scope:** Practical recipes for the exact Rust↔CEF integration WorldScript adopted (Wave 2 decision, ADR-0020, Appendix H) — unsafe/FFI boundary patterns, wrapper ownership idioms, API coverage gaps we've hit, and workarounds, written against our real usage.
 **Tier:** A (release/security-critical) — see [`../OWNERSHIP.yaml`](../OWNERSHIP.yaml).
 **Roadmap context:** [`../ROADMAP-CEF-DESKTOP-MIGRATION.md`](../ROADMAP-CEF-DESKTOP-MIGRATION.md) §4.11.1 ("Rust binding layer" domain), §10 (integration choice), Appendix H (decision scorecard).
 
-## Outline (to be filled in during Wave 2)
+## There is no "CEF binding crate" — that's the point of Option B
 
-- Selected binding crate, pinned version, and why (link to the Appendix H scorecard decision)
-- Unsafe/FFI boundary map — where WorldScript code crosses into unsafe Rust or C/C++, and why each crossing is necessary
-- Wrapper ownership model (who owns what CEF object, when it's valid, how it's dropped)
-- Known API coverage gaps in the chosen binding and how WorldScript works around them
-- Binding upgrade procedure (cross-reference [`binding-upgrade-playbook.md`](binding-upgrade-playbook.md))
+ADR-0020 chose Option B (thin C++ host + Rust core) specifically *because* it means Rust never touches CEF's C++ API at all — no `cef`-style Rust crate wrapping `CefRefPtr<T>`/CEF interfaces exists or is needed. The "binding" here is a plain C FFI boundary between the C++ host and a Rust `staticlib`, nothing CEF-specific on the Rust side. If a future wave changes this decision (Option A), this doc's premise would need a full rewrite, not an update.
 
-## Do not fill this in speculatively
+## What's actually built (PR #388)
 
-No binding has been chosen as of Wave 0. This file is a placeholder for real recipes derived from actual integration work, not a summary of upstream binding documentation.
+- **Crate**: `apps/desktop-cef/rust-core/` (`worldscript_rust_core`), `crate-type = ["staticlib"]`, `panic = "abort"` in the release profile (matches the C++ host's own lack of a Rust-panic-to-C++-exception bridge — a Rust panic across this boundary today is unrecoverable-by-design, not caught and translated).
+- **The entire FFI surface right now**: one function.
+  ```rust
+  #[no_mangle]
+  pub extern "C" fn worldscript_rust_ping() -> i32 { 424242 }
+  ```
+  Declared on the C++ side as a bare forward declaration (`extern "C" int worldscript_rust_ping();` in `worldscript_handler.cpp`) — **no shared/generated header exists between the two languages yet**. This is a real, acknowledged gap: today's single trivial function is hand-matched by inspection: a real API surface (multiple functions, structs crossing the boundary) would need a proper shared header or a tool like `cbindgen` to avoid silent ABI drift between the Rust and C++ sides.
+- **Build integration**: [Corrosion](https://github.com/corrosion-rs/corrosion) (`corrosion_import_crate(MANIFEST_PATH ...)` in `apps/desktop-cef/CMakeLists.txt`), fetched via CMake `FetchContent` (a small MIT-licensed CMake module, not a vendored binary). Corrosion creates a CMake target named after the crate (`worldscript_rust_core`), linked via a plain `target_link_libraries(worldscript_host ... worldscript_rust_core ...)` — no manual `.a` path (the ADR-0020 spike's own documented workaround, now replaced by real integration).
+- **Proven inside the real host, not just isolated**: `worldscript_rust_ping()` is called from `WorldScriptHandler::OnAfterCreated` on every launch cycle, and its exact sentinel return value is observed in CI output (`scripts/cef/run-launch-cycle-proof.mjs`) — stronger evidence than the ADR-0020 spike's decoupled standalone-binary test.
+
+## Unsafe/FFI boundary map
+
+The *entire* unsafe surface today is the `extern "C"` function signature itself — no raw pointers, no shared mutable state, no lifetime crossing the boundary (the function takes no arguments and returns a plain `i32`). This is deliberately the simplest possible boundary, proving the *mechanism* works before any real data crosses it. **Do not extrapolate this simplicity to "the FFI boundary is safe/solved"** — passing strings, structs, or any pointer-based data across this boundary is materially riskier and entirely unproven so far.
+
+## Wrapper ownership model
+
+Not applicable yet — no CEF object (or any pointer-owning type) crosses into Rust. The moment a real API needs to pass e.g. a string or buffer across this boundary, this section needs real content: who allocates, who frees, and on which side.
+
+## Known API coverage gaps
+
+None cataloged — there is no real API surface yet to have gaps in. The competency matrix (`docs/cef/CEF-RUST-COMPETENCY-MATRIX.md`) already flags this explicitly: `binding_model_documented: true` refers to the *integration model* (ADR-0020's Option B choice), not a claim that the FFI surface itself is complete or battle-tested.
+
+## Binding upgrade procedure
+
+Not written yet — see [`binding-upgrade-playbook.md`](binding-upgrade-playbook.md), still a skeleton. With only one trivial function crossing the boundary, there is nothing yet to have an upgrade procedure *for* beyond bumping the Corrosion `GIT_TAG` pin in `CMakeLists.txt`, which has not been exercised even once.

--- a/docs/cef/knowledge/threading-and-lifetimes.md
+++ b/docs/cef/knowledge/threading-and-lifetimes.md
@@ -1,18 +1,41 @@
 # CEF Threading and Lifetimes
 
-**Status:** Not started — no CEF integration exists yet in this repository.
+**Status:** Real, hands-on evidence from `apps/desktop-cef/` (PR #388) — the first genuine content this doc has ever had. Narrower than its full intended scope: UI-thread callback discipline and CEF ref-counting/callback-lifetime patterns are covered with real code + CI proof; IO-thread behavior, render-process-side code, and async cancellation are **not** touched at all yet.
 **Scope:** UI-thread-only callback rules, IO-thread behavior, CEF's reference-counted object model, callback lifetime, renderer/browser process boundaries, async cancellation and object invalidation, and shutdown races — as they actually manifest in WorldScript's host implementation.
 **Tier:** A (release/security-critical) — see [`../OWNERSHIP.yaml`](../OWNERSHIP.yaml).
 **Roadmap context:** [`../ROADMAP-CEF-DESKTOP-MIGRATION.md`](../ROADMAP-CEF-DESKTOP-MIGRATION.md) §4.11.1 ("CEF threading and lifetime rules" domain), §4.11.4 (dual-review requirement for this exact area), Appendix A.1.
 
-## Outline (to be filled in during Wave 2)
+## Thread map: what we've actually proven (PR #388)
 
-- Thread map: which WorldScript operations must run on which CEF thread, and why
-- Reference-counting discipline for CEF objects touched by our code
-- Callback lifetime patterns used in our IPC/bridge implementation
-- Documented shutdown-race scenarios we've hit and how they were resolved
-- Repeated-startup/shutdown test results (link to the learning harness, §4.11.3)
+Every callback our code implements — `WorldScriptApp::OnContextInitialized`, `WorldScriptHandler::OnTitleChange`/`OnAfterCreated`/`DoClose`/`OnBeforeClose`/`PollShutdownFlag`, `WorldScriptWindowDelegate::OnWindowCreated`/`OnWindowDestroyed`/`CanClose` — runs on CEF's **UI thread**, enforced by `CEF_REQUIRE_UI_THREAD()` (a `DCHECK`-style assertion, not just a comment) at the top of each. This is CEF's own contract for these specific interfaces (`CefBrowserProcessHandler`, `CefLifeSpanHandler`, `CefDisplayHandler`, `CefWindowDelegate`) — we didn't have to manually dispatch anything onto the UI thread for these to be correct; CEF delivers them there itself.
 
-## Why this file exists before any code
+**Not touched at all**: IO-thread behavior, render-process-side code (no `CefRenderProcessHandler` implemented — see `docs/cef/CEF-BINDING-DECISION-SCORECARD.md`'s "Renderer callbacks" row, which explicitly scores this as untested), and any cross-thread posting *other than* the one pattern below.
 
-Per roadmap §4.11.4, CEF initialization, message-loop integration, and shutdown require independent dual-review — not a single unchecked implementation path. This document is where that review's findings get recorded, so lifetime knowledge survives beyond one PR conversation.
+## Reference-counting discipline — a real gotcha found via CI, not review
+
+Every CEF-facing class we wrote (`WorldScriptHandler`, `WorldScriptApp`, `WorldScriptWindowDelegate`, `WorldScriptBrowserViewDelegate`, `PollShutdownTask`) uses `IMPLEMENT_REFCOUNTING(ClassName)` — CEF's own ref-counted base (`CefBaseRefCounted`-derived interfaces), not Chromium's `base::RefCounted<T>`.
+
+**The gotcha**: these are two *different* ref-counting schemes. Chromium's `base::BindOnce`/`base::Bind` has automatic ref-counting detection built for its *own* `base::RefCounted` family — it does **not** recognize CEF's `IMPLEMENT_REFCOUNTING` scheme the same way. Binding a bare `this` (a CEF ref-counted object) directly into `base::BindOnce(&Method, this)` produced a real compile failure on the actual CI build (`base::BindFailedCheckPreviousErrors`, "invalid use of incomplete type `OnceCallback<void()>`") — not caught by local review (no CEF SDK available to compile against locally), only by the CI-first loop actually building it. `base::Unretained(this)` fixed the *receiver* half of that error but not the underlying incomplete-type issue.
+
+**What we shipped instead**: a plain `CefTask` subclass (`PollShutdownTask`, in `apps/desktop-cef/src/worldscript_handler.cpp`'s anonymous namespace) holding a `CefRefPtr<WorldScriptHandler> handler_` member, passed to the simpler `CefPostDelayedTask(CefThreadId, CefRefPtr<CefTask>, int64_t)` overload — sidestepping `base::Bind`'s template machinery entirely. `CefRefPtr<WorldScriptHandler>(this)` in the task's constructor calls `AddRef()`, genuinely extending the handler's lifetime for as long as the task holds it — a real lifetime guarantee, not just an "I promise this is safe" annotation like `base::Unretained` would have been.
+
+## Callback lifetime pattern: the shutdown-poll chain
+
+`WorldScriptHandler::OnAfterCreated` schedules the first `PollShutdownTask` via `CefPostDelayedTask(TID_UI, ..., 100ms)`. Each execution either (a) detects the shutdown flag set and calls `TryCloseBrowser()` on every tracked browser, stopping the chain, or (b) reschedules itself only `if (!browser_list_.empty())`. This means the polling chain **self-terminates** once the last browser closes (`OnBeforeClose` empties `browser_list_`) — no explicit cancellation call was needed, and no scheduled-but-orphaned tasks accumulate after the browser closes, confirmed by the clean process-tree check in `scripts/cef/run-launch-cycle-proof.mjs` across 3 repeated cycles.
+
+## Shutdown races — one real one avoided, one real one found and worked around
+
+- **Avoided by design**: CEF APIs are not async-signal-safe (confirmed via CEF's own docs during this investigation). `apps/desktop-cef/src/shutdown_signal.h`/`.cpp`'s SIGTERM/SIGINT handler does *only* an async-signal-safe `sig_atomic_t` flag write — no CEF call happens inside the signal handler itself. The actual `TryCloseBrowser()`/`OnBeforeClose()`/`CefQuitMessageLoop()` sequence runs from the polling task on the UI thread, a normal (non-signal-handler) context.
+- **Found and worked around**: a renderer subprocess can still be alive for a short window after the main (browser) process itself has already exited — an immediate orphan-process check after the main process exits produced a false positive on the first real run that spawned a renderer (once an unrelated ICU/cwd startup bug was fixed — see `docs/cef/knowledge/subprocess-and-shutdown.md`). Worked around with a fixed grace period before checking, not a measured wait — see that doc for the precise, review-corrected wording.
+
+## Repeated-startup/shutdown test results
+
+Real, CI-run evidence — see `docs/cef/knowledge/subprocess-and-shutdown.md` and the `🧪 CEF Learning Harness` workflow's `scripts/cef/run-launch-cycle-proof.mjs` step (PR #388): 3/3 independently-verified clean cycles.
+
+## Still open (not this doc's real content yet)
+
+- IO-thread behavior — never touched.
+- Render-process-side lifetime rules (`CefRenderProcessHandler`) — never implemented.
+- Async cancellation of in-flight CEF work (e.g. a pending `CefPostDelayedTask` explicitly cancelled mid-flight, not just left to self-terminate as above).
+- Object invalidation patterns beyond the one ref-counted-task pattern documented here.
+- The full dual-review this doc's own header requires (roadmap §4.11.4) — this is one author's real findings, not yet an independent second review.


### PR DESCRIPTION
## **User description**
## Summary

`cef-architecture-primer.md`, `threading-and-lifetimes.md`, and `cef-rust-binding-cookbook.md` were the last three "do not fill in speculatively" skeletons in `docs/cef/knowledge/`. All three now have real content grounded in `apps/desktop-cef/`'s actual code and PR #388's CI evidence:

- **`cef-architecture-primer.md`**: process model (single-binary-multi-role via `CefExecuteProcess`), browser/frame/client ownership, message-loop choice, subprocess packaging (real `ls -la` evidence), sandbox posture (unused), and an honest process-tree section that distinguishes directly-observed evidence (renderer, via console-log IPC) from inferred-but-unconfirmed (GPU process, via SwiftShader/Vulkan artifacts).
- **`threading-and-lifetimes.md`**: UI-thread callback discipline, the real `base::Bind`-vs-`CefTask` ref-counting gotcha found via CI (not local review), the shutdown-poll callback-lifetime pattern, and the two shutdown races (one avoided by design, one found and worked around).
- **`cef-rust-binding-cookbook.md`**: reframed around Option B's actual premise (no CEF-facing Rust crate exists or is needed), the real FFI surface (one trivial function, explicitly flagged as not representative of real API coverage), and the Corrosion build integration.

Every doc keeps explicit "still open" sections for what its real scope doesn't cover yet (IO thread, render-process handlers, real data crossing the FFI boundary, sandbox posture, the full dual-review §4.11.4 requires).

`OWNERSHIP.yaml` refreshed for all three (CEF version stamp, honest notes).

Docs-only — no code changes.

## Test plan

- [x] `OWNERSHIP.yaml` re-validated as parseable YAML
- [ ] CI quality gate (lint/typecheck/i18n:check) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document the current CEF integration from real implementation and CI evidence, preserving explicit gaps where behavior remains unverified.

Enhancements:
- Replace the three remaining CEF knowledge-document skeletons with evidence-based guidance covering architecture, threading and lifetimes, and the Rust integration model, while clearly identifying unverified areas.

Documentation:
- Document the implemented CEF process model, ownership, message loop, packaging, sandbox posture, shutdown behavior, and the thin C++/Rust FFI integration based on PR #388 evidence.

Chores:
- Refresh CEF document ownership metadata with verified WorldScript and CEF versions and current scope notes.


___

## **CodeAnt-AI Description**
Document the real CEF architecture, threading rules, and Rust integration

### What Changed
- Replaced three empty CEF knowledge documents with evidence from the working desktop integration and CI runs
- Documented the single-binary process model, browser ownership, message loop, resource packaging, shutdown behavior, and known sandbox and process-tree gaps
- Recorded UI-thread callback rules, CEF object lifetime handling, shutdown polling, signal safety, and repeated clean launch/shutdown results
- Explained the thin C++–Rust FFI model, its current single-function scope, Corrosion build integration, and untested data-ownership scenarios
- Updated ownership records with verified WorldScript and CEF versions and the remaining documentation gaps

### Impact
`✅ Clearer CEF process and shutdown behavior`
`✅ Fewer lifetime and callback integration mistakes`
`✅ Explicit Rust FFI coverage and safety limits`
`✅ Traceable documentation freshness`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
