### PR TITLE
feat(cef): real ldd-based Linux runtime linkage check (roadmap §44.3)

### DIFF
--- a/.github/workflows/cef-learning-harness.yml
+++ b/.github/workflows/cef-learning-harness.yml
@@ -108,6 +108,9 @@ jobs:
       - name: List worldscript_host output directory (diagnostic)
         run: ls -la build/worldscript_host/
 
+      - name: Linux runtime linkage check (ldd against shipped .so files)
+        run: node scripts/cef/check-linux-runtime-linkage.mjs build/worldscript_host
+
       - name: Serve production bundle + repeated launch/close proof
         run: |
           python3 -m http.server 8080 --directory dist &
@@ -139,5 +142,6 @@ jobs:
           echo "- Pinned SDK: \`$(node -e "console.log(require('./scripts/cef/cef-version.json').cefVersion)")\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Cache hit: \`${{ steps.cef-cache.outputs.cache-hit }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- worldscript_host built and repeated launch/close cycles proven against the real production bundle (dist/), under Xvfb." >> "$GITHUB_STEP_SUMMARY"
+          echo "- Linux runtime linkage (ldd against the shipped worldscript_host + libcef.so, not just dpkg package presence): see the \"Linux runtime linkage check\" step above." >> "$GITHUB_STEP_SUMMARY"
           echo "- Wayland smoke (best-effort, roadmap §44.2): \`${{ steps.wayland-smoke.outcome }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Not yet in scope: X11/Wayland matrix beyond this one runner, sandbox posture, accessibility smoke." >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/cef/check-linux-runtime-linkage.mjs
+++ b/scripts/cef/check-linux-runtime-linkage.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+/**
+ * CEF Linux runtime *linkage* check (docs/cef/ROADMAP-CEF-DESKTOP-MIGRATION.md §44.3) —
+ * the specific gap docs/architecture/native-readiness.md and
+ * docs/cef/knowledge/linux-runtime-notes.md have both flagged as open since Wave 2's
+ * first spike: check-linux-runtime-deps.mjs only confirms a *package* is installed via
+ * dpkg, never that the *actual shipped* .so files this build produced can resolve their
+ * real runtime dependencies. A package can be installed and still not satisfy a binary's
+ * exact SONAME/version requirement; dpkg presence alone doesn't prove that.
+ *
+ * Runs `ldd` against the real, already-built worldscript_host executable and the real
+ * libcef.so CEF shipped into the same output directory (COPY_FILES, apps/desktop-cef/
+ * CMakeLists.txt) — not a hypothetical package list. Reports any `=> not found` line as
+ * a genuine unresolved runtime dependency.
+ *
+ * Deliberately non-fatal by default, matching check-linux-runtime-deps.mjs's own
+ * reasoning: an honest inventory data point, not a gate on a specific distro's package
+ * set, until a real compatibility floor (§44.1) has been proven. Pass --strict once it
+ * has.
+ *
+ * Run: node scripts/cef/check-linux-runtime-linkage.mjs <build-output-dir> [--strict]
+ */
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+
+const [outputDir] = process.argv.slice(2);
+const strict = process.argv.includes('--strict');
+
+if (!outputDir) {
+  console.error(
+    '[check-linux-linkage] Usage: node scripts/cef/check-linux-runtime-linkage.mjs <build-output-dir> [--strict]',
+  );
+  process.exit(1);
+}
+
+// QNBS-v3: the two artifacts whose actual runtime linkage matters most — the host executable itself, and libcef.so, CEF's own largest and most dependency-heavy shared library (apps/desktop-cef/CMakeLists.txt's CEF_BINARY_FILES COPY_FILES step puts both in the same output directory).
+const TARGETS = ['worldscript_host', 'libcef.so'];
+
+/** @param {string} target */
+function checkLinkage(target) {
+  const targetPath = path.join(outputDir, target);
+  let out;
+  try {
+    // QNBS-v3: ldd's own exit code is 0 even when a dependency is unresolved (it prints "=> not found" and still exits cleanly) — the unresolved-dependency signal is in stdout text, not the process exit code, so it must be parsed rather than trusted from execFileSync alone.
+    out = execFileSync('ldd', [targetPath], { stdio: ['ignore', 'pipe', 'pipe'] }).toString();
+  } catch (err) {
+    // A genuinely non-dynamic-executable or missing file is itself a real finding, not a script bug.
+    return {
+      target,
+      ok: false,
+      notFound: [],
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+  const notFound = out
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.includes('=> not found') || /^\S+\s+not found/.test(line));
+  return { target, ok: notFound.length === 0, notFound, error: null };
+}
+
+const results = TARGETS.map(checkLinkage);
+
+console.log(
+  '[check-linux-linkage] CEF Linux runtime *linkage* check (ldd against shipped .so files):',
+);
+for (const { target, ok, notFound, error } of results) {
+  if (error) {
+    console.log(`  ✗ ${target} — could not run ldd: ${error}`);
+    continue;
+  }
+  console.log(
+    `  ${ok ? '✓' : '✗'} ${target}${ok ? '' : ` — ${notFound.length} unresolved dependency line(s):`}`,
+  );
+  for (const line of notFound) {
+    console.log(`      ${line}`);
+  }
+}
+
+const anyFailed = results.some((r) => r.error || !r.ok);
+if (anyFailed) {
+  console.log('\n[check-linux-linkage] One or more targets have unresolved runtime dependencies.');
+} else {
+  console.log(
+    `\n[check-linux-linkage] All ${results.length} target(s) fully resolved on this runner.`,
+  );
+}
+
+if (strict && anyFailed) {
+  console.error(
+    '[check-linux-linkage] --strict requested and unresolved dependencies found — failing.',
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
## **User description**
## Summary
- Closes a specific gap both `native-readiness.md` and `linux-runtime-notes.md` have flagged since Wave 2's first spike: `check-linux-runtime-deps.mjs` only confirms dpkg *package* presence, never that the actual shipped `.so` files this build produced can resolve their real runtime dependencies.
- New `scripts/cef/check-linux-runtime-linkage.mjs` runs `ldd` against the real, already-built `worldscript_host` and `libcef.so` (the same output directory `apps/desktop-cef/CMakeLists.txt`'s `COPY_FILES` populates) and reports any `=> not found` line.
- Deliberately non-fatal by default (matches `check-linux-runtime-deps.mjs`'s own reasoning) — an honest inventory data point, not a gate, until a real compatibility floor is proven.
- Wired into `cef-learning-harness.yml` right after the build step.

Docs will be updated in a follow-up once this runs in CI and produces a real result (same discipline as the crash-reporting/Wayland PRs — evidence first, then the doc claim).

## Test plan
- [ ] CI `🧪 CEF host build, dependency inventory, launch-cycle proof` job's new "Linux runtime linkage check" step runs and reports a real result
- [ ] Existing proofs (repeated cycles, crash-reporting, Wayland smoke) remain unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Verify that the built CEF Linux artifacts resolve their actual runtime dependencies during CI.

New Features:
- Add an `ldd`-based check for unresolved runtime dependencies in the shipped `worldscript_host` and `libcef.so` artifacts.

Enhancements:
- Keep linkage findings non-fatal by default while supporting strict failure mode for future compatibility gating.

CI:
- Run the Linux runtime linkage check in the CEF learning harness after the host build and include its result in the job summary.


___

## **CodeAnt-AI Description**
Check shipped Linux CEF files for unresolved runtime dependencies

### What Changed
- CI now checks the built `worldscript_host` and `libcef.so` files with `ldd`, rather than only checking installed packages
- Reports each missing runtime dependency and identifies files that cannot be inspected
- Keeps the check informational by default, with an optional strict mode available for future compatibility gating
- Adds the linkage result to the CEF learning harness summary

### Impact
`✅ Detects missing Linux runtime libraries in shipped CEF files`
`✅ Clearer dependency findings in CI`
`✅ Preserves successful builds while compatibility requirements are being established`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
