### PR TITLE
ci: path-scope Tauri Rust Gate, fast-gate + Cargo/apt caching for CEF harness

### DIFF
--- a/.github/workflows/cef-learning-harness.yml
+++ b/.github/workflows/cef-learning-harness.yml
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
@@ -85,7 +85,7 @@ jobs:
     timeout-minutes: 30
     needs: [fast-gate]
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/cef-learning-harness.yml
+++ b/.github/workflows/cef-learning-harness.yml
@@ -24,6 +24,11 @@
 # CEF-rendering regression introduced by an unrelated app-source PR is still
 # caught promptly (informationally, non-blocking), not silently missed until
 # someone next happens to touch a CEF-specific path.
+#
+# QNBS-v3: docs/cef/** deliberately excluded from the PR path list — a docs-only
+# change (e.g. updating the competency matrix) can't regress the built host, so it
+# doesn't need a ~30min rebuild; code changes under apps/desktop-cef/** or
+# scripts/cef/** still trigger this regardless of whether docs are also touched.
 # ============================================================
 
 name: 🧪 CEF Learning Harness
@@ -34,7 +39,6 @@ on:
     paths:
       - 'apps/desktop-cef/**'
       - 'scripts/cef/**'
-      - 'docs/cef/**'
       - '.github/workflows/cef-learning-harness.yml'
   push:
     branches: [main]
@@ -85,6 +89,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
+
+      - name: Cache apt packages (CEF host + Wayland build deps)
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: /var/cache/apt/archives/*.deb
+          # QNBS-v3: bump the -v suffix if either apt-get install package list in this job changes
+          key: apt-cef-harness-deps-v1
 
       - name: Install worldscript_host build dependencies
         run: |

--- a/.github/workflows/cef-learning-harness.yml
+++ b/.github/workflows/cef-learning-harness.yml
@@ -29,6 +29,15 @@
 # change (e.g. updating the competency matrix) can't regress the built host, so it
 # doesn't need a ~30min rebuild; code changes under apps/desktop-cef/** or
 # scripts/cef/** still trigger this regardless of whether docs are also touched.
+# The push-to-main trigger stays deliberately unscoped (no `paths:`) precisely so an
+# unrelated app-source change that alters dist/'s real inputs is still caught after
+# merge — narrowing that trigger to apps/desktop-cef/** only would reintroduce the
+# PR #388 gap this design already closed.
+#
+# QNBS-v3: `fast-gate` (lint+typecheck) runs before `harness` so a trivial code-style
+# or type error fails in ~2-3min instead of after the full ~30min SDK+CMake+Rust+Xvfb
+# cycle. `Swatinem/rust-cache` caches cargo's registry/git dirs for the rust-core
+# crate Corrosion builds via CMake, cutting redundant crates.io re-fetches.
 # ============================================================
 
 name: 🧪 CEF Learning Harness
@@ -52,10 +61,29 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # QNBS-v3: fast, cheap checks (lint/typecheck) gate the ~30min CEF build so a trivial
+  # code-style or type error doesn't burn the full SDK-fetch+CMake+Rust+Xvfb cycle before
+  # surfacing. Duplicates a subset of ci.yml's quality job (which runs in parallel anyway) —
+  # deliberate trade: a couple extra lint/typecheck minutes vs. up to 30 wasted on a fail-fast case.
+  fast-gate:
+    name: ⚡ Fast gate (lint + typecheck)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
+      - name: Lint (Biome)
+        run: pnpm run lint
+      - name: Typecheck (tsgo)
+        run: npx tsgo --project tsconfig.tsgo.json --noEmit --checkers 4
+
   harness:
     name: 🧪 CEF host build, dependency inventory, launch-cycle proof
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    needs: [fast-gate]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:
@@ -89,6 +117,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: stable
+
+      # QNBS-v3: rust-core (apps/desktop-cef/rust-core) is built via CMake's corrosion_import_crate,
+      # invoking cargo under the hood — this caches the global registry/git dirs cargo uses regardless
+      # of where Corrosion places its target/ output, so repeat runs skip re-fetching crates.io deps.
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          workspaces: apps/desktop-cef/rust-core -> target
 
       - name: Cache apt packages (CEF host + Wayland build deps)
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,43 @@ jobs:
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5
 
   # ----------------------------------------------------------
+  # 0b. CHANGE DETECTION: path-scopes rust-tauri so a docs/frontend-only PR
+  # doesn't pay for a Rust toolchain + apt-get(libgtk/libwebkit) build it can't
+  # affect. Fails OPEN (tauri=true) on any ambiguity — base SHA missing/unreachable
+  # — so a detection error runs the real gate instead of silently skipping it.
+  # ----------------------------------------------------------
+  changes:
+    name: 📂 Detect changed paths
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      tauri: ${{ steps.filter.outputs.tauri }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Detect src-tauri changes
+        id: filter
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE="${{ github.event.before }}"
+          fi
+          if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ] || ! git cat-file -e "$BASE" 2>/dev/null; then
+            echo "::notice::No usable base SHA to diff against — defaulting to tauri=true (fail open)"
+            echo "tauri=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if git diff --name-only "$BASE" "${{ github.sha }}" | grep -qE '^(src-tauri/|\.github/workflows/ci\.yml$)'; then
+            echo "tauri=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "tauri=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # ----------------------------------------------------------
   # 1. QUALITY GATE: Lint + Typecheck + Tests (parallel matrix)
   # ----------------------------------------------------------
   quality:
@@ -177,16 +214,15 @@ jobs:
           fail_ci_if_error: false
 
   # ----------------------------------------------------------
-  # 2. BUILD: Production build + Pages artifact upload
-  # QNBS-v3: Stryker mutation removed from the PR/CI pipeline (2026-06-02) — it added noise as a
-  #          flaky, non-gating check. Mutation now runs ONLY via the manual `.github/workflows/
-  #          mutation.yml` (workflow_dispatch). To be re-integrated in a later iteration.
+  # 1b. RUST-TAURI: Tauri Rust Gate (fmt/check/clippy/test), path-scoped via `changes`
   # ----------------------------------------------------------
   rust-tauri:
     name: 🦀 Tauri Rust Gate
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: [security]
+    needs: [security, changes]
+    # QNBS-v3: skips for PRs that don't touch src-tauri/** — ci-success treats 'skipped' as pass for this job only
+    if: needs.changes.outputs.tauri == 'true'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:
@@ -195,6 +231,12 @@ jobs:
         with:
           toolchain: stable
           components: rustfmt, clippy
+      - name: Cache apt packages (Tauri Linux build deps)
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: /var/cache/apt/archives/*.deb
+          # QNBS-v3: bump the -v suffix if the apt-get install package list below changes
+          key: apt-tauri-linux-deps-v1
       - name: Install Linux Tauri build dependencies
         run: |
           sudo apt-get update
@@ -212,6 +254,12 @@ jobs:
         working-directory: src-tauri
         run: cargo test --locked
 
+  # ----------------------------------------------------------
+  # 2. BUILD: Production build + Pages artifact upload
+  # QNBS-v3: Stryker mutation removed from the PR/CI pipeline (2026-06-02) — it added noise as a
+  #          flaky, non-gating check. Mutation now runs ONLY via the manual `.github/workflows/
+  #          mutation.yml` (workflow_dispatch). To be re-integrated in a later iteration.
+  # ----------------------------------------------------------
   build:
     name: 🏗️ Build
     runs-on: ubuntu-latest
@@ -290,33 +338,40 @@ jobs:
           path: ./dist
 
   # ----------------------------------------------------------
-  # 3. CI SUCCESS: single required-status aggregator (security + quality + build)
+  # 3. CI SUCCESS: single required-status aggregator (security + quality + changes + rust-tauri + build + e2e + vrt)
   # ----------------------------------------------------------
   ci-success:
     name: ✅ CI Success
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [security, quality, rust-tauri, build, e2e, vrt]
+    needs: [security, quality, changes, rust-tauri, build, e2e, vrt]
     if: always()
     steps:
+      # QNBS-v3: rust-tauri may legitimately be 'skipped' (changes.outputs.tauri == 'false') — that's a pass, not a failure
       - name: Verify all required jobs succeeded
         run: |
-          if [ "${{ needs.security.result }}" != "success" ] || \
-             [ "${{ needs.quality.result }}" != "success" ] || \
-             [ "${{ needs.rust-tauri.result }}" != "success" ] || \
-             [ "${{ needs.build.result }}" != "success" ] || \
-             [ "${{ needs.e2e.result }}" != "success" ] || \
-             [ "${{ needs.vrt.result }}" != "success" ]; then
+          FAIL=0
+          [ "${{ needs.security.result }}" = "success" ] || FAIL=1
+          [ "${{ needs.quality.result }}" = "success" ] || FAIL=1
+          [ "${{ needs.changes.result }}" = "success" ] || FAIL=1
+          if [ "${{ needs.rust-tauri.result }}" != "success" ] && [ "${{ needs.rust-tauri.result }}" != "skipped" ]; then
+            FAIL=1
+          fi
+          [ "${{ needs.build.result }}" = "success" ] || FAIL=1
+          [ "${{ needs.e2e.result }}" = "success" ] || FAIL=1
+          [ "${{ needs.vrt.result }}" = "success" ] || FAIL=1
+          if [ "$FAIL" = "1" ]; then
             echo "One or more required jobs did not succeed:"
             echo "  security: ${{ needs.security.result }}"
             echo "  quality:  ${{ needs.quality.result }}"
-            echo "  rust-tauri: ${{ needs.rust-tauri.result }}"
+            echo "  changes:  ${{ needs.changes.result }}"
+            echo "  rust-tauri: ${{ needs.rust-tauri.result }} (skipped = OK, src-tauri untouched)"
             echo "  build:    ${{ needs.build.result }}"
             echo "  e2e:      ${{ needs.e2e.result }}"
             echo "  vrt:      ${{ needs.vrt.result }}"
             exit 1
           fi
-          echo "All required jobs succeeded."
+          echo "All required jobs succeeded (or were legitimately skipped)."
 
   # ----------------------------------------------------------
   # 4. DEPLOY: GitHub Pages (only on main push)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,12 @@ jobs:
         with:
           toolchain: stable
           components: rustfmt, clippy
+      # QNBS-v3: no cargo caching existed before — fmt/check/clippy/test each rebuilt the full
+      # dependency tree from scratch every run. Keyed on Cargo.lock + rustc version, so a toolchain
+      # bump or lockfile change invalidates cleanly rather than reusing stale artifacts.
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          workspaces: src-tauri -> target
       - name: Cache apt packages (Tauri Linux build deps)
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,6 +287,16 @@ jobs:
         env:
           NODE_ENV: production
 
+      # QNBS-v3: caches the apt .deb archives `--with-deps` fetches (fonts, libx11, etc.) — shared
+      # key across every `playwright install --with-deps` call site in this workflow, since they all
+      # install the same system packages on the same runner image. actions/cache/save on a fresh
+      # write here also warms the cache for e2e/e2e-deep/storybook/vrt below.
+      - name: Cache apt packages (Playwright system deps)
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: /var/cache/apt/archives/*.deb
+          key: apt-playwright-chromium-deps-v1
+
       # QNBS-v3: The E2E suite runs `vite dev`, so prod-only rolldown bundling crashes (e.g. the
       # zod DCE "init_locales is not defined" blank screen) never surface there. This guard loads
       # the real production bundle in headless Chromium and fails if React does not mount.
@@ -422,6 +432,12 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
 
+      - name: Cache apt packages (Playwright system deps)
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: /var/cache/apt/archives/*.deb
+          key: apt-playwright-chromium-deps-v1
+
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps chromium
 
@@ -475,6 +491,12 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+
+      - name: Cache apt packages (Playwright system deps)
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: /var/cache/apt/archives/*.deb
+          key: apt-playwright-chromium-deps-v1
 
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps chromium
@@ -567,6 +589,12 @@ jobs:
       - name: Build Storybook
         run: pnpm exec storybook build --output-dir storybook-static
 
+      - name: Cache apt packages (Playwright system deps)
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: /var/cache/apt/archives/*.deb
+          key: apt-playwright-chromium-deps-v1
+
       # QNBS-v3: Chromium-only; test-runner v0.24+ is async-compatible with Storybook v10.
       - name: Install Playwright browsers (test-runner)
         run: pnpm exec playwright install --with-deps chromium
@@ -629,6 +657,12 @@ jobs:
         with:
           name: dist
           path: dist/
+
+      - name: Cache apt packages (Playwright system deps)
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: /var/cache/apt/archives/*.deb
+          key: apt-playwright-chromium-deps-v1
 
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps chromium

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       pull-requests: read
     steps:
       # QNBS-v3: fetch-depth:0 gives gitleaks access to parent commits (sha^) needed for PR diff scans; shallow clone causes "ambiguous argument" errors.
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -98,7 +98,7 @@ jobs:
     outputs:
       tauri: ${{ steps.filter.outputs.tauri }}
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -138,7 +138,7 @@ jobs:
     steps:
       # QNBS-v3: fetch-tags — check-doc-metrics.mjs's stale-PLANNED-status check reads `git tag`
       # and silently no-ops without one; a default shallow checkout has no tags at all.
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           fetch-tags: true
@@ -224,7 +224,7 @@ jobs:
     # QNBS-v3: skips for PRs that don't touch src-tauri/** — ci-success treats 'skipped' as pass for this job only
     if: needs.changes.outputs.tauri == 'true'
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -277,7 +277,7 @@ jobs:
       attestations: write
       id-token: write
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
@@ -420,7 +420,7 @@ jobs:
     timeout-minutes: 50
     needs: [quality]
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
@@ -481,7 +481,7 @@ jobs:
     needs: [quality]
     continue-on-error: true
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
@@ -526,7 +526,7 @@ jobs:
     needs: [build]
     continue-on-error: false
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
@@ -573,7 +573,7 @@ jobs:
     timeout-minutes: 25
     needs: [quality]
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup
@@ -646,7 +646,7 @@ jobs:
     timeout-minutes: 15
     needs: [build]
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -20,6 +20,16 @@ useDefault = true
 # broadening the exemption to "anything in that file" rather than narrowing it. The exact leaked
 # value alone is already a highly-specific, non-generic string that cannot coincidentally match a
 # real secret elsewhere, so it's the narrowest correct scope available in this schema.
+#
+# apt-cef-harness-deps-v1 / apt-tauri-linux-deps-v1
+# (.github/workflows/cef-learning-harness.yml, ci.yml) are actions/cache `key:` values for apt
+# archive caching — static, non-secret cache-namespace strings. Flagged by the same generic-api-key
+# heuristic: YAML `key:` field name next to a hyphenated alphanumeric string. Reviewed 2026-08-19:
+# both are cache keys with a fixed literal suffix (`-v1`), not credentials.
 [allowlist]
-description = "PASSPHRASE_SENTINEL_RECORD_KEY test mock — static IDB record-key identifier, not a credential"
-regexes = ['''^idb_passphrase_sentinel_v1$''']
+description = "Cache-key / record-key literals flagged by generic-api-key's key-adjacent-string heuristic — not credentials"
+regexes = [
+  '''^idb_passphrase_sentinel_v1$''',
+  '''^apt-cef-harness-deps-v1$''',
+  '''^apt-tauri-linux-deps-v1$''',
+]


### PR DESCRIPTION
## **User description**
## Summary

Root cause diagnosed this session for today's recurring CI hangs: `azure.archive.ubuntu.com` apt `.deb` *file* downloads crawling at ~121 kB/s (vs ~3.7 MB/s for the package-index fetch) — a real, external mirror-throughput issue, not repo code. This PR reduces how often, and how much, CI depends on that slow path, plus closes two other real inefficiencies found while investigating:

- **`rust-tauri` is now path-scoped.** New `changes` job diffs against the PR base SHA and gates `🦀 Tauri Rust Gate` so a docs/frontend-only PR skips its `apt-get install libgtk-3-dev libwebkit2gtk-4.1-dev ...` + full `cargo fmt/check/clippy/test` entirely. It was previously unconditional on every PR despite being folded into the required `✅ CI Success` aggregator. Fails **open** (`tauri=true`) on any base-SHA ambiguity, and `ci-success` only treats `rust-tauri: skipped` as a pass — `changes` itself stays a hard requirement, so the detector's own failure doesn't silently skip the gate.
- **CEF Learning Harness no longer triggers on `docs/cef/**` PR changes.** A docs-only edit (e.g. updating the competency matrix) can't regress the built `worldscript_host`, so it no longer pays for the ~30min SDK-fetch+CMake+Rust+Xvfb cycle. Code paths (`apps/desktop-cef/**`, `scripts/cef/**`) are unaffected and still trigger it. The `push`-to-`main` trigger deliberately stays unscoped (no `paths:`) — narrowing *that* to `apps/desktop-cef/**` would reintroduce the PR #388 gap (the harness builds the real production `dist/`, so unrelated app-source changes must still be caught post-merge).
- **`fast-gate` (lint + typecheck) now gates the CEF harness's heavy `harness` job.** A trivial Biome/tsgo error now fails in ~2-3min instead of only surfacing after the full 30-minute build. Small deliberate duplication of a slice of `ci.yml`'s `quality` job, which still runs in parallel.
- **Cargo caching added via `Swatinem/rust-cache`** for both `rust-tauri` (`src-tauri`) and the CEF harness's Corrosion-driven `rust-core` build — neither had *any* Cargo caching before; every run re-fetched and rebuilt the full dependency tree from scratch.
- **Apt-archive caching** (`actions/cache` on `/var/cache/apt/archives/*.deb`) for both jobs' `apt-get install` steps — directly mitigates today's diagnosed root cause: a cache hit skips the slow mirror download outright, not just the index refresh.

`concurrency: cancel-in-progress: true` was already present on both workflows for PR events — no change needed there.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open(f))"` — both files parse as valid YAML
- [x] Confirmed `src-tauri/` is a self-contained crate (no root/shared Cargo workspace with `apps/desktop-cef/rust-core`), so path-scoping `rust-tauri` to `src-tauri/**` is precise
- [x] Confirmed only `✅ CI Success` is a required branch-protection context (not `rust-tauri` by name), so a `skipped` `rust-tauri` can't itself block merge
- [ ] CI run on this PR — `changes` reports `tauri=false` (this PR touches no `src-tauri/` files) → `rust-tauri` should show `skipped`, `ci-success` should still pass
- [ ] CEF Learning Harness run on this PR — `fast-gate` runs and passes before `harness` starts
- [ ] Full review-bot loop (CodeRabbit/CodeAnt/Amazon Q/Graphite) to quiescence before merge, per standing repo policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Reduce unnecessary CI work and accelerate feedback by scoping expensive checks, adding fail-fast validation, and caching dependencies.

Enhancements:
- Path-scope the Tauri Rust gate and allow intentional skips while keeping change detection required for CI success.
- Skip the CEF learning harness for documentation-only CEF changes while retaining coverage for code changes and pushes to main.
- Add an early CEF lint and typecheck gate before the expensive harness build.
- Cache Rust dependencies and Linux package archives across Tauri, CEF, and Playwright-related CI jobs.

CI:
- Update workflow action references to v7.0.1 and expand CI caching to reduce repeated dependency downloads.

Chores:
- Allowlist the new static apt cache keys in gitleaks configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved automated validation workflows for faster, more reliable builds.
  - Added linting and TypeScript checks before the CEF harness runs.
  - Optimized Rust and system dependency handling through caching.
  - Updated change detection to skip unnecessary checks for unaffected changes while preserving accurate overall results.
  - Clarified workflow sequencing and trigger behavior.
  - Refined secret scanning configuration to reduce false positives from approved build-cache values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Reduce unnecessary CI work and surface CEF failures sooner

### What Changed
- Tauri Rust checks now run only when Tauri code or its CI workflow changes; documentation and frontend-only pull requests can skip that build while still passing the required CI summary.
- CEF harness checks no longer run for documentation-only changes, but still run for CEF code changes and every merge to `main`.
- CEF builds now run lint and type checks first, so basic errors are reported before the long SDK, build, and launch-cycle checks.
- CI reuses Rust, apt package, and Playwright dependencies across runs to avoid repeated downloads and compilation.

### Impact
`✅ Faster documentation and frontend-only pull requests`
`✅ Earlier feedback for CEF lint and type errors`
`✅ Fewer CI delays from repeated package downloads and Rust builds`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
