### PR TITLE
docs(ci): fix stale actions/checkout version annotation in remaining workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
         language: [javascript-typescript]
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,7 +23,7 @@ jobs:
       packages: write
     steps:
       # QNBS-v3: SHA-pinned to prevent supply-chain attacks via mutable tags
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -63,7 +63,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -23,7 +23,7 @@ jobs:
       actions: read
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/storybook-debug.yml
+++ b/.github/workflows/storybook-debug.yml
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 35
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -37,7 +37,7 @@ jobs:
           - os: macos-latest
 
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       # QNBS-v3: composite action handles pnpm/node setup + frozen install.

--- a/.github/workflows/voice-nightly.yml
+++ b/.github/workflows/voice-nightly.yml
@@ -25,7 +25,7 @@ jobs:
     # Never gate anything — informational nightly signal only.
     continue-on-error: true
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup


### PR DESCRIPTION
## **User description**
## Summary

Follow-up to CodeRabbit's finding on #398, which was already fixed there for `ci.yml` and `cef-learning-harness.yml`. The same `actions/checkout` SHA (`3d3c42e5aac5ba805825da76410c181273ba90b1`) is pinned across the rest of the repo's workflows with a stale `# v6` comment.

Independently re-verified (not just trusting the bot):
- tag `v6` dereferences to `d23441a48e516b6c34aea4fa41551a30e30af803`
- tag `v7.0.1` dereferences to `3d3c42e5aac5ba805825da76410c181273ba90b1` — matches our pinned SHA

Fixes the annotation in the 7 remaining files: `storybook-debug.yml`, `codeql.yml`, `tauri-build.yml`, `voice-nightly.yml`, `mutation.yml`, `scorecard.yml`, `docker.yml`. Comment-only change — the pinned SHA and workflow behavior are unchanged.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open(f))"` — all 7 files parse as valid YAML
- [x] `grep -rln "...3ba90b1 # v6" .github/workflows/` returns only `ci.yml`/`cef-learning-harness.yml` (already fixed on #398, not yet merged)
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Correct stale actions/checkout version annotations from v6 to v7.0.1 across seven remaining GitHub Actions workflows while preserving the existing pinned SHA and workflow behavior.


___

## **CodeAnt-AI Description**
Correct checkout action version annotations across remaining CI workflows

### What Changed
- Updated the displayed `actions/checkout` version from v6 to v7.0.1 in seven workflows, including CodeQL, Docker, Storybook, mutation testing, Scorecard, nightly voice checks, and Tauri builds
- The pinned checkout revision and workflow behavior remain unchanged

### Impact
`✅ Accurate CI dependency documentation`
`✅ Clearer workflow maintenance`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
