### PR TITLE
fix(cef): raise STARTUP_GRACE_MS to 15s (real post-merge CI failure)

### DIFF
--- a/scripts/cef/run-launch-cycle-proof.mjs
+++ b/scripts/cef/run-launch-cycle-proof.mjs
@@ -58,8 +58,12 @@ const cycles = cyclesArgIdx === -1 ? 3 : Number(cyclesArg);
 // recurred on a main push right after PR #400 added -g to worldscript_host — real, measured
 // evidence: the binary grew from 1.34MB to 6.33MB (target_compile_options in
 // apps/desktop-cef/CMakeLists.txt), a plausible contributor to slower first-launch I/O on a
-// loaded runner. Cycles 2/3 in the same run always passed at the old window — this only ever
-// hits the cold first launch.
+// loaded runner. Cycles 2/3 in runCycle always passed at the old window — the actual observed
+// failure only ever hit the cold first launch there. This constant is also read by
+// runCrashReportingProofCycle's own renderer-crash-detection timeout below (line ~278) — a
+// shared constant, not a runCycle-only one; that consumer's failure-detection window widens by
+// the same 5s as a side effect, which is fine (strictly more lenient, same CI-runner-speed
+// rationale applies), not a dedicated timeout since there's no evidence the two need to differ.
 const STARTUP_GRACE_MS = 15000;
 const SHUTDOWN_GRACE_MS = 6000;
 // QNBS-v3: extra buffer after the main process exits — a renderer/GPU subprocess can take a moment longer to actually be reaped than its parent (docs/cef/knowledge/subprocess-and-shutdown.md's own "not instantaneous" finding applies to the whole tree, not just the browser process).

--- a/scripts/cef/run-launch-cycle-proof.mjs
+++ b/scripts/cef/run-launch-cycle-proof.mjs
@@ -54,7 +54,13 @@ const cyclesArg = cyclesArgIdx !== -1 ? process.argv[cyclesArgIdx + 1] : undefin
 const cycles = cyclesArgIdx === -1 ? 3 : Number(cyclesArg);
 
 // QNBS-v3: raised from 4000ms after two consecutive CI runs on identical code (byte-for-byte matching main, which had passed reliably before) showed the browser process alive but never reaching OnAfterCreated within the old window — runner-speed variance, not a code regression.
-const STARTUP_GRACE_MS = 10000;
+// QNBS-v3: raised again from 10000ms after the same "Cycle 1: no FFI boundary proof" symptom
+// recurred on a main push right after PR #400 added -g to worldscript_host — real, measured
+// evidence: the binary grew from 1.34MB to 6.33MB (target_compile_options in
+// apps/desktop-cef/CMakeLists.txt), a plausible contributor to slower first-launch I/O on a
+// loaded runner. Cycles 2/3 in the same run always passed at the old window — this only ever
+// hits the cold first launch.
+const STARTUP_GRACE_MS = 15000;
 const SHUTDOWN_GRACE_MS = 6000;
 // QNBS-v3: extra buffer after the main process exits — a renderer/GPU subprocess can take a moment longer to actually be reaped than its parent (docs/cef/knowledge/subprocess-and-shutdown.md's own "not instantaneous" finding applies to the whole tree, not just the browser process).
 const ORPHAN_CHECK_GRACE_MS = 3000;


### PR DESCRIPTION
## **User description**
## Summary

`main`'s own post-merge CEF Learning Harness run (triggered by PR #400's merge) failed with the exact "Cycle 1: no FFI boundary proof" symptom this file's own comment already documents as a known runner-speed-variance pattern (`STARTUP_GRACE_MS` was raised `4000->10000ms` for the same reason before, on unrelated code).

Real, measured evidence for a plausible contributing factor this time: PR #400's `-g` flag on `worldscript_host` (`apps/desktop-cef/CMakeLists.txt`) grew the binary from **1.34MB to 6.33MB (4.7x)**, comparing the last pre-#400 successful run's `ls -la` output to this failing run's. Cycles 2/3 in the same run always passed at the old 10s window — this only ever hits the cold first launch, consistent with slower first-time I/O on a larger binary under a loaded runner, not a logic regression.

Bumped `STARTUP_GRACE_MS` 10000 -> 15000ms. Cost is asymmetric: a successful launch resolves the `Promise.race` immediately and never waits the full window, so this only adds latency to the genuine-hang failure path, not the happy path.

## Test plan

- [x] Re-ran the failed main job directly (`gh run rerun --failed`) as an independent data point while this fix was being prepared
- [ ] CI on this PR — full 3-cycle proof + crash-reporting + symbolization proofs all pass
- [ ] Watch the next few `main` pushes for recurrence

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Increase the CEF startup grace period to 15 seconds to prevent cold-start timing variance from causing false CI failures.

Bug Fixes:
- Reduce false CEF launch failures by allowing slower cold-start browser launches to complete before reporting missing FFI proof.

Enhancements:
- Increase the shared CEF startup and crash-detection grace period from 10 to 15 seconds to better accommodate slower CI runners.


___

## **CodeAnt-AI Description**
Prevent false CEF launch failures on slow cold starts

### What Changed
- The CEF launch proof now allows up to 15 seconds for the browser to start, up from 10 seconds
- Slow first launches on loaded CI runners are less likely to be reported as missing FFI proof failures
- Normal launches complete immediately without waiting for the full timeout

### Impact
`✅ Fewer false CI launch failures`
`✅ More reliable cold-start validation`
`✅ No added delay for successful launches`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
