### PR TITLE
fix(ci): apt-archive cache restore was silently failing on every run

### DIFF
--- a/.github/workflows/cef-learning-harness.yml
+++ b/.github/workflows/cef-learning-harness.yml
@@ -144,6 +144,13 @@ jobs:
         with:
           workspaces: apps/desktop-cef/rust-core -> target
 
+      # QNBS-v3: /var/cache/apt/archives is root-owned by default — actions/cache's restore
+      # (tar extraction) runs as the unprivileged runner user and fails with "Permission denied"
+      # on every file without this, silently degrading to a cache miss every time (real CI
+      # evidence: "Cache hit" followed immediately by "Cache not found" from the failed tar).
+      - name: Make apt archive cache dir writable by the runner user
+        run: sudo mkdir -p /var/cache/apt/archives/partial && sudo chmod -R 777 /var/cache/apt/archives
+
       - name: Cache apt packages (CEF host + Wayland build deps)
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:

--- a/.github/workflows/cef-learning-harness.yml
+++ b/.github/workflows/cef-learning-harness.yml
@@ -149,7 +149,7 @@ jobs:
       # on every file without this, silently degrading to a cache miss every time (real CI
       # evidence: "Cache hit" followed immediately by "Cache not found" from the failed tar).
       - name: Make apt archive cache dir writable by the runner user
-        run: sudo mkdir -p /var/cache/apt/archives/partial && sudo chmod -R 777 /var/cache/apt/archives
+        run: sudo mkdir -p /var/cache/apt/archives/partial && sudo chown -R runner:runner /var/cache/apt/archives && sudo chmod -R 755 /var/cache/apt/archives
 
       - name: Cache apt packages (CEF host + Wayland build deps)
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,13 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: src-tauri -> target
+      # QNBS-v3: /var/cache/apt/archives is root-owned by default — actions/cache's restore
+      # (tar extraction) runs as the unprivileged runner user and fails with "Permission denied"
+      # on every file without this, silently degrading to a cache miss every time (real CI
+      # evidence: "Cache hit" followed immediately by "Cache not found" from the failed tar).
+      - name: Make apt archive cache dir writable by the runner user
+        run: sudo mkdir -p /var/cache/apt/archives/partial && sudo chmod -R 777 /var/cache/apt/archives
+
       - name: Cache apt packages (Tauri Linux build deps)
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -291,6 +298,13 @@ jobs:
       # key across every `playwright install --with-deps` call site in this workflow, since they all
       # install the same system packages on the same runner image. actions/cache/save on a fresh
       # write here also warms the cache for e2e/e2e-deep/storybook/vrt below.
+      # QNBS-v3: /var/cache/apt/archives is root-owned by default — actions/cache's restore
+      # (tar extraction) runs as the unprivileged runner user and fails with "Permission denied"
+      # on every file without this, silently degrading to a cache miss every time (real CI
+      # evidence: "Cache hit" followed immediately by "Cache not found" from the failed tar).
+      - name: Make apt archive cache dir writable by the runner user
+        run: sudo mkdir -p /var/cache/apt/archives/partial && sudo chmod -R 777 /var/cache/apt/archives
+
       - name: Cache apt packages (Playwright system deps)
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -432,6 +446,13 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
 
+      # QNBS-v3: /var/cache/apt/archives is root-owned by default — actions/cache's restore
+      # (tar extraction) runs as the unprivileged runner user and fails with "Permission denied"
+      # on every file without this, silently degrading to a cache miss every time (real CI
+      # evidence: "Cache hit" followed immediately by "Cache not found" from the failed tar).
+      - name: Make apt archive cache dir writable by the runner user
+        run: sudo mkdir -p /var/cache/apt/archives/partial && sudo chmod -R 777 /var/cache/apt/archives
+
       - name: Cache apt packages (Playwright system deps)
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -491,6 +512,13 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+
+      # QNBS-v3: /var/cache/apt/archives is root-owned by default — actions/cache's restore
+      # (tar extraction) runs as the unprivileged runner user and fails with "Permission denied"
+      # on every file without this, silently degrading to a cache miss every time (real CI
+      # evidence: "Cache hit" followed immediately by "Cache not found" from the failed tar).
+      - name: Make apt archive cache dir writable by the runner user
+        run: sudo mkdir -p /var/cache/apt/archives/partial && sudo chmod -R 777 /var/cache/apt/archives
 
       - name: Cache apt packages (Playwright system deps)
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -589,6 +617,13 @@ jobs:
       - name: Build Storybook
         run: pnpm exec storybook build --output-dir storybook-static
 
+      # QNBS-v3: /var/cache/apt/archives is root-owned by default — actions/cache's restore
+      # (tar extraction) runs as the unprivileged runner user and fails with "Permission denied"
+      # on every file without this, silently degrading to a cache miss every time (real CI
+      # evidence: "Cache hit" followed immediately by "Cache not found" from the failed tar).
+      - name: Make apt archive cache dir writable by the runner user
+        run: sudo mkdir -p /var/cache/apt/archives/partial && sudo chmod -R 777 /var/cache/apt/archives
+
       - name: Cache apt packages (Playwright system deps)
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -657,6 +692,13 @@ jobs:
         with:
           name: dist
           path: dist/
+
+      # QNBS-v3: /var/cache/apt/archives is root-owned by default — actions/cache's restore
+      # (tar extraction) runs as the unprivileged runner user and fails with "Permission denied"
+      # on every file without this, silently degrading to a cache miss every time (real CI
+      # evidence: "Cache hit" followed immediately by "Cache not found" from the failed tar).
+      - name: Make apt archive cache dir writable by the runner user
+        run: sudo mkdir -p /var/cache/apt/archives/partial && sudo chmod -R 777 /var/cache/apt/archives
 
       - name: Cache apt packages (Playwright system deps)
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,7 +242,7 @@ jobs:
       # on every file without this, silently degrading to a cache miss every time (real CI
       # evidence: "Cache hit" followed immediately by "Cache not found" from the failed tar).
       - name: Make apt archive cache dir writable by the runner user
-        run: sudo mkdir -p /var/cache/apt/archives/partial && sudo chmod -R 777 /var/cache/apt/archives
+        run: sudo mkdir -p /var/cache/apt/archives/partial && sudo chown -R runner:runner /var/cache/apt/archives && sudo chmod -R 755 /var/cache/apt/archives
 
       - name: Cache apt packages (Tauri Linux build deps)
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -303,7 +303,7 @@ jobs:
       # on every file without this, silently degrading to a cache miss every time (real CI
       # evidence: "Cache hit" followed immediately by "Cache not found" from the failed tar).
       - name: Make apt archive cache dir writable by the runner user
-        run: sudo mkdir -p /var/cache/apt/archives/partial && sudo chmod -R 777 /var/cache/apt/archives
+        run: sudo mkdir -p /var/cache/apt/archives/partial && sudo chown -R runner:runner /var/cache/apt/archives && sudo chmod -R 755 /var/cache/apt/archives
 
       - name: Cache apt packages (Playwright system deps)
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -451,7 +451,7 @@ jobs:
       # on every file without this, silently degrading to a cache miss every time (real CI
       # evidence: "Cache hit" followed immediately by "Cache not found" from the failed tar).
       - name: Make apt archive cache dir writable by the runner user
-        run: sudo mkdir -p /var/cache/apt/archives/partial && sudo chmod -R 777 /var/cache/apt/archives
+        run: sudo mkdir -p /var/cache/apt/archives/partial && sudo chown -R runner:runner /var/cache/apt/archives && sudo chmod -R 755 /var/cache/apt/archives
 
       - name: Cache apt packages (Playwright system deps)
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -518,7 +518,7 @@ jobs:
       # on every file without this, silently degrading to a cache miss every time (real CI
       # evidence: "Cache hit" followed immediately by "Cache not found" from the failed tar).
       - name: Make apt archive cache dir writable by the runner user
-        run: sudo mkdir -p /var/cache/apt/archives/partial && sudo chmod -R 777 /var/cache/apt/archives
+        run: sudo mkdir -p /var/cache/apt/archives/partial && sudo chown -R runner:runner /var/cache/apt/archives && sudo chmod -R 755 /var/cache/apt/archives
 
       - name: Cache apt packages (Playwright system deps)
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -622,7 +622,7 @@ jobs:
       # on every file without this, silently degrading to a cache miss every time (real CI
       # evidence: "Cache hit" followed immediately by "Cache not found" from the failed tar).
       - name: Make apt archive cache dir writable by the runner user
-        run: sudo mkdir -p /var/cache/apt/archives/partial && sudo chmod -R 777 /var/cache/apt/archives
+        run: sudo mkdir -p /var/cache/apt/archives/partial && sudo chown -R runner:runner /var/cache/apt/archives && sudo chmod -R 755 /var/cache/apt/archives
 
       - name: Cache apt packages (Playwright system deps)
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -698,7 +698,7 @@ jobs:
       # on every file without this, silently degrading to a cache miss every time (real CI
       # evidence: "Cache hit" followed immediately by "Cache not found" from the failed tar).
       - name: Make apt archive cache dir writable by the runner user
-        run: sudo mkdir -p /var/cache/apt/archives/partial && sudo chmod -R 777 /var/cache/apt/archives
+        run: sudo mkdir -p /var/cache/apt/archives/partial && sudo chown -R runner:runner /var/cache/apt/archives && sudo chmod -R 755 /var/cache/apt/archives
 
       - name: Cache apt packages (Playwright system deps)
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0


### PR DESCRIPTION
## **User description**
## Summary

Real CI evidence from `main`'s post-#402-merge `Build` job: the cache restore genuinely found the key (`Cache hit for: apt-playwright-chromium-deps-v1`) but `tar` extraction then failed with `Permission denied` on **every single** `.deb` file, immediately followed by `Cache not found for input keys` — `actions/cache`'s restore step runs as the unprivileged `runner` user, but `/var/cache/apt/archives` is root-owned by default.

This means every apt-cache added in #398, across all 7 sites (6 in `ci.yml`, 1 in `cef-learning-harness.yml`), has been **silently degrading to a full cache miss on every single run** since it was introduced — undermining the whole point of that fix, and very plausibly contributing to several of today's apt-mirror-timeout failures that were attributed purely to external Azure-mirror throughput (which is real, but this bug meant the cache was never actually mitigating it as intended).

## Fix

`chmod` the archive directory world-writable (via `sudo`, matching how the actual `apt-get install` steps already need `sudo`) immediately before each cache-restore step, so `tar`'s unprivileged extraction can actually write into it.

## Test plan

- [ ] CI on this PR — the "Make apt archive cache dir writable" step runs before each cache-restore step; a subsequent run against a populated cache should show an actual successful restore (`Cache Size: ~X MB` followed by no permission errors), not another silent "Cache not found" after a reported hit
- [ ] No regression to the actual `apt-get install` steps themselves (they already run as root via `sudo`, unaffected by this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enable reliable apt package cache restoration across CI workflows.

Bug Fixes:
- Fix apt package cache restores across CI workflows so populated caches no longer fail extraction due to archive-directory permissions.

CI:
- Prepare the apt archive directory before cache restoration in Tauri, Playwright, Storybook, end-to-end, and CEF harness jobs.


___

## **CodeAnt-AI Description**
Restore apt package caching across CI jobs

### What Changed
- CI jobs now prepare the apt archive directory before restoring cached packages, allowing valid cache entries to be extracted successfully
- Applies to Tauri, Playwright, Storybook, end-to-end, and CEF harness workflows

### Impact
`✅ Fewer repeated apt package downloads`
`✅ Fewer CI failures caused by apt mirror timeouts`
`✅ Working cache restores instead of silent cache misses`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI and automated test reliability by preparing APT package cache directories before restoring cached packages.
  * Prevented permission-related failures during Rust, build, end-to-end, Storybook, visual regression, and learning harness workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->