### PR TITLE
fix(a11y): remove low-contrast translucency on command palette headings

### DIFF
--- a/components/CommandPalette.tsx
+++ b/components/CommandPalette.tsx
@@ -218,7 +218,7 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({
                     {row.kind === 'heading' ? (
                       <div
                         role="presentation"
-                        className="px-3 py-2 text-xs font-semibold text-[var(--sc-text-muted)] uppercase tracking-wider bg-[var(--sc-surface-raised)]/95 backdrop-blur-sm"
+                        className="px-3 py-2 text-xs font-semibold text-[var(--sc-text-muted)] uppercase tracking-wider bg-[var(--sc-surface-raised)]"
                       >
                         {row.label}
                       </div>


### PR DESCRIPTION
## **User description**
## Summary
- The Command Palette's "Suggested"/"All commands" section-heading rows used a 95%-opacity + backdrop-blur background over `--sc-text-muted` text. The raw token pair passes WCAG AA (~5.28:1) on every theme, but the opacity blend drags the actually-rendered contrast down to 4.17:1 on the sepia theme, below the 4.5:1 AA threshold.
- These rows aren't actually sticky — they're regular rows inside the `react-virtual` virtualized list — so the translucency served no functional purpose. Made the background solid instead of re-tuning per-theme colors.

## Why now
Caught by `@axe-core/playwright` 4.13.0's stricter color-contrast detection (dependabot PR #415, currently blocked on this) failing `tests/e2e/a11y.spec.ts`'s "command palette open has no serious axe violations" check. The older 4.11.3 didn't catch it — this is a real pre-existing bug the version bump exposed, not a false positive.

## Test plan
- [x] `pnpm exec biome check components/CommandPalette.tsx` — clean
- [x] `pnpm exec vitest run tests/unit/CommandPalette.test.tsx` — 7/7 pass
- [ ] CI green (E2E a11y suite validates the actual fix, still on the old axe-core version on this PR — real proof comes from re-running #415 after this merges)

## Summary by Sourcery

Bug Fixes:
- Fix low-contrast command palette section headings by using a solid raised-surface background.


___

## **CodeAnt-AI Description**
Improve command palette heading readability across themes

### What Changed
- Command palette section headings now use a solid background instead of a translucent, blurred background
- Heading text maintains accessible contrast while commands scroll behind or around the list

### Impact
`✅ Higher-contrast command palette headings`
`✅ Reliable accessibility checks across themes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
