### PR TITLE
feat(core): wire worldscript_project_validate Tauri command (Wave 2 PR B)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6676,6 +6676,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "worldscript-project"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "worldscript-studio"
 version = "1.27.1"
 dependencies = [
@@ -6699,6 +6707,7 @@ dependencies = [
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
  "tokio",
+ "worldscript-project",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -40,6 +40,7 @@ tauri-plugin-process = "2"
 tokio = { version = "1", features = ["sync", "time", "process", "rt-multi-thread"] }
 candle-core = { version = "0.11", optional = true }
 candle-nn = { version = "0.11", optional = true }
+worldscript-project = { path = "../crates/worldscript-project" }
 
 [profile.release]
 # QNBS-v3: Aggressive size + speed optimizations for desktop bundles

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -3,4 +3,5 @@
 //!          native-compute surface isolated from the flat top-level command files
 //!          (lora.rs / pandoc.rs) so the supervisor can grow its own task registry.
 
+pub mod project_core;
 pub mod task_supervisor;

--- a/src-tauri/src/commands/project_core.rs
+++ b/src-tauri/src/commands/project_core.rs
@@ -5,6 +5,13 @@
 //! `services/fs/projectFsStore.ts`/`services/storageService.ts`'s dispatch are untouched by this
 //! PR. The point of this command is proving the Tauri <-> Rust Core boundary compiles, links, and
 //! runs correctly before any UI wiring is attempted.
+//!
+//! **Cannot yet validate a live persisted project as-is.** `worldscript_project::schema` models
+//! `characters`/`worlds` as plain arrays, not the `Character[] | EntityState<Character, string>`
+//! union `types.ts` uses (Redux normalizes to `EntityState` at runtime) — see that module's own
+//! doc comment. A real frontend caller will need a normalization adapter (array <-> EntityState)
+//! before this command can validate what's actually persisted; that adapter is intentionally not
+//! built here, matching this PR's no-frontend-call-site scope.
 
 use serde::Serialize;
 use worldscript_project::{migrate_to_latest, parse_envelope, validate};

--- a/src-tauri/src/commands/project_core.rs
+++ b/src-tauri/src/commands/project_core.rs
@@ -1,0 +1,131 @@
+//! Wave 2 PR B — strangler proof point: wires one real Tauri command to the renderer-neutral
+//! `worldscript-project` Rust Core crate (`docs/native/CORE-MIGRATION-LEDGER.md`).
+//!
+//! Backend-only. No frontend call site exists yet — `services/desktopPlatform.ts` and
+//! `services/fs/projectFsStore.ts`/`services/storageService.ts`'s dispatch are untouched by this
+//! PR. The point of this command is proving the Tauri <-> Rust Core boundary compiles, links, and
+//! runs correctly before any UI wiring is attempted.
+
+use serde::Serialize;
+use worldscript_project::{migrate_to_latest, parse_envelope, validate};
+
+/// Structured verdict for a project envelope JSON string, mirroring the pipeline a future
+/// desktop load path would run: parse -> migrate to current schema -> validate.
+#[derive(Debug, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectValidationResult {
+    pub valid: bool,
+    /// The schema version after migration, when parsing succeeded. Absent on parse failure.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema_version: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Parses, migrates, and validates a `ProjectEnvelope` JSON string via the `worldscript-project`
+/// crate. Never returns `Err` — parse/migrate/validate failures are reported as a structured
+/// `ProjectValidationResult { valid: false, error: Some(..) }`, matching the honest-failure
+/// convention `commands::task_supervisor` already established for this codebase.
+#[tauri::command]
+pub fn worldscript_project_validate(project_json: String) -> ProjectValidationResult {
+    let envelope = match parse_envelope(&project_json) {
+        Ok(envelope) => envelope,
+        Err(e) => {
+            return ProjectValidationResult {
+                valid: false,
+                schema_version: None,
+                error: Some(e.to_string()),
+            }
+        }
+    };
+
+    let migrated = match migrate_to_latest(envelope) {
+        Ok(migrated) => migrated,
+        Err(e) => {
+            return ProjectValidationResult {
+                valid: false,
+                schema_version: None,
+                error: Some(e.to_string()),
+            }
+        }
+    };
+
+    match validate(&migrated.project) {
+        Ok(()) => ProjectValidationResult {
+            valid: true,
+            schema_version: Some(migrated.schema_version),
+            error: None,
+        },
+        Err(e) => ProjectValidationResult {
+            valid: false,
+            schema_version: Some(migrated.schema_version),
+            error: Some(e.to_string()),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_current_schema_project_passes() {
+        let json = r#"{
+            "schemaVersion": 2,
+            "project": {
+                "title": "T", "logline": "L",
+                "characters": [], "worlds": [], "manuscript": []
+            }
+        }"#;
+        let result = worldscript_project_validate(json.to_string());
+        assert_eq!(
+            result,
+            ProjectValidationResult {
+                valid: true,
+                schema_version: Some(2),
+                error: None,
+            }
+        );
+    }
+
+    #[test]
+    fn v1_project_is_migrated_before_validation() {
+        let json = r#"{
+            "schemaVersion": 1,
+            "project": {
+                "title": "Old", "logline": "L",
+                "characters": [], "worlds": [], "manuscript": []
+            }
+        }"#;
+        let result = worldscript_project_validate(json.to_string());
+        assert!(result.valid);
+        assert_eq!(result.schema_version, Some(2));
+    }
+
+    #[test]
+    fn corrupt_json_reports_structured_failure_not_a_panic() {
+        let result = worldscript_project_validate("{ not json".to_string());
+        assert!(!result.valid);
+        assert_eq!(result.schema_version, None);
+        assert!(result.error.is_some());
+    }
+
+    #[test]
+    fn duplicate_character_ids_fail_validation_with_schema_version_present() {
+        let json = r#"{
+            "schemaVersion": 2,
+            "project": {
+                "title": "T", "logline": "L",
+                "characters": [
+                    {"id": "c1", "name": "A"},
+                    {"id": "c1", "name": "B"}
+                ],
+                "worlds": [], "manuscript": []
+            }
+        }"#;
+        let result = worldscript_project_validate(json.to_string());
+        assert!(!result.valid);
+        assert_eq!(result.schema_version, Some(2));
+        assert!(result.error.unwrap().contains("c1"));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -166,6 +166,7 @@ pub fn run() {
             lora::set_lora_python_path,
             commands::task_supervisor::worldscript_task_supervisor_ping,
             commands::task_supervisor::worldscript_task_supervisor_submit,
+            commands::project_core::worldscript_project_validate,
         ])
         .setup(|app| {
             if cfg!(debug_assertions) {


### PR DESCRIPTION
## **User description**
## Summary
- Wave 2's optional PR B (from the approved plan): wires one real Tauri command, `worldscript_project_validate`, to the renderer-neutral `worldscript-project` Rust Core crate (`docs/native/CORE-MIGRATION-LEDGER.md`).
- New `src-tauri/src/commands/project_core.rs` runs parse → migrate-to-latest → validate via the crate, returning a structured `ProjectValidationResult` — never `Err`, matching `commands::task_supervisor`'s honest-failure convention.
- `worldscript-project` added as a **path dependency** in `src-tauri/Cargo.toml`, even though it's a member of the separate `crates/` Cargo workspace. Confirmed this cross-workspace path dependency compiles/links cleanly (`cargo check`/`test`/`clippy` all pass) without unifying the two workspaces — keeps the original Wave 2 PR 1 decision (`crates/` stays independent from `src-tauri/`) intact.

## Explicitly out of scope
- No frontend call site — `services/desktopPlatform.ts`, `services/fs/projectFsStore.ts`, and `services/storageService.ts`'s dispatch are untouched. This PR only proves the Tauri ↔ Rust Core command boundary compiles and runs correctly.

## Test plan
- [x] `cargo test --lib` in `src-tauri/` — 23/23 pass (4 new: valid-schema-v2 passes, v1-migrates-then-validates, corrupt-JSON structured failure, duplicate-character-id validation failure)
- [x] `cargo clippy --lib -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] CI green (core-rust + Tauri Rust Gate jobs)

## Summary by Sourcery

Wire project validation from the Tauri command boundary to the worldscript-project core crate.

New Features:
- Expose project validation through the desktop Tauri command surface, including parsing, schema migration, and validation with structured results.

Enhancements:
- Report parse, migration, and validation failures as honest structured responses rather than command errors.
- Integrate the renderer-neutral worldscript-project core crate as a path dependency while preserving the independent workspace boundary.

Build:
- Add the worldscript-project Rust core crate as a src-tauri path dependency and update the lockfile.

Tests:
- Add coverage for current-schema validation, legacy-schema migration, malformed JSON, and duplicate character IDs.


___

## **CodeAnt-AI Description**
Expose project validation through the desktop application

### What Changed
- Adds a desktop command that parses project JSON, upgrades older projects to the current schema, and validates the result
- Returns a structured success or failure response, including the schema version and a readable error instead of failing unexpectedly
- Detects invalid JSON and project problems such as duplicate character IDs

### Impact
`✅ Reliable project validation results`
`✅ Automatic validation of older project formats`
`✅ Clearer project data errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added project validation for project-envelope JSON.
  * Automatically migrates supported v1 projects during validation.
  * Reports validation status, schema version, and clear errors for malformed or invalid projects.
  * Detects issues such as duplicate character IDs without crashing the application.
  * Made validation results available to the application interface for reliable project checks.

* **Tests**
  * Added coverage for valid projects, migrations, malformed data, and duplicate character IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->