### PR TITLE
chore: close coverage and token ratchet scope gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Coverage and token ratchets:** coverage now measures the root application/PWA shell, and the
-  token audit baseline was ratcheted down from 160 to the verified current count of 159.
+- **Coverage and token ratchets:** coverage now measures the root application/PWA shell; CI
+  recalibrated floors to L80/F72/B66/S78 from the expanded-scope measurement, and the token audit
+  baseline was ratcheted down from 160 to the verified current count of 159.
 - **Native desktop strategy:** ADR-0021 adopts Qt 6/Qt Quick as the future primary native product,
   keeps React/PWA first-class, makes Tauri transitional, admits GPUI later behind a gate, and
   retires CEF from the target architecture.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Coverage and token ratchets:** coverage now measures the root application/PWA shell; CI
-  recalibrated floors to L80/F72/B66/S78 from the expanded-scope measurement, and the token audit
-  baseline was ratcheted down from 160 to the verified current count of 159.
+- **Coverage scope and threshold calibration:** coverage now measures the root application/PWA
+  shell; CI recalibrated floors to L80/F72/B66/S78 from the expanded-scope measurement, and the
+  token audit baseline was ratcheted down from 160 to the verified current count of 159.
 - **Native desktop strategy:** ADR-0021 adopts Qt 6/Qt Quick as the future primary native product,
   keeps React/PWA first-class, makes Tauri transitional, admits GPUI later behind a gate, and
   retires CEF from the target architecture.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Coverage and token ratchets:** coverage now measures the root application/PWA shell, and the
+  token audit baseline was ratcheted down from 160 to the verified current count of 159.
 - **Native desktop strategy:** ADR-0021 adopts Qt 6/Qt Quick as the future primary native product,
   keeps React/PWA first-class, makes Tauri transitional, admits GPUI later behind a gate, and
   retires CEF from the target architecture.

--- a/README.md
+++ b/README.md
@@ -710,7 +710,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 
 **Current test metrics (2026-07-30, CI-reported):**
 - **6477+ unit tests** across **549 test files** — all passing
-- Coverage thresholds: lines ≥ 74 · branches ≥ 60 · functions ≥ 67 · statements ≥ 72 — enforced in CI (see Codecov badge for live metrics)
+- Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2919 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 
 **CI-cloud-first workflow (recommended):** On constrained hardware run **`pnpm run lint && pnpm run i18n:check && pnpm run typecheck`** locally, then push and let CI handle coverage, E2E, Lighthouse, and Stryker. Authoritative numbers come from CI artifacts (Codecov, JUnit). After CI goes green, update the README badges and `AUDIT.md` quality-gate line from the reported metrics. See **[`docs/CI.md`](docs/CI.md) § Cloud CI-first vs local development** for the full post-merge doc-update checklist.
@@ -755,7 +755,7 @@ Shared Playwright helpers (`waitForSpaReady`, `ensureBlankProject`, `clickNavIte
 - **🐛 Report Bugs** — Open a GitHub Issue with details and reproduction steps
 - **💡 Suggest Features** — Open a Discussion or Issue
 - **🌍 Improve Translations** — Five core locale trees (`en` is the reference); native polish for FR/ES/IT especially welcome in PRs
-- **🧪 Write Tests** — Coverage thresholds: branches ≥ 60 %, functions ≥ 67 %, lines ≥ 74 %; contributions to large components (collaboration, AI streaming paths, OpenRouter provider) are particularly valuable
+- **🧪 Write Tests** — Coverage thresholds: branches ≥ 66 %, functions ≥ 72 %, lines ≥ 80 %; contributions to large components (collaboration, AI streaming paths, OpenRouter provider) are particularly valuable
 
 See **[`CONTRIBUTING.md`](CONTRIBUTING.md)** for the full dev setup, Biome / Vitest / Playwright guide, and architecture notes.
 

--- a/docs/BEST-PRACTICES.md
+++ b/docs/BEST-PRACTICES.md
@@ -46,7 +46,7 @@ Single reference for maintainers: architecture touchpoints, content rules, secur
 
 ## Testing & coverage
 
-- **Unit/integration:** Vitest; global coverage thresholds in `vitest.config.ts` are a regression floor. Current (v1.22.0): lines ≥ 74 / branches ≥ 60 / functions ≥ 67 / statements ≥ 72 (CI-measured). **5 475+ tests / 449 files**. Target for v2.0: lines 85 / branches 75 / functions 80 (C-7).
+- **Unit/integration:** Vitest; global coverage thresholds in `vitest.config.ts` are a regression floor. Current (v1.27.1): lines ≥ 80 / branches ≥ 66 / functions ≥ 72 / statements ≥ 78 (CI-measured after adding the root application/PWA shell). **5 475+ tests / 449 files**. Target for v2.0: lines 85 / branches 75 / functions 80 (C-7).
 - **Risk-hotspots** (aim for focused tests when touching): `dbService`, `dbMigration`, `aiProviderService`, `sceneRevisionService`, `plotBoardService`, `deepLinkService`, project import/export, `storageService` / `storageBackend`.
 - **IDB test isolation:** `sceneRevisionService` and similar IDB tests require `@vitest-environment node` + per-test `IDBFactory` + `_resetDbForTest()`. See `CLAUDE.md § IDB unit tests`.
 - **Custom Select testing:** Components using `Select` or `LanguageSelector` should mock them as native `<select>` elements in tests for compatibility with testing-library queries. See `docs/UI-MODERNIZATION.md` Testing section for the mock pattern.

--- a/docs/COVERAGE-POLICY.md
+++ b/docs/COVERAGE-POLICY.md
@@ -27,14 +27,18 @@ measured value, with a margin that absorbs run-to-run variance (Node 22 vs 24, f
 4. **Record the move.** Every change to `coverage.thresholds` updates the history comment in
    `vitest.config.ts` with the date, the CI-measured value it was derived from, and the new floor.
 
-## Current state (2026-06-09)
+## Current state (2026-08-20)
+
+The scope now includes the root application/PWA shell (`App.tsx`, `index.tsx`, and
+`register-sw.ts`). The Node 22 CI artifact measured the expanded scope below; Node 24's
+quality gate also passed. Floors use `floor(measured − 1.5)` as required by this policy.
 
 | Metric | Threshold (floor) | CI-measured (last full run) | Margin |
 |--------|-------------------|-----------------------------|--------|
-| Lines | 74 | 76.59 | ~2.6 |
-| Statements | 72 | 74.60 | ~2.6 |
-| Functions | 67 | 69.08 | ~2.1 |
-| Branches | 60 | 62.31 | ~2.3 |
+| Lines | 80 | 81.63 | ~1.6 |
+| Statements | 78 | 79.55 | ~1.6 |
+| Functions | 72 | 74.26 | ~2.3 |
+| Branches | 66 | 67.75 | ~1.8 |
 
 **P1 stretch target:** `L85 / B75 / F80` — reached by ratcheting per the rule above, never by a
 one-time jump that would risk inverting the gate again.

--- a/scripts/coverage-thresholds.json
+++ b/scripts/coverage-thresholds.json
@@ -1,6 +1,6 @@
 {
-  "lines": 79,
+  "lines": 80,
   "functions": 72,
-  "branches": 65,
-  "statements": 77
+  "branches": 66,
+  "statements": 78
 }

--- a/token-audit-baseline.json
+++ b/token-audit-baseline.json
@@ -1,12 +1,12 @@
 {
-  "total": 160,
+  "total": 159,
   "summary": {
     "raw-hex": 45,
     "raw-rgb": 1,
     "raw-hsl": 0,
     "dark-prefix": 0,
     "hardcoded-shadow": 0,
-    "inline-svg": 114
+    "inline-svg": 113
   },
-  "updatedAt": "2026-07-28T19:47:24.932Z"
+  "updatedAt": "2026-08-20T19:12:12.000Z"
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -46,6 +46,10 @@ export default defineConfig({
       // scripts/check-coverage-ratchet.mjs (non-blocking CI step suggesting when to ratchet up).
       reporter: ['text', 'lcov', 'html', 'json-summary'],
       include: [
+        // QNBS-v3: Measure the application shell so root composition and PWA lifecycle code cannot evade coverage.
+        'App.tsx',
+        'index.tsx',
+        'register-sw.ts',
         'app/**/*.{ts,tsx}',
         'components/**/*.{ts,tsx}',
         'features/**/*.{ts,tsx}',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -84,10 +84,12 @@ export default defineConfig({
       //   per metric per the quarterly cap below rather than the full ~1pt-below-measured jump,
       //   since the straight ~1pt margin would have exceeded +5 on statements. First ratchet of
       //   Q3 2026 — the prior entries above are all Q2, so this is not a same-quarter stack-up).
+      // → L80/F72/B66/S78 (2026-08-20: expanded scope CI measured L81.63/F74.26/B67.75/S79.55;
+      //   floor(measured − 1.5) per docs/COVERAGE-POLICY.md; Node 24 also passed).
       // P1 target: L85/B75/F80 — next ratchet after verification.
       // RATCHET RULE: After 3 consecutive green CI runs on both Node versions, increase each threshold
       // by 1 point (max 5 points per quarter). Document the new baseline in this comment.
-      // QNBS-v3 (CodeRabbit): raising these enforces the new, stricter CI floor going forward — any PR that drops coverage below L79/F72/B65/S77 now fails the quality gate instead of silently regressing under the old L74/F67/B60/S72 bar.
+      // QNBS-v3 (CodeRabbit): this floor includes the root application/PWA shell and blocks regressions below L80/F72/B66/S78.
       thresholds: {
         ...coverageThresholds,
         perFile: false,


### PR DESCRIPTION
## Scope

- include `App.tsx`, `index.tsx`, and `register-sw.ts` in the authoritative Vitest coverage set;
- recalibrate the coverage floors from the expanded cloud measurement using the repository policy;
- ratchet the verified token-audit baseline from 160 to 159 (current scan: 159; suppression baseline
  remains unchanged at 52);
- record the quality-truth correction in `[Unreleased]`.

## Non-goals

- no local full Vitest or coverage run on constrained hardware;
- no speculative threshold lowering or suppression-baseline change;
- no application behavior change.

## Evidence

- `pnpm run lint` — passed;
- `pnpm run token:audit -- --details` — 159 findings, baseline 159, passed;
- `pnpm run docs:check` — passed;
- `git diff --check` — passed;
- CI run `32411378184` — Node 22 and Node 24 quality gates passed with the expanded scope;
- Node 22 coverage artifact measured lines 81.63%, functions 74.26%, branches 67.75%, statements
  79.55%; Node 24 also passed;
- the documented policy floor of `floor(measured - 1.5)` therefore yields L80/F72/B66/S78.

The expanded scope produced a higher measured aggregate rather than the expected drop, so no
threshold was lowered merely to make CI green. The independent token baseline ratchet is 159;
the suppression baseline remains 52.

## Summary

Expand quality gates to cover the application shell and align documented baselines with verified
CI measurements.

Enhancements:

- Expand authoritative coverage measurement to include the root application and PWA shell.
- Recalibrate coverage quality floors from the expanded CI measurement.
- Ratchet the verified token-audit baseline to 159 while preserving suppression settings.

Documentation:

- Document the expanded coverage scope, calibrated thresholds, and corrected token-audit baseline.
