### PR TITLE
feat(core): add renderer-neutral diagnostics primitives

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -93,6 +93,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "worldscript-diagnostics"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "worldscript-project"
 version = "0.1.0"
 dependencies = [

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
 resolver = "2"
-members = ["worldscript-project"]
+members = ["worldscript-project", "worldscript-diagnostics"]

--- a/crates/worldscript-diagnostics/Cargo.toml
+++ b/crates/worldscript-diagnostics/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "worldscript-diagnostics"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.77.2"
+description = "Renderer-neutral structured logging and redaction primitives (Wave 2)"
+publish = false
+
+[lib]
+name = "worldscript_diagnostics"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/crates/worldscript-diagnostics/src/lib.rs
+++ b/crates/worldscript-diagnostics/src/lib.rs
@@ -1,0 +1,139 @@
+//! Renderer-neutral structured logging primitives for the Rust Core.
+//!
+//! This crate deliberately stops at the portable contract: a typed log entry and the
+//! GDPR-sensitive context redaction chokepoint. IndexedDB, Tauri JSONL, and development
+//! console sinks remain renderer-specific adapters in `services/logger.ts` until a later
+//! authority-switch slice proves their equivalence.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+const REDACTED: &str = "[REDACTED]";
+
+/// Structured log levels shared by renderer-neutral consumers.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LogLevel {
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+/// Renderer-neutral log record. Sink routing and persistence are intentionally absent.
+#[derive(Debug, Clone, Deserialize, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LogEntry {
+    pub ts: u64,
+    pub level: LogLevel,
+    pub module: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context: Option<Map<String, Value>>,
+}
+
+/// Redact sensitive top-level context keys using the existing TypeScript contract.
+///
+/// The current TS implementation intentionally redacts keys only, not values nested under
+/// otherwise-safe keys. Keeping that scope exact avoids an unreviewed wire-contract change.
+pub fn sanitize_context(context: &Map<String, Value>) -> Map<String, Value> {
+    context
+        .iter()
+        .map(|(key, value)| {
+            let sanitized = if is_sensitive_key(key) {
+                Value::String(REDACTED.to_string())
+            } else {
+                value.clone()
+            };
+            (key.clone(), sanitized)
+        })
+        .collect()
+}
+
+/// Return a sanitized copy of a structured log entry without mutating its input.
+pub fn sanitize_entry(mut entry: LogEntry) -> LogEntry {
+    entry.context = entry.context.as_ref().map(sanitize_context);
+    entry
+}
+
+fn is_sensitive_key(key: &str) -> bool {
+    let lowercase = key.to_ascii_lowercase();
+    lowercase.contains("key")
+        || lowercase.contains("token")
+        || lowercase.contains("password")
+        || lowercase.contains("passphrase")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn redacts_sensitive_keys_without_changing_safe_values() {
+        let context = serde_json::from_value(json!({
+            "apiKey": "secret",
+            "userToken": "token",
+            "myPassword": "password",
+            "recoveryPassphrase": "phrase",
+            "userId": 42,
+            "nested": { "token": "still-owned-by-the-nested-value" }
+        }))
+        .expect("fixture context is an object");
+
+        let sanitized = sanitize_context(&context);
+
+        assert_eq!(sanitized["apiKey"], json!(REDACTED));
+        assert_eq!(sanitized["userToken"], json!(REDACTED));
+        assert_eq!(sanitized["myPassword"], json!(REDACTED));
+        assert_eq!(sanitized["recoveryPassphrase"], json!(REDACTED));
+        assert_eq!(sanitized["userId"], json!(42));
+        assert_eq!(
+            sanitized["nested"],
+            json!({ "token": "still-owned-by-the-nested-value" })
+        );
+        assert_eq!(context["apiKey"], json!("secret"));
+    }
+
+    #[test]
+    fn sensitive_key_matching_is_case_insensitive_and_substring_based() {
+        let context = serde_json::from_value(json!({
+            "APIKEY": "one",
+            "accessTOKENValue": "two",
+            "PASSWORD_HINT": "three",
+            "PASSphraseBackup": "four",
+            "keyboardLayout": "safe"
+        }))
+        .expect("fixture context is an object");
+
+        let sanitized = sanitize_context(&context);
+
+        assert_eq!(sanitized["APIKEY"], json!(REDACTED));
+        assert_eq!(sanitized["accessTOKENValue"], json!(REDACTED));
+        assert_eq!(sanitized["PASSWORD_HINT"], json!(REDACTED));
+        assert_eq!(sanitized["PASSphraseBackup"], json!(REDACTED));
+        assert_eq!(sanitized["keyboardLayout"], json!(REDACTED));
+    }
+
+    #[test]
+    fn entry_serializes_with_wire_compatible_field_names() {
+        let entry = sanitize_entry(LogEntry {
+            ts: 1_700_000_000_000,
+            level: LogLevel::Warn,
+            module: "test".to_string(),
+            message: "warning".to_string(),
+            context: Some(serde_json::from_value(json!({ "apiKey": "secret" })).unwrap()),
+        });
+
+        assert_eq!(
+            serde_json::to_value(entry).unwrap(),
+            json!({
+                "ts": 1_700_000_000_000u64,
+                "level": "warn",
+                "module": "test",
+                "message": "warning",
+                "context": { "apiKey": REDACTED }
+            })
+        );
+    }
+}

--- a/crates/worldscript-diagnostics/src/lib.rs
+++ b/crates/worldscript-diagnostics/src/lib.rs
@@ -51,9 +51,11 @@ pub fn sanitize_context(context: &Map<String, Value>) -> Map<String, Value> {
 }
 
 /// Return a sanitized copy of a structured log entry without mutating its input.
-pub fn sanitize_entry(mut entry: LogEntry) -> LogEntry {
-    entry.context = entry.context.as_ref().map(sanitize_context);
-    entry
+pub fn sanitize_entry(entry: &LogEntry) -> LogEntry {
+    LogEntry {
+        context: entry.context.as_ref().map(sanitize_context),
+        ..entry.clone()
+    }
 }
 
 fn is_sensitive_key(key: &str) -> bool {
@@ -117,16 +119,17 @@ mod tests {
 
     #[test]
     fn entry_serializes_with_wire_compatible_field_names() {
-        let entry = sanitize_entry(LogEntry {
+        let entry = LogEntry {
             ts: 1_700_000_000_000,
             level: LogLevel::Warn,
             module: "test".to_string(),
             message: "warning".to_string(),
             context: Some(serde_json::from_value(json!({ "apiKey": "secret" })).unwrap()),
-        });
+        };
+        let sanitized = sanitize_entry(&entry);
 
         assert_eq!(
-            serde_json::to_value(entry).unwrap(),
+            serde_json::to_value(sanitized).unwrap(),
             json!({
                 "ts": 1_700_000_000_000u64,
                 "level": "warn",
@@ -135,5 +138,6 @@ mod tests {
                 "context": { "apiKey": REDACTED }
             })
         );
+        assert_eq!(entry.context.as_ref().unwrap()["apiKey"], json!("secret"));
     }
 }

--- a/docs/native/CORE-MIGRATION-LEDGER.md
+++ b/docs/native/CORE-MIGRATION-LEDGER.md
@@ -11,8 +11,8 @@ scope shifts — it is a living decision record, not a one-time snapshot.
 | 1 | Project schema | TS, `types.ts` (916 lines) — `StoryProject`/`Character`/`World`/`StorySection`/`Settings` | Medium — `characters`/`worlds` are typed `Character[] \| EntityState<Character, string>`, a Redux Toolkit coupling at the type level | Low | High — canonical shape everything else depends on | Low | High — every renderer needs the same shape | **1 — Wave 2 first slice** | Port the array-only member of the union to Rust structs (serde, camelCase); TS type left unchanged | Golden-master JSON fixtures decode identically in Zod and Rust |
 | 2 | Validation | TS, `services/projectImportSchema.ts` (352 lines, Zod, import-only) + `idbProjectStore.ts#validateAndFixState` (hand-written repair-on-load, separate path) | Low, but split across two divergent implementations today | Low-medium (first line of defense against malformed/malicious import files) | High | Low | High | **1 — Wave 2 first slice** | Hand-rolled Rust validation mirroring the Zod ruleset for the modeled fields; does not reconcile the Zod-vs-hand-written TS divergence | Same golden-master fixtures; accept/reject parity asserted per fixture |
 | 3 | Storage — fs backend (plain load/save) | TS, `services/fs/` (7 files, 1,253 lines) | High today (Tauri-fs-plugin coupled) | Low today — `fsCore.ts#encryptText`/`decryptText` are dead code, zero call sites | High (atomic-write semantics, compression) | Medium (large-project I/O) | High | **2 — Wave 2 first slice, narrow** | New crate proves plain JSON load/save on its own format; does not replace `projectFsStore.ts` | Round-trip identity tests inside the new crate only, not yet byte-compared against `.wsproj` |
-| 4 | Logger / diagnostics | TS, `services/logger.ts` (312 lines) — dual-sink (IDB ring buffer + Tauri JSONL), single GDPR-redaction chokepoint | Medium (dual-sink dispatch is renderer-aware, but small) | Medium (redaction chokepoint) | Low | Low | Medium-high — small, self-contained | 3 — natural next fast-follow | Not started | Not started |
-| 5 | Task-orchestration expansion | Rust, `src-tauri/src/commands/task_supervisor.rs` (310 lines, one task type) + TS `packages/worker-bus/` (5,130 lines, full orchestration surface) | worker-bus TS side is Web-Worker-pool coupled; Rust side already renderer-neutral in principle | Low-medium | Low (task results, not persisted project state) | Medium-high | High long-term, existing Rust is a narrow stub | 4 — natural next fast-follow | Not started | Not started |
+| 4 | Logger / diagnostics | TS, `services/logger.ts` (312 lines) — dual-sink (IDB ring buffer + Tauri JSONL), plus Rust Core proof in `crates/worldscript-diagnostics` | Medium (dual-sink dispatch remains renderer-aware) | Medium (redaction chokepoint) | Low | Low | Medium-high — small, self-contained | 3 — Wave 2 fast-follow | **In progress — Core model/redaction locally proven; no authority switch** | Rust unit tests cover top-level key redaction, non-mutation, and serde wire shape; TS sink parity and production wiring remain open |
+| 5 | Task-orchestration expansion | Rust, `src-tauri/src/commands/task_supervisor.rs` (bounded `text.analyze`/`text.diff`) + TS `packages/worker-bus/` (5,130 lines, full orchestration surface) | worker-bus TS side is Web-Worker-pool coupled; Rust side is renderer-neutral for the bounded proof | Low-medium | Low (task results, not persisted project state) | Medium-high | High long-term, existing Rust is a narrow stub | 4 — Wave 2 fast-follow | **Bounded task proof CI-proven in #430; full extraction not started** | Rust tests cover structured failure, input bounds, deterministic analysis, and diff parity; no broad worker-bus authority switch |
 | 6 | Storage — IDB backend (all encryption) | TS, `services/storage/` (18 files, 5,363 lines) — mature AES-256-GCM, ADR-0018 "Accepted and implemented" | High — IndexedDB is browser-only, not portable to Qt/GPUI as-is | High, mature | High | Medium | Low as literally written; high as a design reference | **Deferred to Wave 3-4** | None in Wave 2. ADR-0018's 6 invariants are required reading for Wave 3 crypto design | None in Wave 2 |
 | 7 | `features/project/` domain logic | TS, `features/project/` (24 files, 2,114 lines) — real logic concentrated in `thunks/` + `projectSelectors.ts` (~450-500 lines); `reducers/` (11 files) is CRUD bookkeeping | High — Redux-store-shape/dispatch bound; `reducers/` stays TS-side permanently | Low | Medium (import/restore orchestration) | Low-medium | Medium (only the thunks/selectors subset) | Deferred | Candidate after the schema crate is proven; only thunks/selectors, never `reducers/` | Not started |
 | 8 | AI services | TS, `services/ai/` (44 files, 5,401 lines), mixed portability (retry/routing/error-taxonomy renderer-neutral vs. `computeShaderFactory.ts`/`webGpuDetectorService.ts`/`.wgsl` inherently WebGPU-coupled) | Mixed | Medium-high (API keys) | Low-medium | Medium | Uncertain — too large/mixed to assess narrowly | **Out of scope for all of Wave 2** | None proposed | None |
@@ -39,8 +39,11 @@ scope shifts — it is a living decision record, not a one-time snapshot.
   conversion rejects an `ids` entry without a matching entity, an entity absent from `ids`, or
   duplicate IDs; it never silently drops, synthesizes, or last-write-wins. Valid input preserves
   the declared `ids` order and entity IDs in the golden fixtures.
-- Rows 4-5 (logger, task-orchestration expansion) are the natural next fast-follows after this
-  slice — both small and self-contained, with row 5 already having real Rust code to build on.
+- **Row 4 has a narrow Core proof in progress.** `crates/worldscript-diagnostics` owns only the
+  typed structured-log model and the existing top-level key-redaction semantics. IDB, Tauri JSONL,
+  and development-console sinks remain TS-side; no production caller or authority switch is claimed.
+- Row 5 is already locally and CI-proven as a bounded Tauri supervisor proof (`text.analyze` and
+  `text.diff`, with structured failure semantics); full worker-bus extraction and G1 completion remain open.
 
 ## What Wave 2's first slice does NOT do
 
@@ -49,7 +52,8 @@ reconciling it with fs storage. No `packages/worker-bus` subsumption or `task_su
 registry expansion. No `services/ai/*` work. No changes to `src-tauri/src/lora.rs` or `pandoc.rs`. No
 Qt/GPUI code. No unifying `src-tauri/Cargo.toml` into one repo-root Cargo workspace (see
 `crates/Cargo.toml`'s own scope note). No replacing `projectFsStore.ts`/`storageService.ts`'s
-dispatch — any future Tauri-command wiring is additive-and-unused-by-default only. No adapter
-implementation or authority switch is included in this documentation slice; it only makes the
-compatibility prerequisite explicit. No compression-format parity with the existing `.wsproj`
-files (open question, not solved here).
+dispatch — any future Tauri-command wiring is additive-and-unused-by-default only. No Row-9 adapter
+implementation or authority switch is included in this slice; it only makes the compatibility
+prerequisite explicit. No sink migration, Tauri adapter rewiring, or authority switch is included
+in the logger proof. No compression-format parity with the existing `.wsproj` files (open question,
+not solved here).

--- a/docs/native/ROADMAP-QT-GPUI-DESKTOP.md
+++ b/docs/native/ROADMAP-QT-GPUI-DESKTOP.md
@@ -1107,14 +1107,13 @@ Shared product code cannot casually import Tauri, Qt or GPUI.
 
 ## Wave 2 — Rust Core extraction and headless harness
 
-**Status: IN PROGRESS — first slice shipped.** `crates/worldscript-project` (a new, independent
+**Status: IN PROGRESS — first slice shipped; bounded task proof also merged.** `crates/worldscript-project` (a new, independent
 Cargo workspace — see `docs/native/CORE-MIGRATION-LEDGER.md` for why it's not unified with
 `src-tauri`) implements project schema, validation, a minimal versioned-migration mechanism, and
 plain JSON load/save, proven by a headless `cargo test` suite and a `wsproj demo-lifecycle` CLI with
-zero GUI/Tauri dependencies. This satisfies the wave's exit criterion below. Task orchestration, full
-storage-backend parity, diagnostics, and AI request model extraction are explicitly deferred — see
-the ledger's priority order — so this wave stays "in progress," not "complete," until at least the
-next fast-follow slice (logger/diagnostics, per the ledger) lands. Before G1 is evaluated, the
+zero GUI/Tauri dependencies. This satisfies the wave's exit criterion below. Full task orchestration,
+storage-backend parity, diagnostics sink migration, and AI request model extraction remain deferred —
+see the ledger's priority order — so this wave stays "in progress," not "complete." Before G1 is evaluated, the
 separate row-9 compatibility position must also define and prove the Array↔EntityState boundary:
 the current Core `Vec` model is intentionally renderer-neutral, while production Redux state uses
 `EntityState` for characters and worlds.
@@ -1130,8 +1129,10 @@ Actions (checked = this slice, per `docs/native/CORE-MIGRATION-LEDGER.md`):
 - [ ] storage (fs backend parity, IDB backend — deferred);
 - [ ] Array↔EntityState compatibility adapter contract and fixtures (reject duplicate/missing/orphan
       IDs for characters and worlds; required before G1 evaluation);
-- [ ] task orchestration (deferred fast-follow);
-- [ ] diagnostics (deferred fast-follow);
+- [x] bounded task-supervisor proof (`text.analyze`/`text.diff`, structured failures and input
+      limits; #430) — full worker-bus extraction remains deferred;
+- [~] diagnostics structured model/redaction Core proof (`crates/worldscript-diagnostics`) — sink
+      migration and authority switch remain deferred;
 - [ ] AI request model (out of scope for all of Wave 2 — see ledger);
 - [x] headless CLI/test harness.
 


### PR DESCRIPTION
## **User description**
## Summary

- add the independent `worldscript-diagnostics` Core crate with typed `LogEntry`/`LogLevel` models
- preserve the existing `services/logger.ts` top-level key/token/password/passphrase redaction semantics in Rust
- prove non-mutation, case-insensitive matching, nested-value preservation, and camelCase/lowercase serde output
- reconcile the Wave-2 ledger and roadmap with the already merged #430 bounded task-supervisor proof

## Scope and non-goals

This is a narrow Core proof. IndexedDB, Tauri JSONL, development-console sinks, DesktopPlatform wiring, TS caller migration, and authority switching remain out of scope. The full `packages/worker-bus` extraction, project adapter implementation, R-15, Qt/GPUI work, and AI extraction are also out of scope.

Candidate B was not repeated: live evidence shows #430 already merged the bounded `text.analyze`/`text.diff` supervisor proof. A second task without a real caller would not produce stronger G1 evidence.

## Validation

- `cargo fmt --manifest-path crates/Cargo.toml --all -- --check`
- `cargo check --manifest-path crates/Cargo.toml --workspace --locked`
- `cargo clippy --manifest-path crates/Cargo.toml --workspace --all-targets --locked -- -D warnings`
- `cargo test --manifest-path crates/Cargo.toml --workspace --locked`
- `pnpm run docs:check`

No new JavaScript dependency, no baseline increase, and no `continue-on-error` change.

## Summary by Sourcery

Establish renderer-neutral structured logging and redaction primitives in Rust while deferring sink integration and authority switching.

New Features:
- Add the renderer-neutral `worldscript-diagnostics` Core crate with typed structured log entries and log levels.
- Provide compatible top-level sensitive-context redaction for structured log records.

Enhancements:
- Preserve safe and nested context values while ensuring sanitization does not mutate the original data.
- Update the Core migration ledger and desktop roadmap to reflect the diagnostics proof and previously merged bounded task-supervisor proof.

Build:
- Add the diagnostics crate to the Rust workspace and include its serde dependencies.

Documentation:
- Document the diagnostics proof scope, deferred sink migration, and bounded task-supervisor status in the Core migration ledger and desktop roadmap.

Tests:
- Add coverage for case-insensitive substring redaction, non-mutation, nested-value preservation, and serialized field formats.


___

## **CodeAnt-AI Description**
Add renderer-neutral structured logging and sensitive-context redaction primitives

### What Changed
- Adds typed log entries with stable lowercase levels and camelCase field names for shared Rust Core consumers
- Redacts top-level context keys containing key, token, password, or passphrase, regardless of capitalization
- Preserves safe values and nested objects while leaving the original context unchanged
- Keeps existing IndexedDB, Tauri JSONL, console sinks, and production logging authority unchanged

### Impact
`✅ Consistent structured log records across renderers`
`✅ Sensitive top-level context values are masked`
`✅ Safe nested context data remains intact`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added structured diagnostics with debug, info, warning, and error levels.
  * Added JSON-compatible log entries with timestamps, modules, messages, and optional context.
  * Added automatic redaction of sensitive context values, including passwords, tokens, and passphrases.

* **Documentation**
  * Updated native migration and roadmap documentation to reflect diagnostics and task-supervisor progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->