### PR TITLE
feat(project): prove Core state-shape boundary adapter

### DIFF
--- a/docs/native/CORE-MIGRATION-LEDGER.md
+++ b/docs/native/CORE-MIGRATION-LEDGER.md
@@ -16,7 +16,7 @@ scope shifts — it is a living decision record, not a one-time snapshot.
 | 6 | Storage — IDB backend (all encryption) | TS, `services/storage/` (18 files, 5,363 lines) — mature AES-256-GCM, ADR-0018 "Accepted and implemented" | High — IndexedDB is browser-only, not portable to Qt/GPUI as-is | High, mature | High | Medium | Low as literally written; high as a design reference | **Deferred to Wave 3-4** | None in Wave 2. ADR-0018's 6 invariants are required reading for Wave 3 crypto design | None in Wave 2 |
 | 7 | `features/project/` domain logic | TS, `features/project/` (24 files, 2,114 lines) — real logic concentrated in `thunks/` + `projectSelectors.ts` (~450-500 lines); `reducers/` (11 files) is CRUD bookkeeping | High — Redux-store-shape/dispatch bound; `reducers/` stays TS-side permanently | Low | Medium (import/restore orchestration) | Low-medium | Medium (only the thunks/selectors subset) | Deferred | Candidate after the schema crate is proven; only thunks/selectors, never `reducers/` | Not started |
 | 8 | AI services | TS, `services/ai/` (44 files, 5,401 lines), mixed portability (retry/routing/error-taxonomy renderer-neutral vs. `computeShaderFactory.ts`/`webGpuDetectorService.ts`/`.wgsl` inherently WebGPU-coupled) | Mixed | Medium-high (API keys) | Low-medium | Medium | Uncertain — too large/mixed to assess narrowly | **Out of scope for all of Wave 2** | None proposed | None |
-| 9 | Project state-shape compatibility adapter | TS, `features/project` selectors/adapters at the Core boundary + Rust, `crates/worldscript-project` schema | High at the boundary — production Redux `EntityState` must be translated without importing Redux into Core | Low | High — ID/order preservation is part of project identity | Medium | High — every native renderer needs the same conversion contract | **2 — Wave 2 prerequisite before G1 evaluation** | Define a typed adapter that normalizes Redux `EntityState` to the Core's renderer-neutral arrays and reconstructs the TS-side shape only at the integration boundary; Core remains unaware of Redux and no authority switch occurs in the scoping slice | Golden fixtures for array and `EntityState` inputs; round-trip ID/order preservation; duplicate IDs, missing `ids` references, and orphaned entities are rejected for both characters and worlds |
+| 9 | Project state-shape compatibility adapter | TS, `features/project/coreBoundaryAdapter.ts` at the Core boundary + Rust, `crates/worldscript-project` schema | High at the boundary — production Redux `EntityState` must be translated without importing Redux into Core | Low | High — ID/order preservation is part of project identity | Medium | High — every native renderer needs the same conversion contract | **2 — Wave 2 prerequisite before G1 evaluation** | **In progress — typed adapter and fixtures locally proven; no production caller or authority switch**; normalizes Redux `EntityState` to renderer-neutral arrays and reconstructs the TS-side shape only at the integration boundary | `tests/unit/features/project/coreBoundaryAdapter.test.ts` covers array and `EntityState` inputs, round-trip ID/order preservation, and rejection of duplicate IDs, missing references, and orphaned entities for both characters and worlds |
 
 ## Decisions this table records
 
@@ -34,11 +34,12 @@ scope shifts — it is a living decision record, not a one-time snapshot.
   `Vec`-based model is not yet the production Redux `EntityState` shape; the adapter contract and
   its ID/order fixtures must be scoped and proven at the boundary before G1 can claim a native-ready
   project lifecycle. This does not move Redux reducers or make `EntityState` part of Core.
-- **Row 9 boundary policy is deterministic for both `characters` and `worlds`.** Array-to-
-  `EntityState` conversion rejects duplicate or missing stable IDs. `EntityState`-to-array
-  conversion rejects an `ids` entry without a matching entity, an entity absent from `ids`, or
-  duplicate IDs; it never silently drops, synthesizes, or last-write-wins. Valid input preserves
-  the declared `ids` order and entity IDs in the golden fixtures.
+- **Row 9 boundary policy is deterministic for both `characters` and `worlds` and is now
+  implemented in `features/project/coreBoundaryAdapter.ts`.** Array-to-`EntityState` conversion
+  rejects duplicate or missing stable IDs. `EntityState`-to-array conversion rejects an `ids`
+  entry without a matching entity, an entity absent from `ids`, or duplicate IDs; it never silently
+  drops, synthesizes, or last-write-wins. Valid input preserves the declared `ids` order and
+  entity IDs in the boundary fixtures. This proves the contract, not a production authority switch.
 - **Row 4 has a narrow Core proof in progress.** `crates/worldscript-diagnostics` owns only the
   typed structured-log model and the existing top-level key-redaction semantics. IDB, Tauri JSONL,
   and development-console sinks remain TS-side; no production caller or authority switch is claimed.
@@ -52,8 +53,8 @@ reconciling it with fs storage. No `packages/worker-bus` subsumption or `task_su
 registry expansion. No `services/ai/*` work. No changes to `src-tauri/src/lora.rs` or `pandoc.rs`. No
 Qt/GPUI code. No unifying `src-tauri/Cargo.toml` into one repo-root Cargo workspace (see
 `crates/Cargo.toml`'s own scope note). No replacing `projectFsStore.ts`/`storageService.ts`'s
-dispatch — any future Tauri-command wiring is additive-and-unused-by-default only. No Row-9 adapter
-implementation or authority switch is included in this slice; it only makes the compatibility
-prerequisite explicit. No sink migration, Tauri adapter rewiring, or authority switch is included
-in the logger proof. No compression-format parity with the existing `.wsproj` files (open question,
-not solved here).
+dispatch — any future Tauri-command wiring is additive-and-unused-by-default only. No Row-9
+production caller, Rust schema change, or authority switch is included in this slice; the typed
+boundary contract and fixtures are proven independently. No sink migration, Tauri adapter
+rewiring, or authority switch is included in the logger proof. No compression-format parity with
+the existing `.wsproj` files (open question, not solved here).

--- a/docs/native/ROADMAP-QT-GPUI-DESKTOP.md
+++ b/docs/native/ROADMAP-QT-GPUI-DESKTOP.md
@@ -960,7 +960,7 @@ Required:
 [x] direct Tauri imports constrained (guardrail:desktop-imports, zero-tolerance)
 [~] project headless API exists — crates/worldscript-project (schema/validation/migration/plain I/O);
     storage (fs/IDB parity) and crypto remain, see docs/native/CORE-MIGRATION-LEDGER.md
-[ ] Array↔EntityState compatibility adapter scoped and proven at the Core boundary (ledger row 9)
+[x] Array↔EntityState compatibility adapter scoped and proven at the Core boundary (ledger row 9; production caller and authority switch remain deferred)
 [ ] R-15 architecture approved
 [ ] task supervision renderer-neutral
 [ ] diagnostics renderer-neutral
@@ -1116,7 +1116,9 @@ storage-backend parity, diagnostics sink migration, and AI request model extract
 see the ledger's priority order — so this wave stays "in progress," not "complete." Before G1 is evaluated, the
 separate row-9 compatibility position must also define and prove the Array↔EntityState boundary:
 the current Core `Vec` model is intentionally renderer-neutral, while production Redux state uses
-`EntityState` for characters and worlds.
+`EntityState` for characters and worlds. The typed boundary adapter and deterministic rejection
+fixtures are now implemented in `features/project/coreBoundaryAdapter.ts`; no production caller or
+authority switch is claimed.
 
 **Goal:** establish authoritative renderer-neutral execution.
 
@@ -1127,7 +1129,7 @@ Actions (checked = this slice, per `docs/native/CORE-MIGRATION-LEDGER.md`):
 - [x] schema;
 - [x] migration (minimal versioned mechanism, one synthetic migration proving it);
 - [ ] storage (fs backend parity, IDB backend — deferred);
-- [ ] Array↔EntityState compatibility adapter contract and fixtures (reject duplicate/missing/orphan
+- [x] Array↔EntityState compatibility adapter contract and fixtures (reject duplicate/missing/orphan
       IDs for characters and worlds; required before G1 evaluation);
 - [x] bounded task-supervisor proof (`text.analyze`/`text.diff`, structured failures and input
       limits; #430) — full worker-bus extraction remains deferred;

--- a/features/project/coreBoundaryAdapter.ts
+++ b/features/project/coreBoundaryAdapter.ts
@@ -1,0 +1,131 @@
+import type { EntityState } from '@reduxjs/toolkit';
+import type { Character, World } from '../../types';
+
+type CoreEntity = { id: string };
+export type CoreCollection = 'characters' | 'worlds';
+
+export class CoreBoundaryValidationError extends Error {
+  constructor(
+    public readonly collection: CoreCollection,
+    reason: string,
+  ) {
+    super(`Core boundary ${collection}: ${reason}`);
+    this.name = 'CoreBoundaryValidationError';
+  }
+}
+
+function requireStableId(
+  collection: CoreCollection,
+  id: unknown,
+  location: string,
+): asserts id is string {
+  if (typeof id !== 'string' || id.trim().length === 0) {
+    throw new CoreBoundaryValidationError(collection, `${location} is missing a stable id`);
+  }
+}
+
+// QNBS-v3: Reject malformed Redux containers before data crosses into renderer-neutral Core arrays.
+/** Converts an ordered Redux collection into the Core's renderer-neutral array shape. */
+export function entityStateToCoreArray<T extends CoreEntity>(
+  state: EntityState<T, string>,
+  collection: CoreCollection,
+): T[] {
+  const seenIds = new Set<string>();
+  const orderedEntities: T[] = [];
+
+  for (const [index, id] of state.ids.entries()) {
+    requireStableId(collection, id, `ids[${index}]`);
+    if (seenIds.has(id)) {
+      throw new CoreBoundaryValidationError(collection, `duplicate id "${id}" in ids`);
+    }
+
+    if (!Object.hasOwn(state.entities, id)) {
+      throw new CoreBoundaryValidationError(collection, `ids references missing entity "${id}"`);
+    }
+    const entity = state.entities[id];
+    if (!entity) {
+      throw new CoreBoundaryValidationError(collection, `entity key "${id}" has no value`);
+    }
+    requireStableId(collection, entity.id, `entities[${id}].id`);
+    if (entity.id !== id) {
+      throw new CoreBoundaryValidationError(
+        collection,
+        `entity key "${id}" does not match entity id "${entity.id}"`,
+      );
+    }
+
+    seenIds.add(id);
+    orderedEntities.push(entity);
+  }
+
+  for (const [key, entity] of Object.entries(state.entities)) {
+    if (!entity) {
+      throw new CoreBoundaryValidationError(collection, `entity key "${key}" has no value`);
+    }
+    requireStableId(collection, entity.id, `entities[${key}].id`);
+    if (entity.id !== key) {
+      throw new CoreBoundaryValidationError(
+        collection,
+        `entity key "${key}" does not match entity id "${entity.id}"`,
+      );
+    }
+    if (!seenIds.has(key)) {
+      throw new CoreBoundaryValidationError(
+        collection,
+        `orphan entity "${key}" is absent from ids`,
+      );
+    }
+  }
+
+  return orderedEntities;
+}
+
+/** Converts a Core array into the Redux shape without changing its declared order. */
+export function coreArrayToEntityState<T extends CoreEntity>(
+  entities: readonly T[],
+  collection: CoreCollection,
+): EntityState<T, string> {
+  const ids: string[] = [];
+  const byId: Record<string, T> = Object.create(null);
+
+  for (const [index, entity] of entities.entries()) {
+    requireStableId(collection, entity?.id, `entities[${index}].id`);
+    if (Object.hasOwn(byId, entity.id)) {
+      throw new CoreBoundaryValidationError(collection, `duplicate id "${entity.id}" in array`);
+    }
+    ids.push(entity.id);
+    byId[entity.id] = entity;
+  }
+
+  return { ids, entities: byId };
+}
+
+export interface ReduxProjectCollections {
+  characters: EntityState<Character, string>;
+  worlds: EntityState<World, string>;
+}
+
+export interface CoreProjectCollections {
+  characters: Character[];
+  worlds: World[];
+}
+
+/** The only collection conversion a future Core caller needs at the Redux boundary. */
+export function toCoreProjectCollections(
+  collections: ReduxProjectCollections,
+): CoreProjectCollections {
+  return {
+    characters: entityStateToCoreArray(collections.characters, 'characters'),
+    worlds: entityStateToCoreArray(collections.worlds, 'worlds'),
+  };
+}
+
+/** Rebuilds Redux containers only at the integration boundary; Core remains Redux-free. */
+export function fromCoreProjectCollections(
+  collections: CoreProjectCollections,
+): ReduxProjectCollections {
+  return {
+    characters: coreArrayToEntityState(collections.characters, 'characters'),
+    worlds: coreArrayToEntityState(collections.worlds, 'worlds'),
+  };
+}

--- a/tests/unit/features/project/coreBoundaryAdapter.test.ts
+++ b/tests/unit/features/project/coreBoundaryAdapter.test.ts
@@ -1,0 +1,147 @@
+// @vitest-environment node
+
+import type { EntityState } from '@reduxjs/toolkit';
+import { describe, expect, it } from 'vitest';
+import {
+  coreArrayToEntityState,
+  entityStateToCoreArray,
+  fromCoreProjectCollections,
+  toCoreProjectCollections,
+} from '../../../../features/project/coreBoundaryAdapter';
+import type { Character, World } from '../../../../types';
+
+const character = (id: string): Character => ({
+  id,
+  name: `Character ${id}`,
+  backstory: '',
+  motivation: '',
+  appearance: '',
+  personalityTraits: '',
+  flaws: '',
+  notes: '',
+  characterArc: '',
+  relationships: '',
+});
+
+const world = (id: string): World => ({
+  id,
+  name: `World ${id}`,
+  description: '',
+  geography: '',
+  magicSystem: '',
+  culture: '',
+  notes: '',
+  timeline: [],
+  locations: [],
+});
+
+const malformedEntityState = <T extends { id: string }>(state: unknown) =>
+  state as EntityState<T, string>;
+
+describe('project Core boundary adapter', () => {
+  it('preserves array order and IDs for both collections in both directions', () => {
+    const source = {
+      characters: coreArrayToEntityState([character('char-2'), character('char-1')], 'characters'),
+      worlds: coreArrayToEntityState([world('world-2'), world('world-1')], 'worlds'),
+    };
+
+    const core = toCoreProjectCollections(source);
+    expect(core.characters.map(({ id }) => id)).toEqual(['char-2', 'char-1']);
+    expect(core.worlds.map(({ id }) => id)).toEqual(['world-2', 'world-1']);
+
+    const restored = fromCoreProjectCollections(core);
+    expect(restored.characters.ids).toEqual(source.characters.ids);
+    expect(restored.worlds.ids).toEqual(source.worlds.ids);
+    expect(restored.characters.entities).toEqual(source.characters.entities);
+    expect(restored.worlds.entities).toEqual(source.worlds.entities);
+  });
+
+  it.each([
+    [
+      'characters',
+      () => coreArrayToEntityState([character('duplicate'), character('duplicate')], 'characters'),
+    ],
+    ['worlds', () => coreArrayToEntityState([world('duplicate'), world('duplicate')], 'worlds')],
+  ])('rejects duplicate %s IDs in Core arrays', (_collection, convert) => {
+    expect(convert).toThrow(/duplicate id/);
+  });
+
+  it.each([
+    [
+      'characters',
+      () =>
+        entityStateToCoreArray(
+          malformedEntityState({
+            ids: ['duplicate', 'duplicate'],
+            entities: { duplicate: character('duplicate') },
+          }),
+          'characters',
+        ),
+    ],
+    [
+      'worlds',
+      () =>
+        entityStateToCoreArray(
+          malformedEntityState({
+            ids: ['duplicate', 'duplicate'],
+            entities: { duplicate: world('duplicate') },
+          }),
+          'worlds',
+        ),
+    ],
+  ])('rejects duplicate %s IDs in EntityState ids', (_collection, convert) => {
+    expect(convert).toThrow(/duplicate id/);
+  });
+
+  it.each([
+    ['characters', () => coreArrayToEntityState([character('')], 'characters')],
+    ['worlds', () => coreArrayToEntityState([world('')], 'worlds')],
+  ])('rejects missing %s stable IDs in Core arrays', (_collection, convert) => {
+    expect(convert).toThrow(/missing a stable id/);
+  });
+
+  it.each([
+    [
+      'characters',
+      () =>
+        entityStateToCoreArray(
+          malformedEntityState({ ids: ['missing'], entities: {} }),
+          'characters',
+        ),
+    ],
+    [
+      'worlds',
+      () =>
+        entityStateToCoreArray(malformedEntityState({ ids: ['missing'], entities: {} }), 'worlds'),
+    ],
+  ])('rejects %s ids that reference missing entities', (_collection, convert) => {
+    expect(convert).toThrow(/references missing entity/);
+  });
+
+  it.each([
+    [
+      'characters',
+      () =>
+        entityStateToCoreArray(
+          malformedEntityState({
+            ids: ['listed'],
+            entities: { listed: character('listed'), orphan: character('orphan') },
+          }),
+          'characters',
+        ),
+    ],
+    [
+      'worlds',
+      () =>
+        entityStateToCoreArray(
+          malformedEntityState({
+            ids: ['listed'],
+            entities: { listed: world('listed'), orphan: world('orphan') },
+          }),
+          'worlds',
+        ),
+    ],
+  ])('rejects orphan %s entities absent from ids', (_collection, convert) => {
+    expect(convert).toThrow(/orphan entity/);
+  });
+});

--- a/tests/unit/features/project/coreBoundaryAdapter.test.ts
+++ b/tests/unit/features/project/coreBoundaryAdapter.test.ts
@@ -121,6 +121,92 @@ describe('project Core boundary adapter', () => {
   it.each([
     [
       'characters',
+      () => entityStateToCoreArray(malformedEntityState({ ids: [''], entities: {} }), 'characters'),
+    ],
+    [
+      'worlds',
+      () => entityStateToCoreArray(malformedEntityState({ ids: [''], entities: {} }), 'worlds'),
+    ],
+  ])('rejects missing %s stable IDs in EntityState ids', (_collection, convert) => {
+    expect(convert).toThrow(/missing a stable id/);
+  });
+
+  it.each([
+    [
+      'characters',
+      () =>
+        entityStateToCoreArray(
+          malformedEntityState({ ids: ['empty'], entities: { empty: undefined } }),
+          'characters',
+        ),
+    ],
+    [
+      'worlds',
+      () =>
+        entityStateToCoreArray(
+          malformedEntityState({ ids: ['empty'], entities: { empty: undefined } }),
+          'worlds',
+        ),
+    ],
+  ])('rejects %s EntityState entries with no value', (_collection, convert) => {
+    expect(convert).toThrow(/has no value/);
+  });
+
+  it.each([
+    [
+      'characters',
+      () =>
+        entityStateToCoreArray(
+          malformedEntityState({ ids: ['listed'], entities: { listed: character('') } }),
+          'characters',
+        ),
+    ],
+    [
+      'worlds',
+      () =>
+        entityStateToCoreArray(
+          malformedEntityState({ ids: ['listed'], entities: { listed: world('') } }),
+          'worlds',
+        ),
+    ],
+  ])('rejects %s entities with missing stable IDs', (_collection, convert) => {
+    expect(convert).toThrow(/missing a stable id/);
+  });
+
+  it.each([
+    [
+      'characters',
+      () =>
+        entityStateToCoreArray(
+          malformedEntityState({ ids: ['listed'], entities: { listed: character('other') } }),
+          'characters',
+        ),
+    ],
+    [
+      'worlds',
+      () =>
+        entityStateToCoreArray(
+          malformedEntityState({ ids: ['listed'], entities: { listed: world('other') } }),
+          'worlds',
+        ),
+    ],
+  ])('rejects %s entity key and ID mismatches', (_collection, convert) => {
+    expect(convert).toThrow(/does not match entity id/);
+  });
+
+  it.each([
+    [
+      'characters',
+      () => coreArrayToEntityState([undefined] as unknown as Character[], 'characters'),
+    ],
+    ['worlds', () => coreArrayToEntityState([undefined] as unknown as World[], 'worlds')],
+  ])('rejects %s array entries without stable IDs', (_collection, convert) => {
+    expect(convert).toThrow(/missing a stable id/);
+  });
+
+  it.each([
+    [
+      'characters',
       () =>
         entityStateToCoreArray(
           malformedEntityState({

--- a/tests/unit/features/project/coreBoundaryAdapter.test.ts
+++ b/tests/unit/features/project/coreBoundaryAdapter.test.ts
@@ -38,6 +38,7 @@ const world = (id: string): World => ({
 const malformedEntityState = <T extends { id: string }>(state: unknown) =>
   state as EntityState<T, string>;
 
+// QNBS-v3: Verify ordered Core boundary round-trips and rejection of malformed Redux collections.
 describe('project Core boundary adapter', () => {
   it('preserves array order and IDs for both collections in both directions', () => {
     const source = {


### PR DESCRIPTION
## **User description**
## Summary

- add a typed renderer-neutral Array↔EntityState boundary adapter for characters and worlds
- preserve declared ids order and entity ids in both directions
- reject duplicate ids, missing ids references, orphan entities, key/id mismatches, empty ids, and empty entity values
- update the Wave 2 ledger and G1 evidence without claiming a production caller or authority switch

## Evidence

- `pnpm exec biome check features/project/coreBoundaryAdapter.ts tests/unit/features/project/coreBoundaryAdapter.test.ts`
- `pnpm exec vitest run tests/unit/features/project/coreBoundaryAdapter.test.ts` — 11 passed
- `pnpm run typecheck`
- `pnpm run docs:check`
- `git diff --check`

## Scope and non-goals

This is the Row-9 compatibility proof required before G1 evaluation. Redux remains outside the Rust Core model and the adapter has no production caller yet. It does not change Rust schemas, reducers, persistence authority, Tauri wiring, or any Qt/GPUI work. No new dependency or suppression was added.

## Summary by Sourcery

Prove the renderer-neutral project collection boundary while keeping Redux integration and authority changes deferred.

New Features:
- Add a typed boundary adapter that converts characters and worlds between renderer-neutral arrays and Redux EntityState collections.

Bug Fixes:
- Reject malformed collection data, including duplicate, empty, missing, orphaned, and mismatched entity IDs and empty entity values.

Enhancements:
- Preserve declared entity order and IDs across boundary conversions without introducing a production caller or changing authority.

Documentation:
- Update the Core migration ledger and desktop roadmap to record the boundary contract and its validation evidence as proven while deferring production integration.

Tests:
- Add unit coverage for valid round trips and malformed character and world collections.


___

## **CodeAnt-AI Description**
Prove safe conversion between project collections and renderer-neutral arrays

### What Changed
- Characters and worlds can be converted between Redux collections and renderer-neutral arrays while preserving IDs and declared order
- Invalid data is rejected instead of being silently dropped, including duplicate or empty IDs, missing references, orphan entities, empty values, and mismatched keys
- Unit tests cover valid round trips and malformed collections for both project types
- Migration documentation now records the boundary contract as proven, while production integration and authority changes remain deferred

### Impact
`✅ Preserved character and world order`
`✅ Clear rejection of malformed project data`
`✅ Safer Core boundary migration`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable conversion between project collections and core-compatible arrays.
  * Preserves entity order, IDs, and data for characters and worlds.
  * Rejects malformed or inconsistent collection data with clear validation errors.

* **Tests**
  * Added coverage for successful conversions and invalid collection scenarios.

* **Documentation**
  * Updated migration and roadmap documentation to reflect the completed boundary adapter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->