### PR TITLE
fix(release): enforce v1.28.0 development truth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Release-truth guard:** `docs:check` now verifies the release-tag frontier, package/tag
+  relationship, README release badges, and non-empty `[Unreleased]` history without treating
+  tagless or shallow checkouts as a false failure.
 - **Spotlight tour theme:** the post-rebrand driver.js popover now binds to its WorldScript CSS
   selector, with a regression test protecting the binding.
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -124,6 +124,20 @@ Mutation testing (Stryker) is **not** in this graph — it runs only via manual 
 > Settings → Branches → `main` → Required status checks → remove the 4 individual entries, add
 > `✅ CI Success`.
 
+### Release-truth checks
+
+`pnpm run docs:check` treats `v1.27.1` (the latest stable tag) as the release frontier. A dated
+Keep-a-Changelog heading at or beyond that frontier must have its matching tag; a package version
+behind the frontier fails, while a newer development version is valid only with a populated
+`[Unreleased]` section. README badges may use an explicit `Next`/`unreleased` development label,
+but a released-version badge must resolve to an existing tag. Historical headings below the
+frontier remain valid when old tags are no longer present.
+
+The gate intentionally skips version-based assertions when no tags are available, because a
+tagless or shallow checkout cannot establish a release frontier. CI uses `fetch-tags: true` so the
+authoritative quality job does not silently lose this evidence. Release tags must be created only
+after the release-truth PR is merged and the exact target SHA has passed the release prerequisites.
+
 ---
 
 ## CSP gates — which layer catches which failure class

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -128,8 +128,8 @@ Mutation testing (Stryker) is **not** in this graph — it runs only via manual 
 
 `pnpm run docs:check` treats `v1.27.1` (the latest stable tag) as the release frontier. A dated
 Keep-a-Changelog heading at or beyond that frontier must have its matching tag; a package version
-behind the frontier fails, while a newer development version is valid only with a populated
-`[Unreleased]` section. README badges may use an explicit `Next`/`unreleased` development label,
+behind the frontier fails, while a newer development version requires an `[Unreleased]` section;
+when post-release commits exist, that section must contain meaningful history. README badges may use an explicit `Next`/`unreleased` development label,
 but a released-version badge must resolve to an existing tag. Historical headings below the
 frontier remain valid when old tags are no longer present.
 

--- a/scripts/check-doc-metrics.d.mts
+++ b/scripts/check-doc-metrics.d.mts
@@ -8,6 +8,11 @@ export function scanReleaseTruth(
   packageVersion: string,
   taggedVersions: Set<string>,
 ): string[];
+export function scanReadmeReleaseTruth(readme: string, taggedVersions: Set<string>): string[];
+export function scanUnreleasedTruth(
+  changelog: string,
+  postReleaseCommitSubjects: string[] | null,
+): string[];
 export function scanForDrift(
   content: string,
   filePath: string,

--- a/scripts/check-doc-metrics.mjs
+++ b/scripts/check-doc-metrics.mjs
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
 /**
  * Fails if a doc file states a locale/key count or a release-status claim that no longer matches
  * reality — the drift this audit found repeatedly (ROADMAP.md/TRANSLATION-GUIDE.md/TODO.md/
  * CONTRIBUTING.md/.github/copilot-instructions.md all said "17 locales" after the 17→19 expansion).
- * Historical/dated entries (CHANGELOG-style `## [x.y.z]` headings, or `## vX.Y.Z … RELEASED …`
- * section headings) are exempt — they correctly describe a past state, not the present one.
+ * Historical/dated entries remain exempt from present-tense metric scans, while release truth is
+ * checked separately at the latest tag frontier.
  *
  * Run: node scripts/check-doc-metrics.mjs
  */
@@ -192,6 +193,74 @@ export function scanReleaseTruth(changelog, packageVersion, taggedVersions) {
 }
 
 /**
+ * A version badge may advertise the current development line, but must not present an untagged
+ * version as a released version. Keep this separate from prose drift so the README convention is
+ * explicit and testable.
+ */
+export function scanReadmeReleaseTruth(readme, taggedVersions) {
+  const findings = [];
+  const latestTagged = [...taggedVersions].sort(semverCompare).at(-1) ?? null;
+  if (!latestTagged) return findings;
+
+  const badgePattern = /\b(?:Next|Release|Version|Current)[-_ ]v?(\d+\.\d+\.\d+)/i;
+  for (const [index, line] of readme.split('\n').entries()) {
+    const match = line.match(badgePattern);
+    if (!match || /\b(?:next|unreleased|development|dev|pre[- ]?release)\b/i.test(line)) continue;
+    const version = match[1];
+    if (!taggedVersions.has(version)) {
+      findings.push(
+        `README.md:${index + 1} — release badge advertises v${version}, but no matching git tag exists`,
+      );
+    }
+  }
+  return findings;
+}
+
+function hasMeaningfulUnreleasedContent(changelog) {
+  const heading = /^## \[Unreleased\]\s*$/m.exec(changelog);
+  if (!heading) return false;
+  const afterHeading = changelog.slice(heading.index + heading[0].length);
+  const nextHeading = afterHeading.search(/^##\s/m);
+  const section = nextHeading === -1 ? afterHeading : afterHeading.slice(0, nextHeading);
+  return section.split('\n').some((line) => {
+    const trimmed = line.trim();
+    return trimmed.length > 0 && !trimmed.startsWith('<!--') && !trimmed.startsWith('###');
+  });
+}
+
+/**
+ * Return post-release commit subjects when the checkout has enough history to answer reliably.
+ * A tagless or shallow checkout intentionally returns null, so CI does not turn missing history
+ * into a false release failure.
+ */
+export function getPostReleaseCommitSubjects(repositoryRoot = root) {
+  const taggedVersions = getTaggedVersions(repositoryRoot);
+  const latestTagged = [...taggedVersions].sort(semverCompare).at(-1);
+  if (!latestTagged) return null;
+  try {
+    const output = execFileSync('git', ['log', '--format=%s', `v${latestTagged}..HEAD`], {
+      cwd: repositoryRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return output
+      .split('\n')
+      .map((subject) => subject.trim())
+      .filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+export function scanUnreleasedTruth(changelog, postReleaseCommitSubjects) {
+  if (!postReleaseCommitSubjects || postReleaseCommitSubjects.length === 0) return [];
+  if (hasMeaningfulUnreleasedContent(changelog)) return [];
+  return [
+    `CHANGELOG.md — ${postReleaseCommitSubjects.length} commit(s) exist after the latest release tag, but [Unreleased] is empty`,
+  ];
+}
+
+/**
  * @param {string} [repositoryRoot]
  * @returns {string}
  */
@@ -307,13 +376,15 @@ function main() {
   const canonicalUrl = getCanonicalProductionUrl();
   const packageVersion = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8')).version;
 
+  const taggedVersions = getTaggedVersions();
+  const changelog = readFileSync(join(root, 'CHANGELOG.md'), 'utf8');
   const allFindings = [];
   allFindings.push(
-    ...scanReleaseTruth(
-      readFileSync(join(root, 'CHANGELOG.md'), 'utf8'),
-      packageVersion,
-      getTaggedVersions(),
-    ),
+    ...scanReleaseTruth(changelog, packageVersion, taggedVersions),
+    ...scanUnreleasedTruth(changelog, getPostReleaseCommitSubjects()),
+  );
+  allFindings.push(
+    ...scanReadmeReleaseTruth(readFileSync(join(root, 'README.md'), 'utf8'), taggedVersions),
   );
   for (const relPath of TARGET_FILES) {
     const abs = join(root, relPath);

--- a/scripts/check-doc-metrics.mjs
+++ b/scripts/check-doc-metrics.mjs
@@ -202,15 +202,30 @@ export function scanReadmeReleaseTruth(readme, taggedVersions) {
   const latestTagged = [...taggedVersions].sort(semverCompare).at(-1) ?? null;
   if (!latestTagged) return findings;
 
+  // QNBS-v3: extract each badge label independently so a valid development badge cannot hide a later invalid release badge on the same line.
   const badgePattern = /\b(?:Next|Release|Version|Current)[-_ ]v?(\d+\.\d+\.\d+)/i;
+  const getBadgeTexts = (line) => {
+    const badgeTexts = [];
+    for (const match of line.matchAll(/!\[([^\]]*)\]/g)) badgeTexts.push(match[1]);
+    for (const match of line.matchAll(/<img\b[^>]*\balt=(['"])(.*?)\1[^>]*>/gi)) {
+      badgeTexts.push(match[2]);
+    }
+    for (const match of line.matchAll(/\b(?:Next|Release|Version|Current)[-_ ]v?\d+\.\d+\.\d+/gi)) {
+      badgeTexts.push(match[0]);
+    }
+    return [...new Set(badgeTexts)];
+  };
   for (const [index, line] of readme.split('\n').entries()) {
-    const match = line.match(badgePattern);
-    if (!match || /\b(?:next|unreleased|development|dev|pre[- ]?release)\b/i.test(line)) continue;
-    const version = match[1];
-    if (!taggedVersions.has(version)) {
-      findings.push(
-        `README.md:${index + 1} — release badge advertises v${version}, but no matching git tag exists`,
-      );
+    for (const badgeText of getBadgeTexts(line)) {
+      const match = badgeText.match(badgePattern);
+      if (!match || /\b(?:next|unreleased|development|dev|pre[- ]?release)\b/i.test(badgeText))
+        continue;
+      const version = match[1];
+      if (!taggedVersions.has(version)) {
+        findings.push(
+          `README.md:${index + 1} — release badge advertises v${version}, but no matching git tag exists`,
+        );
+      }
     }
   }
   return findings;
@@ -222,7 +237,8 @@ function hasMeaningfulUnreleasedContent(changelog) {
   const afterHeading = changelog.slice(heading.index + heading[0].length);
   const nextHeading = afterHeading.search(/^##\s/m);
   const section = nextHeading === -1 ? afterHeading : afterHeading.slice(0, nextHeading);
-  return section.split('\n').some((line) => {
+  const withoutHtmlComments = section.replace(/<!--[\s\S]*?(?:-->|$)/g, '');
+  return withoutHtmlComments.split('\n').some((line) => {
     const trimmed = line.trim();
     return trimmed.length > 0 && !trimmed.startsWith('<!--') && !trimmed.startsWith('###');
   });

--- a/tests/unit/checkDocMetrics.test.ts
+++ b/tests/unit/checkDocMetrics.test.ts
@@ -12,14 +12,18 @@ import {
   getTaggedVersions,
   scanForDrift,
   scanForUrlDrift,
-  scanReadmeReleaseTruth,
   scanReleaseTruth,
-  scanUnreleasedTruth,
   stripHistoricalSections,
   VERCEL_URL_PATTERN,
 } from '../../scripts/check-doc-metrics.mjs';
 
 const getTaggedVersionsAt = getTaggedVersions as unknown as (repositoryRoot: string) => Set<string>;
+type ReleaseTruthModule = {
+  scanReadmeReleaseTruth: (readme: string, taggedVersions: Set<string>) => string[];
+  scanUnreleasedTruth: (changelog: string, subjects: string[] | null) => string[];
+};
+const loadReleaseTruthModule = async () =>
+  (await import('../../scripts/check-doc-metrics.mjs')) as unknown as ReleaseTruthModule;
 
 // QNBS-v3: release truth must remain correct in normal repositories and linked worktrees.
 describe('scanReleaseTruth', () => {
@@ -63,13 +67,15 @@ describe('scanReleaseTruth', () => {
 });
 
 describe('README release truth', () => {
-  it('rejects a released-version badge without a matching tag', () => {
+  it('rejects a released-version badge without a matching tag', async () => {
+    const { scanReadmeReleaseTruth } = await loadReleaseTruthModule();
     expect(scanReadmeReleaseTruth('![Release v1.28.0](badge.svg)', new Set(['1.27.1']))).toEqual([
       expect.stringContaining('release badge advertises v1.28.0'),
     ]);
   });
 
-  it('allows an explicitly unreleased development badge', () => {
+  it('allows an explicitly unreleased development badge', async () => {
+    const { scanReadmeReleaseTruth } = await loadReleaseTruthModule();
     expect(
       scanReadmeReleaseTruth(
         '<img alt="Next v1.28.0 (unreleased)" src="Next-v1.28.0-blue">',
@@ -80,13 +86,15 @@ describe('README release truth', () => {
 });
 
 describe('Unreleased truth', () => {
-  it('rejects post-release commits when Unreleased has no meaningful content', () => {
+  it('rejects post-release commits when Unreleased has no meaningful content', async () => {
+    const { scanUnreleasedTruth } = await loadReleaseTruthModule();
     expect(scanUnreleasedTruth('## [Unreleased]\n\n### Added\n', ['feat: new feature'])).toEqual([
       expect.stringContaining('[Unreleased] is empty'),
     ]);
   });
 
-  it('accepts populated Unreleased content after the latest release', () => {
+  it('accepts populated Unreleased content after the latest release', async () => {
+    const { scanUnreleasedTruth } = await loadReleaseTruthModule();
     expect(
       scanUnreleasedTruth('## [Unreleased]\n\n### Added\n\n- New feature\n', ['feat: new feature']),
     ).toEqual([]);

--- a/tests/unit/checkDocMetrics.test.ts
+++ b/tests/unit/checkDocMetrics.test.ts
@@ -12,7 +12,9 @@ import {
   getTaggedVersions,
   scanForDrift,
   scanForUrlDrift,
+  scanReadmeReleaseTruth,
   scanReleaseTruth,
+  scanUnreleasedTruth,
   stripHistoricalSections,
   VERCEL_URL_PATTERN,
 } from '../../scripts/check-doc-metrics.mjs';
@@ -35,9 +37,58 @@ describe('scanReleaseTruth', () => {
     );
   });
 
+  it('accepts a package version equal to the latest release tag', () => {
+    expect(scanReleaseTruth('## [1.27.1] — 2026-08-14\n', '1.27.1', new Set(['1.27.1']))).toEqual(
+      [],
+    );
+  });
+
+  it('rejects a package version older than the latest release tag', () => {
+    expect(scanReleaseTruth('## [Unreleased]\n', '1.27.0', new Set(['1.27.1']))).toEqual([
+      expect.stringContaining('older than the latest git tag v1.27.1'),
+    ]);
+  });
+
+  it('accepts valid historical headings below the current release frontier', () => {
+    expect(scanReleaseTruth('## [1.20.0] — 2026-06-07\n', '1.27.1', new Set(['1.27.1']))).toEqual(
+      [],
+    );
+  });
+
   it('skips dated-release tag checks in a tagless checkout', () => {
     expect(
       scanReleaseTruth('## [1.20.0] — 2025-01-01\n## [1.28.0] — 2026-08-21\n', '1.28.0', new Set()),
+    ).toEqual([]);
+  });
+});
+
+describe('README release truth', () => {
+  it('rejects a released-version badge without a matching tag', () => {
+    expect(scanReadmeReleaseTruth('![Release v1.28.0](badge.svg)', new Set(['1.27.1']))).toEqual([
+      expect.stringContaining('release badge advertises v1.28.0'),
+    ]);
+  });
+
+  it('allows an explicitly unreleased development badge', () => {
+    expect(
+      scanReadmeReleaseTruth(
+        '<img alt="Next v1.28.0 (unreleased)" src="Next-v1.28.0-blue">',
+        new Set(['1.27.1']),
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe('Unreleased truth', () => {
+  it('rejects post-release commits when Unreleased has no meaningful content', () => {
+    expect(scanUnreleasedTruth('## [Unreleased]\n\n### Added\n', ['feat: new feature'])).toEqual([
+      expect.stringContaining('[Unreleased] is empty'),
+    ]);
+  });
+
+  it('accepts populated Unreleased content after the latest release', () => {
+    expect(
+      scanUnreleasedTruth('## [Unreleased]\n\n### Added\n\n- New feature\n', ['feat: new feature']),
     ).toEqual([]);
   });
 });

--- a/tests/unit/checkDocMetrics.test.ts
+++ b/tests/unit/checkDocMetrics.test.ts
@@ -18,10 +18,12 @@ import {
 } from '../../scripts/check-doc-metrics.mjs';
 
 const getTaggedVersionsAt = getTaggedVersions as unknown as (repositoryRoot: string) => Set<string>;
+// QNBS-v3: keep executable-script exports typed locally while tsgo resolves the declaration file.
 type ReleaseTruthModule = {
   scanReadmeReleaseTruth: (readme: string, taggedVersions: Set<string>) => string[];
   scanUnreleasedTruth: (changelog: string, subjects: string[] | null) => string[];
 };
+// QNBS-v3: load the runtime-only scanners without making tsgo infer untyped .mjs exports.
 const loadReleaseTruthModule = async () =>
   (await import('../../scripts/check-doc-metrics.mjs')) as unknown as ReleaseTruthModule;
 
@@ -67,6 +69,7 @@ describe('scanReleaseTruth', () => {
 });
 
 describe('README release truth', () => {
+  // QNBS-v3: exercise the release badge invariant independently from changelog and package checks.
   it('rejects a released-version badge without a matching tag', async () => {
     const { scanReadmeReleaseTruth } = await loadReleaseTruthModule();
     expect(scanReadmeReleaseTruth('![Release v1.28.0](badge.svg)', new Set(['1.27.1']))).toEqual([
@@ -74,6 +77,7 @@ describe('README release truth', () => {
     ]);
   });
 
+  // QNBS-v3: preserve the explicit development-label exception for prerelease badges.
   it('allows an explicitly unreleased development badge', async () => {
     const { scanReadmeReleaseTruth } = await loadReleaseTruthModule();
     expect(
@@ -83,9 +87,21 @@ describe('README release truth', () => {
       ),
     ).toEqual([]);
   });
+
+  // QNBS-v3: inspect every badge in one row so a valid Next badge cannot mask an invalid Release badge.
+  it('checks a later released badge after a development badge', async () => {
+    const { scanReadmeReleaseTruth } = await loadReleaseTruthModule();
+    expect(
+      scanReadmeReleaseTruth(
+        '![Next v1.28.0 (unreleased)](next.svg) ![Release v1.29.0](release.svg)',
+        new Set(['1.27.1']),
+      ),
+    ).toEqual([expect.stringContaining('release badge advertises v1.29.0')]);
+  });
 });
 
 describe('Unreleased truth', () => {
+  // QNBS-v3: require real changelog history after a release instead of accepting comment-only placeholders.
   it('rejects post-release commits when Unreleased has no meaningful content', async () => {
     const { scanUnreleasedTruth } = await loadReleaseTruthModule();
     expect(scanUnreleasedTruth('## [Unreleased]\n\n### Added\n', ['feat: new feature'])).toEqual([
@@ -93,11 +109,22 @@ describe('Unreleased truth', () => {
     ]);
   });
 
+  // QNBS-v3: keep a populated Unreleased section valid for development versions.
   it('accepts populated Unreleased content after the latest release', async () => {
     const { scanUnreleasedTruth } = await loadReleaseTruthModule();
     expect(
       scanUnreleasedTruth('## [Unreleased]\n\n### Added\n\n- New feature\n', ['feat: new feature']),
     ).toEqual([]);
+  });
+
+  // QNBS-v3: treat multiline HTML comments as non-content in the release-history check.
+  it('rejects multiline-comment-only Unreleased content', async () => {
+    const { scanUnreleasedTruth } = await loadReleaseTruthModule();
+    expect(
+      scanUnreleasedTruth('## [Unreleased]\n\n<!--\nplaceholder\ncomment\n-->\n', [
+        'fix: post-release correction',
+      ]),
+    ).toEqual([expect.stringContaining('[Unreleased] is empty')]);
   });
 });
 


### PR DESCRIPTION
## **User description**
## Summary

- Verifies the live release frontier against dated CHANGELOG headings and package.json.
- Rejects released-version README badges without a matching Git tag while allowing explicit Next/unreleased development badges.
- Rejects a silently empty Unreleased section when post-release commits are available.
- Preserves deterministic tagless/shallow behavior by skipping version assertions when no tag frontier can be established.
- Documents the release convention and records the guard in Unreleased.

## Live release decision

Path B applies: v1.27.1 is the latest Git tag and GitHub Release. v1.28.0 is not tagged or released, and the repository already presents it as Next v1.28.0 (unreleased) with populated Unreleased content. This PR creates no tag or release.

## Validation

- 41 targeted release-truth tests
- node scripts/check-doc-metrics.mjs
- sequential pnpm run ci:prepush via the normal pre-push hook
- no local Stryker, E2E, Lighthouse, or Storybook execution

## Summary by Sourcery

Enforce consistent release truth across project metadata and documentation while preserving reliable behavior in incomplete Git checkouts.

Bug Fixes:
- Enforce accurate release-status claims across changelog entries, package versions, README badges, and the Unreleased section.
- Avoid false release-validation failures in tagless or shallow checkouts where no release frontier can be established.

Enhancements:
- Document the release-truth convention and CI requirements for validating release tags and history.

Documentation:
- Add CI guidance describing release-frontier, badge, package-version, and Unreleased-history checks.

Tests:
- Add coverage for package and changelog release validation, README badge status, and meaningful Unreleased content.


___

## **CodeAnt-AI Description**
Enforce accurate release status across project documentation

### What Changed
- Documentation checks now reject untagged released-version claims in the changelog and README.
- Package versions behind the latest release tag are rejected, while newer development versions require meaningful `[Unreleased]` content.
- Historical changelog entries remain valid, and tagless or shallow checkouts avoid unreliable release failures.
- Added coverage for release versions, README badges, and empty `[Unreleased]` sections, plus CI guidance for release validation.

### Impact
`✅ Fewer misleading release claims`
`✅ Clearer development-version status`
`✅ Reliable checks in tagless and shallow checkouts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for release-truth checks, including version tags, README badges, changelog history, and shallow or tagless checkouts.
  * Documented release-tag timing and CI requirements.

* **Bug Fixes**
  * Improved release validation to detect mismatched versions, outdated badges, and empty Unreleased sections after releases.
  * Added reliable handling for repositories without tags or with limited history.

* **Tests**
  * Expanded coverage for valid, invalid, historical, and tagless release scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->