### PR TITLE
fix(ci): make required job authority explicit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -423,7 +423,8 @@ jobs:
     name: ✅ CI Success
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [security, quality, changes, rust-tauri, core-rust, build, e2e, vrt]
+    # QNBS-v3: Every unconditional job is either required here or explicitly advisory at job level.
+    needs: [security, quality, changes, rust-tauri, core-rust, build, e2e, lighthouse, vrt]
     if: always()
     steps:
       - name: Verify all required jobs succeeded
@@ -440,6 +441,7 @@ jobs:
           fi
           [ "${{ needs.build.result }}" = "success" ] || FAIL=1
           [ "${{ needs.e2e.result }}" = "success" ] || FAIL=1
+          [ "${{ needs.lighthouse.result }}" = "success" ] || FAIL=1
           [ "${{ needs.vrt.result }}" = "success" ] || FAIL=1
           if [ "$FAIL" = "1" ]; then
             echo "One or more required jobs did not succeed:"
@@ -450,6 +452,7 @@ jobs:
             echo "  core-rust: ${{ needs.core-rust.result }} (skipped = OK, crates/ untouched)"
             echo "  build:    ${{ needs.build.result }}"
             echo "  e2e:      ${{ needs.e2e.result }}"
+            echo "  lighthouse: ${{ needs.lighthouse.result }}"
             echo "  vrt:      ${{ needs.vrt.result }}"
             exit 1
           fi
@@ -604,7 +607,6 @@ jobs:
     # QNBS-v3: 25 min — two lhci runs (mobile 3× + desktop 2×); was 15 min for mobile only
     timeout-minutes: 25
     needs: [build]
-    continue-on-error: false
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -651,6 +653,8 @@ jobs:
     # QNBS-v3: Cloud-first — Storybook build + test-runner runs only in CI (not local).
     #          25 min = build (~8 min) + server start + test-runner retries + screenshot upload.
     timeout-minutes: 25
+    # QNBS-v3: Storybook remains advisory until ten genuine first-attempt runs establish stability.
+    continue-on-error: true
     needs: [quality]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -694,12 +698,8 @@ jobs:
         # printed --help text, and `|| true` silently turned that into a green step — this gate has
         # produced zero real signal since it was added. Fixed to only pass supported flags.
         # QNBS-v3 (CodeRabbit, 2026-07-29): `|| true` swallowed the exit code so this step showed
-        # green even when it truly failed — literally how the bug above stayed invisible. Moved the
-        # non-blocking behavior to step-level `continue-on-error: true`, which still shows the step
-        # as failed (visible signal for the F-13 "~10 real runs" re-evaluation) without failing the
-        # job. Re-evaluate after ~10 real (non-help-text) runs on main — if none fail on genuine
-        # a11y/story assertions, drop `continue-on-error` and make this blocking.
-        continue-on-error: true
+        # green even when it truly failed — literally how the bug above stayed invisible. The
+        # job-level advisory policy keeps the failed step visible without making it a merge blocker.
         env:
           CI: true
           DEBUG: pw:browser*

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2924_keys-0EA5E9" alt="i18n 19 locales — 2924 keys">
-  <img src="https://img.shields.io/badge/Tests-6906%2B_%2F_567_files-22C55E" alt="6906+ tests / 567 files">
+  <img src="https://img.shields.io/badge/Tests-6907%2B_%2F_567_files-22C55E" alt="6907+ tests / 567 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2924 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (6906+ tests / 567 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (6907+ tests / 567 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (6906+ tests, 567 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (6907+ tests, 567 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -711,7 +711,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-21, source-synchronized; CI remains authoritative for pass/fail):**
-- **6906+ unit tests** across **567 test files** — all passing
+- **6907+ unit tests** across **567 test files** — all passing
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2924 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -711,7 +711,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-21, source-synchronized; CI remains authoritative for pass/fail):**
-- **6907+ unit tests** across **567 test files** — all passing
+- **6907+ unit tests** across **567 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2924 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -100,7 +100,8 @@ Each job that uses the composite must call `actions/checkout@v6` first (local co
 ```text
 security ──► quality ──┬──► build ──┬──► lighthouse
                        ├──► e2e     └──► vrt
-                       └──► storybook
+                       ├──► e2e-deep (advisory)
+                       └──► storybook (advisory)
 
 security ─┬
 quality ──┼──► ci-success (required-status aggregator)
@@ -109,6 +110,7 @@ rust ────┤
 core-rust ┤
 build ────┤
 e2e ──────┤
+lighthouse ─┤
 vrt ──────┘
 
 build (main, non-PR) ──► upload-pages-artifact
@@ -201,7 +203,7 @@ in `ci.yml` is listed here with why it isn't blocking today and what has to be t
 
 | Gate | Why not blocking today | Exit criterion |
 |------|------------------------|-----------------|
-| Storybook `test-storybook` (`storybook` job, `continue-on-error: true`) | Fixed 2026-07-29 (F-12): the invocation was calling flags this test-runner version doesn't support (`--max-workers`/`--retries`/`--screenshot-on-failure`), so it failed on argument parsing before running a single story, on every prior run. This is the first run where it will actually execute real stories/a11y checks — no track record exists yet. Moved from `\|\| true` to step-level `continue-on-error: true` the same day (CodeRabbit-caught): `\|\| true` swallowed the exit code so the step showed green even while genuinely failing — the exact mechanism that let the F-12 bug go unnoticed. | Re-evaluate after **~10 real (non-argument-error) runs on `main`**; drop `continue-on-error` and make blocking if none fail on a genuine story/a11y assertion. |
+| Storybook `test-storybook` (`storybook` job, `continue-on-error: true`) | Fixed 2026-07-29 (F-12): the invocation was calling flags this test-runner version doesn't support (`--max-workers`/`--retries`/`--screenshot-on-failure`), so it failed on argument parsing before running a single story, on every prior run. This is the first run where it will actually execute real stories/a11y checks — no track record exists yet. Moved from `\|\| true` to job-level `continue-on-error: true` the same day (CodeRabbit-caught): `\|\| true` swallowed the exit code so the step showed green even while genuinely failing — the exact mechanism that let the F-12 bug go unnoticed. | Re-evaluate after **~10 real (non-argument-error) runs on `main`**; drop `continue-on-error` and make blocking if none fail on a genuine story/a11y assertion. |
 | `e2e-deep` (feature-flag matrix job, `continue-on-error: true`) | Deliberately informational by design — parametrizes across the full `testConfigurations` flag matrix (`tests/e2e/config/test-matrix.ts`) specifically to surface flag-interaction regressions that the required `e2e` gate's default-flag-state run cannot see; failures here are diagnostic signal, not necessarily a merge-blocking defect in the default configuration. | Promote a **specific flag combination** to blocking (add it to the required `e2e` spec instead) once it has been stable for **3 consecutive weeks of `main` runs** — do not flip the entire matrix job blocking at once, since that reintroduces the flakiness-cascade risk `e2e-deep` was created to avoid. |
 | Lighthouse **Desktop** step (`lighthouse` job, `continue-on-error: true`) — note: accessibility (`minScore: 0.95`) and CLS (`≤ 0.1`) stay **error**-level gates even on this step; only the broader desktop performance/SEO scores are non-blocking | Desktop performance baselines haven't been formally re-verified as stable since the last CI-runner change | Re-run `pnpm exec lhci autorun --config=.lighthouserc.desktop.cjs` locally or via `storybook-debug.yml`-style manual dispatch across **5 consecutive `main` runs**; if performance/SEO scores stay within the existing `warn` thresholds each time, remove `continue-on-error` for the step. |
 | Coverage ratchet (`scripts/check-coverage-ratchet.mjs`, `continue-on-error: true`) | **Deliberately, permanently advisory** — by design (see `vitest.config.ts`'s ratchet-history comment), it exists to *suggest* the next threshold bump, not to gate a merge on hitting one. | None — this is the one gate above intentionally without an exit criterion; its purpose is met by staying advisory. Reviewed here for completeness so it isn't mistaken for forgotten debt. |

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -38,15 +38,15 @@ CI runs for the affected test path before removing a temporary quarantine.
 ### Gate authority
 
 `✅ CI Success` is the required branch-protection status and aggregates `security`, `quality`,
-`changes`, `rust-tauri`, `core-rust`, `build`, `e2e`, and `vrt`. The `deploy` job depends only on
-that aggregate and remains main-push-only.
+`changes`, `rust-tauri`, `core-rust`, `build`, `e2e`, `lighthouse`, and `vrt`. `e2e-deep` and
+`storybook` are explicitly advisory at job level while their stability criteria are measured. The
+`deploy` job depends only on that aggregate and remains main-push-only.
 
-`storybook` and `lighthouse` are currently visible, separately executed advisory jobs rather than
-members of the aggregate. Their failures must still be investigated before merge under the
-repository's full-suite policy; this explicit distinction prevents a red visible job from having
-an undefined authority model. Storybook's test-runner and Lighthouse's desktop performance step
-remain non-blocking under the exit criteria documented below. `e2e-deep` and the coverage ratchet
-are also intentionally advisory.
+`storybook` and `e2e-deep` are separately executed advisory jobs with explicit job-level
+`continue-on-error: true`; their failures remain visible and must still be investigated before merge
+under the repository's full-suite policy. Lighthouse is part of the required aggregate because its
+mobile accessibility and CLS assertions are blocking; only its desktop performance step remains
+non-blocking under the exit criteria documented below. The coverage ratchet remains informational.
 
 **Post-merge doc update workflow:**
 1. Push the commit → CI starts automatically.
@@ -127,7 +127,7 @@ Mutation testing (Stryker) is **not** in this graph — it runs only via manual 
 | `lighthouse` | `build` | LHCI (mobile): **accessibility error gate** `minScore: 0.95`; **CLS error** ≤ 0.1; performance/SEO warn. Desktop run: `continue-on-error: true` until baselines stabilise. Timeout 25 min. |
 | `storybook` | `quality` | Cloud-first — Storybook build + test-runner only run in CI (not locally); Playwright browser cache `v5`; `--maxWorkers=2 --junit` (non-blocking, `continue-on-error: true` — see [exit criteria](#non-blocking-gates--exit-criteria-f-13)); artifacts uploaded always. Debug: manual `storybook-debug.yml` workflow. |
 | `vrt` | `build` | Visual regression against production `dist`; `toHaveScreenshot()` with committed PNG baselines (4 views × Chromium); artifacts uploaded always |
-| `ci-success` | `security`, `quality`, `changes`, `rust-tauri`, `core-rust`, `build`, `e2e`, `vrt` | Required-status **aggregator** — `if: always()`, fails if any required release-safety job does not resolve to `success`; Storybook, Lighthouse and deep-E2E remain informational until their stability criteria are met. Rust jobs are legitimately skipped when their paths are untouched. |
+| `ci-success` | `security`, `quality`, `changes`, `rust-tauri`, `core-rust`, `build`, `e2e`, `lighthouse`, `vrt` | Required-status **aggregator** — `if: always()`, fails if any required release-safety job does not resolve to `success`; Storybook and deep-E2E are explicitly advisory. Rust jobs are legitimately skipped when their paths are untouched. |
 | `deploy` | `ci-success` | **Only** `main` push (not PR), and only after the aggregate gate succeeds; the Pages artifact is resolved from the same workflow run. |
 
 > **Desktop:** On-demand / tag-driven Tauri bundles live in [`tauri-build.yml`](../.github/workflows/tauri-build.yml); **`v*` tags** additionally publish installers on a **GitHub Release**. See [`docs/TAURI-CI.md`](TAURI-CI.md). Desktop CI does not block the web deploy graph above.

--- a/scripts/ci-prepush-lowend.mjs
+++ b/scripts/ci-prepush-lowend.mjs
@@ -5,7 +5,9 @@ const checks = [
   ['toolchain', () => runNodeScript('scripts/check-pnpm-toolchain.mjs', ['--hook'])],
   [
     'typecheck (single checker)',
-    () => runLocalBinary('tsgo', ['--project', 'tsconfig.tsgo.json', '--noEmit']),
+    // QNBS-v3: Make the low-end resource contract explicit; tsgo's default checker count is not a safe local default.
+    () =>
+      runLocalBinary('tsgo', ['--project', 'tsconfig.tsgo.json', '--noEmit', '--checkers', '1']),
   ],
   ['i18n key parity', () => runNodeScript('scripts/check-i18n-keys.mjs')],
   ['i18n bundle rebuild', () => runNodeScript('scripts/build-i18n.mjs')],

--- a/tests/unit/workflowPolicy.test.ts
+++ b/tests/unit/workflowPolicy.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import {
+  extractJobBlock,
   extractJobNames,
   extractLocalPathDependencies,
   extractNeeds,
@@ -78,21 +79,26 @@ describe('CI workflow policy', () => {
 
   // QNBS-v3: Keep every unconditional CI job explicitly required or advisory so deploy cannot false-green.
   it('keeps required and advisory job authority explicit', () => {
-    const ciSuccessBlock = workflowSource.match(/^ {2}ci-success:[\s\S]*?(?=^ {2}deploy:)/m)?.[0];
-    expect(ciSuccessBlock).toBeDefined();
+    const ciSuccessBlock = extractJobBlock(workflowSource, 'ci-success');
     expect(ciSuccessBlock).toContain(
       'Every unconditional job is either required here or explicitly advisory',
     );
-    expect(ciSuccessBlock).toContain('lighthouse');
-    expect(ciSuccessBlock).not.toContain('needs.e2e-deep');
-    expect(ciSuccessBlock).not.toContain('needs.storybook');
+    expect(extractNeeds(workflowSource, 'ci-success')).toEqual([
+      'security',
+      'quality',
+      'changes',
+      'rust-tauri',
+      'core-rust',
+      'build',
+      'e2e',
+      'lighthouse',
+      'vrt',
+    ]);
+    expect(ciSuccessBlock).toMatch(/\$\{\{\s*needs\.lighthouse\.result\s*\}\}/);
 
     for (const jobName of ['e2e-deep', 'storybook']) {
-      const jobBlock = workflowSource.match(
-        new RegExp(`^  ${jobName}:[\\s\\S]*?(?=\\n  [\\w-]+:)`, 'm'),
-      )?.[0];
-      expect(jobBlock, `${jobName} must have an explicit job block`).toBeDefined();
-      expect(jobBlock).toContain('continue-on-error: true');
+      const jobBlock = extractJobBlock(workflowSource, jobName);
+      expect(jobBlock).toMatch(/^ {4}continue-on-error: true$/m);
     }
   });
 });

--- a/tests/unit/workflowPolicy.test.ts
+++ b/tests/unit/workflowPolicy.test.ts
@@ -75,4 +75,24 @@ describe('CI workflow policy', () => {
     visit('deploy');
     expect(visited).toContain('ci-success');
   });
+
+  // QNBS-v3: Keep every unconditional CI job explicitly required or advisory so deploy cannot false-green.
+  it('keeps required and advisory job authority explicit', () => {
+    const ciSuccessBlock = workflowSource.match(/^ {2}ci-success:[\s\S]*?(?=^ {2}deploy:)/m)?.[0];
+    expect(ciSuccessBlock).toBeDefined();
+    expect(ciSuccessBlock).toContain(
+      'Every unconditional job is either required here or explicitly advisory',
+    );
+    expect(ciSuccessBlock).toContain('lighthouse');
+    expect(ciSuccessBlock).not.toContain('needs.e2e-deep');
+    expect(ciSuccessBlock).not.toContain('needs.storybook');
+
+    for (const jobName of ['e2e-deep', 'storybook']) {
+      const jobBlock = workflowSource.match(
+        new RegExp(`^  ${jobName}:[\\s\\S]*?(?=\\n  [\\w-]+:)`, 'm'),
+      )?.[0];
+      expect(jobBlock, `${jobName} must have an explicit job block`).toBeDefined();
+      expect(jobBlock).toContain('continue-on-error: true');
+    }
+  });
 });

--- a/tests/utils/workflowPolicyParsers.ts
+++ b/tests/utils/workflowPolicyParsers.ts
@@ -1,6 +1,6 @@
 import { dirname, relative, resolve } from 'node:path';
 
-function extractJobBlock(workflowSource: string, jobName: string): string {
+export function extractJobBlock(workflowSource: string, jobName: string): string {
   const lines = workflowSource.split('\n');
   const start = lines.indexOf(`  ${jobName}:`);
   if (start === -1) throw new Error(`Could not find CI job: ${jobName}`);


### PR DESCRIPTION
## **User description**
## Summary
- Adds Lighthouse to the authoritative ci-success dependency and failure/diagnostic checks.
- Marks e2e-deep and Storybook explicitly advisory at job level, with matching CI documentation.
- Makes the constrained-workstation pre-push TypeScript check explicitly single-checker.
- Adds a workflow-policy regression test and synchronizes generated README test metrics.

## Verify-First evidence
- ci-success is a required branch-protection status check on main (verified through the GitHub branch-protection API).
- Before: ci-success omitted lighthouse while e2e-deep/storybook were not consistently represented as advisory jobs.
- After: lighthouse is required; e2e-deep and storybook are job-level advisory; the aggregator, failure block, diagnostics, docs, and policy test agree.
- Local dependency-free gates were green before editing: i18n 19 locales/2924 keys, suppressions 48/48, tokens 139/159, docs, CSP, native readiness, and Tauri boundary.

## Validation
- pnpm exec vitest run tests/unit/workflowPolicy.test.ts — passed (6 tests).
- pnpm run ci:prepush — passed sequentially: toolchain, single-checker typecheck, i18n parity/bundles/content/quality, docs, CSP, Tauri boundary, native readiness.
- pnpm exec biome lint --max-diagnostics=200 --error-on-warnings — passed.
- tsgo with one checker — passed.
- Full Vitest, coverage, E2E, Lighthouse, Storybook, VRT, and Stryker remain cloud-CI responsibilities under the low-end hardware policy.

## Scope and non-goals
- This PR corrects CI authority semantics; it does not redesign mutation testing, coverage, CSP allowlists, release metadata, or the native roadmap.
- No suppression baseline was raised and no new suppression was added.

## Deviation
- Lighthouse was classified as blocking because its accessibility and CLS checks are configured as hard failures; the recommendation to make it advisory was not adopted after inspecting the job definition.
- Storybook remains advisory at job level because its current test step is intentionally informational; the status is now explicit rather than implicit.

## Unverified
- The final cloud CI and external review-bot results are pending on this new PR head.

## Review coverage
- CodeRabbit, CodeAnt AI, qodo-code-review, Graphite, Amazon Q, and other configured reviewers will be checked through their respective channels after the first CI run; silence will be recorded, not treated as approval.

## Definition of Done
- [x] Every unconditional CI job is either authoritative in ci-success or explicitly advisory.
- [x] Aggregator needs, FAIL block, and diagnostics list the same required jobs.
- [x] Workflow policy regression coverage added.
- [x] Local low-end gate passed sequentially.
- [ ] Cloud CI green and review threads quiescent.

## Summary by Sourcery

Make CI job authority explicit by requiring Lighthouse for merge success, marking non-blocking jobs as advisory, and enforcing the low-resource local type-check contract.

Bug Fixes:
- Make Lighthouse accessibility and CLS results part of the required CI status so blocking regressions cannot produce a false-green merge check.
- Expose Storybook failures while keeping the Storybook and deep end-to-end jobs explicitly advisory.

Enhancements:
- Make the low-resource pre-push TypeScript check use a single checker.
- Add regression coverage ensuring required and advisory CI job authority remains explicit and consistent.

CI:
- Align the CI success aggregator, diagnostics, failure handling, and job-level advisory policies with the repository's required checks.

Documentation:
- Update CI authority documentation and synchronized test-count metrics.

Tests:
- Add workflow-policy regression coverage for required dependencies and advisory jobs.


___

## **CodeAnt-AI Description**
Make CI failure authority explicit and enforce low-resource local checks

### What Changed
- Lighthouse failures now block the required CI status instead of remaining informational.
- Deep end-to-end tests and Storybook remain visible but explicitly advisory, so their failures do not block merges.
- Storybook failures are no longer silently hidden, allowing genuine test failures to remain visible in CI.
- Low-end pre-push type checks now run with a single checker to reduce local resource usage.
- Added a policy regression test and updated documentation and test-count metrics to match the new CI behavior.

### Impact
`✅ Fewer false-green deploy checks`
`✅ Blocking accessibility and layout regressions`
`✅ Lower local resource usage during type checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **CI Improvements**
  - Lighthouse checks are now required for successful builds.
  - Storybook and deep end-to-end checks are advisory and no longer block overall CI completion.
  - Added safeguards to ensure CI status rules remain consistent.

- **Documentation**
  - Updated CI guidance to clarify required and advisory checks.
  - Refreshed project test-count metrics.

- **Developer Experience**
  - Improved low-end pre-push type-check performance by limiting concurrency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->