### PR TITLE
fix(security): harden pnpm bootstrap and version pin

### DIFF
--- a/.github/CI-AUDIT.md
+++ b/.github/CI-AUDIT.md
@@ -28,7 +28,7 @@ This document summarizes the **current inventory** and **stabilization measures*
 |-------|--------|-------|
 | Node (recommended) | [`.nvmrc`](../.nvmrc) | **22** |
 | Node (CI matrix) | `ci.yml` `quality` | **22** and **24** (explicit, no `node` = "current") |
-| pnpm | `package.json` `packageManager` | **11.5.2** |
+| pnpm | `package.json` `packageManager` | **11.22.0** (security floor **11.11.0**) |
 | Lint | Biome | `pnpm run lint` |
 | i18n | `scripts/check-i18n-keys.mjs` | `pnpm run i18n:check` |
 | Unit | Vitest + V8 | CI: `pnpm exec vitest run --coverage`; local: targeted `pnpm exec vitest run <path>` |

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -16,13 +16,10 @@ inputs:
 runs:
   using: composite
   steps:
-    # QNBS-v3: corepack enable ensures pnpm is available even if the runner has a different default.
-    # Node 24+ changed corepack behavior; explicit enable prevents "pnpm: command not found" errors.
-    - name: Enable corepack
-      shell: bash
-      run: corepack enable
-
-    - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+    # QNBS-v3: install the patched exact pnpm before setup-node reads the repository lockfile for caching.
+    - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      with:
+        version: 11.22.0
 
     # QNBS-v3: When node-version is set (matrix), use it; otherwise read .nvmrc so
     # non-matrix jobs stay pinned to the project's declared Node version.
@@ -32,6 +29,10 @@ runs:
         node-version: ${{ inputs.node-version }}
         node-version-file: ${{ inputs.node-version == '' && inputs.node-version-file || '' }}
         cache: pnpm
+
+    - name: Assert toolchain
+      run: pnpm run toolchain:check
+      shell: bash
 
     - name: Install dependencies
       run: pnpm install --frozen-lockfile

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -31,7 +31,7 @@ runs:
         cache: pnpm
 
     - name: Assert toolchain
-      run: pnpm run toolchain:check
+      run: node scripts/check-pnpm-toolchain.mjs
       shell: bash
 
     - name: Install dependencies

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -31,7 +31,9 @@ runs:
         cache: pnpm
 
     - name: Assert toolchain
-      run: node scripts/check-pnpm-toolchain.mjs
+      run: |
+        export npm_config_user_agent="pnpm/$(pnpm --version)"
+        node scripts/check-pnpm-toolchain.mjs
       shell: bash
 
     - name: Install dependencies

--- a/.github/workflows/deploy-cloudflare-pages.yml.disabled
+++ b/.github/workflows/deploy-cloudflare-pages.yml.disabled
@@ -54,6 +54,11 @@ jobs:
           node-version: 22
           cache: pnpm
 
+      - name: Assert toolchain
+        run: |
+          export npm_config_user_agent="pnpm/$(pnpm --version)"
+          node scripts/check-pnpm-toolchain.mjs
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/deploy-cloudflare-pages.yml.disabled
+++ b/.github/workflows/deploy-cloudflare-pages.yml.disabled
@@ -45,9 +45,9 @@ jobs:
       # QNBS-v3: SHA-pinned to prevent supply-chain attacks via mutable tags
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
-          version: 10
+          version: 11.22.0
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ The app supports a multi-provider AI stack (Gemini, OpenAI, Claude, Grok, OpenRo
 
 | Layer | Technology |
 |-------|------------|
-| Runtime | Node.js `>=22.0.0` (`.nvmrc` → `22`), pnpm `>=11.0.0` (`packageManager: pnpm@11.5.2`) |
+| Runtime | Node.js `>=22.0.0` (`.nvmrc` → `22`), pnpm `11.22.0` (`packageManager: pnpm@11.22.0`) |
 | Framework | React `^19.2.7`, TypeScript 7 via `@typescript/native-preview` (tsgo, strict) — no pinned classic `typescript` package |
 | Build tool | Vite `^8.0.16` (`vite.config.ts`) |
 | Type checker | `tsgo` (TypeScript Go port) via `tsconfig.tsgo.json` with 4 checkers (`pnpm run typecheck`) |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ This project follows the [Contributor Covenant Code of Conduct](.github/CODE_OF_
 
 1. Install **Node.js 22+** LTS from [nodejs.org](https://nodejs.org/) (includes Corepack) or use **nvm-windows** and install `22` from [`.nvmrc`](.nvmrc).
 2. Open **PowerShell or CMD as Administrator** once and run: `corepack enable`
-3. In the repo folder: `corepack prepare pnpm@11.5.2 --activate` (version matches `packageManager` in [`package.json`](package.json); adjust if that field changes).
+3. In the repo folder: `corepack prepare pnpm@11.22.0 --activate` (version matches `packageManager` in [`package.json`](package.json); adjust if that field changes).
 4. Confirm: `pnpm -v` — then `pnpm install` and use `pnpm run …` for all scripts (hooks expect `pnpm` on `PATH`).
 
 If `corepack` is not recognized, reinstall Node or enable the “Tools for Native Modules” / standard installation so `corepack.cmd` is on `PATH`.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2924_keys-0EA5E9" alt="i18n 19 locales — 2924 keys">
-  <img src="https://img.shields.io/badge/Tests-6908%2B_%2F_567_files-22C55E" alt="6908+ tests / 567 files">
+  <img src="https://img.shields.io/badge/Tests-6909%2B_%2F_567_files-22C55E" alt="6909+ tests / 567 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2924 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (6908+ tests / 567 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (6909+ tests / 567 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (6908+ tests, 567 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (6909+ tests, 567 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -711,7 +711,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-21, source-synchronized; CI remains authoritative for pass/fail):**
-- **6908+ unit tests** across **567 test files** — CI is authoritative for pass/fail
+- **6909+ unit tests** across **567 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2924 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2924_keys-0EA5E9" alt="i18n 19 locales — 2924 keys">
-  <img src="https://img.shields.io/badge/Tests-6909%2B_%2F_567_files-22C55E" alt="6909+ tests / 567 files">
+  <img src="https://img.shields.io/badge/Tests-6910%2B_%2F_568_files-22C55E" alt="6910+ tests / 568 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2924 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (6909+ tests / 567 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (6910+ tests / 568 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (6909+ tests, 567 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (6910+ tests, 568 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -711,7 +711,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-21, source-synchronized; CI remains authoritative for pass/fail):**
-- **6909+ unit tests** across **567 test files** — CI is authoritative for pass/fail
+- **6910+ unit tests** across **568 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2924 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -78,7 +78,7 @@ non-blocking under the exit criteria documented below. The coverage ratchet rema
 `.github/actions/setup/action.yml` centralises pnpm + Node.js bootstrap into one reusable step used by every job:
 
 ```
-pnpm/action-setup → actions/setup-node (cache: pnpm) → pnpm install --frozen-lockfile
+pnpm/action-setup (explicit patched 11.22.0) → actions/setup-node (cache: pnpm) → toolchain check → pnpm install --frozen-lockfile
 ```
 
 Each job that uses the composite must call `actions/checkout@v6` first (local composite actions are resolved from the workspace, so the repo must be checked out before `uses: ./.github/actions/setup` can be used). The `quality` job additionally passes `node-version: ${{ matrix.node-version }}` to cover the LTS matrix.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -60,7 +60,7 @@ gh run view <run-id> --log-failed
 5. **Do not use** `npx wrangler deploy` (Workers) nor `wrangler pages deploy` in the deploy step — redundant and often fails on API token scope in the build container.
 6. If the UI forces a deploy command, use: `pnpm run deploy:cloudflare` — it **exits 0** on Cloudflare (`CF_PAGES=1`) without calling Wrangler.
 7. Remove **`CLOUDFLARE_API_TOKEN`** from Pages **build** environment variables unless you have a dedicated manual deploy workflow; it is not needed for Git-based Pages.
-8. **Environment variables (build):** `NODE_VERSION=22`, `PNPM_VERSION=10` (or Corepack).
+8. **Environment variables (build):** `NODE_VERSION=22`, `PNPM_VERSION=11.22.0` (or Corepack using the exact `packageManager` pin).
 9. **Root:** repository root; **Package manager:** pnpm.
 
 > **Status:** Optional GitHub workflow [`.github/workflows/deploy-cloudflare-pages.yml`](../.github/workflows/deploy-cloudflare-pages.yml) is **paused** (`if: false`). Prefer dashboard-only Pages deploy.

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "tauri"
   ],
   "type": "module",
-  "packageManager": "pnpm@11.5.2",
+  "packageManager": "pnpm@11.22.0",
   "engines": {
     "node": ">=22.0.0",
-    "pnpm": "11.5.2"
+    "pnpm": "11.22.0"
   },
   "scripts": {
     "hooks:install": "simple-git-hooks",

--- a/scripts/check-pnpm-toolchain.mjs
+++ b/scripts/check-pnpm-toolchain.mjs
@@ -7,9 +7,39 @@ const expectedPackageManager = projectPackage.packageManager;
 const expectedPnpmVersion = expectedPackageManager?.startsWith('pnpm@')
   ? expectedPackageManager.slice('pnpm@'.length)
   : null;
+const minimumSecurePnpmVersion = '11.11.0';
+
+function parseVersion(version) {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
+  return match ? match.slice(1).map(Number) : null;
+}
+
+function isVersionAtLeast(version, minimum) {
+  const actualParts = parseVersion(version);
+  const minimumParts = parseVersion(minimum);
+  if (!actualParts || !minimumParts) return false;
+  return (
+    actualParts.some((part, index) => {
+      if (part !== minimumParts[index]) return part > minimumParts[index];
+      return false;
+    }) || actualParts.every((part, index) => part === minimumParts[index])
+  );
+}
 
 if (!expectedPnpmVersion) {
   console.error('[toolchain] package.json must pin packageManager to pnpm@<exact-version>.');
+  process.exit(1);
+}
+
+if (projectPackage.engines?.pnpm !== expectedPnpmVersion) {
+  console.error('[toolchain] engines.pnpm must exactly match packageManager.');
+  process.exit(1);
+}
+
+if (!isVersionAtLeast(expectedPnpmVersion, minimumSecurePnpmVersion)) {
+  console.error(
+    `[toolchain] pnpm ${expectedPnpmVersion} is below the security floor ${minimumSecurePnpmVersion}.`,
+  );
   process.exit(1);
 }
 

--- a/scripts/check-pnpm-toolchain.mjs
+++ b/scripts/check-pnpm-toolchain.mjs
@@ -1,4 +1,5 @@
 import process from 'node:process';
+import { isVersionAtLeast } from './pnpm-version-policy.mjs';
 
 const projectPackage = JSON.parse(
   await (await import('node:fs/promises')).readFile('package.json', 'utf8'),
@@ -8,23 +9,6 @@ const expectedPnpmVersion = expectedPackageManager?.startsWith('pnpm@')
   ? expectedPackageManager.slice('pnpm@'.length)
   : null;
 const minimumSecurePnpmVersion = '11.11.0';
-
-function parseVersion(version) {
-  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
-  return match ? match.slice(1).map(Number) : null;
-}
-
-function isVersionAtLeast(version, minimum) {
-  const actualParts = parseVersion(version);
-  const minimumParts = parseVersion(minimum);
-  if (!actualParts || !minimumParts) return false;
-  return (
-    actualParts.some((part, index) => {
-      if (part !== minimumParts[index]) return part > minimumParts[index];
-      return false;
-    }) || actualParts.every((part, index) => part === minimumParts[index])
-  );
-}
 
 if (!expectedPnpmVersion) {
   console.error('[toolchain] package.json must pin packageManager to pnpm@<exact-version>.');
@@ -57,10 +41,6 @@ if (actualNodeMajor < minimumNodeMajor) {
 
 const isDirectHook = process.argv.includes('--hook');
 const userAgentVersion = process.env.npm_config_user_agent?.match(/(?:^|\s)pnpm\/(\S+)/)?.[1];
-if (userAgentVersion && userAgentVersion !== expectedPnpmVersion) {
-  console.error(`[toolchain] pnpm ${expectedPnpmVersion} is required; found ${userAgentVersion}.`);
-  process.exit(1);
-}
 
 if (!userAgentVersion) {
   if (isDirectHook) {
@@ -73,6 +53,9 @@ if (!userAgentVersion) {
     );
     process.exit(1);
   }
+} else if (userAgentVersion !== expectedPnpmVersion) {
+  console.error(`[toolchain] pnpm ${expectedPnpmVersion} is required; found ${userAgentVersion}.`);
+  process.exit(1);
 } else {
   console.log(
     `[toolchain] Node ${process.versions.node} and pnpm ${userAgentVersion} match the project pin.`,

--- a/scripts/pnpm-version-policy.d.mts
+++ b/scripts/pnpm-version-policy.d.mts
@@ -1,0 +1,2 @@
+export function parseVersion(version: string): number[] | null;
+export function isVersionAtLeast(version: string, minimum: string): boolean;

--- a/scripts/pnpm-version-policy.mjs
+++ b/scripts/pnpm-version-policy.mjs
@@ -1,0 +1,19 @@
+export function parseVersion(version) {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
+  return match ? match.slice(1).map(Number) : null;
+}
+
+export function isVersionAtLeast(version, minimum) {
+  const actualParts = parseVersion(version);
+  const minimumParts = parseVersion(minimum);
+  if (!actualParts || !minimumParts) return false;
+
+  for (let index = 0; index < 3; index += 1) {
+    const actualPart = actualParts[index];
+    const minimumPart = minimumParts[index];
+    if (actualPart > minimumPart) return true;
+    if (actualPart < minimumPart) return false;
+  }
+
+  return true;
+}

--- a/tests/unit/pnpmToolchainPolicy.test.ts
+++ b/tests/unit/pnpmToolchainPolicy.test.ts
@@ -1,0 +1,22 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+import { isVersionAtLeast } from '../../scripts/pnpm-version-policy.mjs';
+
+// QNBS-v3: Compare semantic version components left-to-right so a lower major cannot pass on a higher minor.
+describe('pnpm version policy', () => {
+  it.each([
+    ['11.11.0', '11.11.0', true],
+    ['11.12.0', '11.11.0', true],
+    ['12.0.0', '11.11.0', true],
+    ['11.10.9', '11.11.0', false],
+    ['10.99.0', '11.0.0', false],
+    ['11.22.0', '11.11.0', true],
+  ])('%s >= %s is %s', (version, minimum, expected) => {
+    expect(isVersionAtLeast(version, minimum)).toBe(expected);
+  });
+
+  it('rejects malformed versions instead of treating them as secure', () => {
+    expect(isVersionAtLeast('11.22', '11.11.0')).toBe(false);
+    expect(isVersionAtLeast('11.22.0-beta.1', '11.11.0')).toBe(false);
+  });
+});

--- a/tests/unit/workflowPolicy.test.ts
+++ b/tests/unit/workflowPolicy.test.ts
@@ -14,16 +14,40 @@ import {
 
 const repositoryRoot = fileURLToPath(new URL('../../', import.meta.url));
 const workflowPath = fileURLToPath(new URL('../../.github/workflows/ci.yml', import.meta.url));
+const setupActionPath = fileURLToPath(
+  new URL('../../.github/actions/setup/action.yml', import.meta.url),
+);
 const scheduledSecurityWorkflowPath = fileURLToPath(
   new URL('../../.github/workflows/security-scheduled.yml', import.meta.url),
 );
 const tauriManifestPath = fileURLToPath(new URL('../../src-tauri/Cargo.toml', import.meta.url));
 const workflowSource = readFileSync(workflowPath, 'utf8');
+const setupActionSource = readFileSync(setupActionPath, 'utf8');
 const scheduledSecurityWorkflowSource = readFileSync(scheduledSecurityWorkflowPath, 'utf8');
+const packageJson = JSON.parse(
+  readFileSync(fileURLToPath(new URL('../../package.json', import.meta.url)), 'utf8'),
+) as {
+  packageManager: string;
+};
 const tauriManifestSource = readFileSync(tauriManifestPath, 'utf8');
 
 // QNBS-v3: Keep CI path and deployment authority policy executable against the real workflow files.
 describe('CI workflow policy', () => {
+  // QNBS-v3: the first package-manager binary must be patched and explicit before repository caching/install.
+  it('bootstraps the exact secure pnpm before setup-node cache or install', () => {
+    const expectedVersion = packageJson.packageManager.replace('pnpm@', '');
+    const actionIndex = setupActionSource.indexOf('pnpm/action-setup@');
+    const nodeIndex = setupActionSource.indexOf('actions/setup-node@');
+    expect(setupActionSource).toContain(
+      'pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86',
+    );
+    expect(setupActionSource).toContain(`version: ${expectedVersion}`);
+    expect(actionIndex).toBeGreaterThanOrEqual(0);
+    expect(actionIndex).toBeLessThan(nodeIndex);
+    expect(setupActionSource).not.toContain('corepack enable');
+    expect(setupActionSource).toContain('pnpm install --frozen-lockfile');
+    expect(setupActionSource).toContain('pnpm run toolchain:check');
+  });
   // QNBS-v3: preserve first-attempt Vitest failures as visible CI evidence instead of masking flakes with retries.
   it('runs Vitest once so first-attempt failures cannot be hidden by retry', () => {
     const vitestRun = workflowSource.match(/run:\s*pnpm exec vitest run[^\n]*/)?.[0];

--- a/tests/unit/workflowPolicy.test.ts
+++ b/tests/unit/workflowPolicy.test.ts
@@ -46,7 +46,7 @@ describe('CI workflow policy', () => {
     expect(actionIndex).toBeLessThan(nodeIndex);
     expect(setupActionSource).not.toContain('corepack enable');
     expect(setupActionSource).toContain('pnpm install --frozen-lockfile');
-    expect(setupActionSource).toContain('pnpm run toolchain:check');
+    expect(setupActionSource).toContain('node scripts/check-pnpm-toolchain.mjs');
   });
   // QNBS-v3: preserve first-attempt Vitest failures as visible CI evidence instead of masking flakes with retries.
   it('runs Vitest once so first-attempt failures cannot be hidden by retry', () => {

--- a/tests/unit/workflowPolicy.test.ts
+++ b/tests/unit/workflowPolicy.test.ts
@@ -17,12 +17,16 @@ const workflowPath = fileURLToPath(new URL('../../.github/workflows/ci.yml', imp
 const setupActionPath = fileURLToPath(
   new URL('../../.github/actions/setup/action.yml', import.meta.url),
 );
+const cloudflareWorkflowPath = fileURLToPath(
+  new URL('../../.github/workflows/deploy-cloudflare-pages.yml.disabled', import.meta.url),
+);
 const scheduledSecurityWorkflowPath = fileURLToPath(
   new URL('../../.github/workflows/security-scheduled.yml', import.meta.url),
 );
 const tauriManifestPath = fileURLToPath(new URL('../../src-tauri/Cargo.toml', import.meta.url));
 const workflowSource = readFileSync(workflowPath, 'utf8');
 const setupActionSource = readFileSync(setupActionPath, 'utf8');
+const cloudflareWorkflowSource = readFileSync(cloudflareWorkflowPath, 'utf8');
 const scheduledSecurityWorkflowSource = readFileSync(scheduledSecurityWorkflowPath, 'utf8');
 const packageJson = JSON.parse(
   readFileSync(fileURLToPath(new URL('../../package.json', import.meta.url)), 'utf8'),
@@ -45,8 +49,21 @@ describe('CI workflow policy', () => {
     expect(actionIndex).toBeGreaterThanOrEqual(0);
     expect(actionIndex).toBeLessThan(nodeIndex);
     expect(setupActionSource).not.toContain('corepack enable');
-    expect(setupActionSource).toContain('pnpm install --frozen-lockfile');
-    expect(setupActionSource).toContain('node scripts/check-pnpm-toolchain.mjs');
+    const setupToolchainIndex = setupActionSource.indexOf(
+      'export npm_config_user_agent="pnpm/$(pnpm --version)"',
+    );
+    const setupInstallIndex = setupActionSource.indexOf('pnpm install --frozen-lockfile');
+    expect(setupToolchainIndex).toBeGreaterThanOrEqual(0);
+    expect(setupToolchainIndex).toBeLessThan(setupInstallIndex);
+
+    const cloudflareToolchainIndex = cloudflareWorkflowSource.indexOf(
+      'export npm_config_user_agent="pnpm/$(pnpm --version)"',
+    );
+    const cloudflareInstallIndex = cloudflareWorkflowSource.indexOf(
+      'pnpm install --frozen-lockfile',
+    );
+    expect(cloudflareToolchainIndex).toBeGreaterThanOrEqual(0);
+    expect(cloudflareToolchainIndex).toBeLessThan(cloudflareInstallIndex);
   });
   // QNBS-v3: preserve first-attempt Vitest failures as visible CI evidence instead of masking flakes with retries.
   it('runs Vitest once so first-attempt failures cannot be hidden by retry', () => {


### PR DESCRIPTION
## **User description**
## Summary

- Upgrade the repository pin from pnpm 11.5.2 to stable patched pnpm 11.22.0.
- Pin the shared CI bootstrap to immutable pnpm/action-setup v6.0.10 and install the explicit version before setup-node cache resolution.
- Assert the exact toolchain and security floor before frozen dependency installation.
- Synchronize current contributor/CI/deployment documentation and generated README test metrics.

## Root cause

The composite setup previously enabled Corepack and invoked pnpm/action-setup v6.0.8 without an explicit version. The first package-manager bootstrap was therefore not structurally guaranteed to be the patched project version.

## Security evidence

- Base: 87764570e0487c8de3fde99800291f3e79e3f81c, the post-#454 origin/main.
- Current stable 11.x verified from pnpm releases: 11.22.0.
- Official advisory ranges verified: GHSA-vx52-2968-3vc6 patched at 11.11.0; GHSA-fr4h-3cph-29xv and GHSA-72r4-9c5j-mj57 patched at 11.7.0; the other inspected pnpm 11 advisories require at least 11.5.3.
- The repository now pins 11.22.0; check-pnpm-toolchain rejects a declared version below the 11.11.0 floor and requires engines parity.
- pnpm/action-setup is pinned to commit 0977fd99725f1db4007ccb2928dbb4e90d06cc86, v6.0.10.

## Validation

- corepack prepare pnpm@11.22.0 --activate: passed.
- pnpm 11.22.0 frozen install: passed; lockfile unchanged; 1661 entries passed supply-chain policy.
- toolchain check: passed on Node 24.11.1 and pnpm 11.22.0.
- workflowPolicy.test.ts: 8/8 passed.
- targeted Biome check and git diff check: passed.
- ci:prepush: passed sequentially, including single-checker typecheck, i18n, docs, CSP, boundary, and native readiness.
- README metrics regenerated: 6909+ tests / 567 files.
- No lockfile churn.

## Scope and non-goals

This PR hardens package-manager bootstrap and policy only. It does not change dependency resolutions or application runtime behavior, and it does not replace the scheduled OSV workflow from #454. Full coverage, E2E, Lighthouse, Storybook, Stryker, and native builds remain cloud-owned.

## Review coverage

Configured reviewers including CodeRabbit, Graphite, CodeAnt AI, and Qodo will be checked across inline threads, top-level comments, full review bodies, nitpicks, and outside-diff findings. Every valid finding will be fixed or answered before merge.

## Uncertainty

The first hosted Node 22/24 run on this new action bootstrap is pending. Local Node 24 and repository policy tests are green. Advisory applicability was checked against pnpm official GitHub advisory records; no claim is made about advisories outside that inspected set.

## Summary by Sourcery

Harden repository and CI package-manager setup by standardizing on secure pnpm 11.22.0 and validating the toolchain before dependency installation.

Bug Fixes:
- Harden pnpm bootstrapping to ensure the patched project version is installed before dependency caching and installation.
- Enforce a minimum secure pnpm version and exact parity between the package manager and engine declarations.

Enhancements:
- Pin the shared pnpm setup action to an immutable patched release and add executable workflow and version-policy checks to prevent bootstrap regressions.

Documentation:
- Synchronize contributor, CI audit, CI, deployment, and project guidance with the enforced pnpm version.
- Refresh README test metrics.

Tests:
- Add coverage for secure pnpm version comparisons and bootstrap ordering policies.


___

## **CodeAnt-AI Description**
Harden pnpm setup and enforce a secure, consistent CI toolchain

### What Changed
- Updates the project and deployment setup from pnpm 11.5.2 to patched pnpm 11.22.0.
- CI now installs the exact pnpm version before dependency caching and verifies the toolchain before installation.
- Rejects mismatched pnpm declarations and versions below the 11.11.0 security floor.
- Pins the shared pnpm setup action to a specific patched release and adds tests to prevent bootstrap regressions.
- Updates contributor, CI, deployment, and README guidance to reflect the enforced version.

### Impact
`✅ Fewer insecure dependency installations`
`✅ Consistent pnpm versions across CI and deployments`
`✅ Earlier, clearer toolchain configuration failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized the project on pnpm 11.22.0 across development, CI, deployment, and setup documentation.
  * Added stricter validation for the required pnpm version and security baseline.
  * CI now verifies the package toolchain before installing dependencies.

* **Documentation**
  * Updated setup, contribution, deployment, and CI guidance to reflect the current pnpm version.
  * Refreshed the documented test count.

* **Tests**
  * Added coverage to verify consistent package manager configuration and CI setup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->