### PR TITLE
test(mutation): bind services-commands shard to direct tests

### DIFF
--- a/stryker-scope.json
+++ b/stryker-scope.json
@@ -8,6 +8,11 @@
         "services/commands/fuzzyScore.ts",
         "services/commands/palettePreferences.ts",
         "services/commands/commandBuilder.ts"
+      ],
+      "testFiles": [
+        "tests/unit/commands/fuzzyScore.test.ts",
+        "tests/unit/commands/palettePreferences.test.ts",
+        "tests/unit/services/commandBuilder.test.ts"
       ]
     },
     {

--- a/tests/unit/tooling/strykerWorkflowPolicy.test.ts
+++ b/tests/unit/tooling/strykerWorkflowPolicy.test.ts
@@ -30,6 +30,11 @@ describe('Stryker workflow policy', () => {
     expect(mutationModules).toHaveLength(8);
     expect(new Set(mutationFiles).size).toBe(25);
     expect(mutationModules.every(({ riskTier }) => ['A', 'B'].includes(riskTier))).toBe(true);
+    expect(selectMutationModules('services-commands')[0]?.testFiles).toEqual([
+      'tests/unit/commands/fuzzyScore.test.ts',
+      'tests/unit/commands/palettePreferences.test.ts',
+      'tests/unit/services/commandBuilder.test.ts',
+    ]);
     expect(selectMutationModules('tier-a').every(({ riskTier }) => riskTier === 'A')).toBe(true);
     expect(selectMutationModules('services-commands')).toHaveLength(1);
     expect(selectMutationModules('copilot')[0]?.testFiles).toEqual([

--- a/tests/unit/tooling/strykerWorkflowPolicy.test.ts
+++ b/tests/unit/tooling/strykerWorkflowPolicy.test.ts
@@ -30,6 +30,7 @@ describe('Stryker workflow policy', () => {
     expect(mutationModules).toHaveLength(8);
     expect(new Set(mutationFiles).size).toBe(25);
     expect(mutationModules.every(({ riskTier }) => ['A', 'B'].includes(riskTier))).toBe(true);
+    // QNBS-v3: [Validate the services-commands Stryker mapping / prevent test-scope drift / make the policy contract explicit]
     expect(selectMutationModules('services-commands')[0]?.testFiles).toEqual([
       'tests/unit/commands/fuzzyScore.test.ts',
       'tests/unit/commands/palettePreferences.test.ts',


### PR DESCRIPTION
## **User description**
## Summary
- Bind the `services-commands` Stryker shard to its direct unit-test files.
- Keep the selection in the authoritative `stryker-scope.json` and enforce it with the workflow policy test.

## Why
The post-#456 Copilot calibration proved that explicit test selection is required when related-test discovery cannot be trusted. This applies the same bounded, module-specific approach to the three `services-commands` targets without changing production behavior or mutation thresholds.

## Validation
- `pnpm exec vitest run tests/unit/tooling/strykerWorkflowPolicy.test.ts`
- `node scripts/stryker-scope.mjs --selector services-commands`
- `pnpm run ci:prepush`
- Cloud force mutation run: pending

## Scope and non-goals
- No production-code behavior changes.
- No threshold, suppression-baseline, or mutation-scope expansion.
- Full mutation execution remains cloud-only because of the constrained workstation.

## Uncertainty
- The trusted services-commands force-run score and survivor classification are pending the hosted workflow run.

## Review coverage
- CodeRabbit: pending.
- Other review bots: pending.

## Summary by Sourcery

Enforce explicit direct-test coverage for the services-commands mutation shard.

Enhancements:
- Bind the services-commands mutation shard to its three direct unit-test files and codify the mapping in the workflow policy test.

Tests:
- Add policy coverage to prevent drift in the services-commands mutation test selection.


___

## **CodeAnt-AI Description**
Bind services-commands mutation checks to their direct unit tests

### What Changed
- The services-commands mutation shard now runs against its three matching unit-test files
- Workflow policy tests verify that this test selection remains explicit and correct

### Impact
`✅ Focused mutation results for services-commands`
`✅ Fewer unrelated tests in mutation runs`
`✅ Consistent mutation-test coverage enforcement`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify the expected unit tests are included in mutation testing for the services commands module.
* **Chores**
  * Updated mutation testing configuration to include three additional unit-test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->