### PR TITLE
test(mutation): bind ai-core shard to direct tests

### DIFF
--- a/stryker-scope.json
+++ b/stryker-scope.json
@@ -35,6 +35,14 @@
         "services/ai/fetchAdapter.ts",
         "services/ai/routingLogger.ts",
         "services/ai/aiModeService.ts"
+      ],
+      "testFiles": [
+        "tests/unit/ai/modelRecommendations.test.ts",
+        "tests/unit/ai/aiPolicy.test.ts",
+        "tests/unit/ai/aiRetry.test.ts",
+        "tests/unit/services/fetchAdapter.test.ts",
+        "tests/unit/ai/routingLogger.test.ts",
+        "tests/unit/ai/aiModeService.test.ts"
       ]
     },
     {

--- a/tests/unit/tooling/strykerWorkflowPolicy.test.ts
+++ b/tests/unit/tooling/strykerWorkflowPolicy.test.ts
@@ -38,6 +38,15 @@ describe('Stryker workflow policy', () => {
     ]);
     expect(selectMutationModules('tier-a').every(({ riskTier }) => riskTier === 'A')).toBe(true);
     expect(selectMutationModules('services-commands')).toHaveLength(1);
+    // QNBS-v3: [Validate the services-ai-core Stryker mapping / prevent weak related-test selection / bind Tier-A mutants to direct tests]
+    expect(selectMutationModules('services-ai-core')[0]?.testFiles).toEqual([
+      'tests/unit/ai/modelRecommendations.test.ts',
+      'tests/unit/ai/aiPolicy.test.ts',
+      'tests/unit/ai/aiRetry.test.ts',
+      'tests/unit/services/fetchAdapter.test.ts',
+      'tests/unit/ai/routingLogger.test.ts',
+      'tests/unit/ai/aiModeService.test.ts',
+    ]);
     expect(selectMutationModules('copilot')[0]?.testFiles).toEqual([
       'tests/unit/copilot/heuristicEngine.test.ts',
       'tests/unit/copilot/insightGenerator.test.ts',


### PR DESCRIPTION
## Summary
- Bind the `services-ai-core` Stryker shard to six explicit direct unit-test files.
- Keep the mapping in authoritative `stryker-scope.json` and enforce it with the workflow policy test.
- Prove the hosted shard selects and executes the intended tests without changing production behavior or thresholds.

## Why
The Copilot and services-commands calibration runs showed that explicit module test selection is needed where related-test discovery is too narrow. This applies the same bounded approach to the Tier-A AI-core targets.

## Validation
- `pnpm exec vitest run tests/unit/tooling/strykerWorkflowPolicy.test.ts` — 3 passed.
- `node scripts/stryker-scope.mjs --selector services-ai-core` — 6 targets validated.
- `pnpm run ci:prepush` — passed sequentially.
- Cloud force run `32568888182` on `68de883a`: six test files discovered, 93 tests executed, 422 mutants; 302 killed, 101 survived, 1 timeout, 18 no-coverage, 34 ignored, 0 pending/errors; score 71.8%.
- The force run produced a valid report and fail-closed aggregation. The red result is a genuine mutation-quality signal below the unchanged 75% threshold, not a missing-report, selection, or aggregation failure. Survivor hardening is a separate follow-up mutation-quality workstream.

## Scope and non-goals
- No production-code behavior changes.
- No threshold, suppression-baseline, or mutation-scope expansion.
- Full mutation execution remains cloud-only on the constrained workstation.
- This PR proves deterministic test selection and report plumbing; it does not claim complete AI-core mutation quality.

## Uncertainty
- Survivor equivalence versus missing assertions requires the follow-up Tier-A mutation-quality analysis; this PR does not classify all 101 survivors.
- The manual force workflow is intentionally separate from the ordinary PR CI graph.

## Review coverage
- CodeRabbit: rate-limited; no technical review comments returned.
- CodeAnt AI: quality/SAST/SCA/SCR/Test Coverage passed.
- Amazon Q Developer: approval/comment with no findings.
- Graphite: check passed; no findings returned.
- Sourcery: rate-limited; review guide present.
- Outside-diff REST comments: 0.
- GraphQL unresolved review threads: 0.

## Definition of Done
- [x] Explicit services-ai-core test mapping is present and policy-tested.
- [x] Hosted execution proves all six mapped test files are selected.
- [x] Valid report and fail-closed aggregation are proven.
- [x] No threshold or suppression-baseline changes.