### PR TITLE
test(mutation): harden ai-core survivor coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2924_keys-0EA5E9" alt="i18n 19 locales — 2924 keys">
-  <img src="https://img.shields.io/badge/Tests-6912%2B_%2F_568_files-22C55E" alt="6912+ tests / 568 files">
+  <img src="https://img.shields.io/badge/Tests-6919%2B_%2F_568_files-22C55E" alt="6919+ tests / 568 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2924 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (6912+ tests / 568 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (6919+ tests / 568 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (6912+ tests, 568 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (6919+ tests, 568 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -711,7 +711,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-21, source-synchronized; CI remains authoritative for pass/fail):**
-- **6912+ unit tests** across **568 test files** — CI is authoritative for pass/fail
+- **6919+ unit tests** across **568 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2924 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/tests/unit/ai/aiModeService.test.ts
+++ b/tests/unit/ai/aiModeService.test.ts
@@ -56,6 +56,22 @@ describe('shouldRouteLocally()', () => {
     // Hybrid is cloud-first: _localModelsReady does NOT promote to local while online.
     expect(shouldRouteLocally()).toBe(false);
   });
+
+  it('routes cloud and hybrid locally while offline', () => {
+    // QNBS-v3: Offline routing must override cloud-first mode without depending on a real network.
+    const online = Object.getOwnPropertyDescriptor(navigator, 'onLine');
+    Object.defineProperty(navigator, 'onLine', { configurable: true, get: () => false });
+    try {
+      setActiveAiMode('cloud');
+      expect(shouldRouteLocally()).toBe(true);
+      setActiveAiMode('hybrid');
+      expect(shouldRouteLocally()).toBe(true);
+      expect(isCloudOnlyMode()).toBe(false);
+    } finally {
+      if (online) Object.defineProperty(navigator, 'onLine', online);
+      else delete (navigator as { onLine?: boolean }).onLine;
+    }
+  });
 });
 
 describe('notifyLocalModelsReady() / getLocalModelsReady()', () => {

--- a/tests/unit/ai/aiModeService.test.ts
+++ b/tests/unit/ai/aiModeService.test.ts
@@ -60,10 +60,11 @@ describe('shouldRouteLocally()', () => {
   it('routes cloud and hybrid locally while offline', () => {
     // QNBS-v3: Offline routing must override cloud-first mode without depending on a real network.
     const online = Object.getOwnPropertyDescriptor(navigator, 'onLine');
-    Object.defineProperty(navigator, 'onLine', { configurable: true, get: () => false });
     try {
+      Object.defineProperty(navigator, 'onLine', { configurable: true, get: () => false });
       setActiveAiMode('cloud');
       expect(shouldRouteLocally()).toBe(true);
+      expect(isCloudOnlyMode()).toBe(false);
       setActiveAiMode('hybrid');
       expect(shouldRouteLocally()).toBe(true);
       expect(isCloudOnlyMode()).toBe(false);

--- a/tests/unit/ai/aiModeService.test.ts
+++ b/tests/unit/ai/aiModeService.test.ts
@@ -61,6 +61,7 @@ describe('shouldRouteLocally()', () => {
     // QNBS-v3: Offline routing must override cloud-first mode without depending on a real network.
     const online = Object.getOwnPropertyDescriptor(navigator, 'onLine');
     try {
+      // QNBS-v3: Force the offline branch so cloud-only mode cannot be misclassified as network-available.
       Object.defineProperty(navigator, 'onLine', { configurable: true, get: () => false });
       setActiveAiMode('cloud');
       expect(shouldRouteLocally()).toBe(true);

--- a/tests/unit/ai/aiRetry.test.ts
+++ b/tests/unit/ai/aiRetry.test.ts
@@ -124,6 +124,26 @@ describe('parseRetryAfterMs', () => {
     expect(parseRetryAfterMs({ retryAfter: 'not-a-date' })).toBeNull();
   });
 
+  it('falls back to a valid header when the direct string is invalid', () => {
+    expect(
+      parseRetryAfterMs({
+        retryAfter: 'not-a-date',
+        headers: { get: () => '2' },
+      }),
+    ).toBe(2000);
+  });
+
+  it('parses a future HTTP-date and clamps negative delays to zero', () => {
+    const now = 1_700_000_000_000;
+    const restoreNow = vi.spyOn(Date, 'now').mockReturnValue(now);
+    try {
+      expect(parseRetryAfterMs({ retryAfter: new Date(now + 2500).toUTCString() })).toBe(2000);
+      expect(parseRetryAfterMs({ retryAfterMs: -1 })).toBe(0);
+    } finally {
+      restoreNow.mockRestore();
+    }
+  });
+
   it('ignores zero-length header values', () => {
     expect(parseRetryAfterMs({ headers: { get: () => '' } })).toBeNull();
   });

--- a/tests/unit/ai/modelRecommendations.test.ts
+++ b/tests/unit/ai/modelRecommendations.test.ts
@@ -154,6 +154,20 @@ describe('getOllamaModelForDevice', () => {
     expect(rec.downgradedForBattery).toBe(true);
   });
 
+  it('does not downgrade at the exact low-battery threshold', () => {
+    // QNBS-v3: The strict threshold boundary prevents a one-point battery change from altering tiers unexpectedly.
+    const rec = getOllamaModelForDevice({
+      ...baseReport,
+      deviceClass: 'high-end',
+      batteryLevel: 0.2,
+    });
+    expect(rec).toMatchObject({
+      modelId: 'qwen2.5:7b',
+      tier: 'high-end',
+      downgradedForBattery: false,
+    });
+  });
+
   it('does not downgrade below low-end and does not flag when battery is unknown', () => {
     const lowEndLowBattery = getOllamaModelForDevice({
       ...baseReport,

--- a/tests/unit/services/fetchAdapter.test.ts
+++ b/tests/unit/services/fetchAdapter.test.ts
@@ -76,10 +76,10 @@ describe('createWorldScriptFetch', () => {
   it('falls back to AbortController when AbortSignal.timeout is unavailable', async () => {
     const mockFetch = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }));
     vi.stubGlobal('fetch', mockFetch);
-    const originalTimeout = AbortSignal.timeout;
+    const timeoutDescriptor = Object.getOwnPropertyDescriptor(AbortSignal, 'timeout');
     // Simulate a runtime where AbortSignal exists but the static timeout helper does not.
-    (AbortSignal as unknown as { timeout?: unknown }).timeout = undefined;
     try {
+      Object.defineProperty(AbortSignal, 'timeout', { configurable: true, value: undefined });
       const { createWorldScriptFetch } = await import('../../../services/ai/fetchAdapter');
       await createWorldScriptFetch({ timeoutMs: 1000 })('https://api.example.com/tags');
       const init = mockFetch.mock.calls[0]?.[1] as RequestInit | undefined;
@@ -107,33 +107,42 @@ describe('createWorldScriptFetch', () => {
   });
 
   it('propagates caller aborts through the composed timeout signal', async () => {
-    const mockFetch = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }));
+    // QNBS-v3 (#459): keep the request pending so caller abort is verified as an observable rejection.
+    const mockFetch = vi.fn((_input: RequestInfo | URL, init?: RequestInit) =>
+      new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener(
+          'abort',
+          () => reject(new DOMException('The operation was aborted.', 'AbortError')),
+          { once: true },
+        );
+      }),
+    );
     vi.stubGlobal('fetch', mockFetch);
     const caller = new AbortController();
 
     const { createWorldScriptFetch } = await import('../../../services/ai/fetchAdapter');
-    await createWorldScriptFetch({ timeoutMs: 5000 })('https://api.example.com/tags', {
+    const request = createWorldScriptFetch({ timeoutMs: 5000 })('https://api.example.com/tags', {
       signal: caller.signal,
     });
+    const rejection = expect(request).rejects.toMatchObject({ name: 'AbortError' });
+    await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
 
     const signal = (mockFetch.mock.calls[0]?.[1] as RequestInit | undefined)?.signal;
+    expect(signal).toBeInstanceOf(AbortSignal);
     expect(signal?.aborted).toBe(false);
     caller.abort();
     expect(signal?.aborted).toBe(true);
-    vi.unstubAllGlobals();
+    await rejection;
   });
 
   it('uses the manual controller when AbortSignal.any is unavailable', async () => {
     const mockFetch = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }));
     vi.stubGlobal('fetch', mockFetch);
     const caller = new AbortController();
-    const originalAny = AbortSignal.any;
-    Object.defineProperty(AbortSignal, 'any', {
-      configurable: true,
-      value: undefined,
-    });
+    const anyDescriptor = Object.getOwnPropertyDescriptor(AbortSignal, 'any');
 
     try {
+      Object.defineProperty(AbortSignal, 'any', { configurable: true, value: undefined });
       const { createWorldScriptFetch } = await import('../../../services/ai/fetchAdapter');
       await createWorldScriptFetch({ timeoutMs: 5000 })('https://api.example.com/tags', {
         signal: caller.signal,

--- a/tests/unit/services/fetchAdapter.test.ts
+++ b/tests/unit/services/fetchAdapter.test.ts
@@ -3,13 +3,17 @@
  * QNBS-v3: createWorldScriptFetch — uses browser globalThis.fetch when not in Tauri.
  */
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 describe('createWorldScriptFetch', () => {
   beforeEach(() => {
     // Ensure no __TAURI__ context
     delete (window as unknown as Record<string, unknown>)['__TAURI__'];
     vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it('uses globalThis.fetch when not in Tauri environment', async () => {
@@ -81,8 +85,8 @@ describe('createWorldScriptFetch', () => {
       const init = mockFetch.mock.calls[0]?.[1] as RequestInit | undefined;
       expect(init?.signal).toBeInstanceOf(AbortSignal);
     } finally {
-      (AbortSignal as unknown as { timeout: typeof originalTimeout }).timeout = originalTimeout;
-      vi.unstubAllGlobals();
+      if (timeoutDescriptor) Object.defineProperty(AbortSignal, 'timeout', timeoutDescriptor);
+      else delete (AbortSignal as { timeout?: unknown }).timeout;
     }
   });
 
@@ -140,11 +144,8 @@ describe('createWorldScriptFetch', () => {
       caller.abort();
       expect(signal?.aborted).toBe(true);
     } finally {
-      Object.defineProperty(AbortSignal, 'any', {
-        configurable: true,
-        value: originalAny,
-      });
-      vi.unstubAllGlobals();
+      if (anyDescriptor) Object.defineProperty(AbortSignal, 'any', anyDescriptor);
+      else delete (AbortSignal as { any?: unknown }).any;
     }
   });
 
@@ -155,7 +156,8 @@ describe('createWorldScriptFetch', () => {
     const { createWorldScriptFetch } = await import('../../../services/ai/fetchAdapter');
     await createWorldScriptFetch({ timeoutMs: 0 })('https://api.example.com/tags');
 
-    expect(mockFetch).toHaveBeenCalledWith('https://api.example.com/tags', undefined);
-    vi.unstubAllGlobals();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const init = mockFetch.mock.calls[0]?.[1] as RequestInit | undefined;
+    expect(init?.signal).toBeUndefined();
   });
 });

--- a/tests/unit/services/fetchAdapter.test.ts
+++ b/tests/unit/services/fetchAdapter.test.ts
@@ -101,4 +101,55 @@ describe('createWorldScriptFetch', () => {
     expect(init?.signal?.aborted).toBe(false);
     vi.unstubAllGlobals();
   });
+
+  it('propagates caller aborts through the composed timeout signal', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }));
+    vi.stubGlobal('fetch', mockFetch);
+    const caller = new AbortController();
+
+    const { createWorldScriptFetch } = await import('../../../services/ai/fetchAdapter');
+    await createWorldScriptFetch({ timeoutMs: 5000 })('https://api.example.com/tags', {
+      signal: caller.signal,
+    });
+
+    const signal = (mockFetch.mock.calls[0]?.[1] as RequestInit | undefined)?.signal;
+    expect(signal?.aborted).toBe(false);
+    caller.abort();
+    expect(signal?.aborted).toBe(true);
+    vi.unstubAllGlobals();
+  });
+
+  it('uses the manual controller when AbortSignal.any is unavailable', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }));
+    vi.stubGlobal('fetch', mockFetch);
+    const caller = new AbortController();
+    const originalAny = AbortSignal.any;
+    (AbortSignal as unknown as { any?: typeof AbortSignal.any }).any = undefined;
+
+    try {
+      const { createWorldScriptFetch } = await import('../../../services/ai/fetchAdapter');
+      await createWorldScriptFetch({ timeoutMs: 5000 })('https://api.example.com/tags', {
+        signal: caller.signal,
+      });
+
+      const signal = (mockFetch.mock.calls[0]?.[1] as RequestInit | undefined)?.signal;
+      expect(signal).toBeInstanceOf(AbortSignal);
+      caller.abort();
+      expect(signal?.aborted).toBe(true);
+    } finally {
+      (AbortSignal as unknown as { any: typeof originalAny }).any = originalAny;
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it('does not attach a signal for a non-positive timeout', async () => {
+    const mockFetch = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }));
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { createWorldScriptFetch } = await import('../../../services/ai/fetchAdapter');
+    await createWorldScriptFetch({ timeoutMs: 0 })('https://api.example.com/tags');
+
+    expect(mockFetch).toHaveBeenCalledWith('https://api.example.com/tags', undefined);
+    vi.unstubAllGlobals();
+  });
 });

--- a/tests/unit/services/fetchAdapter.test.ts
+++ b/tests/unit/services/fetchAdapter.test.ts
@@ -124,7 +124,10 @@ describe('createWorldScriptFetch', () => {
     vi.stubGlobal('fetch', mockFetch);
     const caller = new AbortController();
     const originalAny = AbortSignal.any;
-    (AbortSignal as unknown as { any?: typeof AbortSignal.any }).any = undefined;
+    Object.defineProperty(AbortSignal, 'any', {
+      configurable: true,
+      value: undefined,
+    });
 
     try {
       const { createWorldScriptFetch } = await import('../../../services/ai/fetchAdapter');
@@ -137,7 +140,10 @@ describe('createWorldScriptFetch', () => {
       caller.abort();
       expect(signal?.aborted).toBe(true);
     } finally {
-      (AbortSignal as unknown as { any: typeof originalAny }).any = originalAny;
+      Object.defineProperty(AbortSignal, 'any', {
+        configurable: true,
+        value: originalAny,
+      });
       vi.unstubAllGlobals();
     }
   });


### PR DESCRIPTION
## Summary\n\n- Add direct survivor-focused tests for fetchAdapter, aiRetry, aiModeService, and modelRecommendations.\n- Cover abort-signal composition and fallback, retry-after parsing and clamping, offline routing, and the exact battery threshold.\n- Synchronize README test metrics through the canonical sync-readme-metrics generator after the new tests.\n\n## Scope and non-goals\n\n- Test-quality work only; no production behavior, mutation scope, Stryker threshold, or suppression baseline changes.\n- The predecessor services-ai-core force run proved selection and aggregation but scored 71.8%; this PR targets representative survivors without masking remaining signal.\n- Full mutation execution remains cloud-only under the low-end workstation policy.\n\n## Validation\n\n- Targeted Vitest: 4 files, 78 tests passed.\n- node scripts/hooks/pre-push.mjs: passed sequentially.\n- Pre-push checks included single-checker typecheck, i18n parity/bundle/content/quality, docs truth, CSP, DesktopPlatform boundary, and native readiness.\n- README metrics were regenerated canonically: 6912 to 6919 tests, 568 files unchanged.\n- Cloud force mutation run on the final head: pending.\n\n## Review coverage\n\n- CodeRabbit: pending fresh review; rate-limit/security-trial notices are not treated as approval.\n- Amazon Q Developer: pending fresh review.\n- Graphite: pending or automatic.\n- CodeAnt AI: pending checks/review.\n- Sourcery: report if silent or rate-limited; silence is not counted as approval.\n\n## Uncertainty\n\n- Final mutation score and survivor distribution require the cloud force run on this exact head.\n

## Summary by Sourcery

Harden AI core mutation coverage with targeted tests for fallback, boundary, and abort behavior.

Enhancements:
- Expand survivor-focused coverage for AI core behavior, including fetch abort handling, retry-after parsing, offline routing, and battery-threshold model selection.

Documentation:
- Synchronize README test metrics with the expanded test suite.

Tests:
- Add seven targeted unit tests across fetchAdapter, aiRetry, aiModeService, and modelRecommendations to strengthen mutation coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated project documentation with the latest test count and coverage metrics.

* **Tests**
  * Expanded coverage for offline AI routing and cloud-mode availability.
  * Added retry-delay parsing tests, including HTTP dates and boundary clamping.
  * Added a battery-level boundary test for model recommendations.
  * Added request cancellation coverage for timeout and abort-signal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->