### PR TITLE
fix(332): make writing overlay feedback immediate

### DIFF
--- a/components/manuscript/ManuscriptEditor.tsx
+++ b/components/manuscript/ManuscriptEditor.tsx
@@ -383,7 +383,7 @@ export const ManuscriptEditor: FC<{ isFocusMode: boolean }> = React.memo(({ isFo
           onClick={handleSelectionEvents}
           onKeyDown={handleKeyDown}
           onScroll={handleTextareaScroll}
-          className={`h-full w-full leading-relaxed resize-none p-4 sm:p-6 md:p-12 pt-2 bg-transparent border-0 focus:ring-0 flex-grow caret-[var(--sc-text-primary)] text-transparent max-w-3xl mx-auto selection:bg-[var(--sc-accent)]/30 transition-all duration-500 ${isFocusMode ? 'max-w-4xl pt-12' : ''}`}
+          className={`h-full w-full leading-relaxed resize-none p-4 sm:p-6 md:p-12 pt-2 bg-transparent border-0 focus:ring-0 flex-grow caret-[var(--sc-text-primary)] text-transparent max-w-3xl mx-auto selection:bg-[var(--sc-accent)]/30 ${isFocusMode ? 'max-w-4xl pt-12' : ''}`}
           placeholder={
             activeSection.prompt ||
             t('manuscript.contentPlaceholder', { title: activeSection.title })

--- a/components/ui/Textarea.tsx
+++ b/components/ui/Textarea.tsx
@@ -30,11 +30,11 @@ const DEFAULT_CLASSES = `
 `;
 
 // QNBS-v3 (#341): no glass/blur/shadow/hover-bg/reserved padding — the caller's own className fully controls appearance (typically text-transparent, sitting over a visible mirror layer).
+// QNBS-v3 (#332): overlay focus feedback must not wait for decorative transitions.
 const OVERLAY_CLASSES = `
     flex min-h-[120px] w-full rounded-sc-lg
     border border-[var(--sc-border-subtle)]
     text-sm placeholder:text-[var(--sc-text-muted)]
-    transition-all duration-sc-fast
     focus-visible:outline-none focus-visible:border-[var(--border-interactive)] focus-visible:ring-2 focus-visible:ring-[var(--sc-ring-focus)]
     disabled:opacity-50 disabled:cursor-not-allowed
     scrollbar-thin scrollbar-thumb-rounded-md

--- a/tests/unit/Textarea.test.tsx
+++ b/tests/unit/Textarea.test.tsx
@@ -156,6 +156,8 @@ describe('Textarea', () => {
     it('does not include the reserved bottom padding for the mic button', () => {
       render(<Textarea variant="overlay" data-testid="ta" />);
       expect(screen.getByTestId('ta').className).not.toContain('pb-12');
+      expect(screen.getByTestId('ta').className).not.toContain('transition-all');
+      expect(screen.getByTestId('ta').className).not.toContain('duration-sc-fast');
     });
 
     it('still applies the resolved font family from settings', () => {

--- a/tests/unit/manuscript/ManuscriptEditor.test.tsx
+++ b/tests/unit/manuscript/ManuscriptEditor.test.tsx
@@ -115,6 +115,7 @@ vi.mock('../../../components/ui/DebouncedInput', () => ({
 
 // QNBS-v3 (#341): captured so tests can assert variant="overlay" is passed and invoke onScroll manually to verify the mirror scroll-sync wiring.
 let lastEditorTextareaVariant: string | undefined;
+let lastEditorTextareaClassName: string | undefined;
 let lastEditorTextareaOnScroll: ((e: React.UIEvent<HTMLTextAreaElement>) => void) | undefined;
 
 // Stub Textarea
@@ -124,6 +125,7 @@ vi.mock('../../../components/ui/Textarea', () => ({
     onChange,
     placeholder,
     variant,
+    className,
     onScroll,
     // QNBS-v3 (#341): destructured out (not spread) so this mock's own stable "editor-textarea" testid always wins over the real component's data-testid.
     'data-testid': _dataTestId,
@@ -133,11 +135,13 @@ vi.mock('../../../components/ui/Textarea', () => ({
     onChange?: React.ChangeEventHandler<HTMLTextAreaElement>;
     placeholder?: string;
     variant?: string;
+    className?: string;
     onScroll?: (e: React.UIEvent<HTMLTextAreaElement>) => void;
     'data-testid'?: string;
     [k: string]: unknown;
   }) => {
     lastEditorTextareaVariant = variant;
+    lastEditorTextareaClassName = className;
     lastEditorTextareaOnScroll = onScroll;
     return (
       <textarea
@@ -145,6 +149,7 @@ vi.mock('../../../components/ui/Textarea', () => ({
         value={value}
         onChange={onChange}
         placeholder={placeholder}
+        className={className}
         onScroll={onScroll}
         {...(rest as object)}
       />
@@ -302,6 +307,8 @@ describe('ManuscriptEditor', () => {
     it('passes variant="overlay" to the real textarea', () => {
       render(<ManuscriptEditor isFocusMode={false} />);
       expect(lastEditorTextareaVariant).toBe('overlay');
+      expect(lastEditorTextareaClassName).not.toContain('transition-all');
+      expect(lastEditorTextareaClassName).not.toContain('duration-500');
     });
 
     it('syncs the mirror scroll position when the real textarea scrolls', () => {


### PR DESCRIPTION
## **User description**
## Summary
- remove decorative transitions from the invisible overlay textarea used by the Writer Studio and manuscript mirror layers
- keep focus-visible accessibility rings and the default textarea glass behavior unchanged
- add a regression assertion so writing-critical overlay feedback cannot silently regain `transition-all`

## Evidence / scope
The overlay input is the interactive layer for the visible editor mirror. Its prior `transition-all duration-sc-fast` delayed visual focus/border acknowledgement even when input state had already changed. This is a narrow high-ROI correction, not a global animation disable and not a claim that the packaged WebKitGTK latency or #332 Alt-Tab hang is fixed.

Refs #332
Refs #341

## Summary by Sourcery

Remove decorative transitions from writing overlays so visual feedback reflects input state immediately.

Bug Fixes:
- Make focus and border feedback immediate for Writer Studio and manuscript overlay textareas by removing decorative transition delays.

Enhancements:
- Preserve standard textarea styling and accessibility focus behavior while isolating overlays from global transition classes.

Tests:
- Add regression coverage ensuring overlay textareas do not regain delayed transition styles.


___

## **CodeAnt-AI Description**
Make writing overlay feedback appear immediately

### What Changed
- Overlay textareas now show focus and border changes without a decorative delay
- Standard textareas keep their existing glass styling, transitions, focus rings, and dictation controls
- Regression coverage prevents delayed transition styles from returning to overlay textareas

### Impact
`✅ Immediate writing focus feedback`
`✅ Preserved standard textarea behavior`
`✅ Fewer regressions in editor overlays`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
