### PR TITLE
release: v1.28.1 bounded checkpoint

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -17,8 +17,41 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  verify-release-tag:
+    name: Verify release tag
+    if: >-
+      ${{ github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/v') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out the tagged source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Verify GitHub signatures for the release tag
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+          GITHUB_REF_TYPE: ${{ github.ref_type }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/signing/verify-github-signatures.mjs
+
   bundle:
     name: Bundle (${{ matrix.os }})
+    needs: [verify-release-tag]
+    if: >-
+      ${{
+        always() &&
+        !cancelled() &&
+        (
+          github.event_name == 'workflow_dispatch' ||
+          needs.verify-release-tag.result == 'success'
+        )
+      }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     strategy:
@@ -113,18 +146,46 @@ jobs:
   release:
     name: GitHub Release
     needs: [bundle]
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: >-
+      ${{ github.event_name == 'push' && github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
       contents: write
     steps:
+      - name: Check out the exact release tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 1
+          persist-credentials: false
+
       - name: Download all bundle artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: tauri-bundle-*
           path: downloaded
           merge-multiple: true
+
+      - name: Extract deterministic release notes
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          awk -v version="$VERSION" '
+            $0 == "## [" version "] — 2026-08-23" { in_release = 1 }
+            in_release && $0 ~ /^## \[/ && $0 != "## [" version "] — 2026-08-23" { exit }
+            in_release { print }
+          ' CHANGELOG.md > release-notes.md
+          test -s release-notes.md
+          grep -Fq "## [$VERSION] — 2026-08-23" release-notes.md
+          if grep -Eiq '(#332|#341).*(closed|resolved|complete|shipped|fixed)|(#332|#341).*(closure|done)' release-notes.md; then
+            echo "::error::Release notes claim #332 or #341 closure"
+            exit 1
+          fi
+          if grep -Eiq '(macOS|Mac)[^\n]*(Intel|x86_64)[^\n]*(supported|available|provided|published|built)|Intel[^\n]*(macOS|Mac)[^\n]*(supported|available|provided|published|built)' release-notes.md; then
+            echo "::error::Release notes claim unsupported Intel macOS support"
+            exit 1
+          fi
 
       - name: Collect release assets
         id: collect
@@ -150,7 +211,8 @@ jobs:
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           files: release-assets/*
-          generate_release_notes: true
+          body_path: release-notes.md
+          generate_release_notes: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -172,12 +172,12 @@ jobs:
           set -euo pipefail
           VERSION="${GITHUB_REF_NAME#v}"
           awk -v version="$VERSION" '
-            $0 == "## [" version "] — 2026-08-23" { in_release = 1 }
-            in_release && $0 ~ /^## \[/ && $0 != "## [" version "] — 2026-08-23" { exit }
+            index($0, "## [" version "] — ") == 1 { in_release = 1 }
+            in_release && $0 ~ /^## \[/ && index($0, "## [" version "] — ") != 1 { exit }
             in_release { print }
           ' CHANGELOG.md > release-notes.md
           test -s release-notes.md
-          grep -Fq "## [$VERSION] — 2026-08-23" release-notes.md
+          grep -Fq "## [$VERSION] — " release-notes.md
           if grep -Eiq '(#332|#341).*(closed|resolved|complete|shipped|fixed)|(#332|#341).*(closure|done)' release-notes.md; then
             echo "::error::Release notes claim #332 or #341 closure"
             exit 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
 - **Primary deploy target:** Static SPA on GitHub Pages (`/WorldScript-Studio/` base path)
 - **Secondary targets:** Vercel (root base) and Cloudflare Pages via edge builds (`pnpm run build:edge`)
 - **Desktop:** Tauri 2 bundles for Linux (AppImage), macOS (DMG), and Windows (MSI); auto-updater enabled via `latest.json`
-- **Version:** `1.28.0`
+- **Version:** `1.28.1`
 - **License:** MIT
 
 The app supports a multi-provider AI stack (Gemini, OpenAI, Claude, Grok, OpenRouter, Ollama, WebLLM, ONNX Runtime Web, Transformers.js), four AI execution modes (Hybrid / Cloud / Local / Eco), real-time collaboration with E2E encryption, a Plot Board v2 with swimlane/canvas/timeline modes, character/world management, manuscript export, voice dictation, and a 19-locale i18n layer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+<!-- release-candidate: v1.28.1 -->
+
+## [1.28.1] — 2026-08-23
+
 ### Added
 
+- **Scenario/Screenplay canonical projection workspace:** the new workspace exposes a
+  renderer-neutral projection for scenario and screenplay work while keeping the existing
+  TypeScript authority intact.
 - **Core project validation shadow caller:** desktop loads now observe the bounded Rust project
   validation verdict through `DesktopPlatform`; this is observation-only and does not switch
   authority from the existing TypeScript path.
 
-### Changed
+### Fixed
 
-- **Post-release documentation truth:** the audit report and README now reflect the published
-  v1.28.0 release, current test/i18n metrics, and the explicit distinction between protected
-  encryption mechanisms and the still-plaintext desktop filesystem path.
+- **Writing-overlay immediacy:** overlay feedback is now visible without waiting for a later
+  render cycle.
+- **Serialized persistence protection:** overlapping persistence writes are coordinated so a
+  later save cannot race an earlier save and corrupt the durable project state.
+
+### Security
+
+- **Verified release source history:** signing doctor, local commit/push enforcement, exact-range
+  verification, annotated-tag enforcement, and GitHub Verified checks now form the release-source
+  trust boundary.
+- **Supply-chain monitoring:** the daily OSV workflow and hardened pnpm bootstrap/version pinning
+  extend the existing dependency and CI security controls.
+
+### Quality and governance
+
+- **Policy and mutation coverage:** CI authority, selector/AI-core mutation oracles, and the
+  packaged editor readability oracle were strengthened for this release line.
+- **Native lifecycle truth:** the #332 lifecycle evidence and Qt early-killer gates are documented
+  without claiming packaged closure.
+
+### Release boundaries
+
+- Packaged Linux lifecycle/Alt+Tab validation for **#332 remains pending**; reporters should
+  validate the new `.deb` using the documented lifecycle, Alt+Tab, and persistence protocol.
+- Packaged dark/sepia/PWA-versus-packaged readability validation for **#341 remains pending**;
+  publication or CI does not close that issue.
+- PWA remains first-class, Tauri remains transitional, and Qt remains the future native target
+  behind its evidence gates.
+- No unsupported macOS Intel artifact is claimed; only artifacts actually produced by the release
+  workflow belong in updater metadata.
 
 ## [1.28.0] — 2026-08-21
 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@
   <img src="https://img.shields.io/badge/TypeScript-7.x_(tsgo)-3178C6?logo=typescript&logoColor=white" alt="TypeScript 7 (tsgo)">
   <img src="https://img.shields.io/badge/AI-Gemini_%7C_OpenAI_%7C_OpenRouter_%7C_Ollama_%7C_WebLLM-4285F4?logo=google" alt="Gemini · OpenAI · OpenRouter · Ollama · WebLLM">
   <img src="https://img.shields.io/badge/Local_AI-WebGPU_%7C_ONNX_%7C_Transformers.js-8B5CF6" alt="WebGPU · ONNX · Transformers.js">
-  <img src="https://img.shields.io/badge/Release-v1.28.0-6366F1" alt="Release v1.28.0">
+  <!-- release-candidate: v1.28.1 -->
+  <img src="https://img.shields.io/badge/Release-v1.28.1-6366F1" alt="Release v1.28.1">
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2925_keys-0EA5E9" alt="i18n 19 locales — 2925 keys">
-  <img src="https://img.shields.io/badge/Tests-6947%2B_%2F_574_files-22C55E" alt="6947+ tests / 574 files">
+  <img src="https://img.shields.io/badge/Tests-6951%2B_%2F_574_files-22C55E" alt="6951+ tests / 574 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +512,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2925 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (6947+ tests / 574 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (6951+ tests / 574 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +550,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (6947+ tests, 574 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (6951+ tests, 574 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -711,7 +712,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-21, source-synchronized; CI remains authoritative for pass/fail):**
-- **6947+ unit tests** across **574 test files** — CI is authoritative for pass/fail
+- **6951+ unit tests** across **574 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2925 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/docs/BEST-PRACTICES.md
+++ b/docs/BEST-PRACTICES.md
@@ -9,7 +9,7 @@ Single reference for maintainers: architecture touchpoints, content rules, secur
 - **AI:** `services/ai/index.ts` (Vercel AI SDK layer, canonical entry). `geminiService` / `aiProviderService` — legacy path. Multi-provider routing: Gemini, OpenAI, OpenRouter (Cloud 5, circuit breaker, free-tier `:free` models), Claude, Grok, Ollama, WebLLM, ONNX, Transformers.js. **AI Execution Modes** (`aiModeService.ts`): `hybrid | cloud | local | eco` — routing strategy persisted to `settings.aiMode`. 4-layer local inference stack: WebLLM (WebGPU) → ONNX (WASM) → Transformers.js → heuristic fallback.
 - **Copilot:** `services/copilot/` — `heuristicEngine.ts` (8 manuscript analysis rules), `insightGenerator.ts`, `copilotContextService.ts`, `actionApplier.ts` (apply-to-chapter, offset-safe). Flag: `enableGlobalCopilot`. Docs: `docs/COPILOT.md`, `docs/HEURISTIC-RULES.md`.
 - **Commands:** `services/commands/` registry; execution via `CommandExecutorProvider` / `runCommandById`.
-- **i18n:** Source modules under `locales/<lang>/*.json`; runtime bundles `public/locales/<lang>/bundle.json` rebuilt by `pnpm run i18n:bundle` / `i18n:check`. **2 594 keys × 11 locales** (de/en/es/fr/it core + ar/he RTL Beta + el/ja/pt/zh Beta).
+- **i18n:** Source modules under `locales/<lang>/*.json`; runtime bundles `public/locales/<lang>/bundle.json` rebuilt by `pnpm run i18n:bundle` / `i18n:check`. **2 925 keys × 19 locales** (de/en/es/fr/it core + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta).
 
 ## Content & copy
 

--- a/docs/BEST-PRACTICES.md
+++ b/docs/BEST-PRACTICES.md
@@ -46,7 +46,7 @@ Single reference for maintainers: architecture touchpoints, content rules, secur
 
 ## Testing & coverage
 
-- **Unit/integration:** Vitest; global coverage thresholds in `vitest.config.ts` are a regression floor. Current (v1.28.0): lines ≥ 80 / branches ≥ 66 / functions ≥ 72 / statements ≥ 78 (CI-measured after adding the root application/PWA shell). **5 475+ tests / 449 files**. Target for v2.0: lines 85 / branches 75 / functions 80 (C-7).
+- **Unit/integration:** Vitest; global coverage thresholds in `vitest.config.ts` are a regression floor. Current (v1.28.1 candidate): lines ≥ 80 / branches ≥ 66 / functions ≥ 72 / statements ≥ 78 (CI-measured after adding the root application/PWA shell). **6 951+ tests / 574 files**. Target for v2.0: lines 85 / branches 75 / functions 80 (C-7).
 - **Risk-hotspots** (aim for focused tests when touching): `dbService`, `dbMigration`, `aiProviderService`, `sceneRevisionService`, `plotBoardService`, `deepLinkService`, project import/export, `storageService` / `storageBackend`.
 - **IDB test isolation:** `sceneRevisionService` and similar IDB tests require `@vitest-environment node` + per-test `IDBFactory` + `_resetDbForTest()`. See `CLAUDE.md § IDB unit tests`.
 - **Custom Select testing:** Components using `Select` or `LanguageSelector` should mock them as native `<select>` elements in tests for compatibility with testing-library queries. See `docs/UI-MODERNIZATION.md` Testing section for the mock pattern.

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -150,7 +150,7 @@ registry gzip-decoding failure mode, while OSV failures remain blocking.
 
 ### Release-truth checks
 
-`pnpm run docs:check` treats `v1.27.1` (the latest stable tag) as the release frontier. A dated
+`pnpm run docs:check` treats the latest available stable tag as the release frontier. A dated
 Keep-a-Changelog heading at or beyond that frontier must have its matching tag; a package version
 behind the frontier fails, while a newer development version requires an `[Unreleased]` section;
 when post-release commits exist, that section must contain meaningful history. README badges may use an explicit `Next`/`unreleased` development label,

--- a/docs/RELEASE-V1.28.1-EVIDENCE.md
+++ b/docs/RELEASE-V1.28.1-EVIDENCE.md
@@ -1,0 +1,77 @@
+# v1.28.1 release evidence ledger
+
+Status: release candidate; this ledger is intentionally incomplete until the protected release
+PR is merged, the annotated tag is independently verified, and the tag-triggered desktop workflow
+publishes its actual assets.
+
+## Verified release base
+
+| Evidence | Value |
+| --- | --- |
+| Previous release tag target | `v1.28.0` → `34b83a22841d0afd58675eb5f563f5bb63bb0bc4` |
+| Release-base branch | `main` → `332b643c686b2a43e6c632a5cc2e34515c6e1675` |
+| Release-base tree | `0400d5155e0301354a16f0c29a796c06261aeda8` |
+| Dynamic range count | `git rev-list --count v1.28.0..main` → **16** |
+| Baseline GitHub verification | `verified=true`, `reason=valid` |
+| Main required signatures | enabled |
+| Main required status | exactly `✅ CI Success` |
+| Main force-push/deletion allowance | disabled / disabled |
+
+The release branch was created from the verified release-base SHA. The range was audited without
+assuming a preselected commit count:
+
+| Commit | Parent | Authored | Subject | GitHub | Merged PR |
+| --- | --- | --- | --- | --- | --- |
+| `d62ac38a325800d5f33b9c03519a37c25034516c` | `34b83a22841d0afd58675eb5f563f5bb63bb0bc4` | 2026-08-22T02:26:58+02:00 | docs: reconcile post-v1.28 release truth (#451) | verified / valid | #451 |
+| `70040aba2f6864549f841a83c1256089e8d1af0b` | `d62ac38a325800d5f33b9c03519a37c25034516c` | 2026-08-22T04:26:13+02:00 | feat(project): wire first shadow caller for worldscript_project_validate (Wave 2) (#452) | verified / valid | #452 |
+| `faadfbbb76ff53120f6c12dc670a2fa1fc1fef73` | `70040aba2f6864549f841a83c1256089e8d1af0b` | 2026-08-22T08:00:50+02:00 | fix(ci): make required job authority explicit (#453) | verified / valid | #453 |
+| `87764570e0487c8de3fde99800291f3e79e3f81c` | `faadfbbb76ff53120f6c12dc670a2fa1fc1fef73` | 2026-08-22T09:14:30+02:00 | fix(security): schedule daily OSV scan (#454) | verified / valid | #454 |
+| `6be4ff96cd9ffd50a28bcad459501f0070200c62` | `87764570e0487c8de3fde99800291f3e79e3f81c` | 2026-08-22T10:25:28+02:00 | fix(security): harden pnpm bootstrap and version pin (#455) | verified / valid | #455 |
+| `9156eba08e2db4fcd99f36ed889e70d753cb65ad` | `6be4ff96cd9ffd50a28bcad459501f0070200c62` | 2026-08-22T11:56:26+02:00 | test(mutation): bind copilot shard to direct tests (#456) | verified / valid | #456 |
+| `9a56f9052f14b29837e1d19dadaabb3fecc440ce` | `9156eba08e2db4fcd99f36ed889e70d753cb65ad` | 2026-08-22T12:40:16+02:00 | test(mutation): bind services-commands shard to direct tests (#457) | verified / valid | #457 |
+| `fded1e22fd4d4b9140cde5fede0df758ba574ad2` | `9a56f9052f14b29837e1d19dadaabb3fecc440ce` | 2026-08-22T13:19:40+02:00 | test(mutation): bind ai-core shard to direct tests (#458) | verified / valid | #458 |
+| `060c85b6d4f8790101aeab794075bf3f3b98551d` | `fded1e22fd4d4b9140cde5fede0df758ba574ad2` | 2026-08-22T15:22:40+02:00 | test(desktop): harden packaged editor readability oracle (#460) | verified / valid | #460 |
+| `511037eb02c9e5df6ab3e6a8c6ea8de3e74f5ef4` | `060c85b6d4f8790101aeab794075bf3f3b98551d` | 2026-08-22T16:23:00+02:00 | test(mutation): harden AI-core survivor oracles (#459) | verified / valid | #459 |
+| `a6e22e536240f8500d8ce976aa9d1c3dc96e522b` | `511037eb02c9e5df6ab3e6a8c6ea8de3e74f5ef4` | 2026-08-22T18:31:48+02:00 | test(project): strengthen selector mutation oracles (#461) | verified / valid | #461 |
+| `287e964bdf3fd58e67a185ef92ec36e251c427d6` | `a6e22e536240f8500d8ce976aa9d1c3dc96e522b` | 2026-08-22T19:22:40+02:00 | fix(332): make writing overlay feedback immediate (#463) | verified / valid | #463 |
+| `4086080333622abcf8cfa33aa5699207965e1ab5` | `287e964bdf3fd58e67a185ef92ec36e251c427d6` | 2026-08-22T19:39:26+02:00 | docs(native): harden #332 lifecycle and Qt killer gates (#462) | verified / valid | #462 |
+| `e298f56b0ae13c4b16f8a2f5003ae4ac93474a61` | `4086080333622abcf8cfa33aa5699207965e1ab5` | 2026-08-22T20:21:11+02:00 | fix(332): serialize overlapping persistence writes (#464) | verified / valid | #464 |
+| `a945907784929b16210432fc3462073d585693a7` | `e298f56b0ae13c4b16f8a2f5003ae4ac93474a61` | 2026-08-23T00:43:13+02:00 | feat(scenario): add canonical projection workspace | verified / valid | #465 |
+| `332b643c686b2a43e6c632a5cc2e34515c6e1675` | `a945907784929b16210432fc3462073d585693a7` | 2026-08-23T03:17:11+02:00 | feat(security): enforce verified signing | verified / valid | #466 |
+
+The merged PR association set is deduplicated as **#451–#466**, and each association above was
+validated with `merged_at` and a merge commit equal to the corresponding range commit.
+
+## Release-branch evidence
+
+| Gate | Result |
+| --- | --- |
+| `pnpm run signing:doctor` | passed with SSH signing probe |
+| Focused policy/signing/version tests | 72/72 passed (`workflowPolicy`, `checkDocMetrics`, `signing`) |
+| `pnpm run docs:check` | passed; 19 locales, 2925 keys, latest tag v1.28.0 |
+| `pnpm run build` | passed; Vite production build completed |
+| `pnpm run ci:prepush` | passed sequentially |
+| Release PR | pending creation |
+| Release PR head / merge SHA / merge tree | pending protected merge |
+
+## Publication evidence to fill after protected merge
+
+- [ ] Re-fetch `origin`; confirm local `main` equals the verified release-PR squash SHA and its
+  reviewed tree before tag creation.
+- [ ] Confirm no local or remote `v1.28.1` tag collision.
+- [ ] Record annotated tag object SHA and target SHA.
+- [ ] Independently verify tag object and target commit through GitHub (`verified=true`,
+  `reason=valid` for each).
+- [ ] Record tag-gate, main CI, security/CodeQL, and Tauri workflow run IDs and conclusions.
+- [ ] Record actual `.deb`, AppImage, RPM, Windows, macOS ARM, updater, and `.sig` asset inventory.
+- [ ] Validate every `latest.json` URL/signature/version/platform mapping; do not add a
+  `darwin-x86_64` entry without an actual Intel artifact.
+- [ ] Record official Tauri/minisign-compatible artifact verification, or the exact installed
+  tool/version and documented limitation if no official verifier is exposed.
+- [ ] Record the published release URL, deterministic changelog-note comparison, and fallback
+  `latest.json` URL if one is part of publication.
+
+The source-signing control (every introduced source commit GitHub Verified) and release-tag
+signing control (the annotated tag object plus its target commit) are separate evidence items.
+Neither one substitutes for the other. #332 packaged Linux lifecycle/Alt+Tab/persistence and
+#341 packaged dark/sepia/readability validation remain pending regardless of CI or publication.

--- a/docs/RELEASE-V1.28.1-EVIDENCE.md
+++ b/docs/RELEASE-V1.28.1-EVIDENCE.md
@@ -73,5 +73,6 @@ validated with `merged_at` and a merge commit equal to the corresponding range c
 
 The source-signing control (every introduced source commit GitHub Verified) and release-tag
 signing control (the annotated tag object plus its target commit) are separate evidence items.
-Neither one substitutes for the other. #332 packaged Linux lifecycle/Alt+Tab/persistence and
-#341 packaged dark/sepia/readability validation remain pending regardless of CI or publication.
+Neither one substitutes for the other. Issue #332 packaged Linux lifecycle/Alt+Tab/persistence
+and Issue #341 packaged dark/sepia/readability validation remain pending regardless of CI or
+publication.

--- a/docs/RELEASE-V1.28.1-REPORTER-PROTOCOL.md
+++ b/docs/RELEASE-V1.28.1-REPORTER-PROTOCOL.md
@@ -1,0 +1,58 @@
+# v1.28.1 packaged reporter protocol
+
+This protocol is for the published v1.28.1 Linux `.deb`. It supplies evidence for the open
+packaged-runtime questions in #332 and #341; green CI, a successful release workflow, or a PWA
+result does not close either issue.
+
+## Record the environment first
+
+For every run, record the release tag and build SHA, package version, `.deb` filename, Linux
+distribution, desktop environment/compositor, Wayland or X11, display scale/resolution, GPU and
+driver, Tauri/WebKitGTK versions when available, launch path (application menu or terminal), and
+result maturity (`PACKAGED_TARGET_ENV`, `PACKAGED_LOCAL`, or `NOT_REPRODUCED_ENVIRONMENT_LIMITED`).
+Keep the PWA comparison on the same source revision and record it separately.
+
+## #332: lifecycle, Alt+Tab, and persistence
+
+1. Install the new `.deb` cleanly and start the packaged app from the normal desktop launcher.
+   Confirm the process and window are the packaged build, not the PWA or a development server.
+2. Create or open a disposable project. Change an appearance setting, make a manuscript edit,
+   and perform the relevant Settings navigation. Repeat the navigation sequence enough to record
+   a small before/after sample (at least 10 transitions); note visible feedback latency and any
+   freeze, dropped input, or delayed repaint.
+3. While the app is idle and while a save is settling, use Alt+Tab away for at least 30 seconds,
+   then return. Repeat with a longer interval if the first pass is clean. Record whether the
+   window repaints, accepts input, and preserves the project without a forced termination.
+4. Change the appearance setting again, wait for the save to settle, quit through the normal
+   application path, relaunch from the desktop launcher, and verify the edit and appearance
+   setting. Repeat once after an Alt+Tab cycle to distinguish ordinary relaunch persistence from
+   lifecycle recovery.
+5. If the app becomes unresponsive, capture timestamps, visible window/process state, and the
+   last interaction before using a forced kill as recovery. A forced kill is evidence of the
+   symptom, not a closure decision. Attach logs and the exact reproduction sequence.
+
+Report separate results for navigation responsiveness, Alt+Tab recovery, and durable persistence;
+do not collapse them into a single “fixed” claim.
+
+## #341: dark/sepia and PWA-versus-packaged readability
+
+1. In the packaged `.deb`, inspect the same manuscript content in the default, dark, and sepia
+   appearance presets. Check normal prose, headings, selected text, editor overlays, links, and
+   focused controls at the supported zoom/display scale.
+2. Repeat the identical content and presets in the PWA from the same release source. Record the
+   computed foreground/background colors and contrast where the symptom appears, plus screenshots
+   showing the full surface rather than only selected text.
+3. Relaunch the packaged build after each dark/sepia change and repeat the inspection. Note any
+   reset, black-on-dark text, overlay occlusion, font mismatch, missing scroll synchronization,
+   or difference between the packaged WebKitGTK surface and the Chromium PWA.
+4. Record the result as reproduced, not reproduced, or environment-limited. A clean PWA result is
+   a comparison signal only; it cannot substitute for packaged evidence.
+
+Attach screenshots, the computed style values, and the environment record to the issue report.
+Keep #341 open until the packaged matrix has a reproducible outcome and an explicit maintainer
+decision.
+
+## Release limitations
+
+PWA remains first-class. Tauri remains transitional, and Qt remains the future native target
+behind its early killer gates. v1.28.1 makes no unsupported macOS Intel artifact claim.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "worldscript-studio",
   "private": true,
-  "version": "1.28.0",
+  "version": "1.28.1",
   "description": "WorldScript Studio — offline-first, AI-powered creative writing application.",
   "author": "QNBS",
   "keywords": [

--- a/public/sw.js
+++ b/public/sw.js
@@ -6,7 +6,7 @@
 // ============================================================
 
 // QNBS-v3 (CodeRabbit): version bump auto-synced from package.json by scripts/sync-sw-version.mjs — every CACHE_STATIC/CACHE_DYNAMIC name changes too, so this alone invalidates all prior caches on next activate.
-const APP_VERSION   = '1.28.0';
+const APP_VERSION   = '1.28.1';
 const CACHE_STATIC  = `worldscript-static-v${APP_VERSION}`;
 const CACHE_DYNAMIC = `worldscript-dynamic-v${APP_VERSION}`;
 const CACHE_IMAGES  = `worldscript-images-v${APP_VERSION}`;

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6685,7 +6685,7 @@ dependencies = [
 
 [[package]]
 name = "worldscript-studio"
-version = "1.28.0"
+version = "1.28.1"
 dependencies = [
  "base64 0.23.1",
  "candle-core",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "worldscript-studio"
-version = "1.28.0"
+version = "1.28.1"
 description = "AI-powered creative writing and world-building application"
 authors = ["QNBS"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "WorldScript Studio",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "identifier": "com.worldscript.studio",
   "build": {
     "frontendDist": "../dist",

--- a/tests/unit/workflowPolicy.test.ts
+++ b/tests/unit/workflowPolicy.test.ts
@@ -228,6 +228,8 @@ describe('Tauri release workflow policy', () => {
     expect(release).toContain('generate_release_notes: false');
     expect(release).toContain('Check out the exact release tag');
     expect(release).toContain('Release notes claim #332 or #341 closure');
+    expect(release).toContain('index($0, "## [" version "] — ")');
+    expect(release).not.toContain('2026-08-23');
   });
 
   it('preserves the authoritative CI Success status gate', () => {

--- a/tests/unit/workflowPolicy.test.ts
+++ b/tests/unit/workflowPolicy.test.ts
@@ -14,6 +14,9 @@ import {
 
 const repositoryRoot = fileURLToPath(new URL('../../', import.meta.url));
 const workflowPath = fileURLToPath(new URL('../../.github/workflows/ci.yml', import.meta.url));
+const tauriWorkflowPath = fileURLToPath(
+  new URL('../../.github/workflows/tauri-build.yml', import.meta.url),
+);
 const setupActionPath = fileURLToPath(
   new URL('../../.github/actions/setup/action.yml', import.meta.url),
 );
@@ -25,6 +28,7 @@ const scheduledSecurityWorkflowPath = fileURLToPath(
 );
 const tauriManifestPath = fileURLToPath(new URL('../../src-tauri/Cargo.toml', import.meta.url));
 const workflowSource = readFileSync(workflowPath, 'utf8');
+const tauriWorkflowSource = readFileSync(tauriWorkflowPath, 'utf8');
 const setupActionSource = readFileSync(setupActionPath, 'utf8');
 const cloudflareWorkflowSource = readFileSync(cloudflareWorkflowPath, 'utf8');
 const scheduledSecurityWorkflowSource = readFileSync(scheduledSecurityWorkflowPath, 'utf8');
@@ -185,5 +189,50 @@ describe('CI workflow policy', () => {
     expect(enforcementStep).toMatch(
       /if \[ ! -s "\$GITHUB_WORKSPACE\/osv-results\.json" \]; then[\s\S]+?exit 1\n\s+fi/,
     );
+  });
+});
+
+// QNBS-v3: keep desktop publication causally downstream of independently verified annotated tags.
+describe('Tauri release workflow policy', () => {
+  it('runs the signature verifier only for real version-tag pushes with read-only access', () => {
+    const verifier = extractJobBlock(tauriWorkflowSource, 'verify-release-tag');
+    expect(verifier).toMatch(
+      /^ {4}if: >-\n {6}\$\{\{ github\.event_name == 'push' && github\.ref_type == 'tag' && startsWith\(github\.ref, 'refs\/tags\/v'\) \}\}$/m,
+    );
+    expect(verifier).toContain('scripts/signing/verify-github-signatures.mjs');
+    expect(verifier).toMatch(/^ {4}permissions:\n {6}contents: read\s*$/m);
+    expect(verifier).not.toContain('workflow_dispatch');
+  });
+
+  it('requires successful tag verification before tagged bundles, while allowing manual builds', () => {
+    const bundle = extractJobBlock(tauriWorkflowSource, 'bundle');
+    expect(extractNeeds(tauriWorkflowSource, 'bundle')).toEqual(['verify-release-tag']);
+    expect(bundle).toContain('always()');
+    expect(bundle).toContain('!cancelled()');
+    expect(bundle).toMatch(/github\.event_name == 'workflow_dispatch'/);
+    expect(bundle).toMatch(/needs\.verify-release-tag\.result == 'success'/);
+    expect(bundle).toMatch(
+      /always\(\)\s*&&\s*!cancelled\(\)[\s\S]+github\.event_name == 'workflow_dispatch'[\s\S]+needs\.verify-release-tag\.result == 'success'/,
+    );
+    expect(bundle).toContain('Skip updater signing for workflow_dispatch test builds');
+  });
+
+  it('keeps release publication tag-only and downstream of bundle output', () => {
+    const release = extractJobBlock(tauriWorkflowSource, 'release');
+    expect(extractNeeds(tauriWorkflowSource, 'release')).toEqual(['bundle']);
+    expect(release).toMatch(
+      /^ {4}if: >-\n {6}\$\{\{ github\.event_name == 'push' && github\.ref_type == 'tag' && startsWith\(github\.ref, 'refs\/tags\/v'\) \}\}$/m,
+    );
+    expect(release).not.toContain('workflow_dispatch');
+    expect(release).toContain('body_path: release-notes.md');
+    expect(release).toContain('generate_release_notes: false');
+    expect(release).toContain('Check out the exact release tag');
+    expect(release).toContain('Release notes claim #332 or #341 closure');
+  });
+
+  it('preserves the authoritative CI Success status gate', () => {
+    const ciSuccess = extractJobBlock(workflowSource, 'ci-success');
+    expect(ciSuccess).toContain('✅ CI Success');
+    expect(workflowSource).toContain('name: ✅ CI Success');
   });
 });


### PR DESCRIPTION
## Scope

- bump v1.28.1 metadata and generated synchronization
- source-derived changelog/release truth and evidence ledger
- causal Tauri release-tag verification gate
- deterministic committed release notes and updater mapping guardrails
- focused workflow/signing/release-truth tests and packaged reporter protocol

## Baseline

- release base: 332b643c686b2a43e6c632a5cc2e34515c6e1675
- base tree: 0400d5155e0301354a16f0c29a796c06261aeda8
- v1.28.0 target: 34b83a22841d0afd58675eb5f563f5bb63bb0bc4
- observed v1.28.0..main range: 16 commits; all GitHub Verified / valid; merged PRs #451–#466

## Verification

- signing doctor passed
- focused policy/signing/release-truth tests: 72/72
- production build passed
- ci:prepush passed sequentially
- release commit be105c48cee4ea9b7266ca96eed5ac080286dfdb is GitHub Verified

## Explicit limits

- #332 packaged Linux lifecycle/Alt+Tab/persistence validation remains pending
- #341 packaged dark/sepia/readability validation remains pending
- PWA remains first-class; Tauri remains transitional; Qt remains future gated native target
- no unsupported macOS Intel artifact is claimed

Release publication and tag creation remain downstream of protected merge and post-merge CI.

## Summary by Sourcery

Prepare the v1.28.1 release candidate with synchronized metadata, bounded release evidence, and verified tag-driven desktop publication guardrails.

New Features:
- Add a canonical scenario/screenplay projection workspace.
- Add causal verification of signed release tags before Tauri release bundles are built.

Bug Fixes:
- Provide immediate writing-overlay feedback and serialize persistence writes to prevent save races.

Enhancements:
- Make release publication use deterministic, committed changelog notes and guard against unsupported issue-closure or macOS Intel claims.
- Update release-truth checks, version synchronization, security controls, and documented evidence boundaries for v1.28.1.

CI:
- Add focused policy tests covering tag verification, bundle dependencies, tag-only publication, and the authoritative CI success gate.

Documentation:
- Add the v1.28.1 evidence ledger and packaged Linux validation reporter protocol.
- Synchronize release metadata, changelog, README metrics, and maintainer guidance for v1.28.1.

Tests:
- Extend workflow policy coverage for the Tauri release and signing gates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Release**
  - Updated the application to version 1.28.1.
  - Refreshed service-worker caching for the new version.

- **Documentation**
  - Added release notes, evidence, and Linux package validation guidance.
  - Updated version, testing metrics, release guidance, and documented release limitations.

- **Release Quality**
  - Strengthened signed-tag verification and release-note validation.
  - Improved safeguards to ensure bundles are published only from verified release tags.
  - Added automated checks covering release verification and publication requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->