### PR TITLE
docs: finalize v1.28.1 release evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- release-candidate: v1.28.1 -->
 
+### Documentation
+
+- **Release evidence ledger:** final v1.28.1 publication, artifact, updater, and verification
+  evidence is recorded for the completed release checkpoint.
+
 ## [1.28.1] — 2026-08-23
 
 ### Added

--- a/docs/RELEASE-V1.28.1-EVIDENCE.md
+++ b/docs/RELEASE-V1.28.1-EVIDENCE.md
@@ -90,9 +90,13 @@ The release contains these non-empty assets (sizes are the published byte sizes)
 | `WorldScript.Studio.app.tar.gz` | 84,781,830 |
 | `WorldScript.Studio.app.tar.gz.sig` | 420 |
 
-The public fallback URL `https://github.com/qnbs/WorldScript-Studio/releases/latest/download/latest.json`
-was fetched successfully. Its `version` is `1.28.1`, its publication timestamp is valid, and its
-three platform mappings are structurally complete:
+The immutable versioned URL
+`https://github.com/qnbs/WorldScript-Studio/releases/download/v1.28.1/latest.json`
+was fetched successfully and is the primary historical updater evidence. Its `version` is
+`1.28.1`, its publication timestamp is valid, and its three platform mappings are structurally
+complete. The public fallback URL
+`https://github.com/qnbs/WorldScript-Studio/releases/latest/download/latest.json` was also fetched
+successfully as a separate time-of-check fallback probe; it resolved to the same `1.28.1` metadata.
 
 | Platform key | Updater artifact | Signature asset | URL / asset check |
 | --- | --- | --- | --- |

--- a/docs/RELEASE-V1.28.1-EVIDENCE.md
+++ b/docs/RELEASE-V1.28.1-EVIDENCE.md
@@ -1,8 +1,6 @@
 # v1.28.1 release evidence ledger
 
-Status: release candidate; this ledger is intentionally incomplete until the protected release
-PR is merged, the annotated tag is independently verified, and the tag-triggered desktop workflow
-publishes its actual assets.
+Status: published and independently verified release checkpoint.
 
 ## Verified release base
 
@@ -48,31 +46,80 @@ validated with `merged_at` and a merge commit equal to the corresponding range c
 | --- | --- |
 | `pnpm run signing:doctor` | passed with SSH signing probe |
 | Focused policy/signing/version tests | 72/72 passed (`workflowPolicy`, `checkDocMetrics`, `signing`) |
-| `pnpm run docs:check` | passed; 19 locales, 2925 keys, latest tag v1.28.0 |
+| `pnpm run docs:check` | passed; 19 locales, 2925 keys, latest tag v1.28.1 |
 | `pnpm run build` | passed; Vite production build completed |
 | `pnpm run ci:prepush` | passed sequentially |
-| Release PR | pending creation |
-| Release PR head / merge SHA / merge tree | pending protected merge |
+| Release PR | [#467](https://github.com/qnbs/WorldScript-Studio/pull/467), merged normally by protected squash merge |
+| Release PR head | `9af3fa5b46ff129c2b3e9abfbe6552fac816621c` (GitHub Verified) |
+| Release merge SHA / tree | `b6c40aa322d56a7e8c337d02394b52962f1e6ef6` / `f622a0804ae5a78bdd46e0f965eea6068ab2ecfa` (GitHub Verified) |
+| Post-merge main CI | run `32614783075`, conclusion `success`; `✅ CI Success` job `97136128385` |
 
-## Publication evidence to fill after protected merge
+## Publication evidence
 
-- [ ] Re-fetch `origin`; confirm local `main` equals the verified release-PR squash SHA and its
-  reviewed tree before tag creation.
-- [ ] Confirm no local or remote `v1.28.1` tag collision.
-- [ ] Record annotated tag object SHA and target SHA.
-- [ ] Independently verify tag object and target commit through GitHub (`verified=true`,
-  `reason=valid` for each).
-- [ ] Record tag-gate, main CI, security/CodeQL, and Tauri workflow run IDs and conclusions.
-- [ ] Record actual `.deb`, AppImage, RPM, Windows, macOS ARM, updater, and `.sig` asset inventory.
-- [ ] Validate every `latest.json` URL/signature/version/platform mapping; do not add a
-  `darwin-x86_64` entry without an actual Intel artifact.
-- [ ] Record official Tauri/minisign-compatible artifact verification, or the exact installed
-  tool/version and documented limitation if no official verifier is exposed.
-- [ ] Record the published release URL, deterministic changelog-note comparison, and fallback
-  `latest.json` URL if one is part of publication.
+| Evidence | Result |
+| --- | --- |
+| Final target before tag creation | `main == origin/main == b6c40aa322d56a7e8c337d02394b52962f1e6ef6`; tree `f622a0804ae5a78bdd46e0f965eea6068ab2ecfa`; GitHub `verified=true`, `reason=valid` |
+| Pre-existing `v1.28.1` collision | none locally or remotely before creation |
+| Annotated tag object / target | `78e6e19168b86b810952f3db7fe092a8dfed168b` / `b6c40aa322d56a7e8c337d02394b52962f1e6ef6` |
+| Tag object verification | GitHub `verified=true`, `reason=valid`; object type `tag` |
+| Tag target verification | GitHub `verified=true`, `reason=valid`; tree matches reviewed release tree |
+| Tauri workflow | run `32616003394`, conclusion `success` |
+| Release-tag gate | job `97136729353`, conclusion `success` |
+| Ubuntu bundle | job `97136760231`, conclusion `success`, 18m36s |
+| Windows bundle | job `97136760230`, conclusion `success`, 15m51s |
+| macOS ARM bundle | job `97136760252`, conclusion `success`, 9m11s |
+| GitHub Release publication | job `97138727477`, conclusion `success`; published `2026-08-23T04:01:28Z` |
+| GitHub Release | [v1.28.1](https://github.com/qnbs/WorldScript-Studio/releases/tag/v1.28.1), published, non-draft, non-prerelease |
+
+The release contains these non-empty assets (sizes are the published byte sizes):
+
+| Asset | Size |
+| --- | ---: |
+| `latest.json` | 1,928 |
+| `WorldScript.Studio_1.28.1_amd64.AppImage` | 162,765,304 |
+| `WorldScript.Studio_1.28.1_amd64.AppImage.sig` | 436 |
+| `WorldScript.Studio_1.28.1_amd64.deb` | 85,249,438 |
+| `WorldScript.Studio_1.28.1_amd64.deb.sig` | 428 |
+| `WorldScript.Studio-1.28.1-1.x86_64.rpm` | 85,250,694 |
+| `WorldScript.Studio-1.28.1-1.x86_64.rpm.sig` | 432 |
+| `WorldScript.Studio_1.28.1_x64-setup.exe` | 83,189,573 |
+| `WorldScript.Studio_1.28.1_x64-setup.exe.sig` | 432 |
+| `WorldScript.Studio_1.28.1_x64_en-US.msi` | 84,484,096 |
+| `WorldScript.Studio_1.28.1_x64_en-US.msi.sig` | 432 |
+| `WorldScript.Studio_1.28.1_aarch64.dmg` | 84,745,084 |
+| `WorldScript.Studio.app.tar.gz` | 84,781,830 |
+| `WorldScript.Studio.app.tar.gz.sig` | 420 |
+
+The public fallback URL `https://github.com/qnbs/WorldScript-Studio/releases/latest/download/latest.json`
+was fetched successfully. Its `version` is `1.28.1`, its publication timestamp is valid, and its
+three platform mappings are structurally complete:
+
+| Platform key | Updater artifact | Signature asset | URL / asset check |
+| --- | --- | --- | --- |
+| `linux-x86_64` | `WorldScript.Studio_1.28.1_amd64.AppImage` | matching `.sig` (436 bytes) | versioned release URL, HTTP 200 |
+| `windows-x86_64` | `WorldScript.Studio_1.28.1_x64-setup.exe` | matching `.sig` (432 bytes) | versioned release URL, HTTP 200 |
+| `darwin-aarch64` | `WorldScript.Studio.app.tar.gz` | matching `.sig` (420 bytes) | versioned release URL, HTTP 200 |
+
+No `darwin-x86_64` entry exists because no Intel macOS artifact was produced or claimed. The
+corresponding updater artifact and signature URLs were each matched to actual non-empty GitHub
+Release assets; `.deb`, AppImage, RPM, Windows `.exe`/`.msi`, and macOS ARM `.dmg` assets are also
+present.
+
+Deterministic release notes were extracted from the committed `v1.28.1` changelog section with
+`generate_release_notes: false` and match the published release body. The notes retain the
+pending status of #332 and #341 and make no unsupported macOS Intel claim.
+
+The installed official toolchain is `tauri-cli 2.11.4`. It exposes `tauri signer sign` and
+`tauri signer generate`, but no artifact verification command; neither `minisign` nor `signify`
+is installed. Accordingly, structural, asset, URL, version, HTTP, and non-empty-signature checks
+are complete, but this checkpoint does not claim independent cryptographic verification of the
+updater artifacts. No private key material was accessed or exposed.
 
 The source-signing control (every introduced source commit GitHub Verified) and release-tag
 signing control (the annotated tag object plus its target commit) are separate evidence items.
-Neither one substitutes for the other. Issue #332 packaged Linux lifecycle/Alt+Tab/persistence
-and Issue #341 packaged dark/sepia/readability validation remain pending regardless of CI or
+Neither one substitutes for the other. Final branch protection remains unchanged: required
+signatures enabled, required status exactly `✅ CI Success`, force-pushes disabled, deletions
+disabled, and required conversation resolution enabled. No admin bypass, force-update, unsigned
+fallback, or hook bypass was used. Issue #332 packaged Linux lifecycle/Alt+Tab/persistence and
+Issue #341 packaged dark/sepia/readability validation remain pending regardless of CI or
 publication.


### PR DESCRIPTION
## **User description**
## Summary
- record the merged release PR, verified squash commit, signed annotated tag, and workflow run IDs
- record the published asset inventory and latest.json structural validation
- document the installed Tauri CLI limitation for independent updater cryptographic verification
- retain the explicit pending packaged validation status for #332 and #341

## Validation
- pnpm run docs:check
- pnpm run ci:prepush

This is documentation-only follow-up evidence for the already published immutable v1.28.1 release.

## Summary by Sourcery

Finalize the documentation audit trail for the published and independently verified v1.28.1 release.

Enhancements:
- Finalize the v1.28.1 release evidence ledger with verified merge, tag, workflow, publication, artifact, and updater metadata records.
- Document the limitation preventing independent cryptographic verification of updater signatures while retaining pending packaged validation for issues #332 and #341.

Documentation:
- Record the published v1.28.1 release, asset inventory, updater metadata validation, release notes comparison, and platform mapping evidence.

Tests:
- Document successful release, updater URL, asset, version, and structural validation checks.


___

## **CodeAnt-AI Description**
Finalize v1.28.1 release evidence and publication records

### What Changed
- Marks v1.28.1 as a published, independently verified release checkpoint
- Records the merged release, signed tag, successful workflows, published assets, release URL, and changelog validation
- Documents successful updater metadata and platform asset checks, including the absence of an unsupported Intel macOS entry
- Records the remaining limitation that updater signatures could not receive independent cryptographic verification, while retaining pending packaged validation for issues #332 and #341

### Impact
`✅ Complete v1.28.1 release audit trail`
`✅ Verified updater asset and platform mappings`
`✅ Clear cryptographic verification limitation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added release evidence confirming version 1.28.1 was published and independently verified.
  - Documented successful checks, build results, tag validation, published assets, updater mappings, release notes, and signing-tool limitations.
  - Updated the changelog to record the completed 1.28.1 release checkpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->