### PR TITLE
docs: record H1-A post-merge checkpoint

### DIFF
--- a/docs/audit/H1-CI-FAILURE-SIGNAL-REPORT.md
+++ b/docs/audit/H1-CI-FAILURE-SIGNAL-REPORT.md
@@ -161,3 +161,17 @@ cache observations are recorded in
 This checkpoint does not alter the original 50-run outcome distribution, the 43 paired-run result,
 or the `UNKNOWN` unique-defect signal. It adds no failure/cancellation or lane-exclusive signal,
 and no H1-B decision is made.
+
+## Post-#475 checkpoint boundary
+
+Main push run `32657261089` on
+`3378fa4327e79bb77bcd98e1213dfe56acaefd09` completed successfully on `run_attempt=1` in
+approximately 23m09s. Security, Verified Signatures, Node 22, Node 24, Build, E2E, Deep E2E,
+Storybook, Visual Regression, Lighthouse, and `✅ CI Success` all completed successfully; the
+Tauri Rust and Core Rust gates were correctly skipped for this docs-only merge. CodeQL run
+`32657261084` also succeeded on the same head.
+
+The run logs provide explicit primary-key cache-hit and restoration evidence for the shared
+pnpm/Node cache and the applicable Playwright browser and APT caches. Historical cache hit/miss
+distribution remains `UNKNOWN`, and this checkpoint adds no failure, cancellation, rerun,
+lane-exclusive, or downstream unique-defect signal. No H1-B decision is made.

--- a/docs/audit/H1-CI-MEASUREMENT-REPORT.md
+++ b/docs/audit/H1-CI-MEASUREMENT-REPORT.md
@@ -237,6 +237,54 @@ signatures, and `✅ CI Success`. It contributes no new failure, cancellation, r
 lane-exclusive defect signal. The original sample's unique Node/advisory defect signal therefore
 remains `UNKNOWN`, and H1-B authority decisions remain pending.
 
+## Post-#475 main checkpoint
+
+This is a third separate `POST_MERGE_CHECKPOINT` evidence class. It follows the normal protected
+squash merge of PR #475 and is not appended to, substituted for, or used to recalculate either the
+original 50-run sample or the earlier checkpoints.
+
+| Field | Value |
+| --- | --- |
+| Workflow run | `32657261089` (`CI / CD`) |
+| Event | `push` |
+| Head SHA | `3378fa4327e79bb77bcd98e1213dfe56acaefd09` |
+| Run attempt | `1` |
+| Created / started | `2026-08-23T18:11:50Z` / `2026-08-23T18:11:50Z` |
+| Completed | `2026-08-23T18:34:59Z` |
+| Conclusion | `success` |
+| CodeQL | Run `32657261084`, push on the same head, attempt `1`, success |
+
+The checkpoint wall-clock was approximately 23m09s. Job timing from the immutable job records was:
+
+| Job | Started | Completed | Duration |
+| --- | --- | --- | ---: |
+| Security Audit | 18:11:52Z | 18:12:39Z | 0m47s |
+| Verified Signatures | 18:12:41Z | 18:12:52Z | 0m11s |
+| Quality Gate (Node 24) | 18:12:41Z | 18:24:02Z | 11m21s |
+| Quality Gate (Node 22) | 18:12:41Z | 18:25:55Z | 13m14s |
+| Build | 18:25:57Z | 18:27:47Z | 1m50s |
+| E2E Deep Coverage | 18:25:57Z | 18:28:22Z | 2m25s |
+| Storybook | 18:25:57Z | 18:27:36Z | 1m39s |
+| Visual Regression | 18:27:50Z | 18:29:16Z | 1m26s |
+| Lighthouse CI | 18:27:49Z | 18:30:01Z | 2m12s |
+| E2E Tests | 18:25:58Z | 18:34:53Z | 8m55s |
+| `✅ CI Success` | 18:34:56Z | 18:34:58Z | 0m02s |
+
+The Tauri Rust and Core Rust gates were correctly skipped for this documentation-only merge.
+Security, signatures, both Node lanes, Build, E2E, Deep E2E, Storybook, Visual Regression,
+Lighthouse, and `✅ CI Success` all completed successfully.
+
+The logs explicitly reported primary-key cache hits and successful restoration for the shared
+pnpm/Node cache in Security, both quality lanes, Build, E2E, Deep E2E, Storybook, Lighthouse, and
+Visual Regression. E2E and Deep E2E also restored the Playwright browser and APT caches; Storybook
+and Visual Regression restored their Playwright/apt caches where configured. Post-run logs reported
+primary-key hits rather than new cache saves. This is checkpoint evidence only; the historical
+50-run cache distribution remains `UNKNOWN`.
+
+This checkpoint is within the original workflow-wall-clock P95 and adds no failure, cancellation,
+rerun, lane-exclusive, or downstream unique-defect signal. The original sample's unique signal
+therefore remains `UNKNOWN`, and no H1-B authority decision is made.
+
 ## Timing measurements
 
 Durations are calculated from GitHub-created timestamps and job start/completion timestamps. Runner

--- a/docs/audit/POST-V1.28.1-PERFECTION-PROGRAM-STATE.md
+++ b/docs/audit/POST-V1.28.1-PERFECTION-PROGRAM-STATE.md
@@ -9,11 +9,11 @@ separates locally implemented evidence from hosted or merge-dependent evidence.
 | --- | --- |
 | Program boundary | Post-v1.28.1; immutable release boundary preserved |
 | Current stage | H1-A signal/timing/cache/rerun evidence integrated for the observable sample + H1-F0 governance inventory active; H0 remains complete |
-| Local state | This evidence branch preserves the original 50-run sample and records separate post-#473 `32648286172` and post-#474 `32654048692` checkpoints; no Node lane, required-status, DAG, build, or advisory policy change made |
-| Last reconciled main checkpoint | `8223d04e0b51443c6490695b0d08a4189bffe3ee` (post-#474 verified main at the recorded checkpoint; not a perpetual live-main claim) |
-| Latest completed PR / branch | PR #474 merged from `h1-a-remaining-signal-evidence`; final PR head `d53aabfd9c3d06bd7c02610127548352d6d9b2da` |
-| Latest completed merge | `8223d04e0b51443c6490695b0d08a4189bffe3ee`; resulting tree `6ab3a6143f872be2da2e1509225deca759b0bc7f`; merged `2026-08-23T17:11:42Z` |
-| Hosted CI / CodeQL / Security | PR #474 final head `d53aabfd…` merged normally; PR CI `32652726821`, PR CodeQL `32652726773`; fresh main CI `32654048692` and CodeQL `32654048709` were successful on merge SHA `8223d04e…`, including `✅ CI Success` |
+| Local state | This evidence branch preserves the original 50-run sample and records separate post-#473 `32648286172`, post-#474 `32654048692`, and post-#475 `32657261089` checkpoints; no Node lane, required-status, DAG, build, or advisory policy change made |
+| Last reconciled main checkpoint | `3378fa4327e79bb77bcd98e1213dfe56acaefd09` (post-#475 verified main at the recorded checkpoint; not a perpetual live-main claim) |
+| Latest completed PR / branch | PR #475 merged from `h1-a-unique-signal-evidence`; final PR head `c088318c4c434b5e2238ce26db1804e290b4f493` |
+| Latest completed merge | `3378fa4327e79bb77bcd98e1213dfe56acaefd09`; resulting tree `d09334ae0e691d5d5cef8f214717a50634946f68`; merged `2026-08-23T18:11:48Z` |
+| Hosted CI / CodeQL / Security | PR #475 final head `c088318c…` merged normally; PR CI `32655915753`, PR CodeQL `32655915784`; fresh main CI `32657261089` and CodeQL `32657261084` were successful on merge SHA `3378fa43…`, including `✅ CI Success` |
 | Affected issues | None claimed closed or remediated by H0 |
 | Release impact | None; no tag, release, updater metadata, or published asset changed |
 
@@ -60,12 +60,14 @@ The first evidence-only H1 slice is also recorded with immutable evidence. Its m
 | H1-A measurement evidence | #472 | `87d8273c02f9598d3f37a2d5c6280fcfcc017228` | `5f4cd85faf853370a958955e88a0f3afebc03907` | `5f4cd85faf853370a958955e88a0f3afebc03907` / tree `da90504d11857359ed167ce6f48af8d3a3c1be6e` | PR CI `32640865997`; post-merge main CI `32642666084`; CodeQL `32642666044`; current-head review threads resolved; squash commit GitHub Verified | Classify sampled failures/cancellations and unique lane/advisory signal before any H1-B/DAG decision |
 | H1-A failure/signal evidence | #473 | `41099f89b1617ac646d78a415609a8e0b32b7ade` | `a536aeebc09f97b45a3094e05c51dfa8e32922df` | `a536aeebc09f97b45a3094e05c51dfa8e32922df` / tree `9cd48b1c78104eb75fcf782431819e4d58935d89` | PR CI `32646942326`; post-merge main CI `32648286172`; CodeQL `32648286205`; 9 failures and 15 cancellations classified; unique signal remains `UNKNOWN` | Preserve the separate post-#473 checkpoint and do not advance H1-B without unique-signal authority evidence |
 | H1-A checkpoint reconciliation | #474 | `d53aabfd9c3d06bd7c02610127548352d6d9b2da` | `8223d04e0b51443c6490695b0d08a4189bffe3ee` | `8223d04e0b51443c6490695b0d08a4189bffe3ee` / tree `6ab3a6143f872be2da2e1509225deca759b0bc7f` | PR CI `32652726821`; PR CodeQL `32652726773`; post-merge main CI `32654048692`; CodeQL `32654048709`; corrected ledger checkpoint, fresh main run ~22m17s, cache hits recorded, GitHub Verified | Continue H1-A evidence only where it can classify unique signal or historical cache/rerun behavior; do not advance H1-B/DAG authority |
+| H1-A post-#475 checkpoint evidence | #475 | `c088318c4c434b5e2238ce26db1804e290b4f493` | `3378fa4327e79bb77bcd98e1213dfe56acaefd09` | `3378fa4327e79bb77bcd98e1213dfe56acaefd09` / tree `d09334ae0e691d5d5cef8f214717a50634946f68` | PR CI `32655915753`; PR CodeQL `32655915784`; post-merge main CI `32657261089`; CodeQL `32657261084`; fresh main run ~23m09s, explicit cache hits, GitHub Verified | Preserve original sample and separate checkpoints; historical cache distribution and unique signal remain `UNKNOWN`; do not advance H1-B/DAG authority |
 
 ## Next exact resume procedure
 
 1. Preserve the original 50-run sample and the separate `POST_MERGE_CHECKPOINT` evidence for
-   #473 and #474; all 50 sample runs and both checkpoints are first attempts (`run_attempt=1`).
-2. Preserve the observed Node-22/24 overlap, explicit cache hits on both post-merge checkpoints,
+   #473, #474, and #475; all 50 sample runs and all three checkpoints are first attempts
+   (`run_attempt=1`).
+2. Preserve the observed Node-22/24 overlap, explicit cache hits on all three post-merge checkpoints,
    historical cache `UNKNOWN`, and the `UNKNOWN` downstream unique-signal state; do not infer a
    lane decision from timing or correlated outcomes alone.
 3. Keep H1-F0 inventory current and defer H1-F1 canonicalization until H1-A through H1-E decisions


### PR DESCRIPTION
## **User description**
## Summary
- record the verified post-#475 main CI and CodeQL checkpoint
- preserve the original 50-run sample and earlier checkpoints as immutable evidence classes
- keep historical cache distribution and unique downstream signal explicitly UNKNOWN

## Scope
Evidence-only H1-A documentation. No Node lane, required-status, DAG, build, release, or advisory policy changes.

## Summary by Sourcery

Record the verified post-#475 CI checkpoint without changing workflow, policy, or H1-B authority decisions.

Enhancements:
- Record a separate post-#475 main CI and CodeQL checkpoint with successful job, timing, and cache observations while preserving earlier evidence classes and unresolved signal classifications.

Documentation:
- Document the verified post-#475 merge checkpoint and update the program state and resume procedure to include it.


___

## **CodeAnt-AI Description**
Record the verified post-#475 CI and CodeQL checkpoint

### What Changed
- Documents a successful post-#475 main CI run and CodeQL scan, including job results, timings, and cache restoration observations
- Adds the checkpoint as a separate evidence record without changing the original 50-run sample or earlier checkpoints
- Updates the program state and resume procedure to include the third checkpoint while keeping historical cache distribution and unique downstream signal unresolved
- Confirms that no H1-B or workflow policy decision is made

### Impact
`✅ Verifiable post-merge CI evidence`
`✅ Preserved historical checkpoint records`
`✅ Clearer audit status for pending H1-B decisions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added audit records for the latest post-merge checkpoint, including CI and CodeQL outcomes, job timings, cache evidence, and skipped validation gates.
  * Updated the quality-program ledger with merge, security, and repository evidence.
  * Expanded checkpoint tracking to include the latest reviewed changes alongside prior checkpoints.
  * Confirmed that no new failure or defect signals were identified and that the existing decision status remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->