### PR TITLE
docs: record updater verification residual risk

### DIFF
--- a/docs/RELEASE-V1.28.1-EVIDENCE.md
+++ b/docs/RELEASE-V1.28.1-EVIDENCE.md
@@ -1,6 +1,7 @@
 # v1.28.1 release evidence ledger
 
-Status: published and independently verified release checkpoint.
+Status: published release checkpoint with structural and asset verification; independent updater
+cryptographic verification remains an H1-E residual risk.
 
 ## Verified release base
 

--- a/docs/RELEASE-V1.28.1-EVIDENCE.md
+++ b/docs/RELEASE-V1.28.1-EVIDENCE.md
@@ -1,7 +1,7 @@
 # v1.28.1 release evidence ledger
 
-Status: published release checkpoint with structural and asset verification; independent updater
-cryptographic verification remains an H1-E residual risk.
+Status: published release checkpoint with structural, asset, and independent updater-payload
+cryptographic verification; platform code-signing and notarization remain separate claims.
 
 ## Verified release base
 
@@ -115,10 +115,13 @@ Deterministic release notes were extracted from the committed `v1.28.1` changelo
 pending status of #332 and #341 and make no unsupported macOS Intel claim.
 
 The installed official toolchain is `tauri-cli 2.11.4`. It exposes `tauri signer sign` and
-`tauri signer generate`, but no artifact verification command; neither `minisign` nor `signify`
-is installed. Accordingly, structural, asset, URL, version, HTTP, and non-empty-signature checks
-are complete, but this checkpoint does not claim independent cryptographic verification of the
-updater artifacts. No private key material was accessed or exposed.
+`tauri signer generate`, but no standalone artifact verification command; neither `minisign` nor
+`signify` is installed. H1-E therefore uses the production-compatible `minisign-verify 0.2.5`
+library already selected by `tauri-plugin-updater 2.10.1`, through the development-only audit
+harness documented in [`H1-E-UPDATER-VERIFICATION-REPORT.md`](audit/H1-E-UPDATER-VERIFICATION-REPORT.md).
+The Linux, Windows, and macOS ARM updater payloads each verified successfully; tampered bytes,
+an unrelated public key, and cross-substituted signatures were rejected. No private key material
+was accessed or exposed.
 
 The source-signing control (every introduced source commit GitHub Verified) and release-tag
 signing control (the annotated tag object plus its target commit) are separate evidence items.

--- a/docs/audit/H1-DEVOPS-GOVERNANCE-INVENTORY.md
+++ b/docs/audit/H1-DEVOPS-GOVERNANCE-INVENTORY.md
@@ -1,7 +1,7 @@
 # H1-F0 DevOps and governance inventory
 
-Status: evidence inventory in progress; H1-A failure/signal evidence is now recorded; no H1-B/C/D/E
-decision is claimed here.
+Status: evidence inventory in progress; H1-A failure/signal evidence is recorded and H1-E updater
+verification capability has been re-audited; no H1-B/C/D decision is claimed here.
 
 Captured from a verified `main` checkpoint on 2026-08-23, branch
 `h1-a-f0-evidence`, based on `c91e37691409aa4b5febbf527219c891256b6487`.
@@ -50,7 +50,7 @@ query in a later session:
 | --- | --- | --- | --- |
 | `.github/workflows/ci.yml` | Push, pull-request, and dispatch workflow with Security, path classification, Verified Signatures, Node 22/24 Quality matrix, path-scoped Rust gates, Build, browser/release evidence jobs, and fail-closed `✅ CI Success` aggregation | CURRENT; MACHINE-DERIVABLE | H1-A measures before H1-B changes the DAG or lane authority |
 | `.github/workflows/codeql.yml` | Push, pull-request, and weekly scheduled JavaScript/TypeScript CodeQL analysis; job-scoped `security-events: write` | CURRENT; MACHINE-DERIVABLE | Preserve as independent security evidence |
-| `.github/workflows/tauri-build.yml` | Workflow dispatch and `v*` tag triggers; Linux, Windows, and `macos-latest` bundle matrix; release publication and updater metadata | CURRENT; MACHINE-DERIVABLE | H1-D/E qualify future Intel/verifier claims; do not mutate v1.28.1 |
+| `.github/workflows/tauri-build.yml` | Workflow dispatch and `v*` tag triggers; Linux, Windows, and `macos-latest` bundle matrix; release publication and updater metadata | CURRENT; MACHINE-DERIVABLE | H1-D owns non-publishing Intel qualification; H1-E records verifier residual risk; do not mutate v1.28.1 |
 | `.github/workflows/mutation.yml` | Manual `workflow_dispatch`; incremental/force modes and scoped matrix | CURRENT; MACHINE-DERIVABLE | H2 owns mutation evidence |
 | Scheduled/support workflows | `security-scheduled.yml`, `scorecard.yml`, `voice-nightly.yml`, `prune-deployments.yml`, `docker.yml`, and debug/deploy surfaces also exist | CURRENT; TIME-SENSITIVE | Include trigger/permission review in H1-F1 |
 | `.github/actions/setup/action.yml` | Shared Node/pnpm/install setup action | CURRENT; MACHINE-DERIVABLE | Treat as Level 0 toolchain authority |
@@ -88,7 +88,7 @@ query in a later session:
 | Intel macOS runner assumptions | P2 | Tauri workflow currently publishes only `macos-latest`; comments record removed Intel hosting and no qualification path | CURRENT pending state; MACHINE-DERIVABLE | H1-D owns non-publishing qualification; no production support claim |
 | Reviewer role/availability assumptions | P2 | Live #470 showed CodeRabbit/Amazon Q/CodeAnt evidence, Qodo billing-blocked, Sourcery rate-limited | EXTERNAL and TIME-SENSITIVE | Canonical registry must distinguish silence, quota, billing, pending, and substantive review |
 | Required/advisory duplication | P1 | Branch protection requires `✅ CI Success`; docs and workflow separately describe advisory jobs and aggregator semantics | DUPLICATED, MACHINE-DERIVABLE | H1-B decides final semantics; H1-F1 documents layers separately |
-| Signing terminology ambiguity | P1 | Source signatures, GitHub squash verification, tag signing, updater signatures, Apple signing, and notarization appear in separate surfaces | DUPLICATED/NOT-AUTHORITATIVE when collapsed | Canonical release/trust model in H1-F1 after H1-E evidence |
+| Signing terminology ambiguity | P1 | Source signatures, GitHub squash verification, tag signing, updater signatures, Apple signing, and notarization appear in separate surfaces | DUPLICATED/NOT-AUTHORITATIVE when collapsed | H1-E report records updater verification as residual risk; canonical release/trust model remains H1-F1 work |
 | Merge-state quirks mixed with policy | P1 | #469 and older audit records show `BLOCKED` presentation despite normal server merge; older docs describe admin fallback | HISTORICAL evidence mixed with current policy | Preserve #469 as an observed instance; never make REST or admin a universal rule |
 | Current versus historical CI audits | P2/P3 | `.github/CI-AUDIT.md`, `.github/ACTIONS-OPTIMIZATIONS.md`, and dated handoffs contain snapshots | HISTORICAL/AUDIT | Label and link; preserve accurate historical evidence |
 | Git/GitHub sandbox assumptions | P1 | H0 restricted sandbox had read-only `.git`/blocked API; authorized context passed probes and signed push | EXTERNAL execution-environment incident | Canonical preflight must detect and classify this before long PR-producing work |
@@ -96,8 +96,9 @@ query in a later session:
 ## H1-F0 boundaries and next work
 
 This inventory does not decide the Node canonical lane, required/advisory promotion, build
-authority, Intel production support, or independent updater verification. Those decisions require
-H1-A through H1-E evidence. It does not authorize H2/H3/H4/H7 implementation, release work,
+authority, or Intel production support. H1-E verifier capability has been re-audited and remains
+`PARTIAL / RESIDUAL RISK`; the independent cryptographic claim is not made. The remaining
+decisions require H1-A through H1-D evidence. It does not authorize H2/H3/H4/H7 implementation, release work,
 product changes, Qt/GPUI work, licensing, or #332/#341 remediation.
 
 The current evidence record and next tasks are:
@@ -112,7 +113,10 @@ The current evidence record and next tasks are:
    cherry-picking only green runs; use a future meaningful H1 PR to reconcile the checkpoint and
    inventory as needed, never a
    recursive ledger-only PR;
-4. defer H1-F1 canonical docs and H1-F2 agent synchronization until the relevant H1 decisions are
+4. retain [`H1-E-UPDATER-VERIFICATION-REPORT.md`](H1-E-UPDATER-VERIFICATION-REPORT.md) as the
+   authoritative H1-E capability result: no verifier was available, so the release claim remains
+   structural-only with residual risk;
+5. defer H1-F1 canonical docs and H1-F2 agent synchronization until the relevant H1 decisions are
    verified, except for the early admin-bypass safety correction already made here.
 
 ## Resume invariant

--- a/docs/audit/H1-DEVOPS-GOVERNANCE-INVENTORY.md
+++ b/docs/audit/H1-DEVOPS-GOVERNANCE-INVENTORY.md
@@ -1,7 +1,7 @@
 # H1-F0 DevOps and governance inventory
 
 Status: evidence inventory in progress; H1-A failure/signal evidence is recorded and H1-E updater
-verification capability has been re-audited; no H1-B/C/D decision is claimed here.
+payload verification is `PASS`; no H1-B/C/D decision is claimed here.
 
 Captured from a verified `main` checkpoint on 2026-08-23, branch
 `h1-a-f0-evidence`, based on `c91e37691409aa4b5febbf527219c891256b6487`.
@@ -50,7 +50,7 @@ query in a later session:
 | --- | --- | --- | --- |
 | `.github/workflows/ci.yml` | Push, pull-request, and dispatch workflow with Security, path classification, Verified Signatures, Node 22/24 Quality matrix, path-scoped Rust gates, Build, browser/release evidence jobs, and fail-closed `✅ CI Success` aggregation | CURRENT; MACHINE-DERIVABLE | H1-A measures before H1-B changes the DAG or lane authority |
 | `.github/workflows/codeql.yml` | Push, pull-request, and weekly scheduled JavaScript/TypeScript CodeQL analysis; job-scoped `security-events: write` | CURRENT; MACHINE-DERIVABLE | Preserve as independent security evidence |
-| `.github/workflows/tauri-build.yml` | Workflow dispatch and `v*` tag triggers; Linux, Windows, and `macos-latest` bundle matrix; release publication and updater metadata | CURRENT; MACHINE-DERIVABLE | H1-D owns non-publishing Intel qualification; H1-E records verifier residual risk; do not mutate v1.28.1 |
+| `.github/workflows/tauri-build.yml` | Workflow dispatch and `v*` tag triggers; Linux, Windows, and `macos-latest` bundle matrix; release publication and updater metadata | CURRENT; MACHINE-DERIVABLE | H1-D owns non-publishing Intel qualification; H1-E verifier evidence is complete; do not mutate v1.28.1 |
 | `.github/workflows/mutation.yml` | Manual `workflow_dispatch`; incremental/force modes and scoped matrix | CURRENT; MACHINE-DERIVABLE | H2 owns mutation evidence |
 | Scheduled/support workflows | `security-scheduled.yml`, `scorecard.yml`, `voice-nightly.yml`, `prune-deployments.yml`, `docker.yml`, and debug/deploy surfaces also exist | CURRENT; TIME-SENSITIVE | Include trigger/permission review in H1-F1 |
 | `.github/actions/setup/action.yml` | Shared Node/pnpm/install setup action | CURRENT; MACHINE-DERIVABLE | Treat as Level 0 toolchain authority |
@@ -69,7 +69,7 @@ query in a later session:
 | `.cursorrules`, `.cursor/rules/**` | Cursor-wide and topic-specific architecture/testing instructions | CURRENT architecture plus DUPLICATED policy | Inventory retained; thin entrypoint work in H1-F2 |
 | `.github/CONTRIBUTING.md` | Contributor workflow entrypoint | CURRENT contributor surface; completeness to verify | Align after canonical H1-F1 model exists |
 | `docs/CI.md`, `docs/CODE_QUALITY.md`, `docs/BEST-PRACTICES.md` | Current-facing CI, quality, and metrics prose with some duplicated thresholds/metrics | CURRENT plus P2 documentation drift candidates | Correct against executable config after H1-A/B evidence |
-| `docs/TAURI-CI.md` and release/security docs | Desktop/release trust and native guidance | CURRENT plus H1-D/E pending claims | Keep Intel/updater status explicitly pending until qualified |
+| `docs/TAURI-CI.md` and release/security docs | Desktop/release trust and native guidance | CURRENT plus H1-D pending claims | Keep Intel status explicitly pending; retain H1-E verifier evidence and separate platform-signing limits |
 | `docs/CODEANT-REVIEW-LOOP.md` and `docs/DEEPSOURCE-REVIEW-LOOP.md` | Review procedures; historical admin fallback language found | P1 process drift where presented as current policy | Corrected in this slice; external availability remains time-sensitive |
 | `.github/CI-AUDIT.md`, `.github/ACTIONS-OPTIMIZATIONS.md` | Audit/optimization snapshots | HISTORICAL or audit evidence unless explicitly current | Label/link from canonical docs; do not rewrite history |
 | `docs/audit/**`, `docs/history/**`, session handoffs | Mixed stage evidence, historical plans, and handoffs | HISTORICAL, IMMUTABLE EVIDENCE, or NOT-AUTHORITATIVE by file | Classify per file before any later truth sweep |
@@ -88,7 +88,7 @@ query in a later session:
 | Intel macOS runner assumptions | P2 | Tauri workflow currently publishes only `macos-latest`; comments record removed Intel hosting and no qualification path | CURRENT pending state; MACHINE-DERIVABLE | H1-D owns non-publishing qualification; no production support claim |
 | Reviewer role/availability assumptions | P2 | Live #470 showed CodeRabbit/Amazon Q/CodeAnt evidence, Qodo billing-blocked, Sourcery rate-limited | EXTERNAL and TIME-SENSITIVE | Canonical registry must distinguish silence, quota, billing, pending, and substantive review |
 | Required/advisory duplication | P1 | Branch protection requires `✅ CI Success`; docs and workflow separately describe advisory jobs and aggregator semantics | DUPLICATED, MACHINE-DERIVABLE | H1-B decides final semantics; H1-F1 documents layers separately |
-| Signing terminology ambiguity | P1 | Source signatures, GitHub squash verification, tag signing, updater signatures, Apple signing, and notarization appear in separate surfaces | DUPLICATED/NOT-AUTHORITATIVE when collapsed | H1-E report records updater verification as residual risk; canonical release/trust model remains H1-F1 work |
+| Signing terminology ambiguity | P1 | Source signatures, GitHub squash verification, tag signing, updater signatures, Apple signing, and notarization appear in separate surfaces | DUPLICATED/NOT-AUTHORITATIVE when collapsed | H1-E now records updater-payload verification as PASS; canonical release/trust model remains H1-F1 work |
 | Merge-state quirks mixed with policy | P1 | #469 and older audit records show `BLOCKED` presentation despite normal server merge; older docs describe admin fallback | HISTORICAL evidence mixed with current policy | Preserve #469 as an observed instance; never make REST or admin a universal rule |
 | Current versus historical CI audits | P2/P3 | `.github/CI-AUDIT.md`, `.github/ACTIONS-OPTIMIZATIONS.md`, and dated handoffs contain snapshots | HISTORICAL/AUDIT | Label and link; preserve accurate historical evidence |
 | Git/GitHub sandbox assumptions | P1 | H0 restricted sandbox had read-only `.git`/blocked API; authorized context passed probes and signed push | EXTERNAL execution-environment incident | Canonical preflight must detect and classify this before long PR-producing work |
@@ -96,9 +96,9 @@ query in a later session:
 ## H1-F0 boundaries and next work
 
 This inventory does not decide the Node canonical lane, required/advisory promotion, build
-authority, or Intel production support. H1-E verifier capability has been re-audited and remains
-`PARTIAL / RESIDUAL RISK`; the independent cryptographic claim is not made. The remaining
-decisions require H1-A through H1-D evidence. It does not authorize H2/H3/H4/H7 implementation, release work,
+authority, or Intel production support. H1-E updater-payload verification is `PASS` using the
+production-compatible `minisign-verify 0.2.5` path and its positive/negative artifact matrix. The
+remaining H1 decisions require H1-A through H1-D evidence. It does not authorize H2/H3/H4/H7 implementation, release work,
 product changes, Qt/GPUI work, licensing, or #332/#341 remediation.
 
 The current evidence record and next tasks are:
@@ -114,8 +114,8 @@ The current evidence record and next tasks are:
    inventory as needed, never a
    recursive ledger-only PR;
 4. retain [`H1-E-UPDATER-VERIFICATION-REPORT.md`](H1-E-UPDATER-VERIFICATION-REPORT.md) as the
-   authoritative H1-E capability result: no verifier was available, so the release claim remains
-   structural-only with residual risk;
+   authoritative H1-E capability result: updater-payload verification is `PASS`; keep platform
+   code-signing, notarization, and Intel qualification as separate evidence questions;
 5. defer H1-F1 canonical docs and H1-F2 agent synchronization until the relevant H1 decisions are
    verified, except for the early admin-bypass safety correction already made here.
 

--- a/docs/audit/H1-E-UPDATER-VERIFICATION-REPORT.md
+++ b/docs/audit/H1-E-UPDATER-VERIFICATION-REPORT.md
@@ -1,7 +1,7 @@
 # H1-E updater artifact verification report
 
-Status: `PARTIAL / RESIDUAL RISK` — structural release evidence is complete, but independent
-cryptographic verification of the historical updater artifacts is not established.
+Status: `PASS` — the historical updater artifacts independently verify with the same
+`minisign-verify 0.2.5` library used by the production Tauri updater path.
 
 ## Scope and immutable release boundary
 
@@ -30,7 +30,8 @@ The existing release ledger establishes that:
   verified by GitHub.
 
 Those facts establish asset identity and publication structure. They do not establish that the
-payload bytes verify against the updater public key.
+payload bytes verify against the updater public key until the verification evidence below is
+considered.
 
 ## Verifier capability audit
 
@@ -41,25 +42,46 @@ The authorized verification environment was checked against the installed reposi
 | Tauri CLI | `tauri-cli 2.11.4`; exposes signer generation/signing, not artifact verification |
 | `minisign` executable | Not installed |
 | `signify` executable | Not installed |
+| Production-compatible verifier | `minisign-verify 0.2.5`, already locked transitively through `tauri-plugin-updater 2.10.1` |
 | Private signing key access | Not performed |
-| Independent public-key verification | Not completed |
+| Independent public-key verification | Completed with the production-compatible library |
 
-No compatible, trustworthy verifier already available in the repository or authorized environment
-was identified. Implementing a verifier here would risk inventing or misapplying cryptography; adding
-an unreviewed replacement is outside this evidence correction.
+The audit harness in `src-tauri/examples/verify-updater-artifact.rs` follows the production updater
+implementation: it Base64-decodes the configured public-key text, decodes the Minisign public key,
+Base64-decodes the release signature text, decodes the Minisign signature, and calls
+`PublicKey::verify(..., true)`. The `true` value preserves the production plugin's legacy-signature
+compatibility behavior. The verifier is a development-only audit dependency; it does not change
+runtime updater behavior or access private signing material.
+
+## Verification results
+
+The harness was run against the immutable release assets represented by `latest.json`:
+
+| Test | Result |
+| --- | --- |
+| Linux AppImage + matching signature | `PASS` |
+| Windows setup executable + matching signature | `PASS` |
+| macOS ARM updater `app.tar.gz` + matching signature | `PASS` |
+| Tampered Linux artifact | `PASS` — rejected |
+| Linux artifact with unrelated public key | `PASS` — rejected |
+| Linux artifact with Windows signature | `PASS` — rejected |
+
+No release tag, asset, manifest, or private key was modified or accessed.
 
 ## Negative-test status
 
-The required tampered-artifact, wrong-key, and cross-substitution tests are `PENDING` because no
-trustworthy compatible verifier is available to execute them. They must be run together with the
-positive checks if H1-E later admits a verifier. No successful signature claim is inferred from a
-non-empty `.sig` file, the presence of a public key, or GitHub commit/tag verification.
+The negative tests reject altered bytes, an unrelated public key, and a signature belonging to a
+different artifact. This is independent updater-payload cryptographic evidence; it is not evidence
+of Apple Developer ID signing, notarization, Windows Authenticode, source-commit signing, or tag
+signing.
 
 ## Decision and next gate
 
-H1-E remains `PARTIAL / RESIDUAL RISK`, not `PASS`. The repository must not claim independent
-cryptographic updater verification until a trustworthy compatible public-key verifier is selected
-and the three positive plus three negative artifact tests pass without private-key access.
+H1-E is `PASS` for the scoped updater-payload verification requirement. The repository may claim
+independent cryptographic verification of these three historical updater payloads using the
+configured public key and production-compatible verifier, while retaining the separate platform
+code-signing and notarization limitations.
 
-This does not block unrelated H1 evidence work. It does block any documentation or release claim
-that calls the historical updater artifacts independently cryptographically verified.
+This does not block unrelated H1 evidence work. Claims beyond updater-payload verification, such as
+platform code signing or notarization, still require their own evidence and must not be inferred
+from this result.

--- a/docs/audit/H1-E-UPDATER-VERIFICATION-REPORT.md
+++ b/docs/audit/H1-E-UPDATER-VERIFICATION-REPORT.md
@@ -1,0 +1,65 @@
+# H1-E updater artifact verification report
+
+Status: `PARTIAL / RESIDUAL RISK` — structural release evidence is complete, but independent
+cryptographic verification of the historical updater artifacts is not established.
+
+## Scope and immutable release boundary
+
+This report evaluates the published, immutable `v1.28.1` release only. It does not modify the tag,
+release assets, `latest.json`, or any private signing material. The target artifacts are the three
+updater payloads represented in the published manifest:
+
+| Platform | Payload | Signature |
+| --- | --- | --- |
+| `linux-x86_64` | `WorldScript.Studio_1.28.1_amd64.AppImage` | matching `.sig` |
+| `windows-x86_64` | `WorldScript.Studio_1.28.1_x64-setup.exe` | matching `.sig` |
+| `darwin-aarch64` | `WorldScript.Studio.app.tar.gz` | matching `.sig` |
+
+The release has no `darwin-x86_64` entry and no Intel artifact is inferred or added.
+
+## Evidence established
+
+The existing release ledger establishes that:
+
+- the immutable versioned release URLs resolve to the expected `v1.28.1` assets;
+- `latest.json` has the expected version and platform mappings;
+- each listed updater payload has a matching non-empty `.sig` asset;
+- the updater public key configured in `src-tauri/tauri.conf.json` is recorded without exposing a
+  private key;
+- source commit verification, the annotated release tag, and the tag target were independently
+  verified by GitHub.
+
+Those facts establish asset identity and publication structure. They do not establish that the
+payload bytes verify against the updater public key.
+
+## Verifier capability audit
+
+The authorized verification environment was checked against the installed repository toolchain:
+
+| Capability | Result |
+| --- | --- |
+| Tauri CLI | `tauri-cli 2.11.4`; exposes signer generation/signing, not artifact verification |
+| `minisign` executable | Not installed |
+| `signify` executable | Not installed |
+| Private signing key access | Not performed |
+| Independent public-key verification | Not completed |
+
+No compatible, trustworthy verifier already available in the repository or authorized environment
+was identified. Implementing a verifier here would risk inventing or misapplying cryptography; adding
+an unreviewed replacement is outside this evidence correction.
+
+## Negative-test status
+
+The required tampered-artifact, wrong-key, and cross-substitution tests are `PENDING` because no
+trustworthy compatible verifier is available to execute them. They must be run together with the
+positive checks if H1-E later admits a verifier. No successful signature claim is inferred from a
+non-empty `.sig` file, the presence of a public key, or GitHub commit/tag verification.
+
+## Decision and next gate
+
+H1-E remains `PARTIAL / RESIDUAL RISK`, not `PASS`. The repository must not claim independent
+cryptographic updater verification until a trustworthy compatible public-key verifier is selected
+and the three positive plus three negative artifact tests pass without private-key access.
+
+This does not block unrelated H1 evidence work. It does block any documentation or release claim
+that calls the historical updater artifacts independently cryptographically verified.

--- a/docs/audit/H1-E-UPDATER-VERIFICATION-REPORT.md
+++ b/docs/audit/H1-E-UPDATER-VERIFICATION-REPORT.md
@@ -50,8 +50,68 @@ The audit harness in `src-tauri/examples/verify-updater-artifact.rs` follows the
 implementation: it Base64-decodes the configured public-key text, decodes the Minisign public key,
 Base64-decodes the release signature text, decodes the Minisign signature, and calls
 `PublicKey::verify(..., true)`. The `true` value preserves the production plugin's legacy-signature
-compatibility behavior. The verifier is a development-only audit dependency; it does not change
-runtime updater behavior or access private signing material.
+compatibility behavior. The harness reads `plugins.updater.pubkey` directly from the checked-in
+`src-tauri/tauri.conf.json`; the positive path cannot be pointed at an arbitrary public key. The
+unrelated key is available only through the explicit `--wrong-key` negative-test option. Negative
+mode accepts only an explicit cryptographic rejection (`Ok(false)`); artifact-read, signature-decode,
+public-key-decode, and other setup errors fail the test. The verifier is a development-only audit
+dependency; it does not change runtime updater behavior or access private signing material.
+
+## Immutable asset acquisition and digest evidence
+
+The verification inputs were fetched from the immutable `v1.28.1` release with the following
+command. `$VERIFY_DIR` was a newly created temporary directory and is shown as
+`/tmp/worldscript-h1e-verify.AgLQxd` below for reproducibility:
+
+```bash
+VERIFY_DIR=/tmp/worldscript-h1e-verify.AgLQxd
+gh release download v1.28.1 --repo qnbs/WorldScript-Studio \
+  --pattern 'WorldScript.Studio_1.28.1_amd64.AppImage' \
+  --pattern 'WorldScript.Studio_1.28.1_amd64.AppImage.sig' \
+  --pattern 'WorldScript.Studio_1.28.1_x64-setup.exe' \
+  --pattern 'WorldScript.Studio_1.28.1_x64-setup.exe.sig' \
+  --pattern 'WorldScript.Studio.app.tar.gz' \
+  --pattern 'WorldScript.Studio.app.tar.gz.sig' \
+  --pattern 'latest.json' \
+  --dir "$VERIFY_DIR"
+sha256sum "$VERIFY_DIR"/*
+```
+
+The local hashes matched the GitHub Release API `digest` for every input. The GitHub asset IDs,
+published sizes, and matched SHA-256 digests are retained here as immutable external anchors:
+
+| Asset | GitHub asset ID | Size | SHA-256 |
+| --- | --- | ---: | --- |
+| `latest.json` | `RA_kwDOQOeAgc4fVw-x` | 1,928 | `06527480219279919002825c631b78d48e35e725f4981d984f0dec02f5643d09` |
+| `WorldScript.Studio.app.tar.gz` | `RA_kwDOQOeAgc4fVw9N` | 84,781,830 | `dd5366e0d47c69c0c3fdbc9351211ebf5d9d59c94bc0ed1bc866155afcda51a3` |
+| `WorldScript.Studio.app.tar.gz.sig` | `RA_kwDOQOeAgc4fVw9J` | 420 | `6d465c73c66585eb548a5d8ab7c7e512d8a05771c001b5635bea73bfd1fa0e32` |
+| `WorldScript.Studio_1.28.1_amd64.AppImage` | `RA_kwDOQOeAgc4fVw9I` | 162,765,304 | `db1a4f7269dd0579ea61824adfd386a107ee286525301e00d4568216ab1a32ee` |
+| `WorldScript.Studio_1.28.1_amd64.AppImage.sig` | `RA_kwDOQOeAgc4fVw9K` | 436 | `87bdbe1f2f66ddff8975634d94e607af8b97564bdf5d57e201a806f3125845fb` |
+| `WorldScript.Studio_1.28.1_x64-setup.exe` | `RA_kwDOQOeAgc4fVw9H` | 83,189,573 | `1582b8979cf9006f07fb2a43ed861658994c525f7498738181487c80ab4c132e` |
+| `WorldScript.Studio_1.28.1_x64-setup.exe.sig` | `RA_kwDOQOeAgc4fVw9F` | 432 | `38a7b896fb292dfbcdba0f0b3798f54387001b34afb47f42936eaf296feca4f7` |
+
+The exact harness invocations were:
+
+```bash
+cargo run --manifest-path src-tauri/Cargo.toml --locked --example verify-updater-artifact -- \
+  "$VERIFY_DIR/WorldScript.Studio_1.28.1_amd64.AppImage" \
+  "$VERIFY_DIR/WorldScript.Studio_1.28.1_amd64.AppImage.sig"
+cargo run --manifest-path src-tauri/Cargo.toml --locked --example verify-updater-artifact -- \
+  "$VERIFY_DIR/WorldScript.Studio_1.28.1_x64-setup.exe" \
+  "$VERIFY_DIR/WorldScript.Studio_1.28.1_x64-setup.exe.sig"
+cargo run --manifest-path src-tauri/Cargo.toml --locked --example verify-updater-artifact -- \
+  "$VERIFY_DIR/WorldScript.Studio.app.tar.gz" \
+  "$VERIFY_DIR/WorldScript.Studio.app.tar.gz.sig"
+cargo run --manifest-path src-tauri/Cargo.toml --locked --example verify-updater-artifact -- \
+  "$VERIFY_DIR/WorldScript.Studio_1.28.1_amd64.AppImage" \
+  "$VERIFY_DIR/WorldScript.Studio_1.28.1_amd64.AppImage.sig" --expect-failure --tamper
+cargo run --manifest-path src-tauri/Cargo.toml --locked --example verify-updater-artifact -- \
+  "$VERIFY_DIR/WorldScript.Studio_1.28.1_amd64.AppImage" \
+  "$VERIFY_DIR/WorldScript.Studio_1.28.1_amd64.AppImage.sig" --expect-failure --wrong-key
+cargo run --manifest-path src-tauri/Cargo.toml --locked --example verify-updater-artifact -- \
+  "$VERIFY_DIR/WorldScript.Studio_1.28.1_amd64.AppImage" \
+  "$VERIFY_DIR/WorldScript.Studio_1.28.1_x64-setup.exe.sig" --expect-failure
+```
 
 ## Verification results
 

--- a/docs/audit/H1-E-UPDATER-VERIFICATION-REPORT.md
+++ b/docs/audit/H1-E-UPDATER-VERIFICATION-REPORT.md
@@ -95,23 +95,36 @@ The exact harness invocations were:
 ```bash
 cargo run --manifest-path src-tauri/Cargo.toml --locked --example verify-updater-artifact -- \
   "$VERIFY_DIR/WorldScript.Studio_1.28.1_amd64.AppImage" \
-  "$VERIFY_DIR/WorldScript.Studio_1.28.1_amd64.AppImage.sig"
+  "$VERIFY_DIR/latest.json" --manifest-platform linux-x86_64
 cargo run --manifest-path src-tauri/Cargo.toml --locked --example verify-updater-artifact -- \
   "$VERIFY_DIR/WorldScript.Studio_1.28.1_x64-setup.exe" \
-  "$VERIFY_DIR/WorldScript.Studio_1.28.1_x64-setup.exe.sig"
+  "$VERIFY_DIR/latest.json" --manifest-platform windows-x86_64
 cargo run --manifest-path src-tauri/Cargo.toml --locked --example verify-updater-artifact -- \
   "$VERIFY_DIR/WorldScript.Studio.app.tar.gz" \
-  "$VERIFY_DIR/WorldScript.Studio.app.tar.gz.sig"
+  "$VERIFY_DIR/latest.json" --manifest-platform darwin-aarch64
 cargo run --manifest-path src-tauri/Cargo.toml --locked --example verify-updater-artifact -- \
   "$VERIFY_DIR/WorldScript.Studio_1.28.1_amd64.AppImage" \
-  "$VERIFY_DIR/WorldScript.Studio_1.28.1_amd64.AppImage.sig" --expect-failure --tamper
+  "$VERIFY_DIR/latest.json" --manifest-platform linux-x86_64 --expect-failure --tamper
 cargo run --manifest-path src-tauri/Cargo.toml --locked --example verify-updater-artifact -- \
   "$VERIFY_DIR/WorldScript.Studio_1.28.1_amd64.AppImage" \
-  "$VERIFY_DIR/WorldScript.Studio_1.28.1_amd64.AppImage.sig" --expect-failure --wrong-key
+  "$VERIFY_DIR/latest.json" --manifest-platform linux-x86_64 --expect-failure --wrong-key
 cargo run --manifest-path src-tauri/Cargo.toml --locked --example verify-updater-artifact -- \
   "$VERIFY_DIR/WorldScript.Studio_1.28.1_amd64.AppImage" \
-  "$VERIFY_DIR/WorldScript.Studio_1.28.1_x64-setup.exe.sig" --expect-failure
+  "$VERIFY_DIR/latest.json" --manifest-platform windows-x86_64 --expect-failure
 ```
+
+Each manifest signature was also compared with its published sidecar after decoding the outer
+Base64 representation. The decoded SHA-256 and byte length matched for all three platforms:
+
+| Platform | Manifest signature decoded SHA-256 | Decoded bytes | Sidecar match |
+| --- | --- | ---: | --- |
+| `linux-x86_64` | `ad52be57357eb0381e7135dda5d49a5367da507a23c080adcbe609ede576a4d3` | 325 | `yes` |
+| `windows-x86_64` | `9aae27463d52dabc9f94598931faef07da90a79b2e636e6d179533c440490c90` | 324 | `yes` |
+| `darwin-aarch64` | `a70ae9536a872be2a41e9b20b0fc698f6f7488d146ba87e917594b9a1f772a02` | 314 | `yes` |
+
+The positive and negative harness cases therefore consume the exact signature strings embedded in
+the immutable published manifest; the sidecar comparison is retained as corroborating release
+asset evidence.
 
 ## Verification results
 

--- a/docs/audit/POST-V1.28.1-PERFECTION-PROGRAM-STATE.md
+++ b/docs/audit/POST-V1.28.1-PERFECTION-PROGRAM-STATE.md
@@ -8,14 +8,14 @@ separates locally implemented evidence from hosted or merge-dependent evidence.
 | Field | Value |
 | --- | --- |
 | Program boundary | Post-v1.28.1; immutable release boundary preserved |
-| Current stage | H1-A signal/timing/cache/rerun evidence integrated for the observable sample + H1-F0 governance inventory active; H0 remains complete |
+| Current stage | H1-A signal/timing/cache/rerun evidence integrated for the observable sample; H1-E updater verification capability re-audited as residual risk; H1-F0 governance inventory active; H0 remains complete |
 | Local state | This evidence branch preserves the original 50-run sample, verifies 0 observed reruns among those IDs, and records separate post-#473 `32648286172`, post-#474 `32654048692`, post-#475 `32657261089`, and post-#476 `32660607709` checkpoints; no Node lane, required-status, DAG, build, or advisory policy change made |
 | Last reconciled main checkpoint | `fdd60c9465d7515dabc713d4e11f8ff2662fc5c4` (post-#476 verified main at the recorded checkpoint; not a perpetual live-main claim) |
 | Latest completed PR / branch | PR #476 merged from `h1-a-failure-cause-evidence`; final PR head `84b5c187ab2040b1edcc7418ae6ee46ee324ffa1` |
 | Latest completed merge | `fdd60c9465d7515dabc713d4e11f8ff2662fc5c4`; resulting tree `f0d24290765c4eb5e132941b2472117e7cfc3316`; merged `2026-08-23T19:14:20Z` |
 | Hosted CI / CodeQL / Security | PR #476 final head `84b5c187…` merged normally; PR CI `32659129361`, PR CodeQL `32659129403`; fresh main CI `32660607709` and CodeQL `32660607683` were successful on merge SHA `fdd60c94…`, including `✅ CI Success`; historical sample rerun count is 0 and historical cache distribution remains `UNKNOWN` |
 | Affected issues | None claimed closed or remediated by H0 |
-| Release impact | None; no tag, release, updater metadata, or published asset changed |
+| Release impact | None; no tag, release, updater metadata, or published asset changed; H1-E evidence confirms that no cryptographic updater claim is being made |
 
 The Git/GitHub access root cause and preflight are recorded in
 [`GIT-GITHUB-ACCESS-RELIABILITY.md`](GIT-GITHUB-ACCESS-RELIABILITY.md). The repository itself did
@@ -73,6 +73,9 @@ The first evidence-only H1 slice is also recorded with immutable evidence. Its m
    lane decision from timing or correlated outcomes alone.
 3. Keep H1-F0 inventory current and defer H1-F1 canonicalization until H1-A through H1-E decisions
    are measured and verified; carry the H1-F DevOps operating-model augmentation as binding.
+4. Preserve [`H1-E-UPDATER-VERIFICATION-REPORT.md`](H1-E-UPDATER-VERIFICATION-REPORT.md): the
+   installed toolchain has no trustworthy artifact verifier, so updater cryptographic verification
+   remains a documented residual risk and must not be claimed as complete.
 
 ## Verification record for the current working tree
 
@@ -95,8 +98,10 @@ The first evidence-only H1 slice is also recorded with immutable evidence. Its m
 
 H0 is complete. H1-A measurement is integrated and failure/cancellation evidence is classified, but
 its lane decision remains pending: the sample shows substantial Node-22/24 overlap and no
-lane-exclusive failure, while unique defect signal remains `UNKNOWN`. Residual risks carried forward are the unavailable independent
-updater verifier, fail-closed bundle-budget work deferred to H2-C, Intel qualification, and the later
+lane-exclusive failure, while unique defect signal remains `UNKNOWN`. H1-E independently re-audited
+the updater verifier gap and records it as `PARTIAL / RESIDUAL RISK`; no cryptographic updater
+verification claim is made. Residual risks carried forward are the unavailable independent updater
+verifier, fail-closed bundle-budget work deferred to H2-C, Intel qualification, and the later
 R-15/native, plugin, collaboration, Scenario, and Qt evidence gates.
 The restricted Codex sandbox incident remains an execution-environment limitation, not repository
 corruption; the authorized writable context completed the signed branch/commit/push and GitHub

--- a/docs/audit/POST-V1.28.1-PERFECTION-PROGRAM-STATE.md
+++ b/docs/audit/POST-V1.28.1-PERFECTION-PROGRAM-STATE.md
@@ -8,14 +8,14 @@ separates locally implemented evidence from hosted or merge-dependent evidence.
 | Field | Value |
 | --- | --- |
 | Program boundary | Post-v1.28.1; immutable release boundary preserved |
-| Current stage | H1-A signal/timing/cache/rerun evidence integrated for the observable sample; H1-E updater verification capability re-audited as residual risk; H1-F0 governance inventory active; H0 remains complete |
+| Current stage | H1-A signal/timing/cache/rerun evidence integrated for the observable sample; H1-E updater-payload verification `PASS`; H1-F0 governance inventory active; H0 remains complete |
 | Local state | This evidence branch preserves the original 50-run sample, verifies 0 observed reruns among those IDs, and records separate post-#473 `32648286172`, post-#474 `32654048692`, post-#475 `32657261089`, and post-#476 `32660607709` checkpoints; no Node lane, required-status, DAG, build, or advisory policy change made |
 | Last reconciled main checkpoint | `fdd60c9465d7515dabc713d4e11f8ff2662fc5c4` (post-#476 verified main at the recorded checkpoint; not a perpetual live-main claim) |
 | Latest completed PR / branch | PR #476 merged from `h1-a-failure-cause-evidence`; final PR head `84b5c187ab2040b1edcc7418ae6ee46ee324ffa1` |
 | Latest completed merge | `fdd60c9465d7515dabc713d4e11f8ff2662fc5c4`; resulting tree `f0d24290765c4eb5e132941b2472117e7cfc3316`; merged `2026-08-23T19:14:20Z` |
 | Hosted CI / CodeQL / Security | PR #476 final head `84b5c187…` merged normally; PR CI `32659129361`, PR CodeQL `32659129403`; fresh main CI `32660607709` and CodeQL `32660607683` were successful on merge SHA `fdd60c94…`, including `✅ CI Success`; historical sample rerun count is 0 and historical cache distribution remains `UNKNOWN` |
 | Affected issues | None claimed closed or remediated by H0 |
-| Release impact | None; no tag, release, updater metadata, or published asset changed; H1-E evidence confirms that no cryptographic updater claim is being made |
+| Release impact | None; no tag, release, updater metadata, or published asset changed; H1-E independently verified the three published updater payloads without private-key access |
 
 The Git/GitHub access root cause and preflight are recorded in
 [`GIT-GITHUB-ACCESS-RELIABILITY.md`](GIT-GITHUB-ACCESS-RELIABILITY.md). The repository itself did
@@ -74,8 +74,9 @@ The first evidence-only H1 slice is also recorded with immutable evidence. Its m
 3. Keep H1-F0 inventory current and defer H1-F1 canonicalization until H1-A through H1-E decisions
    are measured and verified; carry the H1-F DevOps operating-model augmentation as binding.
 4. Preserve [`H1-E-UPDATER-VERIFICATION-REPORT.md`](H1-E-UPDATER-VERIFICATION-REPORT.md): the
-   installed toolchain has no trustworthy artifact verifier, so updater cryptographic verification
-   remains a documented residual risk and must not be claimed as complete.
+   production-compatible `minisign-verify 0.2.5` harness passed all three positive and three
+   negative tests. H1-E is complete for updater-payload verification; platform code-signing,
+   notarization, and Intel qualification remain separate evidence questions.
 
 ## Verification record for the current working tree
 
@@ -98,10 +99,10 @@ The first evidence-only H1 slice is also recorded with immutable evidence. Its m
 
 H0 is complete. H1-A measurement is integrated and failure/cancellation evidence is classified, but
 its lane decision remains pending: the sample shows substantial Node-22/24 overlap and no
-lane-exclusive failure, while unique defect signal remains `UNKNOWN`. H1-E independently re-audited
-the updater verifier gap and records it as `PARTIAL / RESIDUAL RISK`; no cryptographic updater
-verification claim is made. Residual risks carried forward are the unavailable independent updater
-verifier, fail-closed bundle-budget work deferred to H2-C, Intel qualification, and the later
+lane-exclusive failure, while unique defect signal remains `UNKNOWN`. H1-E is `PASS` for independent
+updater-payload verification through the production-compatible verifier; platform code-signing and
+notarization remain separate. Residual risks carried forward are fail-closed bundle-budget work
+deferred to H2-C, Intel qualification, and the later
 R-15/native, plugin, collaboration, Scenario, and Qt evidence gates.
 The restricted Codex sandbox incident remains an execution-environment limitation, not repository
 corruption; the authorized writable context completed the signed branch/commit/push and GitHub

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6691,6 +6691,7 @@ dependencies = [
  "candle-core",
  "candle-nn",
  "log",
+ "minisign-verify",
  "serde",
  "serde_json",
  "tauri",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,6 +42,9 @@ candle-core = { version = "0.11", optional = true }
 candle-nn = { version = "0.11", optional = true }
 worldscript-project = { path = "../crates/worldscript-project" }
 
+[dev-dependencies]
+minisign-verify = "0.2.5"
+
 [profile.release]
 # QNBS-v3: Aggressive size + speed optimizations for desktop bundles
 opt-level = 3

--- a/src-tauri/examples/verify-updater-artifact.rs
+++ b/src-tauri/examples/verify-updater-artifact.rs
@@ -1,4 +1,4 @@
-use std::{env, fs, process};
+use std::{env, fs, path::PathBuf, process};
 
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use minisign_verify::{PublicKey, Signature};
@@ -7,7 +7,7 @@ const WRONG_PUBLIC_KEY_TEXT: &str = "untrusted comment: minisign public key E762
 
 fn usage() -> ! {
     eprintln!(concat!(
-        "usage: verify-updater-artifact <tauri-public-key> <artifact> <signature> ",
+        "usage: verify-updater-artifact <artifact> <signature> ",
         "[--expect-failure] [--tamper] [--wrong-key]"
     ));
     process::exit(2);
@@ -21,16 +21,29 @@ fn decode_configured_public_key(encoded: &str) -> Result<PublicKey, String> {
     PublicKey::decode(&text).map_err(|error| format!("public-key minisign encoding: {error:?}"))
 }
 
+fn configured_public_key() -> Result<PublicKey, String> {
+    let config_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tauri.conf.json");
+    let config_text =
+        fs::read_to_string(&config_path).map_err(|error| format!("Tauri config read: {error}"))?;
+    let config: serde_json::Value = serde_json::from_str(&config_text)
+        .map_err(|error| format!("Tauri config JSON: {error}"))?;
+    let encoded_key = config
+        .pointer("/plugins/updater/pubkey")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| "Tauri config updater.pubkey is missing or not a string".to_string())?;
+    decode_configured_public_key(encoded_key)
+}
+
 fn main() {
     let args: Vec<String> = env::args().skip(1).collect();
-    if args.len() < 3 {
+    if args.len() < 2 {
         usage();
     }
 
     let expect_failure = args.iter().any(|argument| argument == "--expect-failure");
     let tamper = args.iter().any(|argument| argument == "--tamper");
     let wrong_key = args.iter().any(|argument| argument == "--wrong-key");
-    if args.iter().skip(3).any(|argument| {
+    if args.iter().skip(2).any(|argument| {
         !matches!(
             argument.as_str(),
             "--expect-failure" | "--tamper" | "--wrong-key"
@@ -45,11 +58,11 @@ fn main() {
         ));
         decode_configured_public_key(&wrong_key_config)
     } else {
-        decode_configured_public_key(&args[0])
+        configured_public_key()
     };
 
     let verification = public_key.and_then(|public_key| {
-        let mut artifact = fs::read(&args[1]).map_err(|error| format!("artifact read: {error}"))?;
+        let mut artifact = fs::read(&args[0]).map_err(|error| format!("artifact read: {error}"))?;
         if tamper {
             let index = artifact.len() / 2;
             let byte = artifact
@@ -59,7 +72,7 @@ fn main() {
         }
 
         let signature_config =
-            fs::read_to_string(&args[2]).map_err(|error| format!("signature read: {error}"))?;
+            fs::read_to_string(&args[1]).map_err(|error| format!("signature read: {error}"))?;
         let signature_text = STANDARD
             .decode(signature_config.trim())
             .map_err(|error| format!("signature base64: {error}"))
@@ -74,7 +87,11 @@ fn main() {
 
     match (expect_failure, verification) {
         (false, Ok(true)) => println!("verified"),
-        (true, Ok(false)) | (true, Err(_)) => println!("rejected as expected"),
+        (true, Ok(false)) => println!("rejected as expected"),
+        (true, Err(error)) => {
+            eprintln!("verification error in negative test: {error}");
+            process::exit(1);
+        }
         (false, Ok(false)) => {
             eprintln!("signature rejected");
             process::exit(1);

--- a/src-tauri/examples/verify-updater-artifact.rs
+++ b/src-tauri/examples/verify-updater-artifact.rs
@@ -7,8 +7,8 @@ const WRONG_PUBLIC_KEY_TEXT: &str = "untrusted comment: minisign public key E762
 
 fn usage() -> ! {
     eprintln!(concat!(
-        "usage: verify-updater-artifact <artifact> <signature> ",
-        "[--expect-failure] [--tamper] [--wrong-key]"
+        "usage: verify-updater-artifact <artifact> <signature-file-or-manifest> ",
+        "[--manifest-platform <platform>] [--expect-failure] [--tamper] [--wrong-key]"
     ));
     process::exit(2);
 }
@@ -21,6 +21,7 @@ fn decode_configured_public_key(encoded: &str) -> Result<PublicKey, String> {
     PublicKey::decode(&text).map_err(|error| format!("public-key minisign encoding: {error:?}"))
 }
 
+// QNBS-v3: bind audit verification to the production updater key and published manifest data.
 fn configured_public_key() -> Result<PublicKey, String> {
     let config_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tauri.conf.json");
     let config_text =
@@ -34,22 +35,55 @@ fn configured_public_key() -> Result<PublicKey, String> {
     decode_configured_public_key(encoded_key)
 }
 
+fn signature_source(path: &str, manifest_platform: Option<&str>) -> Result<String, String> {
+    let source =
+        fs::read_to_string(path).map_err(|error| format!("signature source read: {error}"))?;
+    let Some(platform) = manifest_platform else {
+        return Ok(source);
+    };
+
+    let manifest: serde_json::Value =
+        serde_json::from_str(&source).map_err(|error| format!("latest.json JSON: {error}"))?;
+    manifest
+        .get("platforms")
+        .and_then(serde_json::Value::as_object)
+        .and_then(|platforms| platforms.get(platform))
+        .and_then(serde_json::Value::as_object)
+        .and_then(|entry| entry.get("signature"))
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_owned)
+        .ok_or_else(|| format!("latest.json signature missing for platform {platform}"))
+}
+
 fn main() {
     let args: Vec<String> = env::args().skip(1).collect();
     if args.len() < 2 {
         usage();
     }
 
-    let expect_failure = args.iter().any(|argument| argument == "--expect-failure");
-    let tamper = args.iter().any(|argument| argument == "--tamper");
-    let wrong_key = args.iter().any(|argument| argument == "--wrong-key");
-    if args.iter().skip(2).any(|argument| {
-        !matches!(
-            argument.as_str(),
-            "--expect-failure" | "--tamper" | "--wrong-key"
-        )
-    }) {
-        usage();
+    let mut expect_failure = false;
+    let mut tamper = false;
+    let mut wrong_key = false;
+    let mut manifest_platform = None;
+    let mut option_index = 2;
+    while option_index < args.len() {
+        match args[option_index].as_str() {
+            "--expect-failure" => expect_failure = true,
+            "--tamper" => tamper = true,
+            "--wrong-key" => wrong_key = true,
+            "--manifest-platform" => {
+                let Some(platform) = args.get(option_index + 1) else {
+                    usage();
+                };
+                if platform.starts_with("--") {
+                    usage();
+                }
+                manifest_platform = Some(platform.as_str());
+                option_index += 1;
+            }
+            _ => usage(),
+        }
+        option_index += 1;
     }
 
     let public_key = if wrong_key {
@@ -71,8 +105,7 @@ fn main() {
             *byte ^= 0x01;
         }
 
-        let signature_config =
-            fs::read_to_string(&args[1]).map_err(|error| format!("signature read: {error}"))?;
+        let signature_config = signature_source(&args[1], manifest_platform)?;
         let signature_text = STANDARD
             .decode(signature_config.trim())
             .map_err(|error| format!("signature base64: {error}"))

--- a/src-tauri/examples/verify-updater-artifact.rs
+++ b/src-tauri/examples/verify-updater-artifact.rs
@@ -1,0 +1,91 @@
+use std::{env, fs, process};
+
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use minisign_verify::{PublicKey, Signature};
+
+const WRONG_PUBLIC_KEY_TEXT: &str = "untrusted comment: minisign public key E7620F1842B4E81F\n";
+
+fn usage() -> ! {
+    eprintln!(concat!(
+        "usage: verify-updater-artifact <tauri-public-key> <artifact> <signature> ",
+        "[--expect-failure] [--tamper] [--wrong-key]"
+    ));
+    process::exit(2);
+}
+
+fn decode_configured_public_key(encoded: &str) -> Result<PublicKey, String> {
+    let decoded = STANDARD
+        .decode(encoded)
+        .map_err(|error| format!("public-key base64: {error}"))?;
+    let text = String::from_utf8(decoded).map_err(|error| format!("public-key text: {error}"))?;
+    PublicKey::decode(&text).map_err(|error| format!("public-key minisign encoding: {error:?}"))
+}
+
+fn main() {
+    let args: Vec<String> = env::args().skip(1).collect();
+    if args.len() < 3 {
+        usage();
+    }
+
+    let expect_failure = args.iter().any(|argument| argument == "--expect-failure");
+    let tamper = args.iter().any(|argument| argument == "--tamper");
+    let wrong_key = args.iter().any(|argument| argument == "--wrong-key");
+    if args.iter().skip(3).any(|argument| {
+        !matches!(
+            argument.as_str(),
+            "--expect-failure" | "--tamper" | "--wrong-key"
+        )
+    }) {
+        usage();
+    }
+
+    let public_key = if wrong_key {
+        let wrong_key_config = STANDARD.encode(format!(
+            "{WRONG_PUBLIC_KEY_TEXT}RWQf6LRCGA9i53mlYecO4IzT51TGPpvWucNSCh1CBM0QTaLn73Y7GFO3\n"
+        ));
+        decode_configured_public_key(&wrong_key_config)
+    } else {
+        decode_configured_public_key(&args[0])
+    };
+
+    let verification = public_key.and_then(|public_key| {
+        let mut artifact = fs::read(&args[1]).map_err(|error| format!("artifact read: {error}"))?;
+        if tamper {
+            let index = artifact.len() / 2;
+            let byte = artifact
+                .get_mut(index)
+                .ok_or_else(|| "artifact is empty".to_string())?;
+            *byte ^= 0x01;
+        }
+
+        let signature_config =
+            fs::read_to_string(&args[2]).map_err(|error| format!("signature read: {error}"))?;
+        let signature_text = STANDARD
+            .decode(signature_config.trim())
+            .map_err(|error| format!("signature base64: {error}"))
+            .and_then(|decoded| {
+                String::from_utf8(decoded).map_err(|error| format!("signature text: {error}"))
+            })?;
+        let signature = Signature::decode(&signature_text)
+            .map_err(|error| format!("signature minisign encoding: {error:?}"))?;
+
+        Ok::<bool, String>(public_key.verify(&artifact, &signature, true).is_ok())
+    });
+
+    match (expect_failure, verification) {
+        (false, Ok(true)) => println!("verified"),
+        (true, Ok(false)) | (true, Err(_)) => println!("rejected as expected"),
+        (false, Ok(false)) => {
+            eprintln!("signature rejected");
+            process::exit(1);
+        }
+        (false, Err(error)) => {
+            eprintln!("verification error: {error}");
+            process::exit(1);
+        }
+        (true, Ok(true)) => {
+            eprintln!("expected verification failure, but signature was accepted");
+            process::exit(1);
+        }
+    }
+}


### PR DESCRIPTION
## **User description**
H1-E evidence slice: re-audits the available updater verification tooling for immutable v1.28.1 artifacts, records that no trustworthy independent verifier is available in the authorized environment, and keeps the cryptographic verification claim explicitly unresolved. No release assets, tags, keys, workflows, or product behavior changed. Structural and asset evidence remains separate from cryptographic verification.

## Summary by Sourcery

Document and independently verify the immutable v1.28.1 updater artifacts while keeping platform-signing and notarization claims separate.

New Features:
- Add an audit report and development-only verifier for independently checking the immutable v1.28.1 updater payloads.

Enhancements:
- Record successful verification of Linux, Windows, and macOS ARM updater artifacts, including rejection of tampered, mismatched, and incorrectly keyed inputs.
- Clarify that updater verification is distinct from platform code signing, notarization, source signing, tag signing, and Intel qualification.

Build:
- Add the minisign verification library as a Tauri development dependency.

Documentation:
- Update release, governance, and program-state records to reflect the completed H1-E updater verification evidence and preserve the immutable release boundary.

Tests:
- Document positive and negative verification coverage for all published updater payloads.


___

## **CodeAnt-AI Description**
Document the unresolved cryptographic verification status of the v1.28.1 updater artifacts

### What Changed
- Added an H1-E report covering the three published updater payloads, their signatures, available verification tools, and required future checks
- Recorded that no trustworthy independent verifier is available, so positive or tampered-artifact verification tests remain pending
- Updated release and governance records to distinguish structural asset checks from cryptographic verification and prohibit unsupported verification claims
- Confirmed that the immutable v1.28.1 tag, release assets, updater metadata, and product behavior remain unchanged

### Impact
`✅ Clearer release verification status`
`✅ No unsupported cryptographic claims`
`✅ Preserved immutable release artifacts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated release evidence and audit records to confirm independent verification of Linux, Windows, and macOS ARM updater payloads.
  * Documented successful checks for valid, tampered, wrong-key, and cross-substituted artifacts.
  * Clarified that platform code signing, notarization, and Intel qualification remain separate items.

* **Tests**
  * Added a verification utility for validating updater signatures and detecting rejected or invalid artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->