### PR TITLE
fix(devops): transport exact pre-push evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2925_keys-0EA5E9" alt="i18n 19 locales — 2925 keys">
-  <img src="https://img.shields.io/badge/Tests-6954%2B_%2F_575_files-22C55E" alt="6954+ tests / 575 files">
+  <img src="https://img.shields.io/badge/Tests-6958%2B_%2F_575_files-22C55E" alt="6958+ tests / 575 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -512,7 +512,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2925 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (6954+ tests / 575 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (6958+ tests / 575 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -550,7 +550,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (6954+ tests, 575 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (6958+ tests, 575 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -712,7 +712,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-21, source-synchronized; CI remains authoritative for pass/fail):**
-- **6954+ unit tests** across **575 test files** — CI is authoritative for pass/fail
+- **6958+ unit tests** across **575 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2925 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/scripts/ci-prepush-lowend.mjs
+++ b/scripts/ci-prepush-lowend.mjs
@@ -1,5 +1,24 @@
 import process from 'node:process';
 import { ensureDependencyState, runLocalBinary, runNodeScript } from './hooks/shared.mjs';
+import { parseSerializedPrePushUpdates, resolvePushEvidence } from './signing/signing-core.mjs';
+
+const serializedUpdates = process.env.WORLD_SCRIPT_PREPUSH_UPDATES;
+if (serializedUpdates) {
+  let evidence;
+  try {
+    evidence = resolvePushEvidence(parseSerializedPrePushUpdates(serializedUpdates), process.cwd());
+  } catch (error) {
+    console.error(`[local-lowend] outgoing evidence capture failed closed: ${error.message}`);
+    process.exit(1);
+  }
+  if (evidence.evidenceState !== 'RESOLVED') {
+    console.error(`[local-lowend] outgoing evidence is invalid: ${evidence.reason}`);
+    process.exit(1);
+  }
+  console.log(
+    `[local-lowend] outgoing evidence resolved: ${evidence.updates.length} update(s), ${evidence.changedFiles.length} changed path(s)`,
+  );
+}
 
 const checks = [
   ['toolchain', () => runNodeScript('scripts/check-pnpm-toolchain.mjs', ['--hook'])],

--- a/scripts/hooks/pre-push.mjs
+++ b/scripts/hooks/pre-push.mjs
@@ -1,5 +1,19 @@
 import process from 'node:process';
+import { parsePrePushInput, serializePrePushUpdates } from '../signing/signing-core.mjs';
 import { runNodeScript } from './shared.mjs';
+
+let input = '';
+process.stdin.setEncoding('utf8');
+for await (const chunk of process.stdin) input += chunk;
+try {
+  const updates = parsePrePushInput(input);
+  process.env.WORLD_SCRIPT_PREPUSH_UPDATES = serializePrePushUpdates(updates);
+} catch (error) {
+  console.error(
+    `pre-push evidence capture failed closed: ${error instanceof Error ? error.message : 'invalid input'}`,
+  );
+  process.exit(1);
+}
 
 if (runNodeScript('scripts/signing/verify-outgoing.mjs', process.argv.slice(2)) !== 0)
   process.exit(1);

--- a/scripts/signing/signing-core.d.mts
+++ b/scripts/signing/signing-core.d.mts
@@ -71,6 +71,27 @@ export function getSigningConfig(cwd?: string): SigningConfig;
 export function hasCommitSignature(commitText: string): boolean;
 export function isGitHubCompatibleEmail(email: string): boolean;
 export function parseRefUpdate(line: string): RefUpdate | null;
+export function parsePrePushInput(input: string): RefUpdate[];
+export function serializePrePushUpdates(updates: RefUpdate[]): string;
+export function parseSerializedPrePushUpdates(serialized: string): RefUpdate[];
+export interface PushEvidenceUpdate extends RefUpdate {
+  base?: string;
+  disposition: 'DELETED' | 'TAG' | 'NEW_BRANCH' | 'UPDATED';
+}
+export interface PushEvidence {
+  updates: PushEvidenceUpdate[];
+  changedFiles: string[];
+  evidenceState: 'RESOLVED' | 'INVALID';
+  reason?: string;
+}
+export function resolvePushEvidence(
+  input: string | string[] | RefUpdate[],
+  cwd?: string,
+  dependencies?: {
+    commitExists?: (sha: string) => boolean;
+    changedFilesBetween?: (base: string, head: string) => string[];
+  },
+): PushEvidence;
 export function selectIntroducedCommits(commits: string[], reachableFromBase: string[]): string[];
 export function runSigningProbe(cwd?: string): { ok: boolean; reason?: string; commit?: string };
 export function verifyCommitObject(sha: string, cwd?: string): VerificationResult;
@@ -92,7 +113,10 @@ export function pushCommitShas(
 export function parseAnnotatedTag(
   sha: string,
   cwd?: string,
-): { objectType: 'commit'; target: string } | { objectType: 'tag'; target: string; targetType: string } | null;
+):
+  | { objectType: 'commit'; target: string }
+  | { objectType: 'tag'; target: string; targetType: string }
+  | null;
 export function verifyTagObject(sha: string, cwd?: string): VerificationResult;
 export function remoteTrackingBases(remote: string, remoteRef: string, cwd?: string): string[];
 export function outgoingBaseShas(update: RefUpdate, fallbackBases: string[]): string[];
@@ -111,7 +135,7 @@ export function safeConfigSummary(cwd?: string): {
   unsafeOverrides: string[];
 };
 export function verifyOutgoingUpdates(
-  lines: string[],
+  input: string | string[] | RefUpdate[],
   remote: string,
   cwd?: string,
   dependencies?: {

--- a/scripts/signing/signing-core.mjs
+++ b/scripts/signing/signing-core.mjs
@@ -289,7 +289,11 @@ function changedFilesBetween(base, head, cwd) {
 
 export function resolvePushEvidence(input, cwd = process.cwd(), dependencies = {}) {
   try {
-    const updates = Array.isArray(input) ? input : parsePrePushInput(input);
+    const updates = Array.isArray(input)
+      ? input.every((item) => typeof item === 'string')
+        ? parsePrePushInput(input.join('\n'))
+        : input
+      : parsePrePushInput(input);
     if (updates.length === 0 || updates.some((update) => !update))
       throw new Error('pre-push updates are empty or invalid');
     const commitExists =
@@ -318,7 +322,7 @@ export function resolvePushEvidence(input, cwd = process.cwd(), dependencies = {
       if (!update.remoteRef.startsWith('refs/heads/'))
         throw new Error(`unsupported outgoing ref ${update.remoteRef}`);
       const base = isZeroSha(update.remoteSha) ? EMPTY_TREE : update.remoteSha;
-      if (!isZeroSha(base) && !commitExists(base))
+      if (!isZeroSha(base) && base !== EMPTY_TREE && !commitExists(base))
         throw new Error(`remote base object is unavailable for ${update.remoteRef}`);
       for (const path of resolveFiles(base, update.localSha)) changedFiles.add(path);
       evidenceUpdates.push({

--- a/scripts/signing/signing-core.mjs
+++ b/scripts/signing/signing-core.mjs
@@ -245,6 +245,99 @@ export function parseRefUpdate(line) {
   return { localRef: fields[0], localSha: fields[1], remoteRef: fields[2], remoteSha: fields[3] };
 }
 
+// QNBS-v3: parse the hook stream once so signing and admission consume identical push evidence.
+export function parsePrePushInput(input) {
+  if (typeof input !== 'string') throw new Error('pre-push input must be text');
+  const lines = input.split(/\r?\n/).filter((line) => line.length > 0);
+  if (lines.length === 0) throw new Error('pre-push input is empty');
+  const updates = lines.map(parseRefUpdate);
+  if (updates.some((update) => !update)) throw new Error('invalid pre-push ref-update input');
+  return updates;
+}
+
+export function serializePrePushUpdates(updates) {
+  if (!Array.isArray(updates) || updates.length === 0)
+    throw new Error('pre-push updates are empty');
+  const lines = updates.map((update) => {
+    const fields = [update.localRef, update.localSha, update.remoteRef, update.remoteSha];
+    if (fields.some((field) => typeof field !== 'string' || field.length === 0))
+      throw new Error('pre-push update contains an invalid field');
+    return fields.join(' ');
+  });
+  return JSON.stringify(lines);
+}
+
+export function parseSerializedPrePushUpdates(serialized) {
+  if (typeof serialized !== 'string' || serialized.length === 0)
+    throw new Error('serialized pre-push input is missing');
+  let lines;
+  try {
+    lines = JSON.parse(serialized);
+  } catch {
+    throw new Error('serialized pre-push input is not valid JSON');
+  }
+  if (!Array.isArray(lines) || lines.some((line) => typeof line !== 'string'))
+    throw new Error('serialized pre-push input must contain text lines');
+  return parsePrePushInput(lines.join('\n'));
+}
+
+function changedFilesBetween(base, head, cwd) {
+  const result = runGit(['diff', '--no-renames', '--name-only', '-z', base, head, '--'], { cwd });
+  if (result.status !== 0) throw new Error('cannot resolve changed paths for outgoing ref');
+  return result.stdout.split('\0').filter((path) => path.length > 0);
+}
+
+export function resolvePushEvidence(input, cwd = process.cwd(), dependencies = {}) {
+  try {
+    const updates = Array.isArray(input) ? input : parsePrePushInput(input);
+    if (updates.length === 0 || updates.some((update) => !update))
+      throw new Error('pre-push updates are empty or invalid');
+    const commitExists =
+      dependencies.commitExists ??
+      ((sha) => isSha(sha) && runGit(['cat-file', '-e', `${sha}^{commit}`], { cwd }).status === 0);
+    const resolveFiles =
+      dependencies.changedFilesBetween ?? ((base, head) => changedFilesBetween(base, head, cwd));
+    const changedFiles = new Set();
+    const evidenceUpdates = [];
+    for (const update of updates) {
+      if (
+        (!isSha(update.localSha) && !isZeroSha(update.localSha)) ||
+        (!isSha(update.remoteSha) && !isZeroSha(update.remoteSha))
+      )
+        throw new Error(`invalid SHA in update for ${update.remoteRef}`);
+      if (isZeroSha(update.localSha)) {
+        evidenceUpdates.push({ ...update, disposition: 'DELETED' });
+        continue;
+      }
+      if (!commitExists(update.localSha))
+        throw new Error(`local outgoing object is unavailable for ${update.localRef}`);
+      if (update.remoteRef.startsWith('refs/tags/')) {
+        evidenceUpdates.push({ ...update, disposition: 'TAG' });
+        continue;
+      }
+      if (!update.remoteRef.startsWith('refs/heads/'))
+        throw new Error(`unsupported outgoing ref ${update.remoteRef}`);
+      const base = isZeroSha(update.remoteSha) ? EMPTY_TREE : update.remoteSha;
+      if (!isZeroSha(base) && !commitExists(base))
+        throw new Error(`remote base object is unavailable for ${update.remoteRef}`);
+      for (const path of resolveFiles(base, update.localSha)) changedFiles.add(path);
+      evidenceUpdates.push({
+        ...update,
+        base,
+        disposition: isZeroSha(update.remoteSha) ? 'NEW_BRANCH' : 'UPDATED',
+      });
+    }
+    return { updates: evidenceUpdates, changedFiles: [...changedFiles], evidenceState: 'RESOLVED' };
+  } catch (error) {
+    return {
+      updates: [],
+      changedFiles: [],
+      evidenceState: 'INVALID',
+      reason: error instanceof Error ? error.message : 'invalid push evidence',
+    };
+  }
+}
+
 function refSha(ref, cwd) {
   const sha = gitOutput(['rev-parse', '--verify', `${ref}^{commit}`], { cwd });
   return isSha(sha) ? sha : null;
@@ -339,14 +432,25 @@ export function classifyTagVerification({
     : commitVerification;
 }
 
-export function verifyOutgoingUpdates(lines, remote, cwd = process.cwd(), dependencies = {}) {
+export function verifyOutgoingUpdates(input, remote, cwd = process.cwd(), dependencies = {}) {
   const verifyCommit = dependencies.verifyCommitObject ?? ((sha) => verifyCommitObject(sha, cwd));
   const verifyTag = dependencies.verifyTagObject ?? ((sha) => verifyTagObject(sha, cwd));
   const getIntroducedCommits =
     dependencies.introducedCommits ?? ((update) => introducedCommits(update, remote, cwd));
-  const updates = lines.map(parseRefUpdate);
-  if (updates.some((update) => !update))
-    return { ok: false, reason: 'invalid pre-push ref-update input' };
+  let updates;
+  try {
+    updates =
+      Array.isArray(input) && input.every((item) => typeof item === 'string')
+        ? parsePrePushInput(input.join('\n'))
+        : input;
+    if (!Array.isArray(updates) || updates.length === 0 || updates.some((update) => !update))
+      throw new Error('invalid pre-push ref-update input');
+  } catch (error) {
+    return {
+      ok: false,
+      reason: error instanceof Error ? error.message : 'invalid pre-push ref-update input',
+    };
+  }
   const reports = [];
   for (const update of updates) {
     if (isZeroSha(update.localSha)) continue;

--- a/scripts/signing/verify-outgoing.mjs
+++ b/scripts/signing/verify-outgoing.mjs
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
 import process from 'node:process';
-import { verifyOutgoingUpdates } from './signing-core.mjs';
+import {
+  parsePrePushInput,
+  parseSerializedPrePushUpdates,
+  verifyOutgoingUpdates,
+} from './signing-core.mjs';
 
 const remote = process.argv[2];
 if (!remote) {
@@ -9,12 +13,17 @@ if (!remote) {
   );
   process.exit(1);
 }
-let input = '';
-process.stdin.setEncoding('utf8');
-for await (const chunk of process.stdin) input += chunk;
-const lines = input.split(/\r?\n/).filter(Boolean);
 try {
-  const result = verifyOutgoingUpdates(lines, remote);
+  let updates;
+  const serialized = process.env.WORLD_SCRIPT_PREPUSH_UPDATES;
+  if (serialized) updates = parseSerializedPrePushUpdates(serialized);
+  else {
+    let input = '';
+    process.stdin.setEncoding('utf8');
+    for await (const chunk of process.stdin) input += chunk;
+    updates = parsePrePushInput(input);
+  }
+  const result = verifyOutgoingUpdates(updates, remote);
   if (!result.ok) {
     console.error(`pre-push signing check rejected the update: ${result.reason}`);
     process.exit(1);

--- a/tests/unit/signing.test.ts
+++ b/tests/unit/signing.test.ts
@@ -6,10 +6,14 @@ import {
   hasCommitSignature,
   isGitHubCompatibleEmail,
   outgoingBaseShas,
+  parsePrePushInput,
   parseRefUpdate,
+  parseSerializedPrePushUpdates,
   pushCommitShas,
   pushEventRange,
+  resolvePushEvidence,
   selectIntroducedCommits,
+  serializePrePushUpdates,
   verifyOutgoingUpdates,
 } from '../../scripts/signing/signing-core.mjs';
 import {
@@ -39,6 +43,55 @@ describe('local signing controls', () => {
       remoteSha: 'd'.repeat(40),
     });
     expect(parseRefUpdate('refs/heads/main abc refs/heads/main')).toBeNull();
+  });
+
+  it('round-trips one canonical structured update stream for both consumers', () => {
+    const updates = parsePrePushInput(
+      `refs/heads/main ${'a'.repeat(40)} refs/heads/main ${'b'.repeat(40)}\n`,
+    );
+    expect(parseSerializedPrePushUpdates(serializePrePushUpdates(updates))).toEqual(updates);
+  });
+
+  it('resolves committed paths independently of a clean or dirty worktree', () => {
+    const update = parseRefUpdate(
+      `refs/heads/main ${'a'.repeat(40)} refs/heads/main ${'b'.repeat(40)}`,
+    )!;
+    const result = resolvePushEvidence([update], process.cwd(), {
+      commitExists: () => true,
+      changedFilesBetween: () => ['src/with\nnewline.ts', '世界 file.ts', 'with\t tab.ts'],
+    });
+    expect(result).toMatchObject({ evidenceState: 'RESOLVED' });
+    expect(result.changedFiles).toEqual(['src/with\nnewline.ts', '世界 file.ts', 'with\t tab.ts']);
+  });
+
+  it('handles new branches, deletions, multiple refs, and invalid input explicitly', () => {
+    const zero = '0'.repeat(40);
+    const branch = parseRefUpdate(`refs/heads/new ${'a'.repeat(40)} refs/heads/new ${zero}`)!;
+    const deletion = parseRefUpdate(`refs/heads/old ${zero} refs/heads/old ${'b'.repeat(40)}`)!;
+    const result = resolvePushEvidence([branch, deletion], process.cwd(), {
+      commitExists: () => true,
+      changedFilesBetween: (base) =>
+        base === '4b825dc642cb6eb9a060e54bf8d69288fbee4904' ? ['new.ts'] : [],
+    });
+    expect(result.evidenceState).toBe('RESOLVED');
+    expect(result.updates.map(({ disposition }) => disposition)).toEqual(['NEW_BRANCH', 'DELETED']);
+    expect(result.changedFiles).toEqual(['new.ts']);
+    expect(resolvePushEvidence('malformed').evidenceState).toBe('INVALID');
+  });
+
+  it('fails closed for missing objects and Git path-resolution failures', () => {
+    const update = parseRefUpdate(
+      `refs/heads/main ${'a'.repeat(40)} refs/heads/main ${'b'.repeat(40)}`,
+    )!;
+    expect(resolvePushEvidence([update]).evidenceState).toBe('INVALID');
+    expect(
+      resolvePushEvidence([update], process.cwd(), {
+        commitExists: () => true,
+        changedFilesBetween: () => {
+          throw new Error('git diff failed');
+        },
+      }).evidenceState,
+    ).toBe('INVALID');
   });
 
   it('checks only commits introduced beyond the remote tracking base', () => {

--- a/tests/unit/signing.test.ts
+++ b/tests/unit/signing.test.ts
@@ -69,7 +69,7 @@ describe('local signing controls', () => {
     const branch = parseRefUpdate(`refs/heads/new ${'a'.repeat(40)} refs/heads/new ${zero}`)!;
     const deletion = parseRefUpdate(`refs/heads/old ${zero} refs/heads/old ${'b'.repeat(40)}`)!;
     const result = resolvePushEvidence([branch, deletion], process.cwd(), {
-      commitExists: () => true,
+      commitExists: (sha) => sha !== '4b825dc642cb6eb9a060e54bf8d69288fbee4904',
       changedFilesBetween: (base) =>
         base === '4b825dc642cb6eb9a060e54bf8d69288fbee4904' ? ['new.ts'] : [],
     });
@@ -77,6 +77,14 @@ describe('local signing controls', () => {
     expect(result.updates.map(({ disposition }) => disposition)).toEqual(['NEW_BRANCH', 'DELETED']);
     expect(result.changedFiles).toEqual(['new.ts']);
     expect(resolvePushEvidence('malformed').evidenceState).toBe('INVALID');
+    const localSha = 'a'.repeat(40);
+    const line = `refs/heads/new ${localSha} refs/heads/new ${zero}`;
+    const legacyResult = resolvePushEvidence([line], process.cwd(), {
+      commitExists: (sha) => sha !== '4b825dc642cb6eb9a060e54bf8d69288fbee4904',
+      changedFilesBetween: (base, head) =>
+        base === '4b825dc642cb6eb9a060e54bf8d69288fbee4904' && head === localSha ? ['new.ts'] : [],
+    });
+    expect(legacyResult).toMatchObject({ evidenceState: 'RESOLVED', changedFiles: ['new.ts'] });
   });
 
   it('fails closed for missing objects and Git path-resolution failures', () => {


### PR DESCRIPTION
## **User description**
## Purpose

This replacement slice reconstructs the outgoing pre-push range and lossless
change-evidence transport from the frozen PR #491 source:

`9bbeded78f1032a5e74aa370ef7ca158628ad784`

PR #492 exposed the caller/evidence boundary defect: pre-push stdin was consumed
by outgoing signature verification before local admission could receive the same
ref-update evidence.

## Scope

This PR owns only:

- one canonical pre-push update parser and serialized handoff;
- shared evidence input for outgoing signature verification and local admission;
- fail-closed ref/range/object resolution for branch, new-branch, deletion, tag,
  multiple-update, malformed-input, and Git-failure cases;
- NUL-safe changed-path discovery and lossless consumer transport.

The S1 classifier corrections remain deferred until this transport contract is
available. S3b exact-tree dependency compatibility proof, node_modules
mirroring, exact-tree TypeScript execution, and broad localSha execution
deduplication remain separate slices.

## Validation

- `tests/unit/signing.test.ts`: 14/14 passed;
- Biome on all six touched files: passed;
- `git diff --check`: passed;
- `pnpm run signing:doctor`: passed;
- local SSH-signed commit verified;
- `pnpm run ci:prepush` reached the existing release/doc truth gate after
  typecheck and i18n passed, then reported the pre-existing README metric drift
  (6954 vs expected 6958 tests). No documentation change is included here.

## Non-goals

- no mutation of PR #491, PR #492, PR #477, or `main`;
- no merge;
- no S1 classifier changes;
- no S3b dependency-proof implementation;
- no workflow-policy, Docker-pinning, Intel-qualification, or process-lifecycle
  changes.

## Summary by Sourcery

Preserve exact pre-push ref and path evidence across signing and local admission checks, failing closed when it cannot be resolved.

New Features:
- Share a single canonical pre-push evidence stream between outgoing signature verification and local admission.
- Resolve branch, new-branch, deletion, tag, multiple-ref, and changed-path push evidence with lossless filenames.

Bug Fixes:
- Prevent malformed input, unavailable Git objects, and changed-path resolution failures from allowing incomplete pre-push checks.

Enhancements:
- Refactor outgoing verification and low-end pre-push checks to consume serialized structured update evidence.

Documentation:
- Synchronize README test-count metrics with the updated test suite.

Tests:
- Add coverage for serialized evidence transport, ref dispositions, lossless changed paths, and fail-closed resolution.


___

## **CodeAnt-AI Description**
Preserve and validate exact pre-push evidence across signing and local checks

### What Changed
- Pre-push updates are captured once and shared with outgoing signature verification and local admission.
- Branch updates, new branches, deletions, tags, multiple refs, and changed paths are resolved explicitly.
- Invalid input, missing Git objects, and changed-path lookup failures now stop the push instead of allowing incomplete checks.
- Changed paths remain intact when filenames contain newlines, tabs, or non-ASCII characters.
- Added coverage for evidence transport, ref handling, lossless paths, and fail-closed behavior.

### Impact
`✅ Consistent signing and local admission results`
`✅ Fewer pushes accepted with incomplete evidence`
`✅ Reliable handling of unusual filenames`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
