### PR TITLE
refactor(admission): make local checks change aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2925_keys-0EA5E9" alt="i18n 19 locales — 2925 keys">
-  <img src="https://img.shields.io/badge/Tests-6963%2B_%2F_576_files-22C55E" alt="6963+ tests / 576 files">
+  <img src="https://img.shields.io/badge/Tests-6964%2B_%2F_576_files-22C55E" alt="6964+ tests / 576 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -512,7 +512,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2925 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (6963+ tests / 576 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (6964+ tests / 576 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -550,7 +550,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (6963+ tests, 576 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (6964+ tests, 576 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -712,7 +712,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-21, source-synchronized; CI remains authoritative for pass/fail):**
-- **6963+ unit tests** across **576 test files** — CI is authoritative for pass/fail
+- **6964+ unit tests** across **576 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2925 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2925_keys-0EA5E9" alt="i18n 19 locales — 2925 keys">
-  <img src="https://img.shields.io/badge/Tests-6962%2B_%2F_576_files-22C55E" alt="6962+ tests / 576 files">
+  <img src="https://img.shields.io/badge/Tests-6963%2B_%2F_576_files-22C55E" alt="6963+ tests / 576 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -512,7 +512,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2925 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (6962+ tests / 576 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (6963+ tests / 576 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -550,7 +550,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (6962+ tests, 576 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (6963+ tests, 576 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -712,7 +712,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-21, source-synchronized; CI remains authoritative for pass/fail):**
-- **6962+ unit tests** across **576 test files** — CI is authoritative for pass/fail
+- **6963+ unit tests** across **576 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2925 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2925_keys-0EA5E9" alt="i18n 19 locales — 2925 keys">
-  <img src="https://img.shields.io/badge/Tests-6959%2B_%2F_575_files-22C55E" alt="6959+ tests / 575 files">
+  <img src="https://img.shields.io/badge/Tests-6962%2B_%2F_576_files-22C55E" alt="6962+ tests / 576 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -512,7 +512,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2925 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (6959+ tests / 575 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (6962+ tests / 576 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -550,7 +550,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (6959+ tests, 575 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (6962+ tests, 576 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -712,7 +712,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-21, source-synchronized; CI remains authoritative for pass/fail):**
-- **6959+ unit tests** across **575 test files** — CI is authoritative for pass/fail
+- **6962+ unit tests** across **576 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2925 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/scripts/ci-prepush-check-registry.d.mts
+++ b/scripts/ci-prepush-check-registry.d.mts
@@ -1,0 +1,1 @@
+export function shouldRunAdmissionCheck(name: string, files: readonly string[]): boolean;

--- a/scripts/ci-prepush-check-registry.mjs
+++ b/scripts/ci-prepush-check-registry.mjs
@@ -1,4 +1,5 @@
 const routingAuthority = 'scripts/ci-prepush-check-registry.mjs';
+const runnerAuthority = 'scripts/ci-prepush-lowend.mjs';
 const i18nPolicyFiles = new Set([
   'scripts/check-i18n-keys.mjs',
   'scripts/i18n-locales.mjs',
@@ -13,7 +14,11 @@ export const admissionCheckRegistry = Object.freeze([
       file.startsWith('locales/') ||
       file.startsWith('public/locales/') ||
       i18nPolicyFiles.has(file),
-    implementationFiles: new Set([routingAuthority, 'scripts/ci-prepush-classifier.mjs']),
+    implementationFiles: new Set([
+      routingAuthority,
+      runnerAuthority,
+      'scripts/ci-prepush-classifier.mjs',
+    ]),
   },
   {
     name: 'contentGuard',
@@ -21,7 +26,11 @@ export const admissionCheckRegistry = Object.freeze([
       file === 'scripts/content-guard.mjs' ||
       file.startsWith('community-templates/') ||
       file.startsWith('public/community-templates/'),
-    implementationFiles: new Set([routingAuthority, 'scripts/ci-prepush-classifier.mjs']),
+    implementationFiles: new Set([
+      routingAuthority,
+      runnerAuthority,
+      'scripts/ci-prepush-classifier.mjs',
+    ]),
   },
 ]);
 

--- a/scripts/ci-prepush-check-registry.mjs
+++ b/scripts/ci-prepush-check-registry.mjs
@@ -1,0 +1,27 @@
+const routingAuthority = 'scripts/ci-prepush-check-registry.mjs';
+const i18nPolicyFiles = new Set(['scripts/check-i18n-keys.mjs', 'scripts/i18n-locales.mjs']);
+
+export const admissionCheckRegistry = Object.freeze([
+  {
+    name: 'i18n',
+    matches: (file) =>
+      file.startsWith('locales/') ||
+      file.startsWith('public/locales/') ||
+      i18nPolicyFiles.has(file),
+    implementationFiles: new Set([routingAuthority, 'scripts/ci-prepush-classifier.mjs']),
+  },
+  {
+    name: 'contentGuard',
+    matches: (file) =>
+      file === 'scripts/content-guard.mjs' ||
+      file.startsWith('community-templates/') ||
+      file.startsWith('public/community-templates/'),
+    implementationFiles: new Set([routingAuthority, 'scripts/ci-prepush-classifier.mjs']),
+  },
+]);
+
+export function shouldRunAdmissionCheck(name, files) {
+  const entry = admissionCheckRegistry.find((candidate) => candidate.name === name);
+  if (!entry) throw new Error(`unknown local admission check: ${name}`);
+  return files.some((file) => entry.matches(file) || entry.implementationFiles.has(file));
+}

--- a/scripts/ci-prepush-check-registry.mjs
+++ b/scripts/ci-prepush-check-registry.mjs
@@ -1,5 +1,10 @@
 const routingAuthority = 'scripts/ci-prepush-check-registry.mjs';
-const i18nPolicyFiles = new Set(['scripts/check-i18n-keys.mjs', 'scripts/i18n-locales.mjs']);
+const i18nPolicyFiles = new Set([
+  'scripts/check-i18n-keys.mjs',
+  'scripts/i18n-locales.mjs',
+  'scripts/build-i18n.mjs',
+  'scripts/i18n-quality-report.mjs',
+]);
 
 export const admissionCheckRegistry = Object.freeze([
   {

--- a/scripts/ci-prepush-classifier.d.mts
+++ b/scripts/ci-prepush-classifier.d.mts
@@ -1,0 +1,26 @@
+export type ChangeKind =
+  | 'NO_CHANGES'
+  | 'DOCS_ONLY'
+  | 'WORKFLOW_ONLY'
+  | 'NON_CODE_ONLY'
+  | 'RUST_TAURI'
+  | 'TOOLING'
+  | 'TEST_ONLY'
+  | 'TYPESCRIPT_APPLICATION'
+  | 'DEPENDENCY_TOOLCHAIN'
+  | 'BUILD_CONFIGURATION'
+  | 'AMBIGUOUS'
+  | 'MIXED';
+
+export interface ChangeClassification {
+  readonly kind: ChangeKind;
+  readonly categories: readonly string[];
+  readonly files: readonly string[];
+}
+
+export function classifyFile(file: string): string;
+export function classifyChangedFiles(files: readonly string[]): ChangeClassification;
+export function requiresTypecheck(
+  classification: ChangeClassification,
+  options?: { readonly full?: boolean },
+): boolean;

--- a/scripts/ci-prepush-classifier.d.mts
+++ b/scripts/ci-prepush-classifier.d.mts
@@ -24,3 +24,4 @@ export function requiresTypecheck(
   classification: ChangeClassification,
   options?: { readonly full?: boolean },
 ): boolean;
+export function manualAdmissionNeedsFullValidation(rangeResolved: boolean): boolean;

--- a/scripts/ci-prepush-classifier.mjs
+++ b/scripts/ci-prepush-classifier.mjs
@@ -1,5 +1,5 @@
 const DOC_FILE = /\.(?:md|mdx)$/i;
-const TS_FILE = /\.(?:c|m)?tsx?$|\.(?:c|m)?jsx?$/i;
+const TS_FILE = /\.(?:c|m)?tsx?$/i;
 const WORKFLOW_ROOTS = ['.github/workflows/', '.github/actions/'];
 const RUST_ROOTS = ['src-tauri/', 'crates/'];
 const TOOLING_ROOTS = ['scripts/'];
@@ -59,6 +59,7 @@ export function classifyFile(file) {
   }
   if (normalized.startsWith('tests/'))
     return TS_FILE.test(normalized) ? 'TYPESCRIPT_APPLICATION' : 'TEST_ONLY';
+  if (TS_FILE.test(normalized)) return 'TYPESCRIPT_APPLICATION';
   if (TOOLING_FILES.has(normalized) || startsWithRoot(normalized, TOOLING_ROOTS)) return 'TOOLING';
   if (
     DEPENDENCY_FILES.has(base) ||
@@ -68,7 +69,6 @@ export function classifyFile(file) {
     return 'DEPENDENCY_TOOLCHAIN';
   }
   if (BUILD_CONFIG_FILES.has(base)) return 'BUILD_CONFIGURATION';
-  if (TS_FILE.test(normalized)) return 'TYPESCRIPT_APPLICATION';
   return 'UNKNOWN';
 }
 

--- a/scripts/ci-prepush-classifier.mjs
+++ b/scripts/ci-prepush-classifier.mjs
@@ -1,0 +1,111 @@
+const DOC_FILE = /\.(?:md|mdx)$/i;
+const TS_FILE = /\.(?:c|m)?tsx?$|\.(?:c|m)?jsx?$/i;
+const WORKFLOW_ROOTS = ['.github/workflows/', '.github/actions/'];
+const RUST_ROOTS = ['src-tauri/', 'crates/'];
+const TOOLING_ROOTS = ['scripts/'];
+const TOOLING_FILES = new Set(['.gitleaks.toml']);
+const DEPENDENCY_FILES = new Set([
+  'package.json',
+  'pnpm-lock.yaml',
+  'pnpm-workspace.yaml',
+  '.npmrc',
+  '.nvmrc',
+  'rust-toolchain',
+  'rust-toolchain.toml',
+]);
+const BUILD_CONFIG_FILES = new Set([
+  'biome.json',
+  'index.html',
+  'playwright.config.ts',
+  'postcss.config.js',
+  'postcss.config.mjs',
+  'tailwind.config.js',
+  'tailwind.config.ts',
+  'turbo.json',
+  'vite.config.ts',
+  'vitest.config.ts',
+]);
+
+function startsWithRoot(file, roots) {
+  return roots.some((root) => file.startsWith(root));
+}
+
+function normalizePath(file) {
+  return file.replaceAll('\\', '/').replace(/^\.\//, '');
+}
+
+function isInstructionFile(file) {
+  return (
+    file === 'AGENTS.md' ||
+    file === 'CLAUDE.md' ||
+    file === '.cursorrules' ||
+    file === '.github/copilot-instructions.md' ||
+    file.startsWith('.cursor/rules/')
+  );
+}
+
+export function classifyFile(file) {
+  const normalized = normalizePath(file);
+  const base = normalized.split('/').at(-1) ?? normalized;
+
+  if (startsWithRoot(normalized, WORKFLOW_ROOTS)) return 'WORKFLOW';
+  if (DOC_FILE.test(normalized) || isInstructionFile(normalized)) return 'DOCS';
+  if (
+    RUST_ROOTS.some((root) => normalized.startsWith(root)) ||
+    /(?:^|\/)(?:Cargo\.toml|Cargo\.lock)$/.test(normalized) ||
+    normalized.endsWith('.rs')
+  ) {
+    return 'RUST_TAURI';
+  }
+  if (normalized.startsWith('tests/'))
+    return TS_FILE.test(normalized) ? 'TYPESCRIPT_APPLICATION' : 'TEST_ONLY';
+  if (TOOLING_FILES.has(normalized) || startsWithRoot(normalized, TOOLING_ROOTS)) return 'TOOLING';
+  if (
+    DEPENDENCY_FILES.has(base) ||
+    normalized.startsWith('patches/') ||
+    (normalized.startsWith('packages/') && base === 'package.json')
+  ) {
+    return 'DEPENDENCY_TOOLCHAIN';
+  }
+  if (BUILD_CONFIG_FILES.has(base)) return 'BUILD_CONFIGURATION';
+  if (TS_FILE.test(normalized)) return 'TYPESCRIPT_APPLICATION';
+  return 'UNKNOWN';
+}
+
+// QNBS-v3: classify change impact before starting expensive local checks.
+export function classifyChangedFiles(files) {
+  const normalizedFiles = [...new Set(files.map(normalizePath).filter(Boolean))].sort();
+  const categories = [...new Set(normalizedFiles.map(classifyFile))];
+
+  if (normalizedFiles.length === 0)
+    return { kind: 'NO_CHANGES', categories, files: normalizedFiles };
+  if (categories.every((category) => category === 'DOCS'))
+    return { kind: 'DOCS_ONLY', categories, files: normalizedFiles };
+  if (categories.every((category) => category === 'WORKFLOW'))
+    return { kind: 'WORKFLOW_ONLY', categories, files: normalizedFiles };
+  if (categories.length === 1) {
+    if (categories[0] === 'UNKNOWN')
+      return { kind: 'AMBIGUOUS', categories, files: normalizedFiles };
+    return { kind: categories[0], categories, files: normalizedFiles };
+  }
+  if (
+    categories.every((category) => ['DOCS', 'WORKFLOW', 'TOOLING', 'TEST_ONLY'].includes(category))
+  )
+    return { kind: 'NON_CODE_ONLY', categories, files: normalizedFiles };
+  if (categories.includes('UNKNOWN'))
+    return { kind: 'AMBIGUOUS', categories, files: normalizedFiles };
+  return { kind: 'MIXED', categories, files: normalizedFiles };
+}
+
+export function requiresTypecheck(classification, { full = false } = {}) {
+  if (full) return true;
+  return ![
+    'NO_CHANGES',
+    'DOCS_ONLY',
+    'WORKFLOW_ONLY',
+    'NON_CODE_ONLY',
+    'RUST_TAURI',
+    'TOOLING',
+    'TEST_ONLY',
+  ].includes(classification.kind);
+}

--- a/scripts/ci-prepush-classifier.mjs
+++ b/scripts/ci-prepush-classifier.mjs
@@ -109,3 +109,7 @@ export function requiresTypecheck(classification, { full = false } = {}) {
     'TEST_ONLY',
   ].includes(classification.kind);
 }
+
+export function manualAdmissionNeedsFullValidation(rangeResolved) {
+  return !rangeResolved;
+}

--- a/scripts/ci-prepush-lowend.mjs
+++ b/scripts/ci-prepush-lowend.mjs
@@ -30,6 +30,18 @@ function gitRaw(args) {
   return result.stdout ?? '';
 }
 
+function gitRequired(args, description) {
+  const result = spawnSync('git', args, { encoding: 'utf8' });
+  if (result.status !== 0)
+    throw new Error(`${description} failed${result.stderr ? `: ${result.stderr.trim()}` : ''}`);
+  return result.stdout ?? '';
+}
+
+function gitOptional(args) {
+  const result = spawnSync('git', args, { encoding: 'utf8' });
+  return result.status === 0 ? (result.stdout ?? '') : null;
+}
+
 function parseNulDelimitedPaths(output) {
   return output.split('\0').filter(Boolean);
 }
@@ -38,6 +50,25 @@ function changedFilesFromWorkingTree() {
   return parseNulDelimitedPaths(
     gitRaw(['diff', '--no-renames', '--name-only', '-z', 'HEAD']),
   ).concat(parseNulDelimitedPaths(gitRaw(['ls-files', '--others', '--exclude-standard', '-z'])));
+}
+
+function changedFilesFromManualRange() {
+  const upstream = gitOptional(['rev-parse', '--verify', '@{upstream}'])?.trim();
+  if (upstream)
+    return parseNulDelimitedPaths(
+      gitRequired(
+        ['diff', '--no-renames', '--name-only', '-z', `${upstream}..HEAD`],
+        'resolve manual committed range',
+      ),
+    ).concat(changedFilesFromWorkingTree());
+
+  const head = gitRequired(['rev-parse', '--verify', 'HEAD'], 'resolve HEAD').trim();
+  return parseNulDelimitedPaths(
+    gitRequired(
+      ['diff-tree', '--root', '--no-commit-id', '--name-only', '-r', '-z', head],
+      'resolve manual HEAD changes',
+    ),
+  ).concat(changedFilesFromWorkingTree());
 }
 
 function report(name, status, detail = '') {
@@ -51,7 +82,7 @@ function runCheck(name, run) {
   if (status !== 0) process.exit(status ?? 1);
 }
 
-const files = evidenceIndex >= 0 ? evidenceChangedFiles : changedFilesFromWorkingTree();
+const files = evidenceIndex >= 0 ? evidenceChangedFiles : changedFilesFromManualRange();
 const classification = classifyChangedFiles(files);
 const typecheckRequired = requiresTypecheck(classification, { full });
 
@@ -89,6 +120,7 @@ if (shouldRunAdmissionCheck('contentGuard', classification.files) || full)
 
 if (typecheckRequired) {
   runCheck('TypeScript (single checker)', () =>
+    // QNBS-v3: one checker bounds memory use on constrained developer machines.
     runLocalBinary('tsgo', ['--project', 'tsconfig.tsgo.json', '--noEmit', '--checkers', '1']),
   );
 } else {

--- a/scripts/ci-prepush-lowend.mjs
+++ b/scripts/ci-prepush-lowend.mjs
@@ -6,6 +6,7 @@ import { ensureDependencyState, runLocalBinary, runNodeScript } from './hooks/sh
 import { readPrePushEvidenceFile, resolvePushEvidence } from './signing/signing-core.mjs';
 
 const evidenceIndex = process.argv.indexOf('--prepush-evidence-file');
+let evidenceChangedFiles;
 if (evidenceIndex >= 0) {
   try {
     const evidence = resolvePushEvidence(
@@ -14,6 +15,7 @@ if (evidenceIndex >= 0) {
     );
     if (evidence.evidenceState !== 'RESOLVED')
       throw new Error(evidence.reason ?? 'invalid evidence');
+    evidenceChangedFiles = evidence.changedFiles;
   } catch (error) {
     console.error(`[local-lowend] outgoing evidence rejected: ${error.message}`);
     process.exit(1);
@@ -49,7 +51,7 @@ function runCheck(name, run) {
   if (status !== 0) process.exit(status ?? 1);
 }
 
-const files = changedFilesFromWorkingTree();
+const files = evidenceIndex >= 0 ? evidenceChangedFiles : changedFilesFromWorkingTree();
 const classification = classifyChangedFiles(files);
 const typecheckRequired = requiresTypecheck(classification, { full });
 

--- a/scripts/ci-prepush-lowend.mjs
+++ b/scripts/ci-prepush-lowend.mjs
@@ -1,7 +1,11 @@
 import { spawnSync } from 'node:child_process';
 import process from 'node:process';
 import { shouldRunAdmissionCheck } from './ci-prepush-check-registry.mjs';
-import { classifyChangedFiles, requiresTypecheck } from './ci-prepush-classifier.mjs';
+import {
+  classifyChangedFiles,
+  manualAdmissionNeedsFullValidation,
+  requiresTypecheck,
+} from './ci-prepush-classifier.mjs';
 import { ensureDependencyState, runLocalBinary, runNodeScript } from './hooks/shared.mjs';
 import { readPrePushEvidenceFile, resolvePushEvidence } from './signing/signing-core.mjs';
 
@@ -22,18 +26,11 @@ if (evidenceIndex >= 0) {
   }
 }
 
-const full = process.argv.includes('--full');
+const fullRequested = process.argv.includes('--full');
 
 function gitRaw(args) {
   const result = spawnSync('git', args, { encoding: 'utf8' });
   if (result.status !== 0) return '';
-  return result.stdout ?? '';
-}
-
-function gitRequired(args, description) {
-  const result = spawnSync('git', args, { encoding: 'utf8' });
-  if (result.status !== 0)
-    throw new Error(`${description} failed${result.stderr ? `: ${result.stderr.trim()}` : ''}`);
   return result.stdout ?? '';
 }
 
@@ -55,20 +52,14 @@ function changedFilesFromWorkingTree() {
 function changedFilesFromManualRange() {
   const upstream = gitOptional(['rev-parse', '--verify', '@{upstream}'])?.trim();
   if (upstream)
-    return parseNulDelimitedPaths(
-      gitRequired(
-        ['diff', '--no-renames', '--name-only', '-z', `${upstream}..HEAD`],
-        'resolve manual committed range',
-      ),
-    ).concat(changedFilesFromWorkingTree());
+    return {
+      files: parseNulDelimitedPaths(
+        gitRaw(['diff', '--no-renames', '--name-only', '-z', `${upstream}..HEAD`]),
+      ).concat(changedFilesFromWorkingTree()),
+      rangeResolved: true,
+    };
 
-  const head = gitRequired(['rev-parse', '--verify', 'HEAD'], 'resolve HEAD').trim();
-  return parseNulDelimitedPaths(
-    gitRequired(
-      ['diff-tree', '--root', '--no-commit-id', '--name-only', '-r', '-z', head],
-      'resolve manual HEAD changes',
-    ),
-  ).concat(changedFilesFromWorkingTree());
+  return { files: [], rangeResolved: false };
 }
 
 function report(name, status, detail = '') {
@@ -82,12 +73,24 @@ function runCheck(name, run) {
   if (status !== 0) process.exit(status ?? 1);
 }
 
-const files = evidenceIndex >= 0 ? evidenceChangedFiles : changedFilesFromManualRange();
-const classification = classifyChangedFiles(files);
+const manualEvidence =
+  evidenceIndex >= 0
+    ? { files: evidenceChangedFiles, rangeResolved: true }
+    : changedFilesFromManualRange();
+const full =
+  fullRequested || (!manualEvidence.rangeResolved && manualAdmissionNeedsFullValidation(false));
+const files = manualEvidence.files;
+const classification = manualEvidence.rangeResolved
+  ? classifyChangedFiles(files)
+  : { kind: 'AMBIGUOUS', categories: ['UNKNOWN'], files: [] };
 const typecheckRequired = requiresTypecheck(classification, { full });
 
 console.log(`[local-admission] change class: ${classification.kind}`);
 console.log(`[local-admission] files considered: ${classification.files.length}`);
+if (!manualEvidence.rangeResolved && evidenceIndex < 0)
+  console.log(
+    '[local-admission] manual committed range unresolved; using conservative full admission',
+  );
 
 if (!ensureDependencyState()) {
   report('Dependency state', 'FAIL');

--- a/scripts/ci-prepush-lowend.mjs
+++ b/scripts/ci-prepush-lowend.mjs
@@ -1,4 +1,7 @@
+import { spawnSync } from 'node:child_process';
 import process from 'node:process';
+import { shouldRunAdmissionCheck } from './ci-prepush-check-registry.mjs';
+import { classifyChangedFiles, requiresTypecheck } from './ci-prepush-classifier.mjs';
 import { ensureDependencyState, runLocalBinary, runNodeScript } from './hooks/shared.mjs';
 import { readPrePushEvidenceFile, resolvePushEvidence } from './signing/signing-core.mjs';
 
@@ -17,43 +20,80 @@ if (evidenceIndex >= 0) {
   }
 }
 
-const checks = [
-  ['toolchain', () => runNodeScript('scripts/check-pnpm-toolchain.mjs', ['--hook'])],
-  [
-    'typecheck (single checker)',
-    // QNBS-v3: Make the low-end resource contract explicit; tsgo's default checker count is not a safe local default.
-    () =>
-      runLocalBinary('tsgo', ['--project', 'tsconfig.tsgo.json', '--noEmit', '--checkers', '1']),
-  ],
-  ['i18n key parity', () => runNodeScript('scripts/check-i18n-keys.mjs')],
-  ['i18n bundle rebuild', () => runNodeScript('scripts/build-i18n.mjs')],
-  ['i18n content guard', () => runNodeScript('scripts/content-guard.mjs')],
-  [
-    'i18n translation quality',
-    () =>
-      runNodeScript('scripts/i18n-quality-report.mjs', [
-        '--strict',
-        '--min-coverage',
-        '75',
-        '--max-length-outliers',
-        '8',
-      ]),
-  ],
-  ['release/doc truth', () => runNodeScript('scripts/check-doc-metrics.mjs')],
-  ['CSP policy', () => runNodeScript('scripts/check-csp-policy.mjs')],
-  ['desktop import boundary', () => runNodeScript('scripts/check-tauri-import-boundary.mjs')],
-  ['native readiness', () => runNodeScript('scripts/check-native-readiness.mjs')],
-];
+const full = process.argv.includes('--full');
 
-if (!ensureDependencyState()) process.exit(1);
-
-for (const [name, run] of checks) {
-  console.log(`[local-lowend] ${name}`);
-  const status = run();
-  if (status !== 0) {
-    console.error(`[local-lowend] failed: ${name}`);
-    process.exit(status);
-  }
+function gitRaw(args) {
+  const result = spawnSync('git', args, { encoding: 'utf8' });
+  if (result.status !== 0) return '';
+  return result.stdout ?? '';
 }
 
-console.log('[local-lowend] pre-push checks passed sequentially.');
+function parseNulDelimitedPaths(output) {
+  return output.split('\0').filter(Boolean);
+}
+
+function changedFilesFromWorkingTree() {
+  return parseNulDelimitedPaths(
+    gitRaw(['diff', '--no-renames', '--name-only', '-z', 'HEAD']),
+  ).concat(parseNulDelimitedPaths(gitRaw(['ls-files', '--others', '--exclude-standard', '-z'])));
+}
+
+function report(name, status, detail = '') {
+  console.log(`[local-admission] ${name.padEnd(26)} ${status}${detail ? ` — ${detail}` : ''}`);
+  return status;
+}
+
+function runCheck(name, run) {
+  const status = run();
+  report(name, status === 0 ? 'PASS' : 'FAIL');
+  if (status !== 0) process.exit(status ?? 1);
+}
+
+const files = changedFilesFromWorkingTree();
+const classification = classifyChangedFiles(files);
+const typecheckRequired = requiresTypecheck(classification, { full });
+
+console.log(`[local-admission] change class: ${classification.kind}`);
+console.log(`[local-admission] files considered: ${classification.files.length}`);
+
+if (!ensureDependencyState()) {
+  report('Dependency state', 'FAIL');
+  process.exit(1);
+}
+report('Dependency state', 'PASS');
+
+runCheck('Toolchain', () => runNodeScript('scripts/check-pnpm-toolchain.mjs', ['--hook']));
+runCheck('Docs/release truth', () => runNodeScript('scripts/check-doc-metrics.mjs'));
+runCheck('CSP policy', () => runNodeScript('scripts/check-csp-policy.mjs'));
+runCheck('Desktop import boundary', () => runNodeScript('scripts/check-tauri-import-boundary.mjs'));
+runCheck('Native readiness', () => runNodeScript('scripts/check-native-readiness.mjs'));
+
+if (shouldRunAdmissionCheck('i18n', classification.files) || full) {
+  runCheck('i18n key parity', () => runNodeScript('scripts/check-i18n-keys.mjs'));
+  runCheck('i18n bundle rebuild', () => runNodeScript('scripts/build-i18n.mjs'));
+  runCheck('i18n translation quality', () =>
+    runNodeScript('scripts/i18n-quality-report.mjs', [
+      '--strict',
+      '--min-coverage',
+      '75',
+      '--max-length-outliers',
+      '8',
+    ]),
+  );
+}
+
+if (shouldRunAdmissionCheck('contentGuard', classification.files) || full)
+  runCheck('Content guard', () => runNodeScript('scripts/content-guard.mjs'));
+
+if (typecheckRequired) {
+  runCheck('TypeScript (single checker)', () =>
+    runLocalBinary('tsgo', ['--project', 'tsconfig.tsgo.json', '--noEmit', '--checkers', '1']),
+  );
+} else {
+  report('TypeScript', 'DEFERRED_TO_REQUIRED_CI', 'no TypeScript-impacting changes detected');
+}
+
+console.log('\nLOCAL ADMISSION RESULT');
+console.log('Local checks completed sequentially.');
+console.log('Cloud validation required YES');
+console.log(`Classification             ${classification.kind}`);

--- a/tests/unit/tooling/ciPrepushClassifier.test.ts
+++ b/tests/unit/tooling/ciPrepushClassifier.test.ts
@@ -3,6 +3,7 @@ import { shouldRunAdmissionCheck } from '../../../scripts/ci-prepush-check-regis
 import {
   classifyChangedFiles,
   classifyFile,
+  manualAdmissionNeedsFullValidation,
   requiresTypecheck,
 } from '../../../scripts/ci-prepush-classifier.mjs';
 
@@ -59,5 +60,18 @@ describe('change-aware local admission classifier', () => {
 
     expect(classification.kind).toBe('TYPESCRIPT_APPLICATION');
     expect(requiresTypecheck(classification)).toBe(true);
+  });
+
+  it('requires conservative full admission when the manual range is unresolved', () => {
+    expect(manualAdmissionNeedsFullValidation(true)).toBe(false);
+    expect(manualAdmissionNeedsFullValidation(false)).toBe(true);
+
+    const earlierTypeScript = classifyChangedFiles(['src/app.tsx']);
+    const earlierI18n = classifyChangedFiles(['locales/en/common.json']);
+    const earlierContent = classifyChangedFiles(['community-templates/index.json']);
+
+    expect(requiresTypecheck(earlierTypeScript)).toBe(true);
+    expect(earlierI18n.kind).toBe('AMBIGUOUS');
+    expect(earlierContent.kind).toBe('AMBIGUOUS');
   });
 });

--- a/tests/unit/tooling/ciPrepushClassifier.test.ts
+++ b/tests/unit/tooling/ciPrepushClassifier.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { shouldRunAdmissionCheck } from '../../../scripts/ci-prepush-check-registry.mjs';
+import {
+  classifyChangedFiles,
+  classifyFile,
+  requiresTypecheck,
+} from '../../../scripts/ci-prepush-classifier.mjs';
+
+describe('change-aware local admission classifier', () => {
+  it.each([
+    ['README.md', 'DOCS'],
+    ['.github/workflows/ci.yml', 'WORKFLOW'],
+    ['tests/unit/example.test.ts', 'TYPESCRIPT_APPLICATION'],
+    ['tests/fixtures/example.json', 'TEST_ONLY'],
+    ['src-tauri/src/lib.rs', 'RUST_TAURI'],
+    ['scripts/check-example.mjs', 'TOOLING'],
+    ['unknown-extension.data', 'UNKNOWN'],
+  ])('classifies %s as %s', (file, expected) => {
+    expect(classifyFile(file)).toBe(expected);
+  });
+
+  it('runs TypeScript for TypeScript tests but defers non-TypeScript tests', () => {
+    const ts = classifyChangedFiles(['tests/unit/example.test.ts']);
+    const fixture = classifyChangedFiles(['tests/fixtures/example.json']);
+
+    expect(ts.kind).toBe('TYPESCRIPT_APPLICATION');
+    expect(requiresTypecheck(ts)).toBe(true);
+    expect(fixture.kind).toBe('TEST_ONLY');
+    expect(requiresTypecheck(fixture)).toBe(false);
+  });
+
+  it('uses the broad safe class for unknown or mixed changes', () => {
+    const unknown = classifyChangedFiles(['README.md', 'new-file.data']);
+    const mixed = classifyChangedFiles(['components/App.tsx', 'README.md']);
+
+    expect(unknown.kind).toBe('AMBIGUOUS');
+    expect(requiresTypecheck(unknown)).toBe(true);
+    expect(mixed.kind).toBe('MIXED');
+    expect(requiresTypecheck(mixed)).toBe(true);
+  });
+
+  it('routes only governed files and implementation changes to admission checks', () => {
+    expect(shouldRunAdmissionCheck('i18n', ['locales/en/common.json'])).toBe(true);
+    expect(shouldRunAdmissionCheck('i18n', ['README.md'])).toBe(false);
+    expect(shouldRunAdmissionCheck('i18n', ['scripts/ci-prepush-classifier.mjs'])).toBe(true);
+    expect(shouldRunAdmissionCheck('contentGuard', ['community-templates/index.json'])).toBe(true);
+    expect(shouldRunAdmissionCheck('contentGuard', ['README.md'])).toBe(false);
+  });
+});

--- a/tests/unit/tooling/ciPrepushClassifier.test.ts
+++ b/tests/unit/tooling/ciPrepushClassifier.test.ts
@@ -43,7 +43,19 @@ describe('change-aware local admission classifier', () => {
     expect(shouldRunAdmissionCheck('i18n', ['locales/en/common.json'])).toBe(true);
     expect(shouldRunAdmissionCheck('i18n', ['README.md'])).toBe(false);
     expect(shouldRunAdmissionCheck('i18n', ['scripts/ci-prepush-classifier.mjs'])).toBe(true);
+    expect(shouldRunAdmissionCheck('i18n', ['scripts/build-i18n.mjs'])).toBe(true);
+    expect(shouldRunAdmissionCheck('i18n', ['scripts/i18n-quality-report.mjs'])).toBe(true);
     expect(shouldRunAdmissionCheck('contentGuard', ['community-templates/index.json'])).toBe(true);
     expect(shouldRunAdmissionCheck('contentGuard', ['README.md'])).toBe(false);
+  });
+
+  it('keeps TypeScript tooling files in the typecheck-required class', () => {
+    const classification = classifyChangedFiles([
+      'scripts/check-tooling.ts',
+      'scripts/types.d.mts',
+    ]);
+
+    expect(classification.kind).toBe('TYPESCRIPT_APPLICATION');
+    expect(requiresTypecheck(classification)).toBe(true);
   });
 });

--- a/tests/unit/tooling/ciPrepushClassifier.test.ts
+++ b/tests/unit/tooling/ciPrepushClassifier.test.ts
@@ -47,6 +47,8 @@ describe('change-aware local admission classifier', () => {
     expect(shouldRunAdmissionCheck('i18n', ['scripts/i18n-quality-report.mjs'])).toBe(true);
     expect(shouldRunAdmissionCheck('contentGuard', ['community-templates/index.json'])).toBe(true);
     expect(shouldRunAdmissionCheck('contentGuard', ['README.md'])).toBe(false);
+    expect(shouldRunAdmissionCheck('i18n', ['scripts/ci-prepush-lowend.mjs'])).toBe(true);
+    expect(shouldRunAdmissionCheck('contentGuard', ['scripts/ci-prepush-lowend.mjs'])).toBe(true);
   });
 
   it('keeps TypeScript tooling files in the typecheck-required class', () => {


### PR DESCRIPTION
## **User description**
## Scope

Reconstructed from frozen PR #491 source SHA `9bbeded78f1032a5e74aa370ef7ca158628ad784` and fresh post-#494 `main`.

This replacement owns only the S1-final local-admission classifier and declarative check-routing registry:

- classify changed files before expensive local checks;
- defer TypeScript for docs/workflow/tooling/non-TypeScript test/Rust-only changes;
- keep mandatory cheap policy checks and cloud CI authority;
- route i18n/content checks from one narrow registry;
- include implementation self-impact;
- preserve #494 S3a evidence consumption in the existing pre-push path.

## Non-goals

- no S3b exact-tree dependency compatibility proof;
- no process-lifecycle redesign;
- no workflow/Docker/Intel changes;
- no mutation of PR #491, #492, #493, #477, or `main`;
- no merge of this replacement PR in this execution stage.

## Validation

- focused classifier tests: 10 passed;
- Biome: passed;
- `pnpm run docs:check`: passed;
- `pnpm run ci:prepush`: passed;
- signing doctor and signed commit verification: passed;
- README metrics synchronized to source-derived 6962 tests / 576 files.

The independent clone used its own frozen-lockfile dependency reconciliation and clone-local pnpm store; no dependency manifests or lockfiles changed.

## Summary by Sourcery

Make local pre-push admission checks change-aware while retaining conservative validation for ambiguous changes.

New Features:
- Classify changed files to determine which local admission checks are relevant.
- Add declarative routing for i18n and content validation based on changed files and checker implementation changes.
- Support explicit full validation and conservative fallback when the changed range cannot be resolved.

Enhancements:
- Make pre-push admission output clearly distinguish passed, failed, and deferred checks while preserving mandatory policy checks and cloud validation authority.

Documentation:
- Synchronize README test counts and file metrics with the updated test suite.

Tests:
- Add focused coverage for change classification, TypeScript routing, admission-check routing, and conservative validation behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved pre-push validation by selecting checks based on changed files.
  * Added clearer sequential reporting, conservative full validation, and optional full-check mode.
  * Improved TypeScript check gating and expanded internationalization tooling coverage.
  * Added more reliable handling when the changed-file range cannot be determined.

* **Documentation**
  * Updated README test metrics to reflect 6,964+ tests across 576 files.

* **Tests**
  * Added coverage for file classification, check routing, and validation decisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Make local pre-push checks depend on the files changed

### What Changed
- Classifies changed files and runs TypeScript checks only when the changes can affect TypeScript, while retaining an explicit full-check option
- Defers TypeScript checks for documentation, workflows, tooling, non-TypeScript tests, and Rust-only changes; ambiguous or mixed changes still require them
- Runs i18n and content validation only for relevant files or their check implementations
- Always keeps dependency, policy, readiness, and documentation checks in the local admission flow, with clear pass, fail, and deferred results
- Adds coverage for file classification and check routing, and updates documented test totals

### Impact
`✅ Faster pre-push checks for non-TypeScript changes`
`✅ Fewer unnecessary local validation runs`
`✅ Clearer check results and deferred-check explanations`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
