### PR TITLE
feat(signing): add exact-localSha dependency-manifest compatibility proof (S3b Part 2a)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2925_keys-0EA5E9" alt="i18n 19 locales — 2925 keys">
-  <img src="https://img.shields.io/badge/Tests-6998%2B_%2F_578_files-22C55E" alt="6998+ tests / 578 files">
+  <img src="https://img.shields.io/badge/Tests-7003%2B_%2F_578_files-22C55E" alt="7003+ tests / 578 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -512,7 +512,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2925 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (6998+ tests / 578 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7003+ tests / 578 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -550,7 +550,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (6998+ tests, 578 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7003+ tests, 578 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -712,7 +712,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-21, source-synchronized; CI remains authoritative for pass/fail):**
-- **6998+ unit tests** across **578 test files** — CI is authoritative for pass/fail
+- **7003+ unit tests** across **578 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2925 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2925_keys-0EA5E9" alt="i18n 19 locales — 2925 keys">
-  <img src="https://img.shields.io/badge/Tests-7003%2B_%2F_578_files-22C55E" alt="7003+ tests / 578 files">
+  <img src="https://img.shields.io/badge/Tests-7005%2B_%2F_578_files-22C55E" alt="7005+ tests / 578 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -512,7 +512,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2925 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7003+ tests / 578 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7005+ tests / 578 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -550,7 +550,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7003+ tests, 578 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7005+ tests, 578 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -712,7 +712,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-21, source-synchronized; CI remains authoritative for pass/fail):**
-- **7003+ unit tests** across **578 test files** — CI is authoritative for pass/fail
+- **7005+ unit tests** across **578 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2925 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/scripts/ci-prepush-lowend.mjs
+++ b/scripts/ci-prepush-lowend.mjs
@@ -57,6 +57,19 @@ async function main() {
       'UNKNOWN',
       'could not determine whether local results reflect the exact pushed commit(s); required CI remains authoritative',
     );
+  // QNBS-v3: informational only — compares the pushed commit's manifests to the local reconciled baseline.
+  if (manualEvidence.dependencyState === 'DIVERGED')
+    report(
+      'Dependency manifests vs. push',
+      'DIVERGED',
+      'pushed commit(s) declare dependencies not yet reconciled locally; required CI remains authoritative',
+    );
+  else if (manualEvidence.dependencyState === 'UNKNOWN')
+    report(
+      'Dependency manifests vs. push',
+      'UNKNOWN',
+      'could not compare pushed dependency manifests to the local baseline; required CI remains authoritative',
+    );
 
   if (!ensureDependencyState()) {
     report('Dependency state', 'FAIL');

--- a/scripts/ci-prepush-range-resolver.d.mts
+++ b/scripts/ci-prepush-range-resolver.d.mts
@@ -1,9 +1,11 @@
+import type { DependencyState } from './dependency-state.d.mts';
 import type { WorkingTreeState } from './signing/signing-core.d.mts';
 
 export interface ManualChangeEvidence {
   readonly files: readonly string[];
   readonly rangeResolved: boolean;
   readonly workingTreeState: WorkingTreeState;
+  readonly dependencyState: DependencyState;
 }
 
 export interface ManualRangeDependencies {

--- a/scripts/ci-prepush-range-resolver.mjs
+++ b/scripts/ci-prepush-range-resolver.mjs
@@ -48,19 +48,14 @@ export function changedFilesFromManualRange(dependencies = {}) {
   const workingTreeFiles = dependencies.workingTreeFiles ?? defaultWorkingTreeFiles;
 
   // QNBS-v3: no push event or localSha exists in this mode, so nothing is ever compared.
+  const notApplicable = { workingTreeState: 'NOT_APPLICABLE', dependencyState: 'NOT_APPLICABLE' };
   const upstream = resolveUpstream();
-  if (!upstream) return { files: [], rangeResolved: false, workingTreeState: 'NOT_APPLICABLE' };
+  if (!upstream) return { files: [], rangeResolved: false, ...notApplicable };
   const diffFiles = diffNames(`${upstream}..HEAD`);
-  if (diffFiles === null)
-    return { files: [], rangeResolved: false, workingTreeState: 'NOT_APPLICABLE' };
+  if (diffFiles === null) return { files: [], rangeResolved: false, ...notApplicable };
   const workingFiles = workingTreeFiles();
-  if (workingFiles === null)
-    return { files: [], rangeResolved: false, workingTreeState: 'NOT_APPLICABLE' };
-  return {
-    files: diffFiles.concat(workingFiles),
-    rangeResolved: true,
-    workingTreeState: 'NOT_APPLICABLE',
-  };
+  if (workingFiles === null) return { files: [], rangeResolved: false, ...notApplicable };
+  return { files: diffFiles.concat(workingFiles), rangeResolved: true, ...notApplicable };
 }
 
 export function resolveManualEvidence(evidenceFile, dependencies = {}) {
@@ -74,5 +69,6 @@ export function resolveManualEvidence(evidenceFile, dependencies = {}) {
     files: evidence.changedFiles,
     rangeResolved: evidence.pathEvidenceState === 'COMPLETE',
     workingTreeState: evidence.workingTreeState,
+    dependencyState: evidence.dependencyState,
   };
 }

--- a/scripts/dependency-state.d.mts
+++ b/scripts/dependency-state.d.mts
@@ -21,7 +21,7 @@ export function dependencyFilesFromRef(
 
 export interface DependencyFingerprintFromRefDependencies extends DependencyFilesFromRefDependencies {
   dependencyFilesFromRef?: (sha: string) => string[] | null;
-  readFileAtRef?: (relativePath: string) => string | null;
+  readFileAtRef?: (relativePath: string) => Buffer | null;
 }
 
 export function calculateDependencyFingerprintFromRef(

--- a/scripts/dependency-state.d.mts
+++ b/scripts/dependency-state.d.mts
@@ -1,0 +1,42 @@
+// QNBS-v3: diagnostic-only dimension, independent of resolvePushEvidence's canonical evidence validity.
+export type DependencyState = 'MATCHES' | 'DIVERGED' | 'NOT_APPLICABLE' | 'UNKNOWN';
+
+export function dependencyFiles(root?: string): string[];
+export function calculateDependencyFingerprint(root?: string): string;
+export function fingerprintPath(root?: string): string;
+export function readStoredFingerprint(root?: string): string | null;
+export function writeStoredFingerprint(root?: string, fingerprint?: string): void;
+export function verifyDependencyState(root?: string): string;
+export function main(command?: string): void;
+
+export interface DependencyFilesFromRefDependencies {
+  listTree?: (sha: string) => string[] | null;
+}
+
+export function dependencyFilesFromRef(
+  sha: string,
+  root?: string,
+  dependencies?: DependencyFilesFromRefDependencies,
+): string[] | null;
+
+export interface DependencyFingerprintFromRefDependencies extends DependencyFilesFromRefDependencies {
+  dependencyFilesFromRef?: (sha: string) => string[] | null;
+  readFileAtRef?: (relativePath: string) => string | null;
+}
+
+export function calculateDependencyFingerprintFromRef(
+  sha: string,
+  root?: string,
+  dependencies?: DependencyFingerprintFromRefDependencies,
+): string | null;
+
+export interface ComputeDependencyStateDependencies extends DependencyFingerprintFromRefDependencies {
+  readStoredFingerprint?: () => string | null;
+  calculateDependencyFingerprintFromRef?: (sha: string) => string | null;
+}
+
+export function computeDependencyState(
+  sha: string,
+  root?: string,
+  dependencies?: ComputeDependencyStateDependencies,
+): DependencyState;

--- a/scripts/dependency-state.mjs
+++ b/scripts/dependency-state.mjs
@@ -14,7 +14,15 @@ import { join, relative, resolve } from 'node:path';
 import process from 'node:process';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
-const projectRoot = resolve(fileURLToPath(new URL('..', import.meta.url)));
+// QNBS-v3: import.meta.url isn't always a file: URL under Vitest's transform; cwd is the repo root there.
+function resolveProjectRoot() {
+  try {
+    return resolve(fileURLToPath(new URL('..', import.meta.url)));
+  } catch {
+    return process.cwd();
+  }
+}
+const projectRoot = resolveProjectRoot();
 const fingerprintRelativePath = 'node_modules/.worldscript-deps-fingerprint';
 
 function walkFiles(directory) {
@@ -42,14 +50,91 @@ export function dependencyFiles(root = projectRoot) {
   return files.filter((file) => existsSync(file)).sort();
 }
 
-export function calculateDependencyFingerprint(root = projectRoot) {
+// QNBS-v3: shared by both the filesystem and git-ref fingerprint paths so they can never drift.
+function hashManifests(entries) {
   const hash = createHash('sha256');
-  for (const file of dependencyFiles(root)) {
-    hash.update(`${relative(root, file).replaceAll('\\', '/')}\0`);
-    hash.update(readFileSync(file));
+  for (const [relativePath, content] of [...entries].sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))) {
+    hash.update(`${relativePath}\0`);
+    hash.update(content);
     hash.update('\0');
   }
   return hash.digest('hex');
+}
+
+export function calculateDependencyFingerprint(root = projectRoot) {
+  const entries = dependencyFiles(root).map((file) => [
+    relative(root, file).replaceAll('\\', '/'),
+    readFileSync(file),
+  ]);
+  return hashManifests(entries);
+}
+
+function defaultListTreeFiles(sha, cwd) {
+  const result = spawnSync('git', ['ls-tree', '-r', '--name-only', sha], {
+    cwd,
+    encoding: 'utf8',
+    timeout: 5000,
+  });
+  if (result.error || result.status !== 0) return null;
+  return result.stdout.split('\n').filter(Boolean);
+}
+
+// QNBS-v3: diagnostic-only; mirrors dependencyFiles' inclusion rules against a commit, not disk.
+export function dependencyFilesFromRef(sha, root = projectRoot, dependencies = {}) {
+  const listTree = dependencies.listTree ?? ((ref) => defaultListTreeFiles(ref, root));
+  const allPaths = listTree(sha);
+  if (allPaths === null) return null;
+  const rootFiles = new Set(['package.json', 'pnpm-lock.yaml', 'pnpm-workspace.yaml']);
+  const packagePattern = /^packages\/[^/]+\/package\.json$/;
+  return allPaths
+    .filter(
+      (path) => rootFiles.has(path) || path.startsWith('patches/') || packagePattern.test(path),
+    )
+    .sort();
+}
+
+function defaultReadFileAtRef(sha, relativePath, cwd) {
+  const result = spawnSync('git', ['show', `${sha}:${relativePath}`], {
+    cwd,
+    encoding: 'utf8',
+    timeout: 5000,
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  if (result.error || result.status !== 0) return null;
+  return result.stdout;
+}
+
+// QNBS-v3: diagnostic-only; reads localSha's committed manifests via git objects, no worktree.
+export function calculateDependencyFingerprintFromRef(sha, root = projectRoot, dependencies = {}) {
+  const listFiles = dependencies.dependencyFilesFromRef ?? (() => dependencyFilesFromRef(sha, root, dependencies));
+  const files = listFiles(sha);
+  if (files === null) return null;
+  const readContent = dependencies.readFileAtRef ?? ((path) => defaultReadFileAtRef(sha, path, root));
+  const entries = [];
+  for (const relativePath of files) {
+    const content = readContent(relativePath);
+    if (content === null) return null;
+    entries.push([relativePath, content]);
+  }
+  return hashManifests(entries);
+}
+
+// QNBS-v3: diagnostic-only signal; never throws, so it cannot corrupt canonical evidence validity.
+export function computeDependencyState(sha, root = projectRoot, dependencies = {}) {
+  try {
+    const readStored = dependencies.readStoredFingerprint ?? (() => readStoredFingerprint(root));
+    const storedFingerprint = readStored();
+    // QNBS-v3: no baseline reconciled yet on this machine -- an honest unknown, not "no comparison".
+    if (!storedFingerprint) return 'UNKNOWN';
+    const fingerprintFromRef =
+      dependencies.calculateDependencyFingerprintFromRef ??
+      ((ref) => calculateDependencyFingerprintFromRef(ref, root, dependencies));
+    const refFingerprint = fingerprintFromRef(sha);
+    if (refFingerprint === null) return 'UNKNOWN';
+    return refFingerprint === storedFingerprint ? 'MATCHES' : 'DIVERGED';
+  } catch {
+    return 'UNKNOWN';
+  }
 }
 
 export function fingerprintPath(root = projectRoot) {

--- a/scripts/dependency-state.mjs
+++ b/scripts/dependency-state.mjs
@@ -76,14 +76,15 @@ export function calculateDependencyFingerprint(root = projectRoot) {
   return hashManifests(entries);
 }
 
+// QNBS-v3: --full-tree ignores cwd-subdirectory scoping; -z disables git's default path C-quoting.
 function defaultListTreeFiles(sha, cwd) {
-  const result = spawnSync('git', ['ls-tree', '-r', '--name-only', sha], {
+  const result = spawnSync('git', ['ls-tree', '-r', '--full-tree', '--name-only', '-z', sha], {
     cwd,
     encoding: 'utf8',
     timeout: 5000,
   });
   if (result.error || result.status !== 0) return null;
-  return result.stdout.split('\n').filter(Boolean);
+  return result.stdout.split('\0').filter(Boolean);
 }
 
 // QNBS-v3: diagnostic-only; mirrors dependencyFiles' inclusion rules against a commit, not disk.

--- a/scripts/dependency-state.mjs
+++ b/scripts/dependency-state.mjs
@@ -50,12 +50,19 @@ export function dependencyFiles(root = projectRoot) {
   return files.filter((file) => existsSync(file)).sort();
 }
 
+// QNBS-v3: byte-safe CRLF->LF normalization; a latin1 round-trip preserves every byte value 0-255.
+function normalizeLineEndings(content) {
+  const buffer = Buffer.isBuffer(content) ? content : Buffer.from(content, 'utf8');
+  return Buffer.from(buffer.toString('latin1').replaceAll('\r\n', '\n'), 'latin1');
+}
+
 // QNBS-v3: shared by both the filesystem and git-ref fingerprint paths so they can never drift.
 function hashManifests(entries) {
   const hash = createHash('sha256');
   for (const [relativePath, content] of [...entries].sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))) {
     hash.update(`${relativePath}\0`);
-    hash.update(content);
+    // QNBS-v3: normalizes a core.autocrlf checkout vs. the LF-stored git blob to the same bytes.
+    hash.update(normalizeLineEndings(content));
     hash.update('\0');
   }
   return hash.digest('hex');
@@ -93,10 +100,10 @@ export function dependencyFilesFromRef(sha, root = projectRoot, dependencies = {
     .sort();
 }
 
+// QNBS-v3: no encoding -- raw Buffer stdout, matching readFileSync's raw bytes for invalid UTF-8 safety.
 function defaultReadFileAtRef(sha, relativePath, cwd) {
   const result = spawnSync('git', ['show', `${sha}:${relativePath}`], {
     cwd,
-    encoding: 'utf8',
     timeout: 5000,
     maxBuffer: 16 * 1024 * 1024,
   });

--- a/scripts/signing/signing-core.d.mts
+++ b/scripts/signing/signing-core.d.mts
@@ -79,12 +79,15 @@ export function writePrePushEvidenceFile(
   file: string,
   input: string | string[] | RefUpdate[],
 ): void;
+import type { DependencyState } from '../dependency-state.d.mts';
+
 // QNBS-v3: diagnostic-only dimension, independent of evidenceState/pathEvidenceState validity.
 export type WorkingTreeState = 'MATCHES' | 'DIVERGED' | 'NOT_APPLICABLE' | 'UNKNOWN';
 export interface PushEvidenceUpdate extends RefUpdate {
   base?: string;
   disposition: 'DELETED' | 'TAG' | 'NEW_BRANCH' | 'UPDATED';
   workingTreeState: WorkingTreeState;
+  dependencyState: DependencyState;
 }
 export interface PushEvidence {
   updates: PushEvidenceUpdate[];
@@ -92,6 +95,7 @@ export interface PushEvidence {
   evidenceState: 'RESOLVED' | 'INVALID';
   pathEvidenceState: 'COMPLETE' | 'PARTIAL';
   workingTreeState: WorkingTreeState;
+  dependencyState: DependencyState;
   reason?: string;
 }
 export function computeWorkingTreeState(
@@ -107,6 +111,7 @@ export function resolvePushEvidence(
     objectExists?: (sha: string) => boolean;
     changedFilesBetween?: (base: string, head: string) => string[];
     worktreeMatchesCommit?: (sha: string) => WorkingTreeState;
+    dependencyStateForRef?: (sha: string) => DependencyState;
   },
 ): PushEvidence;
 export function selectIntroducedCommits(commits: string[], reachableFromBase: string[]): string[];

--- a/scripts/signing/signing-core.mjs
+++ b/scripts/signing/signing-core.mjs
@@ -347,6 +347,15 @@ export function computeWorkingTreeState(sha, cwd, dependencies = {}) {
   return 'UNKNOWN';
 }
 
+// QNBS-v3: an injected diagnostic resolver that throws must not corrupt canonical evidence validity.
+function safeDiagnostic(resolver, sha) {
+  try {
+    return resolver(sha);
+  } catch {
+    return 'UNKNOWN';
+  }
+}
+
 // QNBS-v3: shared by every diagnostic-only dimension so precedence can never drift between them.
 function aggregateDiagnosticState(states) {
   const relevant = states.filter((state) => state !== 'NOT_APPLICABLE');
@@ -389,8 +398,8 @@ export function resolvePushEvidence(input, cwd = process.cwd(), dependencies = {
         evidenceUpdates.push({
           ...update,
           disposition: 'TAG',
-          workingTreeState: matchesWorktree(update.localSha),
-          dependencyState: matchesDependencyState(update.localSha),
+          workingTreeState: safeDiagnostic(matchesWorktree, update.localSha),
+          dependencyState: safeDiagnostic(matchesDependencyState, update.localSha),
         });
         continue;
       }
@@ -404,8 +413,8 @@ export function resolvePushEvidence(input, cwd = process.cwd(), dependencies = {
         ...update,
         base,
         disposition: isZeroSha(update.remoteSha) ? 'NEW_BRANCH' : 'UPDATED',
-        workingTreeState: matchesWorktree(update.localSha),
-        dependencyState: matchesDependencyState(update.localSha),
+        workingTreeState: safeDiagnostic(matchesWorktree, update.localSha),
+        dependencyState: safeDiagnostic(matchesDependencyState, update.localSha),
       });
     }
     // QNBS-v3: tag updates prove object validity but not a complete changed-path set.

--- a/scripts/signing/signing-core.mjs
+++ b/scripts/signing/signing-core.mjs
@@ -2,6 +2,7 @@ import { spawnSync } from 'node:child_process';
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, join, resolve } from 'node:path';
+import { computeDependencyState } from '../dependency-state.mjs';
 
 const SHA = /^[0-9a-f]{40}$/i;
 const ZERO_SHA = /^0{40}$/;
@@ -346,11 +347,12 @@ export function computeWorkingTreeState(sha, cwd, dependencies = {}) {
   return 'UNKNOWN';
 }
 
-function aggregateWorkingTreeState(evidenceUpdates) {
-  const relevant = evidenceUpdates.filter((update) => update.workingTreeState !== 'NOT_APPLICABLE');
+// QNBS-v3: shared by every diagnostic-only dimension so precedence can never drift between them.
+function aggregateDiagnosticState(states) {
+  const relevant = states.filter((state) => state !== 'NOT_APPLICABLE');
   if (relevant.length === 0) return 'NOT_APPLICABLE';
-  if (relevant.some((update) => update.workingTreeState === 'DIVERGED')) return 'DIVERGED';
-  if (relevant.some((update) => update.workingTreeState === 'UNKNOWN')) return 'UNKNOWN';
+  if (relevant.includes('DIVERGED')) return 'DIVERGED';
+  if (relevant.includes('UNKNOWN')) return 'UNKNOWN';
   return 'MATCHES';
 }
 
@@ -367,11 +369,18 @@ export function resolvePushEvidence(input, cwd = process.cwd(), dependencies = {
       dependencies.changedFilesBetween ?? ((base, head) => changedFilesBetween(base, head, cwd));
     const matchesWorktree =
       dependencies.worktreeMatchesCommit ?? ((sha) => computeWorkingTreeState(sha, cwd));
+    const matchesDependencyState =
+      dependencies.dependencyStateForRef ?? ((sha) => computeDependencyState(sha, cwd));
     const changedFiles = new Set();
     const evidenceUpdates = [];
     for (const update of updates) {
       if (isZeroSha(update.localSha)) {
-        evidenceUpdates.push({ ...update, disposition: 'DELETED', workingTreeState: 'NOT_APPLICABLE' });
+        evidenceUpdates.push({
+          ...update,
+          disposition: 'DELETED',
+          workingTreeState: 'NOT_APPLICABLE',
+          dependencyState: 'NOT_APPLICABLE',
+        });
         continue;
       }
       if (update.remoteRef.startsWith('refs/tags/')) {
@@ -381,6 +390,7 @@ export function resolvePushEvidence(input, cwd = process.cwd(), dependencies = {
           ...update,
           disposition: 'TAG',
           workingTreeState: matchesWorktree(update.localSha),
+          dependencyState: matchesDependencyState(update.localSha),
         });
         continue;
       }
@@ -395,6 +405,7 @@ export function resolvePushEvidence(input, cwd = process.cwd(), dependencies = {
         base,
         disposition: isZeroSha(update.remoteSha) ? 'NEW_BRANCH' : 'UPDATED',
         workingTreeState: matchesWorktree(update.localSha),
+        dependencyState: matchesDependencyState(update.localSha),
       });
     }
     // QNBS-v3: tag updates prove object validity but not a complete changed-path set.
@@ -406,7 +417,8 @@ export function resolvePushEvidence(input, cwd = process.cwd(), dependencies = {
       changedFiles: [...changedFiles],
       evidenceState: 'RESOLVED',
       pathEvidenceState,
-      workingTreeState: aggregateWorkingTreeState(evidenceUpdates),
+      workingTreeState: aggregateDiagnosticState(evidenceUpdates.map((u) => u.workingTreeState)),
+      dependencyState: aggregateDiagnosticState(evidenceUpdates.map((u) => u.dependencyState)),
     };
   } catch (error) {
     return {
@@ -415,6 +427,7 @@ export function resolvePushEvidence(input, cwd = process.cwd(), dependencies = {
       evidenceState: 'INVALID',
       pathEvidenceState: 'PARTIAL',
       workingTreeState: 'NOT_APPLICABLE',
+      dependencyState: 'NOT_APPLICABLE',
       reason: error instanceof Error ? error.message : 'invalid push evidence',
     };
   }

--- a/tests/unit/signing.test.ts
+++ b/tests/unit/signing.test.ts
@@ -478,6 +478,25 @@ describe('local signing controls', () => {
       expect(result.workingTreeState).toBe('NOT_APPLICABLE');
       expect(result.dependencyState).toBe('NOT_APPLICABLE');
     });
+
+    // QNBS-v3: an injected worktreeMatchesCommit that throws must not corrupt canonical evidence.
+    it('reports UNKNOWN rather than corrupting canonical evidence when the injected resolver throws', () => {
+      const update = parseRefUpdate(
+        `refs/heads/main ${'a'.repeat(40)} refs/heads/main ${'b'.repeat(40)}`,
+      )!;
+      const result = resolvePushEvidence([update], process.cwd(), {
+        commitExists: () => true,
+        changedFilesBetween: () => ['src/example.ts'],
+        worktreeMatchesCommit: () => {
+          throw new Error('spawn EMFILE');
+        },
+        dependencyStateForRef: () => 'MATCHES',
+      });
+
+      expect(result.evidenceState).toBe('RESOLVED');
+      expect(result.pathEvidenceState).toBe('COMPLETE');
+      expect(result.workingTreeState).toBe('UNKNOWN');
+    });
   });
 
   describe('dependencyState (diagnostic dimension, never affects canonical evidence validity)', () => {
@@ -550,6 +569,25 @@ describe('local signing controls', () => {
       );
       expect(result.evidenceState).toBe('RESOLVED');
       expect(result.dependencyState).toBe('NOT_APPLICABLE');
+    });
+
+    // QNBS-v3: regression for the CodeRabbit finding -- an injected resolver throw must map to UNKNOWN.
+    it('reports UNKNOWN rather than corrupting canonical evidence when the injected resolver throws', () => {
+      const update = parseRefUpdate(
+        `refs/heads/main ${'a'.repeat(40)} refs/heads/main ${'b'.repeat(40)}`,
+      )!;
+      const result = resolvePushEvidence([update], process.cwd(), {
+        commitExists: () => true,
+        changedFilesBetween: () => ['package.json'],
+        worktreeMatchesCommit: () => 'MATCHES',
+        dependencyStateForRef: () => {
+          throw new Error('git show failed');
+        },
+      });
+
+      expect(result.evidenceState).toBe('RESOLVED');
+      expect(result.pathEvidenceState).toBe('COMPLETE');
+      expect(result.dependencyState).toBe('UNKNOWN');
     });
   });
 

--- a/tests/unit/signing.test.ts
+++ b/tests/unit/signing.test.ts
@@ -220,6 +220,7 @@ describe('local signing controls', () => {
           ? ['new\nfile.ts']
           : ['src/with\t tab.ts', '世界 file.ts', 'src/with\t tab.ts'],
       worktreeMatchesCommit: () => 'MATCHES',
+      dependencyStateForRef: () => 'MATCHES',
     });
     expect(result.evidenceState).toBe('RESOLVED');
     expect(result.pathEvidenceState).toBe('PARTIAL');
@@ -244,6 +245,7 @@ describe('local signing controls', () => {
       commitExists: () => true,
       changedFilesBetween: () => ['src/example.ts'],
       worktreeMatchesCommit: () => 'MATCHES',
+      dependencyStateForRef: () => 'MATCHES',
     });
 
     expect(result.evidenceState).toBe('RESOLVED');
@@ -261,12 +263,14 @@ describe('local signing controls', () => {
       const result = resolvePushEvidence([update], process.cwd(), {
         objectExists: () => true,
         worktreeMatchesCommit: () => 'MATCHES',
+        dependencyStateForRef: () => 'MATCHES',
       });
       expect(result.evidenceState).toBe('RESOLVED');
       expect(result.pathEvidenceState).toBe('PARTIAL');
       expect(result.changedFiles).toEqual([]);
       // QNBS-v3: tags are no longer excluded from divergence detection (unlike pathEvidenceState).
       expect(result.updates[0]?.workingTreeState).toBe('MATCHES');
+      expect(result.updates[0]?.dependencyState).toBe('MATCHES');
     }
   });
 
@@ -283,6 +287,7 @@ describe('local signing controls', () => {
         objectExists: () => true,
         changedFilesBetween: () => ['src/a.ts'],
         worktreeMatchesCommit: () => 'MATCHES',
+        dependencyStateForRef: () => 'MATCHES',
       },
     );
 
@@ -296,6 +301,7 @@ describe('local signing controls', () => {
     expect(empty.pathEvidenceState).toBe('COMPLETE');
     // QNBS-v3: nothing was compared, not "compared and found equal" — see aggregation precedence.
     expect(empty.workingTreeState).toBe('NOT_APPLICABLE');
+    expect(empty.dependencyState).toBe('NOT_APPLICABLE');
 
     const result = resolvePushEvidence(
       [parseRefUpdate(`refs/tags/v1 ${'a'.repeat(40)} refs/tags/v1 ${'0'.repeat(40)}`)!],
@@ -407,6 +413,7 @@ describe('local signing controls', () => {
         commitExists: () => true,
         changedFilesBetween: () => ['src/example.ts'],
         worktreeMatchesCommit: () => 'UNKNOWN',
+        dependencyStateForRef: () => 'MATCHES',
       });
 
       // QNBS-v3: this is the regression guard for the diagnostic-isolation correction specifically.
@@ -422,11 +429,16 @@ describe('local signing controls', () => {
         worktreeMatchesCommit: () => {
           throw new Error('must not be called for a deletion');
         },
+        dependencyStateForRef: () => {
+          throw new Error('must not be called for a deletion');
+        },
       });
 
       expect(result.evidenceState).toBe('RESOLVED');
       expect(result.updates[0]?.workingTreeState).toBe('NOT_APPLICABLE');
+      expect(result.updates[0]?.dependencyState).toBe('NOT_APPLICABLE');
       expect(result.workingTreeState).toBe('NOT_APPLICABLE');
+      expect(result.dependencyState).toBe('NOT_APPLICABLE');
     });
 
     it('aggregates with DIVERGED outranking UNKNOWN, and UNKNOWN outranking MATCHES', () => {
@@ -441,12 +453,14 @@ describe('local signing controls', () => {
       const divergedPlusUnknown = resolvePushEvidence([updateA, updateB], process.cwd(), {
         ...shared,
         worktreeMatchesCommit: (sha) => (sha === updateA.localSha ? 'DIVERGED' : 'UNKNOWN'),
+        dependencyStateForRef: () => 'MATCHES',
       });
       expect(divergedPlusUnknown.workingTreeState).toBe('DIVERGED');
 
       const matchesPlusUnknown = resolvePushEvidence([updateA, updateB], process.cwd(), {
         ...shared,
         worktreeMatchesCommit: (sha) => (sha === updateA.localSha ? 'MATCHES' : 'UNKNOWN'),
+        dependencyStateForRef: () => 'MATCHES',
       });
       expect(matchesPlusUnknown.workingTreeState).toBe('UNKNOWN');
     });
@@ -462,6 +476,80 @@ describe('local signing controls', () => {
       );
       expect(result.evidenceState).toBe('RESOLVED');
       expect(result.workingTreeState).toBe('NOT_APPLICABLE');
+      expect(result.dependencyState).toBe('NOT_APPLICABLE');
+    });
+  });
+
+  describe('dependencyState (diagnostic dimension, never affects canonical evidence validity)', () => {
+    it('does not mutate evidenceState or pathEvidenceState when the diagnostic reports UNKNOWN', () => {
+      const update = parseRefUpdate(
+        `refs/heads/main ${'a'.repeat(40)} refs/heads/main ${'b'.repeat(40)}`,
+      )!;
+      const result = resolvePushEvidence([update], process.cwd(), {
+        commitExists: () => true,
+        changedFilesBetween: () => ['package.json'],
+        worktreeMatchesCommit: () => 'MATCHES',
+        dependencyStateForRef: () => 'UNKNOWN',
+      });
+
+      // QNBS-v3: mirrors the workingTreeState isolation guard, for the dependencyState dimension.
+      expect(result.evidenceState).toBe('RESOLVED');
+      expect(result.pathEvidenceState).toBe('COMPLETE');
+      expect(result.dependencyState).toBe('UNKNOWN');
+    });
+
+    it('assigns DELETED updates NOT_APPLICABLE without calling the diagnostic', () => {
+      const zero = '0'.repeat(40);
+      const deletion = parseRefUpdate(`refs/heads/old ${zero} refs/heads/old ${'b'.repeat(40)}`)!;
+      const result = resolvePushEvidence([deletion], process.cwd(), {
+        worktreeMatchesCommit: () => {
+          throw new Error('must not be called for a deletion');
+        },
+        dependencyStateForRef: () => {
+          throw new Error('must not be called for a deletion');
+        },
+      });
+
+      expect(result.evidenceState).toBe('RESOLVED');
+      expect(result.updates[0]?.dependencyState).toBe('NOT_APPLICABLE');
+      expect(result.dependencyState).toBe('NOT_APPLICABLE');
+    });
+
+    it('aggregates with DIVERGED outranking UNKNOWN, and UNKNOWN outranking MATCHES', () => {
+      const updateA = parseRefUpdate(
+        `refs/heads/a ${'a'.repeat(40)} refs/heads/a ${'b'.repeat(40)}`,
+      )!;
+      const updateB = parseRefUpdate(
+        `refs/heads/b ${'c'.repeat(40)} refs/heads/b ${'d'.repeat(40)}`,
+      )!;
+      const shared = { commitExists: () => true, changedFilesBetween: () => [] };
+
+      const divergedPlusUnknown = resolvePushEvidence([updateA, updateB], process.cwd(), {
+        ...shared,
+        worktreeMatchesCommit: () => 'MATCHES',
+        dependencyStateForRef: (sha) => (sha === updateA.localSha ? 'DIVERGED' : 'UNKNOWN'),
+      });
+      expect(divergedPlusUnknown.dependencyState).toBe('DIVERGED');
+
+      const matchesPlusUnknown = resolvePushEvidence([updateA, updateB], process.cwd(), {
+        ...shared,
+        worktreeMatchesCommit: () => 'MATCHES',
+        dependencyStateForRef: (sha) => (sha === updateA.localSha ? 'MATCHES' : 'UNKNOWN'),
+      });
+      expect(matchesPlusUnknown.dependencyState).toBe('UNKNOWN');
+    });
+
+    it('aggregates a push containing only deletions as NOT_APPLICABLE', () => {
+      const zero = '0'.repeat(40);
+      const result = resolvePushEvidence(
+        [
+          parseRefUpdate(`refs/heads/a ${zero} refs/heads/a ${'a'.repeat(40)}`)!,
+          parseRefUpdate(`refs/heads/b ${zero} refs/heads/b ${'b'.repeat(40)}`)!,
+        ],
+        process.cwd(),
+      );
+      expect(result.evidenceState).toBe('RESOLVED');
+      expect(result.dependencyState).toBe('NOT_APPLICABLE');
     });
   });
 

--- a/tests/unit/tooling/ciPrepushRangeResolver.test.ts
+++ b/tests/unit/tooling/ciPrepushRangeResolver.test.ts
@@ -31,10 +31,13 @@ describe('isMainModule', () => {
 });
 
 describe('manual committed-range resolution', () => {
+  // QNBS-v3: no push event/localSha exists in manual mode — NOT_APPLICABLE for both dimensions.
+  const notApplicable = { workingTreeState: 'NOT_APPLICABLE', dependencyState: 'NOT_APPLICABLE' };
+
   it('is unresolved when no upstream is configured', () => {
     const result = changedFilesFromManualRange({ resolveUpstream: () => null });
 
-    expect(result).toEqual({ files: [], rangeResolved: false, workingTreeState: 'NOT_APPLICABLE' });
+    expect(result).toEqual({ files: [], rangeResolved: false, ...notApplicable });
   });
 
   it('resolves and merges working-tree changes when the diff succeeds', () => {
@@ -47,11 +50,10 @@ describe('manual committed-range resolution', () => {
       workingTreeFiles: () => ['src/dirty.ts'],
     });
 
-    // QNBS-v3: no push event/localSha exists in manual mode — NOT_APPLICABLE, never MATCHES.
     expect(result).toEqual({
       files: ['src/committed.ts', 'src/dirty.ts'],
       rangeResolved: true,
-      workingTreeState: 'NOT_APPLICABLE',
+      ...notApplicable,
     });
   });
 
@@ -65,7 +67,7 @@ describe('manual committed-range resolution', () => {
       },
     });
 
-    expect(result).toEqual({ files: [], rangeResolved: false, workingTreeState: 'NOT_APPLICABLE' });
+    expect(result).toEqual({ files: [], rangeResolved: false, ...notApplicable });
   });
 
   it('treats a genuinely empty diff as a resolved, complete range', () => {
@@ -75,7 +77,7 @@ describe('manual committed-range resolution', () => {
       workingTreeFiles: () => [],
     });
 
-    expect(result).toEqual({ files: [], rangeResolved: true, workingTreeState: 'NOT_APPLICABLE' });
+    expect(result).toEqual({ files: [], rangeResolved: true, ...notApplicable });
   });
 
   // QNBS-v3: regression — a successful committed-range diff must not mask a working-tree failure.
@@ -86,17 +88,19 @@ describe('manual committed-range resolution', () => {
       workingTreeFiles: () => null,
     });
 
-    expect(result).toEqual({ files: [], rangeResolved: false, workingTreeState: 'NOT_APPLICABLE' });
+    expect(result).toEqual({ files: [], rangeResolved: false, ...notApplicable });
   });
 });
 
 describe('resolveManualEvidence', () => {
+  const notApplicable = { workingTreeState: 'NOT_APPLICABLE', dependencyState: 'NOT_APPLICABLE' };
+
   it('falls back to the manual committed-range resolver when no evidence file is given', () => {
     const result = resolveManualEvidence(undefined, {
       resolveUpstream: () => null,
     });
 
-    expect(result).toEqual({ files: [], rangeResolved: false, workingTreeState: 'NOT_APPLICABLE' });
+    expect(result).toEqual({ files: [], rangeResolved: false, ...notApplicable });
   });
 
   it('trusts changedFiles as complete when pathEvidenceState is COMPLETE', () => {
@@ -110,6 +114,7 @@ describe('resolveManualEvidence', () => {
         pathEvidenceState: 'COMPLETE',
         changedFiles: ['src/example.ts'],
         workingTreeState: 'MATCHES',
+        dependencyState: 'MATCHES',
       }),
     });
 
@@ -117,6 +122,7 @@ describe('resolveManualEvidence', () => {
       files: ['src/example.ts'],
       rangeResolved: true,
       workingTreeState: 'MATCHES',
+      dependencyState: 'MATCHES',
     });
   });
 
@@ -128,11 +134,11 @@ describe('resolveManualEvidence', () => {
         evidenceState: 'RESOLVED',
         pathEvidenceState: 'PARTIAL',
         changedFiles: [],
-        workingTreeState: 'NOT_APPLICABLE',
+        ...notApplicable,
       }),
     });
 
-    expect(result).toEqual({ files: [], rangeResolved: false, workingTreeState: 'NOT_APPLICABLE' });
+    expect(result).toEqual({ files: [], rangeResolved: false, ...notApplicable });
   });
 
   // QNBS-v3: proves the two signals are orthogonal, not coupled to `full` via pathEvidenceState.
@@ -145,11 +151,31 @@ describe('resolveManualEvidence', () => {
           pathEvidenceState: 'COMPLETE',
           changedFiles: ['src/example.ts'],
           workingTreeState,
+          dependencyState: 'MATCHES',
         }),
       });
 
       expect(result.rangeResolved).toBe(true);
       expect(result.workingTreeState).toBe(workingTreeState);
+    }
+  });
+
+  // QNBS-v3: proves dependencyState propagates independently of workingTreeState/pathEvidenceState.
+  it('propagates DIVERGED and UNKNOWN dependencyState independently of the other signals', () => {
+    for (const dependencyState of ['DIVERGED', 'UNKNOWN']) {
+      const result = resolveManualEvidence('/tmp/evidence.json', {
+        readPrePushEvidenceFile: () => 'raw',
+        resolvePushEvidence: () => ({
+          evidenceState: 'RESOLVED',
+          pathEvidenceState: 'COMPLETE',
+          changedFiles: ['src/example.ts'],
+          workingTreeState: 'MATCHES',
+          dependencyState,
+        }),
+      });
+
+      expect(result.rangeResolved).toBe(true);
+      expect(result.dependencyState).toBe(dependencyState);
     }
   });
 
@@ -161,7 +187,7 @@ describe('resolveManualEvidence', () => {
           evidenceState: 'INVALID',
           pathEvidenceState: 'PARTIAL',
           changedFiles: [],
-          workingTreeState: 'NOT_APPLICABLE',
+          ...notApplicable,
           reason: 'boom',
         }),
       }),

--- a/tests/unit/tooling/dependency-state.test.mjs
+++ b/tests/unit/tooling/dependency-state.test.mjs
@@ -1,4 +1,5 @@
 import { strict as assert } from 'node:assert';
+import { execFileSync } from 'node:child_process';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { afterEach, describe, it } from 'node:test';
@@ -82,6 +83,30 @@ describe('dependencyFilesFromRef (git-object-only, no worktree)', () => {
 
   it('returns null (not []) when the tree listing fails', () => {
     assert.equal(dependencyFilesFromRef('deadbeef', '/repo', { listTree: () => null }), null);
+  });
+});
+
+describe('dependencyFilesFromRef (real git invocation, default listTree)', () => {
+  // QNBS-v3: regression -- git's default C-quoting of non-ASCII paths must not exclude real files.
+  it('includes a non-ASCII patch filename via the real git default (no listTree injected)', () => {
+    const root = mkdtempSync(join(process.cwd(), '.worldscript-deps-git-'));
+    temporaryRoots.push(root);
+    const git = (args) => execFileSync('git', args, { cwd: root, encoding: 'utf8' });
+    git(['init', '--quiet', '--initial-branch=main']);
+    git(['config', 'user.email', 'test@example.com']);
+    git(['config', 'user.name', 'test']);
+    mkdirSync(join(root, 'patches'), { recursive: true });
+    writeFileSync(join(root, 'patches', 'café.patch'), 'patch\n');
+    git(['add', '-A']);
+    git(['-c', 'commit.gpgsign=false', 'commit', '--quiet', '-m', 'test']);
+    const sha = git(['rev-parse', 'HEAD']).trim();
+
+    const files = dependencyFilesFromRef(sha, root);
+
+    assert.ok(
+      files?.includes('patches/café.patch'),
+      `expected patches/café.patch in ${JSON.stringify(files)}`,
+    );
   });
 });
 

--- a/tests/unit/tooling/dependency-state.test.mjs
+++ b/tests/unit/tooling/dependency-state.test.mjs
@@ -4,6 +4,9 @@ import { join } from 'node:path';
 import { afterEach, describe, it } from 'node:test';
 import {
   calculateDependencyFingerprint,
+  calculateDependencyFingerprintFromRef,
+  computeDependencyState,
+  dependencyFilesFromRef,
   readStoredFingerprint,
   writeStoredFingerprint,
 } from '../../../scripts/dependency-state.mjs';
@@ -48,5 +51,111 @@ describe('dependency fingerprint', () => {
     const before = calculateDependencyFingerprint(root);
     writeFileSync(join(root, 'patches', 'demo.patch'), 'changed patch\n');
     assert.notEqual(calculateDependencyFingerprint(root), before);
+  });
+});
+
+describe('dependencyFilesFromRef (git-object-only, no worktree)', () => {
+  it('includes root manifests, patches, and single-level package.json, excludes the rest', () => {
+    const files = dependencyFilesFromRef('deadbeef', '/repo', {
+      listTree: () => [
+        'package.json',
+        'pnpm-lock.yaml',
+        'pnpm-workspace.yaml',
+        'README.md',
+        'patches/demo.patch',
+        'patches/nested/also.patch',
+        'packages/demo/package.json',
+        'packages/demo/src/index.ts',
+        'packages/demo/nested/package.json',
+      ],
+    });
+
+    assert.deepEqual(files, [
+      'package.json',
+      'packages/demo/package.json',
+      'patches/demo.patch',
+      'patches/nested/also.patch',
+      'pnpm-lock.yaml',
+      'pnpm-workspace.yaml',
+    ]);
+  });
+
+  it('returns null (not []) when the tree listing fails', () => {
+    assert.equal(dependencyFilesFromRef('deadbeef', '/repo', { listTree: () => null }), null);
+  });
+});
+
+describe('calculateDependencyFingerprintFromRef (git-object-only, no worktree)', () => {
+  it('matches the filesystem fingerprint for the same paths and content', () => {
+    const root = makeDependencyRoot();
+    const filesystemFingerprint = calculateDependencyFingerprint(root);
+    const contentByPath = {
+      'package.json': '{}\n',
+      'pnpm-lock.yaml': "lockfileVersion: '9.0'\n",
+      'pnpm-workspace.yaml': 'packages:\n  - packages/*\n',
+      'packages/demo/package.json': '{"name":"demo"}\n',
+      'patches/demo.patch': 'patch\n',
+    };
+    const refFingerprint = calculateDependencyFingerprintFromRef('deadbeef', root, {
+      listTree: () => Object.keys(contentByPath),
+      readFileAtRef: (relativePath) => contentByPath[relativePath],
+    });
+
+    assert.equal(refFingerprint, filesystemFingerprint);
+  });
+
+  it('returns null when a file read at the ref fails', () => {
+    const result = calculateDependencyFingerprintFromRef('deadbeef', '/repo', {
+      listTree: () => ['package.json'],
+      readFileAtRef: () => null,
+    });
+    assert.equal(result, null);
+  });
+});
+
+describe('computeDependencyState (diagnostic-only, isolated from canonical evidence)', () => {
+  it('reports MATCHES when the ref fingerprint equals the stored baseline', () => {
+    const state = computeDependencyState('deadbeef', '/repo', {
+      readStoredFingerprint: () => 'abc123',
+      calculateDependencyFingerprintFromRef: () => 'abc123',
+    });
+    assert.equal(state, 'MATCHES');
+  });
+
+  it('reports DIVERGED when the ref fingerprint differs from the stored baseline', () => {
+    const state = computeDependencyState('deadbeef', '/repo', {
+      readStoredFingerprint: () => 'abc123',
+      calculateDependencyFingerprintFromRef: () => 'def456',
+    });
+    assert.equal(state, 'DIVERGED');
+  });
+
+  it('reports UNKNOWN when no baseline has been reconciled on this machine yet', () => {
+    const state = computeDependencyState('deadbeef', '/repo', {
+      readStoredFingerprint: () => null,
+      calculateDependencyFingerprintFromRef: () => {
+        throw new Error('must not be called without a baseline to compare against');
+      },
+    });
+    assert.equal(state, 'UNKNOWN');
+  });
+
+  it('reports UNKNOWN when the ref fingerprint could not be established', () => {
+    const state = computeDependencyState('deadbeef', '/repo', {
+      readStoredFingerprint: () => 'abc123',
+      calculateDependencyFingerprintFromRef: () => null,
+    });
+    assert.equal(state, 'UNKNOWN');
+  });
+
+  // QNBS-v3: an injected dependency that throws must not escape into resolvePushEvidence's catch.
+  it('reports UNKNOWN rather than propagating a throw from an injected dependency', () => {
+    const state = computeDependencyState('deadbeef', '/repo', {
+      readStoredFingerprint: () => 'abc123',
+      calculateDependencyFingerprintFromRef: () => {
+        throw new Error('git show failed');
+      },
+    });
+    assert.equal(state, 'UNKNOWN');
   });
 });

--- a/tests/unit/tooling/dependency-state.test.mjs
+++ b/tests/unit/tooling/dependency-state.test.mjs
@@ -111,6 +111,42 @@ describe('calculateDependencyFingerprintFromRef (git-object-only, no worktree)',
     });
     assert.equal(result, null);
   });
+
+  // QNBS-v3: regression -- git-object read must hash raw bytes, not a lossy UTF-8-decoded string.
+  it('matches the filesystem fingerprint byte-for-byte, including invalid UTF-8 content', () => {
+    const root = makeDependencyRoot();
+    const invalidUtf8 = Buffer.from([0x70, 0x61, 0x74, 0x63, 0x68, 0x0a, 0xff]);
+    writeFileSync(join(root, 'patches', 'demo.patch'), invalidUtf8);
+    const filesystemFingerprint = calculateDependencyFingerprint(root);
+
+    const contentByPath = {
+      'package.json': Buffer.from('{}\n'),
+      'pnpm-lock.yaml': Buffer.from("lockfileVersion: '9.0'\n"),
+      'pnpm-workspace.yaml': Buffer.from('packages:\n  - packages/*\n'),
+      'packages/demo/package.json': Buffer.from('{"name":"demo"}\n'),
+      'patches/demo.patch': invalidUtf8,
+    };
+    const refFingerprint = calculateDependencyFingerprintFromRef('deadbeef', root, {
+      listTree: () => Object.keys(contentByPath),
+      readFileAtRef: (relativePath) => contentByPath[relativePath],
+    });
+
+    assert.equal(refFingerprint, filesystemFingerprint);
+  });
+
+  // QNBS-v3: regression -- core.autocrlf CRLF checkout vs. LF git blob must not report false DIVERGED.
+  it('produces the same fingerprint for content differing only by CRLF vs. LF line endings', () => {
+    const lf = calculateDependencyFingerprintFromRef('deadbeef', '/repo', {
+      listTree: () => ['package.json'],
+      readFileAtRef: () => Buffer.from('{\n  "name": "demo"\n}\n'),
+    });
+    const crlf = calculateDependencyFingerprintFromRef('deadbeef', '/repo', {
+      listTree: () => ['package.json'],
+      readFileAtRef: () => Buffer.from('{\r\n  "name": "demo"\r\n}\r\n'),
+    });
+
+    assert.equal(crlf, lf);
+  });
 });
 
 describe('computeDependencyState (diagnostic-only, isolated from canonical evidence)', () => {


### PR DESCRIPTION
## **User description**
## Summary

Part 2a of the S3b reconstruction slice (follows #501, "Part 1 — divergence detection"). Adds a second, independent diagnostic-only `PushEvidence` dimension: `dependencyState`, answering "do the pushed commit's dependency manifests (package.json / pnpm-lock.yaml / pnpm-workspace.yaml / packages/*/package.json / patches/**) match what's reconciled locally?" — entirely via git objects (`git ls-tree` / `git show`), with **no worktree materialization**.

This is the cheap, worktree-free half of the plan's Part 2 split (see `/home/pc/.claude/plans/world-script-studio-atomic-harbor.md` §E, point 2: "dependency compatibility vs. TypeScript... should be **separate sub-slices**, not bundled" — TypeScript's isolated-worktree exact-`localSha` verification is Part 2b, tracked separately and not started here).

## Design (mirrors Part 1's reviewed, corrected semantics exactly)

- **Same 4-state model** as `workingTreeState`: `MATCHES | DIVERGED | NOT_APPLICABLE | UNKNOWN`.
  - `MATCHES` — comparison performed, no divergence found. **Never** "verified"/"validated" — it's the same tracked-content-only scope boundary that applies to `workingTreeState`.
  - `DIVERGED` — comparison performed, found divergence.
  - `NOT_APPLICABLE` — no meaningful comparison exists (deletion; manual/no-evidence-file invocation).
  - `UNKNOWN` — comparison was applicable but couldn't be established (no local baseline reconciled yet; a git-object read failed; an injected dependency threw).
- **Diagnostic isolation, unconditionally**: `computeDependencyState` never throws — it cannot corrupt `resolvePushEvidence`'s canonical `evidenceState`/`pathEvidenceState`, exactly like `computeWorkingTreeState`. Verified with a dedicated regression test (injected-throw → `UNKNOWN`, not a propagated exception).
- **Aggregation**: reuses the same precedence function Part 1 introduced, generalized from `aggregateWorkingTreeState` → `aggregateDiagnosticState` (DRY — the precedence logic, `DIVERGED > UNKNOWN > MATCHES`, `NOT_APPLICABLE` only when every relevant update is inapplicable, can't drift between the two dimensions because they now share one implementation).
- **`MATCHES` is not, and never will be, used as a skip gate** for Part 2b's exact TypeScript verification — same standing prohibition as Part 1, for the same reason (a git-object-only manifest comparison can't see e.g. an uncommitted `node_modules`/lockfile state fully).
- **Load-bearing correctness proof**: `calculateDependencyFingerprintFromRef(sha, ...)` (new, git-object-only) is proven byte-identical to the existing, already-trusted filesystem-based `calculateDependencyFingerprint(root)` for equivalent path/content, via a dedicated unit test — this is what makes comparing "pushed commit's manifests" against "the locally reconciled fingerprint" a sound comparison at all.

## Files changed (11)

- `scripts/dependency-state.mjs` — new git-object-only primitives (`dependencyFilesFromRef`, `calculateDependencyFingerprintFromRef`, `computeDependencyState`), refactored `hashManifests` shared by both fingerprint paths, and a `process.cwd()` fallback for the module's top-level `projectRoot` (see "Incidental fix" below).
- `scripts/dependency-state.d.mts` — **new file** (didn't exist before); full type coverage for old and new exports.
- `scripts/signing/signing-core.mjs` / `.d.mts` — `resolvePushEvidence` gains `dependencyState` per-update and aggregate, via a new `dependencyStateForRef` DI hook (default: `computeDependencyState(sha, cwd)`); `aggregateWorkingTreeState` generalized to `aggregateDiagnosticState`.
- `scripts/ci-prepush-range-resolver.mjs` / `.d.mts` — `dependencyState` propagated through `ManualChangeEvidence` in parallel with `workingTreeState` (manual mode → `NOT_APPLICABLE`; evidence-file mode → passthrough).
- `scripts/ci-prepush-lowend.mjs` — new non-blocking report line, same pattern as the existing `workingTreeState` line, gated on `DIVERGED`/`UNKNOWN` only.
- `tests/unit/tooling/dependency-state.test.mjs` (`node:test`, 12 tests), `tests/unit/signing.test.ts` + `tests/unit/tooling/ciPrepushRangeResolver.test.ts` (Vitest, 47 tests) — full coverage of the new dimension, mirroring every test Part 1 required for `workingTreeState`.
- `README.md` — test-count metric resync (`pnpm run sync:readme`).

## Incidental fix (not a new feature — a regression this change would otherwise cause)

`dependency-state.mjs` computes `projectRoot` at module-eval time from `import.meta.url`. Under Vitest's transform, `import.meta.url` is not always a `file:` URL, and `fileURLToPath` throws — this is a **pre-existing, documented** limitation (it's why `dependency-state.mjs`'s own tests run under `node:test`, not Vitest). It was previously dormant because nothing Vitest-tested ever imported this module. This PR's `signing-core.mjs → dependency-state.mjs` import changes that, so a `process.cwd()` fallback (consistent with `signing-core.mjs`'s own existing convention — every one of its exports already defaults `cwd = process.cwd()`) was added to keep the real CLI/hook behavior byte-identical while fixing the Vitest-only crash.

## Explicitly out of scope

- Part 2b (isolated-`localSha`-worktree TypeScript verification) — separate PR, per the plan's own split.
- `scripts/hooks/shared.mjs` has the identical dormant `import.meta.url` pattern but is never imported by a Vitest-run file today, so it isn't touched here (no live regression to fix, and it's outside this slice's file list).
- S4/S5/#477 — untouched.

## Test plan

- [x] `pnpm exec vitest run tests/unit/signing.test.ts tests/unit/tooling/ciPrepushRangeResolver.test.ts` — 47/47 passing
- [x] `node --test tests/unit/tooling/dependency-state.test.mjs` — 12/12 passing
- [x] `pnpm run typecheck` (4-checker, CI-exact) — clean
- [x] `pnpm run lint` — clean (pre-existing unrelated info-level findings in `strykerWorkflowPolicy.test.ts` only)
- [x] `pnpm run ci:prepush` — full local admission PASS
- [x] QNBS-v3 one-line comment self-check — clean
- [x] `pnpm run signing:doctor` — signing config verified before push

## Summary by Sourcery

Add isolated, worktree-free dependency-manifest compatibility diagnostics to push evidence.

New Features:
- Add diagnostic dependency-manifest compatibility states to push evidence by comparing pushed commit contents with the locally reconciled baseline.
- Report dependency-manifest divergence or unavailable comparisons in pre-push diagnostics without blocking otherwise valid evidence.

Bug Fixes:
- Prevent dependency-state diagnostic failures from invalidating canonical push evidence by reporting UNKNOWN instead of propagating errors.
- Support transformed test environments where module URL resolution is unavailable without changing normal CLI behavior.

Enhancements:
- Reuse shared fingerprinting and diagnostic aggregation semantics across filesystem and git-object dependency checks.
- Propagate dependency-state results through manual and evidence-file pre-push resolution paths.

Tests:
- Add coverage for git-object manifest discovery, fingerprint equivalence, line-ending and binary-content handling, state aggregation, failure isolation, deletion handling, and manual-mode propagation.

Chores:
- Synchronize documented test-count metrics.


___

## **CodeAnt-AI Description**
Add dependency-manifest compatibility checks to push evidence

### What Changed
- Push evidence now reports whether dependency manifests in each pushed commit match the locally reconciled baseline.
- Checks cover root manifests, workspace package manifests, and patch files using committed content without changing the working tree.
- Dependency results use `MATCHES`, `DIVERGED`, `UNKNOWN`, and `NOT_APPLICABLE`, while remaining informational and separate from evidence validity.
- Pre-push reporting now identifies dependency-manifest divergence or unavailable comparisons; manual range checks correctly mark both diagnostics as not applicable.
- Added coverage for matching, divergence, unavailable data, deletion handling, aggregation, and diagnostic failures.

### Impact
`✅ Detects unreconciled dependency changes before push`
`✅ Keeps valid push evidence usable when diagnostics are unavailable`
`✅ Clearer dependency compatibility warnings`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added dependency-state diagnostics to pre-push checks, indicating whether dependency manifests match, diverge, or cannot be determined.
  - Dependency diagnostics appear alongside push evidence while preserving existing required CI behavior.
  - Diagnostic failures are reported as unknown without invalidating other push evidence.

- **Documentation**
  - Updated README references to reflect more than 7,005 tests.

- **Tests**
  - Expanded coverage for dependency-state reporting, push scenarios, manual checks, manifest comparison, and diagnostic error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->