### PR TITLE
feat(native): add Intel macOS qualification-only build lane (S5)

### DIFF
--- a/.github/workflows/tauri-intel-qualification.yml
+++ b/.github/workflows/tauri-intel-qualification.yml
@@ -1,0 +1,61 @@
+# Intel macOS (x86_64) build-qualification lane — NOT part of the production release matrix.
+# See docs/TAURI-CI.md "Follow-ups" and docs/native/INTEL-MACOS-QUALIFICATION.md for context.
+
+name: Tauri Intel macOS qualification
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tauri-intel-qualification-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  qualify:
+    name: Build qualification (macos-15-intel)
+    runs-on: macos-15-intel
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # QNBS-v3: composite action handles pnpm/node setup + frozen install.
+      - uses: ./.github/actions/setup
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
+        with:
+          workspaces: src-tauri
+          cache-all-crates: true
+          prefix-key: "v1-intel"
+
+      - name: Install macOS dependencies (create-dmg)
+        run: brew install create-dmg
+
+      # QNBS-v3: qualification-only, no updater secrets — disables updater artifacts, never publishes.
+      - name: Build Tauri app (qualification, no updater artifacts)
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! command -v jq &>/dev/null; then
+            echo "::error::jq is required for Tauri build configuration but not installed"
+            exit 1
+          fi
+          jq '.bundle.createUpdaterArtifacts = false' src-tauri/tauri.conf.json > src-tauri/tauri.conf.json.tmp
+          mv src-tauri/tauri.conf.json.tmp src-tauri/tauri.conf.json
+          echo "Building Tauri app for macos-15-intel (qualification only)..."
+          pnpm exec tauri build
+          echo "Tauri build completed successfully"
+
+      - name: Upload bundle directory (qualification evidence, not a release asset)
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: tauri-bundle-macos-15-intel-qualification
+          path: src-tauri/target/release/bundle/
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/tauri-intel-qualification.yml
+++ b/.github/workflows/tauri-intel-qualification.yml
@@ -52,10 +52,11 @@ jobs:
           pnpm exec tauri build
           echo "Tauri build completed successfully"
 
+      # QNBS-v3: a missing bundle means the qualification claim itself is false — error, not warn.
       - name: Upload bundle directory (qualification evidence, not a release asset)
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: tauri-bundle-macos-15-intel-qualification
           path: src-tauri/target/release/bundle/
-          if-no-files-found: warn
+          if-no-files-found: error
           retention-days: 14

--- a/README.md
+++ b/README.md
@@ -812,6 +812,7 @@ See **[`CONTRIBUTING.md`](CONTRIBUTING.md)** for the full dev setup, Biome / Vit
 | [`docs/PWA-AUDIT.md`](docs/PWA-AUDIT.md) | PWA manifest, service worker, share-target checklist |
 | [`infra/low-end-ci/`](infra/low-end-ci/) | Local CI on low-end hardware (act + Eco-Forgejo) |
 | [`docs/TAURI-CI.md`](docs/TAURI-CI.md) | Tauri desktop workflow: manual/tag builds, 7-step first-release checklist |
+| [`docs/native/INTEL-MACOS-QUALIFICATION.md`](docs/native/INTEL-MACOS-QUALIFICATION.md) | Intel macOS (x86_64) qualification-only build lane status (`macos-15-intel`), not yet in the release matrix |
 | [`docs/TAURI-UPDATER.md`](docs/TAURI-UPDATER.md) | Tauri plugin-updater: secrets table, `latest.json` auto-generation, signing |
 | [`docs/graphify.md`](docs/graphify.md) | Graphify knowledge graph — multi-modal AST graph (`pnpm run graphify:update`) |
 | [`docs/codegraph.md`](docs/codegraph.md) | CodeGraph semantic code intelligence — MCP-powered symbol graph (`pnpm run codegraph:update`) |

--- a/docs/TAURI-CI.md
+++ b/docs/TAURI-CI.md
@@ -17,17 +17,27 @@ Workflow: [`.github/workflows/tauri-build.yml`](../.github/workflows/tauri-build
 | `windows-latest` | x86_64 (NSIS `-setup.exe`, MSI fallback) | `windows-x86_64` |
 | `macos-latest` | **aarch64** (Apple Silicon) | `darwin-aarch64` |
 
-**Native Intel-Mac (x86_64) builds are currently unavailable.** `macos-13` (the last GitHub-hosted
-Intel runner) was removed from the matrix on 2026-07-28: 3 consecutive tagged-release runs each had
-the `macos-13` job sit in GitHub's runner queue indefinitely (never reaching `in_progress`, so the
-job's own `timeout-minutes: 45` never applied) until GitHub's ~24h queue ceiling auto-cancelled it —
-and because the `release` job's `needs: [bundle]` only resolves once every matrix leg reaches a
-terminal state, this blocked the entire release for 24h even though Ubuntu/Windows/macOS-ARM all
-finished in ~12 minutes. This is a GitHub-hosted-runner availability issue (Intel macOS images are
-being phased out), not a bug in this repo's build logic — the `latest.json` generator already
-tolerates a missing arch (per-arch warning, hard-fail only if *no* arch signs), so once a working
-Intel runner option exists again (self-hosted, `macos-latest-large`, or a new hosted image), re-adding
-it to the matrix needs no other changes. Tracked as a re-opened follow-up in `TODO.md`.
+**Native Intel-Mac (x86_64) builds are not in the production release matrix.** `macos-13` (the last
+GitHub-hosted Intel runner using that label) was removed from the matrix on 2026-07-28: 3 consecutive
+tagged-release runs each had the `macos-13` job sit in GitHub's runner queue indefinitely (never
+reaching `in_progress`, so the job's own `timeout-minutes: 45` never applied) until GitHub's ~24h
+queue ceiling auto-cancelled it — and because the `release` job's `needs: [bundle]` only resolves
+once every matrix leg reaches a terminal state, this blocked the entire release for 24h even though
+Ubuntu/Windows/macOS-ARM all finished in ~12 minutes. This was a GitHub-hosted-runner availability
+issue (Intel macOS images were being phased out), not a bug in this repo's build logic.
+
+**Update (empirically re-verified):** GitHub's replacement label `macos-15-intel` (introduced
+2025-09-18, available through August 2027) does schedule and run successfully on this org's plan — a
+throwaway `workflow_dispatch` probe completed in full. A separate, qualification-only workflow,
+[`tauri-intel-qualification.yml`](../.github/workflows/tauri-intel-qualification.yml), builds the
+app on `macos-15-intel` to confirm the toolchain still works there; it is deliberately **not** wired
+into the production release matrix or `latest.json` — one successful build proves the runner label
+works, not that it's ready for regular release qualification (soak testing, artifact size/behavior
+parity with the ARM build, and a decision on ongoing maintenance cost are still open). Promoting it
+into the release matrix is tracked separately — see `docs/native/INTEL-MACOS-QUALIFICATION.md` and
+the Follow-ups section below. The `latest.json` generator already tolerates a missing arch (per-arch
+warning, hard-fail only if *no* arch signs), so re-adding Intel to the release matrix needs no other
+changes once that decision is made.
 
 ## Outputs
 
@@ -183,3 +193,4 @@ See [`docs/TAURI-UPDATER.md`](TAURI-UPDATER.md) for full secrets reference and p
 
 - macOS notarization requires `APPLE_*` secrets — see [`docs/TAURI-UPDATER.md`](TAURI-UPDATER.md) § macOS code signing.
 - Windows Authenticode signing requires a CA-issued Authenticode certificate — track in [`TODO.md`](../TODO.md).
+- Promoting `tauri-intel-qualification.yml`'s `macos-15-intel` build into the production release matrix (real `latest.json` entry, `darwin-x86_64` updater key, ongoing soak testing) — see `docs/native/INTEL-MACOS-QUALIFICATION.md` for current status and the tracking issue.

--- a/docs/native/INTEL-MACOS-QUALIFICATION.md
+++ b/docs/native/INTEL-MACOS-QUALIFICATION.md
@@ -1,0 +1,49 @@
+# Intel macOS (x86_64) Qualification — Status
+
+**Status:** Runner-availability qualified, not release-matrix qualified.
+**Owner lane:** `tauri-intel-qualification.yml` (`workflow_dispatch` only).
+
+## History
+
+- `macos-13` (the last GitHub-hosted Intel runner using that label) was removed from
+  `tauri-build.yml`'s production matrix on 2026-07-28 after 3 consecutive tagged-release runs each
+  had the job sit in GitHub's queue indefinitely, never reaching `in_progress` — see
+  [`docs/TAURI-CI.md`](../TAURI-CI.md) for the full incident detail.
+- On 2026-08-26, GitHub's replacement label `macos-15-intel` (introduced 2025-09-18, available
+  through August 2027) was empirically probed via a throwaway `workflow_dispatch` workflow: it
+  scheduled and completed successfully on this organization's plan.
+
+## Current qualification lane
+
+[`tauri-intel-qualification.yml`](../../.github/workflows/tauri-intel-qualification.yml) runs a real
+`pnpm exec tauri build` on `macos-15-intel`, manually triggered only (`workflow_dispatch`). It is
+deliberately **not**:
+
+- part of the production release matrix (`tauri-build.yml`'s `bundle` job),
+- wired into `latest.json` generation or any `darwin-x86_64` updater key,
+- able to mutate a GitHub Release (`permissions: contents: read` only, no signing secrets, no
+  release-publication steps of any kind — verified structurally sound by `scripts/workflow-policy-check.mjs`'s
+  publishing-boundary check, since this job is not on the `PUBLISHING_ALLOWLIST`).
+
+A single successful qualification build proves the *runner label* works — it does not by itself
+prove the build is ready for regular release inclusion.
+
+## What's still open before promoting Intel to the release matrix
+
+1. **Soak/repeat testing.** One successful run isn't enough evidence that `macos-15-intel`
+   provisions reliably at release time (the exact failure mode that removed `macos-13` was
+   *queue* unavailability, not build failure — that requires repeated real-world observation, not
+   a single manual dispatch, to rule out).
+2. **Artifact parity check** against the existing `macos-latest` (Apple Silicon) bundle — bundle
+   size, `.dmg`/`.app.tar.gz` structure, and updater-signature behavior should be verified
+   equivalent before shipping both architectures under one release.
+3. **Ongoing maintenance-cost decision.** Adding a second macOS architecture to the release matrix
+   roughly doubles macOS CI minutes per release; whether that's worth it for the current Intel-Mac
+   user base is a product decision, not a technical one — out of scope for this qualification lane.
+4. **Explicit promotion PR.** When (1)–(3) are resolved, promoting means: adding `macos-15-intel` to
+   `tauri-build.yml`'s `bundle` matrix, adding a `darwin-x86_64` entry to the `latest.json`
+   generator's expected-platform set, and updating `docs/TAURI-CI.md`'s Build matrix table.
+
+## Tracking
+
+Issue: [#507](https://github.com/qnbs/WorldScript-Studio/issues/507).


### PR DESCRIPTION
## **User description**
## Summary

Adds a qualification-only Intel macOS (x86_64) build lane, closing S5 from the post-#477 reconstruction reconciliation program's residual-cluster ledger.

## Background

`macos-13` (the last GitHub-hosted Intel runner) was removed from `tauri-build.yml`'s production matrix on 2026-07-28 after 3 consecutive tagged-release runs each had the job sit in GitHub's queue indefinitely — see `docs/TAURI-CI.md` for the full incident. No issue tracked the "re-opened follow-up" the workflow's own comment referenced.

## What changed

- **Empirically re-tested** (2026-08-26, throwaway `workflow_dispatch` probe, deleted after use): GitHub's replacement runner label `macos-15-intel` (available since 2025-09-18, through August 2027) schedules and completes successfully on this org's plan.
- **New workflow**: `.github/workflows/tauri-intel-qualification.yml` — `workflow_dispatch` only, `permissions: contents: read`, no signing secrets, no Release/`latest.json` mutation of any kind. Runs a real `pnpm exec tauri build` on `macos-15-intel` (updater-artifact creation disabled), uploading the bundle as a plain build artifact.
- **Structurally verified non-publishing**: `scripts/workflow-policy-check.mjs`'s publishing-boundary check (from #505/S4) passes against this new file — the job is correctly absent from `PUBLISHING_ALLOWLIST` and never declares `contents: write`.
- **Docs**: `docs/TAURI-CI.md`'s stale "currently unavailable" framing updated to reflect the empirical re-test (without claiming Intel is back in the release matrix — it explicitly isn't yet); new `docs/native/INTEL-MACOS-QUALIFICATION.md` records status and what's still open before promotion; added to README's Documentation Hub index.
- **Tracking issue**: #507 records the remaining promotion criteria (soak testing, artifact parity with the ARM build, an ongoing-cost decision, the explicit promotion PR) — deliberately not attempted in this PR.

## Non-goals (explicitly out of scope)

- Adding `macos-15-intel` to the production release matrix or `latest.json`.
- Any code-signing/notarization work.
- Deciding whether Intel Mac support should ship — this PR only re-establishes that it's technically possible to build there again.

## Test plan

- [x] `pnpm run workflow-policy:check` — passes, including against the new workflow file
- [x] `pnpm run lint` — clean
- [x] `pnpm run docs:check` — clean
- [x] `pnpm run ci:prepush` — full local admission green
- [x] `git diff --check` — clean
- [x] Commit SSH-signed
- [x] Real empirical validation: `macos-15-intel` throwaway probe completed successfully (evidence in commit message / PR description above, probe branch deleted after use)

## Summary by Sourcery

Re-establish Intel macOS build verification through a safe, manual qualification lane without adding Intel builds to production releases.

New Features:
- Add a manually triggered Intel macOS qualification workflow that builds the Tauri application on `macos-15-intel` and uploads the resulting bundle as temporary evidence.

Enhancements:
- Keep Intel qualification builds isolated from production releases, updater metadata, signing, and release mutations.
- Document Intel macOS runner availability, qualification status, remaining promotion criteria, and tracking information.

CI:
- Add a non-publishing Intel macOS build lane with read-only repository permissions and policy validation.

Documentation:
- Update the Tauri CI documentation and documentation hub with the current Intel macOS qualification status and future promotion requirements.


___

## **CodeAnt-AI Description**
Add a manual Intel macOS build qualification lane without affecting releases

### What Changed
- Adds a manually triggered workflow that builds the app on GitHub’s `macos-15-intel` runner and stores the bundle as a temporary artifact.
- Keeps the qualification build separate from production releases: it does not publish releases, update `latest.json`, create updater artifacts, or use signing secrets.
- Documents the runner’s availability, the remaining checks before release inclusion, and the tracking issue for future promotion.

### Impact
`✅ Intel macOS build availability can be verified on demand`
`✅ No qualification run can change published releases`
`✅ Clearer path to supporting Intel Mac releases`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
