### PR TITLE
feat(ci): add PR-size governance gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,7 @@ jobs:
   pr-size:
     name: 📏 PR Size Governance
     if: github.event_name == 'pull_request'
+    needs: [workflow-policy]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -200,15 +201,24 @@ jobs:
           set -e
           echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
 
-      # QNBS-v3: stays silent when within target — only comments when there's something to say.
+      # QNBS-v3: fork PRs get a read-only token — a failed comment must never fail this advisory job.
+      # QNBS-v3: --edit-last upserts one comment (stable bot identity) instead of accumulating new ones.
       - name: Post PR size comment (advisory or blocking tiers only)
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          PR="${{ github.event.pull_request.number }}"
+          MARKER="<!-- pr-size-governance -->"
           if grep -qE 'within target' /tmp/pr-size-report.txt; then
+            printf '%s\nPR size is back within target — previous warning below is resolved.\n' "$MARKER" > /tmp/pr-size-resolved.txt
+            gh pr comment "$PR" --edit-last --body-file /tmp/pr-size-resolved.txt || true
             exit 0
           fi
-          gh pr comment "${{ github.event.pull_request.number }}" --body-file /tmp/pr-size-report.txt
+          { printf '%s\n' "$MARKER"; cat /tmp/pr-size-report.txt; } > /tmp/pr-size-marked.txt
+          gh pr comment "$PR" --edit-last --body-file /tmp/pr-size-marked.txt \
+            || gh pr comment "$PR" --body-file /tmp/pr-size-marked.txt \
+            || true
 
       - name: Fail only on an absolute-ceiling violation
         if: steps.size.outputs.exit_code == '1'
@@ -548,7 +558,10 @@ jobs:
         run: |
           FAIL=0
           [ "${{ needs.workflow-policy.result }}" = "success" ] || FAIL=1
-          if [ "${{ needs.pr-size.result }}" != "success" ] && [ "${{ needs.pr-size.result }}" != "skipped" ]; then
+          # QNBS-v3: pr-size's own if: matches this event check — unconditional skip-tolerance would let a tampered if: pass.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            [ "${{ needs.pr-size.result }}" = "success" ] || FAIL=1
+          elif [ "${{ needs.pr-size.result }}" != "success" ] && [ "${{ needs.pr-size.result }}" != "skipped" ]; then
             FAIL=1
           fi
           [ "${{ needs.security.result }}" = "success" ] || FAIL=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,15 +210,24 @@ jobs:
         run: |
           PR="${{ github.event.pull_request.number }}"
           MARKER="<!-- pr-size-governance -->"
+          # QNBS-v3: only --edit-last when it's actually ours — never overwrite an unrelated job's comment.
+          LAST_BODY=$(gh api "repos/${{ github.repository }}/issues/$PR/comments" \
+            --jq '[.[] | select(.user.login == "github-actions[bot]")] | last | .body // ""' 2>/dev/null || echo "")
+          LAST_IS_OURS=false
+          printf '%s' "$LAST_BODY" | grep -qF "$MARKER" && LAST_IS_OURS=true
           if grep -qE 'within target' /tmp/pr-size-report.txt; then
-            printf '%s\nPR size is back within target — previous warning below is resolved.\n' "$MARKER" > /tmp/pr-size-resolved.txt
-            gh pr comment "$PR" --edit-last --body-file /tmp/pr-size-resolved.txt || true
+            if [ "$LAST_IS_OURS" = "true" ]; then
+              printf '%s\nPR size is back within target — previous warning below is resolved.\n' "$MARKER" > /tmp/pr-size-resolved.txt
+              gh pr comment "$PR" --edit-last --body-file /tmp/pr-size-resolved.txt || true
+            fi
             exit 0
           fi
           { printf '%s\n' "$MARKER"; cat /tmp/pr-size-report.txt; } > /tmp/pr-size-marked.txt
-          gh pr comment "$PR" --edit-last --body-file /tmp/pr-size-marked.txt \
-            || gh pr comment "$PR" --body-file /tmp/pr-size-marked.txt \
-            || true
+          if [ "$LAST_IS_OURS" = "true" ]; then
+            gh pr comment "$PR" --edit-last --body-file /tmp/pr-size-marked.txt || true
+          else
+            gh pr comment "$PR" --body-file /tmp/pr-size-marked.txt || true
+          fi
 
       - name: Fail only on an absolute-ceiling violation
         if: steps.size.outputs.exit_code == '1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,10 +211,11 @@ jobs:
           PR="${{ github.event.pull_request.number }}"
           REPO="${{ github.repository }}"
           MARKER="<!-- pr-size-governance -->"
-          # QNBS-v3: --paginate concatenates every page — a marker comment past page 1 must still be found.
-          OWNED_ID=$(gh api --paginate "repos/$REPO/issues/$PR/comments" \
-            --jq "[.[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"$MARKER\")))] | last | .id // empty" \
-            2>/dev/null || echo "")
+          # QNBS-v3: --paginate + --jq filters each page separately — pipe to external jq -s to combine first.
+          OWNED_ID=$(gh api --paginate "repos/$REPO/issues/$PR/comments" 2>/dev/null \
+            | jq -s --arg marker "$MARKER" \
+              '[.[][] | select(.user.login == "github-actions[bot]" and (.body | contains($marker)))] | last | .id // empty' \
+            || echo "")
           if grep -qE 'within target' /tmp/pr-size-report.txt; then
             if [ -n "$OWNED_ID" ]; then
               printf '%s\nPR size is back within target — previous warning below is resolved.\n' "$MARKER" > /tmp/pr-size-resolved.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,10 +186,16 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p /tmp/base-scripts
-          git show "$BASE_SHA:scripts/check-pr-size.mjs" > /tmp/base-scripts/check-pr-size.mjs
-          git show "$BASE_SHA:scripts/ci-prepush-classifier.mjs" > /tmp/base-scripts/ci-prepush-classifier.mjs
+          # QNBS-v3: bootstrap fallback — the PR introducing this checker has no base-ref copy yet.
+          if git show "$BASE_SHA:scripts/check-pr-size.mjs" > /tmp/base-scripts/check-pr-size.mjs 2>/dev/null \
+             && git show "$BASE_SHA:scripts/ci-prepush-classifier.mjs" > /tmp/base-scripts/ci-prepush-classifier.mjs 2>/dev/null; then
+            CHECKER=/tmp/base-scripts/check-pr-size.mjs
+          else
+            echo "::notice::check-pr-size.mjs not found on base ref (bootstrap PR) — using this PR's own copy this one time."
+            CHECKER=scripts/check-pr-size.mjs
+          fi
           set +e
-          node /tmp/base-scripts/check-pr-size.mjs "$BASE_SHA" "$HEAD_SHA" | tee /tmp/pr-size-report.txt
+          node "$CHECKER" "$BASE_SHA" "$HEAD_SHA" | tee /tmp/pr-size-report.txt
           exit_code=${PIPESTATUS[0]}
           set -e
           echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,55 @@ jobs:
             echo "crates=false" >> "$GITHUB_OUTPUT"
           fi
 
+  # ----------------------------------------------------------
+  # PR SIZE GOVERNANCE: advisory below the absolute ceiling, blocking above it.
+  # QNBS-v3: runs the BASE ref's checker copy — a PR touching it can't raise its own limits.
+  # ----------------------------------------------------------
+  pr-size:
+    name: 📏 PR Size Governance
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Evaluate PR size (base-ref checker)
+        id: size
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/base-scripts
+          git show "$BASE_SHA:scripts/check-pr-size.mjs" > /tmp/base-scripts/check-pr-size.mjs
+          git show "$BASE_SHA:scripts/ci-prepush-classifier.mjs" > /tmp/base-scripts/ci-prepush-classifier.mjs
+          set +e
+          node /tmp/base-scripts/check-pr-size.mjs "$BASE_SHA" "$HEAD_SHA" | tee /tmp/pr-size-report.txt
+          exit_code=${PIPESTATUS[0]}
+          set -e
+          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+
+      # QNBS-v3: stays silent when within target — only comments when there's something to say.
+      - name: Post PR size comment (advisory or blocking tiers only)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if grep -qE 'within target' /tmp/pr-size-report.txt; then
+            exit 0
+          fi
+          gh pr comment "${{ github.event.pull_request.number }}" --body-file /tmp/pr-size-report.txt
+
+      - name: Fail only on an absolute-ceiling violation
+        if: steps.size.outputs.exit_code == '1'
+        run: exit 1
+
   signatures:
     name: 🔏 Verified Signatures
     runs-on: ubuntu-latest
@@ -475,6 +524,7 @@ jobs:
     needs:
       [
         workflow-policy,
+        pr-size,
         security,
         signatures,
         quality,
@@ -492,6 +542,9 @@ jobs:
         run: |
           FAIL=0
           [ "${{ needs.workflow-policy.result }}" = "success" ] || FAIL=1
+          if [ "${{ needs.pr-size.result }}" != "success" ] && [ "${{ needs.pr-size.result }}" != "skipped" ]; then
+            FAIL=1
+          fi
           [ "${{ needs.security.result }}" = "success" ] || FAIL=1
           [ "${{ needs.signatures.result }}" = "success" ] || FAIL=1
           [ "${{ needs.quality.result }}" = "success" ] || FAIL=1
@@ -509,6 +562,7 @@ jobs:
           if [ "$FAIL" = "1" ]; then
             echo "One or more required jobs did not succeed:"
             echo "  workflow-policy: ${{ needs.workflow-policy.result }}"
+            echo "  pr-size: ${{ needs.pr-size.result }} (skipped = OK, not a pull_request event)"
             echo "  security: ${{ needs.security.result }}"
             echo "  signatures: ${{ needs.signatures.result }}"
             echo "  quality:  ${{ needs.quality.result }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,35 +202,36 @@ jobs:
           echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
 
       # QNBS-v3: fork PRs get a read-only token — a failed comment must never fail this advisory job.
-      # QNBS-v3: --edit-last upserts one comment (stable bot identity) instead of accumulating new ones.
+      # QNBS-v3: edits by owned comment ID (not --edit-last) so an intervening bot comment can't be overwritten.
       - name: Post PR size comment (advisory or blocking tiers only)
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           PR="${{ github.event.pull_request.number }}"
+          REPO="${{ github.repository }}"
           MARKER="<!-- pr-size-governance -->"
-          # QNBS-v3: only --edit-last when it's actually ours — never overwrite an unrelated job's comment.
-          LAST_BODY=$(gh api "repos/${{ github.repository }}/issues/$PR/comments" \
-            --jq '[.[] | select(.user.login == "github-actions[bot]")] | last | .body // ""' 2>/dev/null || echo "")
-          LAST_IS_OURS=false
-          printf '%s' "$LAST_BODY" | grep -qF "$MARKER" && LAST_IS_OURS=true
+          # QNBS-v3: find OUR comment by marker, anywhere in history — not just whichever bot comment is last.
+          OWNED_ID=$(gh api "repos/$REPO/issues/$PR/comments" \
+            --jq "[.[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"$MARKER\")))] | last | .id // empty" \
+            2>/dev/null || echo "")
           if grep -qE 'within target' /tmp/pr-size-report.txt; then
-            if [ "$LAST_IS_OURS" = "true" ]; then
+            if [ -n "$OWNED_ID" ]; then
               printf '%s\nPR size is back within target — previous warning below is resolved.\n' "$MARKER" > /tmp/pr-size-resolved.txt
-              gh pr comment "$PR" --edit-last --body-file /tmp/pr-size-resolved.txt || true
+              gh api "repos/$REPO/issues/comments/$OWNED_ID" -X PATCH -F body=@/tmp/pr-size-resolved.txt || true
             fi
             exit 0
           fi
           { printf '%s\n' "$MARKER"; cat /tmp/pr-size-report.txt; } > /tmp/pr-size-marked.txt
-          if [ "$LAST_IS_OURS" = "true" ]; then
-            gh pr comment "$PR" --edit-last --body-file /tmp/pr-size-marked.txt || true
+          if [ -n "$OWNED_ID" ]; then
+            gh api "repos/$REPO/issues/comments/$OWNED_ID" -X PATCH -F body=@/tmp/pr-size-marked.txt || true
           else
             gh pr comment "$PR" --body-file /tmp/pr-size-marked.txt || true
           fi
 
-      - name: Fail only on an absolute-ceiling violation
-        if: steps.size.outputs.exit_code == '1'
+      # QNBS-v3: any nonzero exit (crash, OOM-kill, etc.) must fail, not just the literal '1' ceiling code.
+      - name: Fail on a checker crash or an absolute-ceiling violation
+        if: steps.size.outputs.exit_code != '0'
         run: exit 1
 
   signatures:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,8 +211,8 @@ jobs:
           PR="${{ github.event.pull_request.number }}"
           REPO="${{ github.repository }}"
           MARKER="<!-- pr-size-governance -->"
-          # QNBS-v3: find OUR comment by marker, anywhere in history — not just whichever bot comment is last.
-          OWNED_ID=$(gh api "repos/$REPO/issues/$PR/comments" \
+          # QNBS-v3: --paginate concatenates every page — a marker comment past page 1 must still be found.
+          OWNED_ID=$(gh api --paginate "repos/$REPO/issues/$PR/comments" \
             --jq "[.[] | select(.user.login == \"github-actions[bot]\" and (.body | contains(\"$MARKER\")))] | last | .id // empty" \
             2>/dev/null || echo "")
           if grep -qE 'within target' /tmp/pr-size-report.txt; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -374,10 +374,10 @@ procedure.
 
 ```
 workflow-policy ──► security ──► quality ──┬──► build ──► lighthouse
-                                           ├──► e2e
-                                           ├──► e2e-deep (non-blocking)
-                                           ├──► storybook
-                                           └──► vrt
+                    │                      ├──► e2e
+                    ▼                      ├──► e2e-deep (non-blocking)
+                  pr-size (pull_request     ├──► storybook
+                  only) ──► ci-success      └──► vrt
 build (main, non-PR) ──► upload-pages-artifact
 deploy (main, non-PR) needs: ci-success ──► GitHub Pages
 ```
@@ -387,6 +387,7 @@ deploy (main, non-PR) needs: ci-success ──► GitHub Pages
 | Job | Purpose |
 |-----|---------|
 | `workflow-policy` | Structural gate on `.github/workflows/*.yml` + `.github/actions/**/action.yml` (`scripts/workflow-policy-check.mjs`) — permissions, needs graph, SHA-pinned action references, publishing boundary. Runs first, before any job invokes the governed `./.github/actions/setup` composite; sets up pnpm/Node with external SHA-pinned actions directly instead of that composite. |
+| `pr-size` | PR-size governance (`scripts/check-pr-size.mjs`) — tiered file/line/commit limits, advisory below the absolute ceiling and blocking only above it. Needs `workflow-policy`; `pull_request` only. |
 | `security` | `pnpm audit --audit-level=high`, OSV scanner (pnpm + `src-tauri/` + `crates/` Cargo lockfiles), gitleaks secrets scan, dependency review on PRs |
 | `quality` | Node 22 + 24 matrix → Biome lint, suppression-debt ratchet, `i18n:check`, `docs:check`, `csp:verify`, `parity:check`, `tsgo --noEmit`, Storybook build, Vitest + coverage, Codecov upload |
 | `rust-tauri` | `fmt`/`check`/`clippy`/`test` for `src-tauri/`; path-scoped (skips on PRs that don't touch it), needs GTK/WebKit apt-get steps |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -373,11 +373,11 @@ procedure.
 ### Pipeline Graph
 
 ```
-workflow-policy ──► security ──► quality ──┬──► build ──► lighthouse
-                    │                      ├──► e2e
-                    ▼                      ├──► e2e-deep (non-blocking)
-                  pr-size (pull_request     ├──► storybook
-                  only) ──► ci-success      └──► vrt
+workflow-policy ─┬─► security ──► quality ──┬──► build ──► lighthouse
+                 │                          ├──► e2e
+                 ▼                          ├──► e2e-deep (non-blocking)
+               pr-size (pull_request         ├──► storybook
+               only) ──► ci-success          └──► vrt
 build (main, non-PR) ──► upload-pages-artifact
 deploy (main, non-PR) needs: ci-success ──► GitHub Pages
 ```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2925_keys-0EA5E9" alt="i18n 19 locales — 2925 keys">
-  <img src="https://img.shields.io/badge/Tests-7112%2B_%2F_580_files-22C55E" alt="7112+ tests / 580 files">
+  <img src="https://img.shields.io/badge/Tests-7114%2B_%2F_580_files-22C55E" alt="7114+ tests / 580 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -512,7 +512,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2925 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7112+ tests / 580 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7114+ tests / 580 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -550,7 +550,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7112+ tests, 580 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7114+ tests, 580 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -712,7 +712,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-21, source-synchronized; CI remains authoritative for pass/fail):**
-- **7112+ unit tests** across **580 test files** — CI is authoritative for pass/fail
+- **7114+ unit tests** across **580 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2925 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2925_keys-0EA5E9" alt="i18n 19 locales — 2925 keys">
-  <img src="https://img.shields.io/badge/Tests-7109%2B_%2F_580_files-22C55E" alt="7109+ tests / 580 files">
+  <img src="https://img.shields.io/badge/Tests-7112%2B_%2F_580_files-22C55E" alt="7112+ tests / 580 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -512,7 +512,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2925 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7109+ tests / 580 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7112+ tests / 580 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -550,7 +550,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7109+ tests, 580 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7112+ tests, 580 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -712,7 +712,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-21, source-synchronized; CI remains authoritative for pass/fail):**
-- **7109+ unit tests** across **580 test files** — CI is authoritative for pass/fail
+- **7112+ unit tests** across **580 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2925 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2925_keys-0EA5E9" alt="i18n 19 locales — 2925 keys">
-  <img src="https://img.shields.io/badge/Tests-7099%2B_%2F_580_files-22C55E" alt="7099+ tests / 580 files">
+  <img src="https://img.shields.io/badge/Tests-7103%2B_%2F_580_files-22C55E" alt="7103+ tests / 580 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -512,7 +512,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2925 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7099+ tests / 580 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7103+ tests / 580 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -550,7 +550,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7099+ tests, 580 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7103+ tests, 580 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -712,7 +712,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-21, source-synchronized; CI remains authoritative for pass/fail):**
-- **7099+ unit tests** across **580 test files** — CI is authoritative for pass/fail
+- **7103+ unit tests** across **580 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2925 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2925_keys-0EA5E9" alt="i18n 19 locales — 2925 keys">
-  <img src="https://img.shields.io/badge/Tests-7103%2B_%2F_580_files-22C55E" alt="7103+ tests / 580 files">
+  <img src="https://img.shields.io/badge/Tests-7104%2B_%2F_580_files-22C55E" alt="7104+ tests / 580 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -512,7 +512,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2925 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7103+ tests / 580 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7104+ tests / 580 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -550,7 +550,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7103+ tests, 580 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7104+ tests, 580 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -712,7 +712,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-21, source-synchronized; CI remains authoritative for pass/fail):**
-- **7103+ unit tests** across **580 test files** — CI is authoritative for pass/fail
+- **7104+ unit tests** across **580 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2925 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2925_keys-0EA5E9" alt="i18n 19 locales — 2925 keys">
-  <img src="https://img.shields.io/badge/Tests-7076%2B_%2F_579_files-22C55E" alt="7076+ tests / 579 files">
+  <img src="https://img.shields.io/badge/Tests-7099%2B_%2F_580_files-22C55E" alt="7099+ tests / 580 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -512,7 +512,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2925 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7076+ tests / 579 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7099+ tests / 580 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -550,7 +550,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7076+ tests, 579 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7099+ tests, 580 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -712,7 +712,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-21, source-synchronized; CI remains authoritative for pass/fail):**
-- **7076+ unit tests** across **579 test files** — CI is authoritative for pass/fail
+- **7099+ unit tests** across **580 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2925 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2925_keys-0EA5E9" alt="i18n 19 locales — 2925 keys">
-  <img src="https://img.shields.io/badge/Tests-7104%2B_%2F_580_files-22C55E" alt="7104+ tests / 580 files">
+  <img src="https://img.shields.io/badge/Tests-7109%2B_%2F_580_files-22C55E" alt="7109+ tests / 580 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -512,7 +512,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2925 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7104+ tests / 580 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7109+ tests / 580 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -550,7 +550,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7104+ tests, 580 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7109+ tests, 580 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -712,7 +712,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-21, source-synchronized; CI remains authoritative for pass/fail):**
-- **7104+ unit tests** across **580 test files** — CI is authoritative for pass/fail
+- **7109+ unit tests** across **580 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2925 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -101,13 +101,13 @@ Each job that uses the composite must call `actions/checkout@v6` first (local co
 ## Job graph
 
 ```text
-workflow-policy ──► security ──► quality ──┬──► build ──┬──► lighthouse
-                                           ├──► e2e     └──► vrt
-                                           ├──► e2e-deep (advisory)
-                                           └──► storybook (advisory)
+workflow-policy ─┬─► security ──► quality ──┬──► build ──┬──► lighthouse
+                 │                          ├──► e2e     └──► vrt
+                 └──► pr-size (pull_request  ├──► e2e-deep (advisory)
+                      only)                  └──► storybook (advisory)
 
 workflow-policy ─┐
-pr-size ─────────┤ (pull_request only — skipped otherwise)
+pr-size (needs workflow-policy) ─┤ (pull_request only — skipped otherwise)
 security ────────┤
 signatures ──────┤
 quality ─────────┼──► ci-success (required-status aggregator)
@@ -133,7 +133,7 @@ registry gzip-decoding failure mode, while OSV failures remain blocking.
 | Job | Needs | Purpose |
 |-----|--------|---------|
 | `workflow-policy` | — | Structural (real-parser, not regex) validation of every `.github/workflows/*.yml` and `.github/actions/**/action.yml` — permissions, needs graph, SHA-pinned action references, publishing boundary (`scripts/workflow-policy-check.mjs`). Runs first, before any job invokes the governed `./.github/actions/setup` composite, using only external SHA-pinned actions directly (never that composite) and an `--ignore-scripts --ignore-pnpmfile` install, so a PR tampering with the composite (or its own install hooks) can't execute before the gate evaluates it. |
-| `pr-size` | `workflow-policy` | PR-size governance (`scripts/check-pr-size.mjs`) — tiered file/line/commit limits, advisory below the absolute ceiling and blocking only above it. `pull_request` only. Runs the **base ref's** own copy of the checker (never the PR's working-tree copy) so a PR touching it can't raise its own limits. |
+| `pr-size` | `workflow-policy` | PR-size governance (`scripts/check-pr-size.mjs`) — tiered file/line/commit limits, advisory below the absolute ceiling and blocking only above it. `pull_request` only. Runs the **base ref's** own copy of the checker (never the PR's working-tree copy) when it exists there, so a PR touching it can't raise its own limits; falls back to the PR's own copy one time only, for the introducing PR whose base ref has no checker yet. |
 | `security` | `workflow-policy` | `pnpm audit --audit-level=high`; **OSV scanner** (`google/osv-scanner-action`) for npm + Rust lockfiles; `gitleaks` secrets scan; on PRs: `dependency-review-action` |
 | `scheduled-osv` | — | Separate daily and manually triggerable (`workflow_dispatch`) `.github/workflows/security-scheduled.yml` scan of the same three lockfiles; `contents: read` only; fails closed and writes lockfile/package/advisory details to the step summary |
 | `quality` | `security` | Matrix **Node 22** and **24** → Biome lint, **`pnpm run i18n:check`**, **`pnpm run docs:check`**, **`pnpm run csp:verify`**, **`pnpm run parity:check`**, `pnpm run typecheck`, Vitest + coverage (+ non-blocking coverage-ratchet suggestion), Codecov (optional token), coverage artifact |

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -37,8 +37,9 @@ CI runs for the affected test path before removing a temporary quarantine.
 
 ### Gate authority
 
-`✅ CI Success` is the required branch-protection status and aggregates `workflow-policy`, `security`,
-`signatures`, `quality`, `changes`, `rust-tauri`, `core-rust`, `build`, `e2e`, `lighthouse`, and `vrt`. `e2e-deep` and
+`✅ CI Success` is the required branch-protection status and aggregates `workflow-policy`, `pr-size`,
+`security`, `signatures`, `quality`, `changes`, `rust-tauri`, `core-rust`, `build`, `e2e`, `lighthouse`, and `vrt` (`pr-size`
+only runs on `pull_request` events — legitimately skipped otherwise). `e2e-deep` and
 `storybook` are explicitly advisory at job level while their stability criteria are measured. The
 `deploy` job depends only on that aggregate and remains main-push-only.
 
@@ -106,6 +107,7 @@ workflow-policy ──► security ──► quality ──┬──► build �
                                            └──► storybook (advisory)
 
 workflow-policy ─┐
+pr-size ─────────┤ (pull_request only — skipped otherwise)
 security ────────┤
 signatures ──────┤
 quality ─────────┼──► ci-success (required-status aggregator)
@@ -131,6 +133,7 @@ registry gzip-decoding failure mode, while OSV failures remain blocking.
 | Job | Needs | Purpose |
 |-----|--------|---------|
 | `workflow-policy` | — | Structural (real-parser, not regex) validation of every `.github/workflows/*.yml` and `.github/actions/**/action.yml` — permissions, needs graph, SHA-pinned action references, publishing boundary (`scripts/workflow-policy-check.mjs`). Runs first, before any job invokes the governed `./.github/actions/setup` composite, using only external SHA-pinned actions directly (never that composite) and an `--ignore-scripts --ignore-pnpmfile` install, so a PR tampering with the composite (or its own install hooks) can't execute before the gate evaluates it. |
+| `pr-size` | `workflow-policy` | PR-size governance (`scripts/check-pr-size.mjs`) — tiered file/line/commit limits, advisory below the absolute ceiling and blocking only above it. `pull_request` only. Runs the **base ref's** own copy of the checker (never the PR's working-tree copy) so a PR touching it can't raise its own limits. |
 | `security` | `workflow-policy` | `pnpm audit --audit-level=high`; **OSV scanner** (`google/osv-scanner-action`) for npm + Rust lockfiles; `gitleaks` secrets scan; on PRs: `dependency-review-action` |
 | `scheduled-osv` | — | Separate daily and manually triggerable (`workflow_dispatch`) `.github/workflows/security-scheduled.yml` scan of the same three lockfiles; `contents: read` only; fails closed and writes lockfile/package/advisory details to the step summary |
 | `quality` | `security` | Matrix **Node 22** and **24** → Biome lint, **`pnpm run i18n:check`**, **`pnpm run docs:check`**, **`pnpm run csp:verify`**, **`pnpm run parity:check`**, `pnpm run typecheck`, Vitest + coverage (+ non-blocking coverage-ratchet suggestion), Codecov (optional token), coverage artifact |
@@ -141,7 +144,7 @@ registry gzip-decoding failure mode, while OSV failures remain blocking.
 | `storybook` | `quality` | Cloud-first — Storybook build + test-runner only run in CI (not locally); Playwright browser cache `v5`; `--maxWorkers=2 --junit` (non-blocking, `continue-on-error: true` — see [exit criteria](#non-blocking-gates--exit-criteria-f-13)); artifacts uploaded always. Debug: manual `storybook-debug.yml` workflow. |
 | `vrt` | `build` | Visual regression against production `dist`; `toHaveScreenshot()` with committed PNG baselines (4 views × Chromium); artifacts uploaded always |
 | `signatures` | `security` | Read-only GitHub API verification of every commit in the complete introduced range; pull-request commit pagination; and annotated release-tag plus target-commit verification. |
-| `ci-success` | `workflow-policy`, `security`, `signatures`, `quality`, `changes`, `rust-tauri`, `core-rust`, `build`, `e2e`, `lighthouse`, `vrt` | Required-status **aggregator** — `if: always()`, fails if any required release-safety job does not resolve to `success`; signature verification is authoritative; Storybook and deep-E2E are explicitly advisory. Rust jobs are legitimately skipped when their paths are untouched. |
+| `ci-success` | `workflow-policy`, `pr-size`, `security`, `signatures`, `quality`, `changes`, `rust-tauri`, `core-rust`, `build`, `e2e`, `lighthouse`, `vrt` | Required-status **aggregator** — `if: always()`, fails if any required release-safety job does not resolve to `success`; signature verification is authoritative; Storybook and deep-E2E are explicitly advisory. Rust jobs are legitimately skipped when their paths are untouched; `pr-size` is legitimately skipped only on non-`pull_request` events. |
 | `deploy` | `ci-success` | **Only** `main` push (not PR), and only after the aggregate gate succeeds; the Pages artifact is resolved from the same workflow run. |
 
 > **Desktop:** On-demand / tag-driven Tauri bundles live in [`tauri-build.yml`](../.github/workflows/tauri-build.yml); **`v*` tags** additionally publish installers on a **GitHub Release**. See [`docs/TAURI-CI.md`](TAURI-CI.md). Desktop CI does not block the web deploy graph above.

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "csp:verify": "node scripts/sync-csp.mjs && git diff --exit-code -- index.html nginx.conf public/_headers vercel.json src-tauri/tauri.conf.json && node scripts/check-csp-policy.mjs",
     "native-readiness:check": "node scripts/check-native-readiness.mjs",
     "workflow-policy:check": "node scripts/workflow-policy-check.mjs",
+    "pr-size:check": "node scripts/check-pr-size.mjs",
     "suppressions:check": "node scripts/check-suppressions.mjs",
     "token:audit": "node scripts/audit-tokens.mjs",
     "guardrail:desktop-imports": "node scripts/check-tauri-import-boundary.mjs",

--- a/scripts/check-pr-size.d.mts
+++ b/scripts/check-pr-size.d.mts
@@ -1,0 +1,79 @@
+export interface GitDependencies {
+  spawnSync?: (
+    command: string,
+    args: string[],
+    options: { encoding: 'utf8' },
+  ) => { status: number | null; stdout: string; stderr: string; error?: Error };
+}
+
+export function getChangedFilesNumstat(
+  base: string,
+  head: string,
+  dependencies?: GitDependencies,
+): string | null;
+
+export function getCommitCount(
+  base: string,
+  head: string,
+  dependencies?: GitDependencies,
+): number | null;
+
+export interface NumstatRow {
+  path: string;
+  added: number;
+  removed: number;
+}
+
+export function parseNumstat(numstatOutput: string): NumstatRow[];
+
+export function computeMeaningfulLines(rows: NumstatRow[]): number;
+
+export function isAllDocs(rows: NumstatRow[]): boolean;
+
+export interface SizeTierLimits {
+  files: number;
+  lines: number;
+  commits: number;
+}
+
+export type SizeTier = 'ok' | 'target' | 'hard' | 'docsGovernance' | 'absolute';
+
+export interface SizeSeverity {
+  tier: SizeTier;
+  blocking: boolean;
+  limits: SizeTierLimits;
+}
+
+export function selectSeverity(input: {
+  fileCount: number;
+  lineCount: number;
+  commitCount: number;
+  allDocs: boolean;
+}): SizeSeverity;
+
+export function formatReport(input: {
+  fileCount: number;
+  lineCount: number;
+  commitCount: number;
+  allDocs: boolean;
+  severity: SizeSeverity;
+}): string;
+
+export interface PrSizeEvaluation {
+  ok: boolean;
+  error?: string;
+  fileCount?: number;
+  lineCount?: number;
+  commitCount?: number;
+  allDocs?: boolean;
+  severity?: SizeSeverity;
+  report?: string;
+}
+
+export function evaluatePrSize(
+  base: string,
+  head: string,
+  dependencies?: GitDependencies,
+): PrSizeEvaluation;
+
+export function main(): void;

--- a/scripts/check-pr-size.d.mts
+++ b/scripts/check-pr-size.d.mts
@@ -28,6 +28,8 @@ export function parseNumstat(numstatOutput: string): NumstatRow[];
 
 export function computeMeaningfulLines(rows: NumstatRow[]): number;
 
+export function computeGovernedFileCount(rows: NumstatRow[]): number;
+
 export function isAllDocs(rows: NumstatRow[]): boolean;
 
 export interface SizeTierLimits {
@@ -53,6 +55,7 @@ export function selectSeverity(input: {
 
 export function formatReport(input: {
   fileCount: number;
+  totalFileCount: number;
   lineCount: number;
   commitCount: number;
   allDocs: boolean;
@@ -63,6 +66,7 @@ export interface PrSizeEvaluation {
   ok: boolean;
   error?: string;
   fileCount?: number;
+  totalFileCount?: number;
   lineCount?: number;
   commitCount?: number;
   allDocs?: boolean;

--- a/scripts/check-pr-size.mjs
+++ b/scripts/check-pr-size.mjs
@@ -100,14 +100,23 @@ export function parseNumstat(numstatOutput) {
 // QNBS-v3: only rebuilt public/ bundles are generated — locales/**/community-templates/** source content still counts.
 const GENERATED_ARTIFACT_ROOTS = ['public/locales/', 'public/community-templates/'];
 
+function isGovernanceExcluded(path) {
+  if (path.split('/').pop() === 'pnpm-lock.yaml') return true;
+  return GENERATED_ARTIFACT_ROOTS.some((root) => path.startsWith(root));
+}
+
 export function computeMeaningfulLines(rows) {
   let total = 0;
   for (const row of rows) {
-    if (row.path.split('/').pop() === 'pnpm-lock.yaml') continue;
-    if (GENERATED_ARTIFACT_ROOTS.some((root) => row.path.startsWith(root))) continue;
+    if (isGovernanceExcluded(row.path)) continue;
     total += row.added + row.removed;
   }
   return total;
+}
+
+// QNBS-v3: a locale-parity edit always touches 19 rebuilt bundles — exclude them, mirroring lines.
+export function computeGovernedFileCount(rows) {
+  return rows.filter((row) => !isGovernanceExcluded(row.path)).length;
 }
 
 export function isAllDocs(rows) {
@@ -138,14 +147,15 @@ export function selectSeverity({ fileCount, lineCount, commitCount, allDocs }) {
   return { tier: 'ok', blocking: false, limits: TIERS.target };
 }
 
-export function formatReport({ fileCount, lineCount, commitCount, allDocs, severity }) {
+export function formatReport({ fileCount, totalFileCount, lineCount, commitCount, allDocs, severity }) {
   const { tier, blocking, limits } = severity;
+  const filesNote = totalFileCount > fileCount ? ` (${totalFileCount} total incl. generated)` : '';
   if (tier === 'ok') {
-    return `PR size within target: ${fileCount} files, ${lineCount} meaningful lines, ${commitCount} commits (limit: ≤${limits.files}/≤${limits.lines}/≤${limits.commits}).`;
+    return `PR size within target: ${fileCount} files${filesNote}, ${lineCount} meaningful lines, ${commitCount} commits (limit: ≤${limits.files}/≤${limits.lines}/≤${limits.commits}).`;
   }
   const kind = blocking ? 'exceeds the absolute ceiling' : `is over the ${tier} tier`;
   const profile = allDocs ? 'docs/governance' : 'normal';
-  return `PR size ${kind} (${profile} profile): ${fileCount} files, ${lineCount} meaningful lines, ${commitCount} commits — limit ≤${limits.files} files / ≤${limits.lines} lines / ≤${limits.commits} commits. ${blocking ? 'Split this PR into smaller, independently reviewable PRs before merge.' : 'Consider splitting into smaller, independently reviewable PRs.'}`;
+  return `PR size ${kind} (${profile} profile): ${fileCount} files${filesNote}, ${lineCount} meaningful lines, ${commitCount} commits — limit ≤${limits.files} files / ≤${limits.lines} lines / ≤${limits.commits} commits. ${blocking ? 'Split this PR into smaller, independently reviewable PRs before merge.' : 'Consider splitting into smaller, independently reviewable PRs.'}`;
 }
 
 export function evaluatePrSize(base, head, dependencies = {}) {
@@ -155,18 +165,20 @@ export function evaluatePrSize(base, head, dependencies = {}) {
     return { ok: false, error: 'could not resolve diff/commit range via git' };
   }
   const rows = parseNumstat(numstat);
-  const fileCount = rows.length;
+  const totalFileCount = rows.length;
+  const fileCount = computeGovernedFileCount(rows);
   const lineCount = computeMeaningfulLines(rows);
   const allDocs = isAllDocs(rows);
   const severity = selectSeverity({ fileCount, lineCount, commitCount, allDocs });
   return {
     ok: true,
     fileCount,
+    totalFileCount,
     lineCount,
     commitCount,
     allDocs,
     severity,
-    report: formatReport({ fileCount, lineCount, commitCount, allDocs, severity }),
+    report: formatReport({ fileCount, totalFileCount, lineCount, commitCount, allDocs, severity }),
   };
 }
 

--- a/scripts/check-pr-size.mjs
+++ b/scripts/check-pr-size.mjs
@@ -98,15 +98,15 @@ export function parseNumstat(numstatOutput) {
   return rows;
 }
 
-// QNBS-v3: every public/locales/** file is i18n:bundle output — the whole subtree is safe to exclude.
-const GENERATED_ARTIFACT_ROOTS = ['public/locales/'];
+// QNBS-v3: build-i18n.mjs only ever writes <lang>/bundle.json — a same-named non-bundle file must still count.
+const LOCALE_BUNDLE_PATTERN = /^public\/locales\/[^/]+\/bundle\.json$/;
 // QNBS-v3: only index.json is content-guard's mirror of community-templates/ — index.<locale>.json are hand-authored.
 const GENERATED_ARTIFACT_EXACT_PATHS = ['public/community-templates/index.json'];
 
 function isGovernanceExcluded(path) {
   if (path.split('/').pop() === 'pnpm-lock.yaml') return true;
   if (GENERATED_ARTIFACT_EXACT_PATHS.includes(path)) return true;
-  return GENERATED_ARTIFACT_ROOTS.some((root) => path.startsWith(root));
+  return LOCALE_BUNDLE_PATTERN.test(path);
 }
 
 export function computeMeaningfulLines(rows) {

--- a/scripts/check-pr-size.mjs
+++ b/scripts/check-pr-size.mjs
@@ -1,4 +1,5 @@
 import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
 import process from 'node:process';
 import { pathToFileURL } from 'node:url';
 import { classifyFile } from './ci-prepush-classifier.mjs';
@@ -18,9 +19,45 @@ function runGit(args, dependencies = {}) {
   return result.stdout;
 }
 
+// QNBS-v3: $GIT_DIR/info/attributes outranks the PR's own tracked .gitattributes and is never versioned.
+function resolveInfoAttributesPath(dependencies = {}) {
+  const output = runGit(['rev-parse', '--git-path', 'info/attributes'], dependencies);
+  return output === null ? null : output.trim();
+}
+
+// QNBS-v3: a PR-controlled "path -diff" in .gitattributes hides edits from numstat — override locally.
+function withForcedTextDiff(dependencies, fn) {
+  const readFile = dependencies.readFileSync ?? readFileSync;
+  const writeFile = dependencies.writeFileSync ?? writeFileSync;
+  const exists = dependencies.existsSync ?? existsSync;
+  const unlink = dependencies.unlinkSync ?? unlinkSync;
+  const attrPath = resolveInfoAttributesPath(dependencies);
+  if (!attrPath) return fn();
+  const hadFile = exists(attrPath);
+  const original = hadFile ? readFile(attrPath, 'utf8') : '';
+  try {
+    const separator = original && !original.endsWith('\n') ? '\n' : '';
+    writeFile(attrPath, `${original}${separator}* diff\n`);
+  } catch {
+    return fn(); // best-effort — proceed unprotected rather than fail the whole check
+  }
+  try {
+    return fn();
+  } finally {
+    try {
+      if (hadFile) writeFile(attrPath, original);
+      else unlink(attrPath);
+    } catch {
+      // best-effort restore; a leftover override in a CI-ephemeral checkout is harmless
+    }
+  }
+}
+
 // QNBS-v3: -z gives raw UTF-8 paths (git otherwise octal-escapes non-ASCII) and keeps rename detection.
 export function getChangedFilesNumstat(base, head, dependencies = {}) {
-  return runGit(['diff', '--numstat', '-z', `${base}...${head}`], dependencies);
+  return withForcedTextDiff(dependencies, () =>
+    runGit(['diff', '--numstat', '-z', `${base}...${head}`], dependencies),
+  );
 }
 
 export function getCommitCount(base, head, dependencies = {}) {

--- a/scripts/check-pr-size.mjs
+++ b/scripts/check-pr-size.mjs
@@ -26,7 +26,8 @@ function resolveInfoAttributesPath(dependencies = {}) {
 }
 
 // QNBS-v3: a PR-controlled "path -diff" in .gitattributes hides edits from numstat — override locally.
-function withForcedTextDiff(dependencies, fn) {
+// QNBS-v3: "!diff" unspecifies (not forces-true) so genuine binaries still auto-detect, unlike a bare "diff".
+function withNeutralizedDiffAttribute(dependencies, fn) {
   const readFile = dependencies.readFileSync ?? readFileSync;
   const writeFile = dependencies.writeFileSync ?? writeFileSync;
   const exists = dependencies.existsSync ?? existsSync;
@@ -37,7 +38,7 @@ function withForcedTextDiff(dependencies, fn) {
   const original = hadFile ? readFile(attrPath, 'utf8') : '';
   try {
     const separator = original && !original.endsWith('\n') ? '\n' : '';
-    writeFile(attrPath, `${original}${separator}* diff\n`);
+    writeFile(attrPath, `${original}${separator}* !diff\n`);
   } catch {
     return fn(); // best-effort — proceed unprotected rather than fail the whole check
   }
@@ -55,7 +56,7 @@ function withForcedTextDiff(dependencies, fn) {
 
 // QNBS-v3: -z gives raw UTF-8 paths (git otherwise octal-escapes non-ASCII) and keeps rename detection.
 export function getChangedFilesNumstat(base, head, dependencies = {}) {
-  return withForcedTextDiff(dependencies, () =>
+  return withNeutralizedDiffAttribute(dependencies, () =>
     runGit(['diff', '--numstat', '-z', `${base}...${head}`], dependencies),
   );
 }

--- a/scripts/check-pr-size.mjs
+++ b/scripts/check-pr-size.mjs
@@ -1,0 +1,136 @@
+import { spawnSync } from 'node:child_process';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+import { classifyFile } from './ci-prepush-classifier.mjs';
+
+// QNBS-v3: a distinct, stricter gate from CLAUDE.md's ~100-file CodeAnt-visibility rule (different purpose).
+const TIERS = {
+  target: { files: 8, lines: 400, commits: 6 },
+  hard: { files: 20, lines: 1200, commits: 10 },
+  docsGovernance: { files: 15, lines: 2400, commits: 8 },
+  absolute: { files: 30, lines: 3000, commits: 15 },
+};
+
+function runGit(args, dependencies = {}) {
+  const spawn = dependencies.spawnSync ?? spawnSync;
+  const result = spawn('git', args, { encoding: 'utf8' });
+  if (result.error || result.status !== 0) return null;
+  return result.stdout;
+}
+
+export function getChangedFilesNumstat(base, head, dependencies = {}) {
+  return runGit(['diff', '--no-renames', '--numstat', `${base}...${head}`], dependencies);
+}
+
+export function getCommitCount(base, head, dependencies = {}) {
+  const output = runGit(['rev-list', '--count', `${base}..${head}`], dependencies);
+  if (output === null) return null;
+  const count = Number.parseInt(output.trim(), 10);
+  return Number.isFinite(count) ? count : null;
+}
+
+// QNBS-v3: binary files report "-\t-\tpath" in numstat — treated as 0 meaningful lines, not NaN.
+export function parseNumstat(numstatOutput) {
+  const rows = [];
+  for (const line of numstatOutput.split('\n')) {
+    if (!line.trim()) continue;
+    const [added, removed, ...pathParts] = line.split('\t');
+    const path = pathParts.join('\t');
+    rows.push({
+      path,
+      added: added === '-' ? 0 : Number.parseInt(added, 10),
+      removed: removed === '-' ? 0 : Number.parseInt(removed, 10),
+    });
+  }
+  return rows;
+}
+
+// QNBS-v3: zeroes generated/non-code diffs so e.g. a locale bundle rebuild can't trip this gate.
+export function computeMeaningfulLines(rows) {
+  let total = 0;
+  for (const row of rows) {
+    if (row.path.split('/').pop() === 'pnpm-lock.yaml') continue;
+    if (classifyFile(row.path) === 'NON_CODE_ONLY') continue;
+    total += row.added + row.removed;
+  }
+  return total;
+}
+
+export function isAllDocs(rows) {
+  if (rows.length === 0) return false;
+  return rows.every((row) => classifyFile(row.path) === 'DOCS');
+}
+
+// QNBS-v3: absolute is a fixed ceiling; docsGovernance replaces hard (not target) for all-DOCS PRs.
+export function selectSeverity({ fileCount, lineCount, commitCount, allDocs }) {
+  const overAbsolute =
+    fileCount > TIERS.absolute.files ||
+    lineCount > TIERS.absolute.lines ||
+    commitCount > TIERS.absolute.commits;
+  if (overAbsolute) return { tier: 'absolute', blocking: true, limits: TIERS.absolute };
+
+  const midTier = allDocs ? 'docsGovernance' : 'hard';
+  const midLimits = TIERS[midTier];
+  const overMid =
+    fileCount > midLimits.files || lineCount > midLimits.lines || commitCount > midLimits.commits;
+  if (overMid) return { tier: midTier, blocking: false, limits: midLimits };
+
+  const overTarget =
+    fileCount > TIERS.target.files ||
+    lineCount > TIERS.target.lines ||
+    commitCount > TIERS.target.commits;
+  if (overTarget) return { tier: 'target', blocking: false, limits: TIERS.target };
+
+  return { tier: 'ok', blocking: false, limits: TIERS.target };
+}
+
+export function formatReport({ fileCount, lineCount, commitCount, allDocs, severity }) {
+  const { tier, blocking, limits } = severity;
+  if (tier === 'ok') {
+    return `PR size within target: ${fileCount} files, ${lineCount} meaningful lines, ${commitCount} commits (limit: ≤${limits.files}/≤${limits.lines}/≤${limits.commits}).`;
+  }
+  const kind = blocking ? 'exceeds the absolute ceiling' : `is over the ${tier} tier`;
+  const profile = allDocs ? 'docs/governance' : 'normal';
+  return `PR size ${kind} (${profile} profile): ${fileCount} files, ${lineCount} meaningful lines, ${commitCount} commits — limit ≤${limits.files} files / ≤${limits.lines} lines / ≤${limits.commits} commits. ${blocking ? 'Split this PR into smaller, independently reviewable PRs before merge.' : 'Consider splitting into smaller, independently reviewable PRs.'}`;
+}
+
+export function evaluatePrSize(base, head, dependencies = {}) {
+  const numstat = getChangedFilesNumstat(base, head, dependencies);
+  const commitCount = getCommitCount(base, head, dependencies);
+  if (numstat === null || commitCount === null) {
+    return { ok: false, error: 'could not resolve diff/commit range via git' };
+  }
+  const rows = parseNumstat(numstat);
+  const fileCount = rows.length;
+  const lineCount = computeMeaningfulLines(rows);
+  const allDocs = isAllDocs(rows);
+  const severity = selectSeverity({ fileCount, lineCount, commitCount, allDocs });
+  return {
+    ok: true,
+    fileCount,
+    lineCount,
+    commitCount,
+    allDocs,
+    severity,
+    report: formatReport({ fileCount, lineCount, commitCount, allDocs, severity }),
+  };
+}
+
+export function main() {
+  const [base, head] = process.argv.slice(2);
+  if (!base || !head) {
+    console.error('Usage: node scripts/check-pr-size.mjs <base-sha> <head-sha>');
+    process.exitCode = 1;
+    return;
+  }
+  const result = evaluatePrSize(base, head);
+  if (!result.ok) {
+    console.error(`[check-pr-size] ${result.error}`);
+    process.exitCode = 1;
+    return;
+  }
+  console.log(`[check-pr-size] ${result.report}`);
+  if (result.severity.blocking) process.exitCode = 1;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) main();

--- a/scripts/check-pr-size.mjs
+++ b/scripts/check-pr-size.mjs
@@ -18,8 +18,9 @@ function runGit(args, dependencies = {}) {
   return result.stdout;
 }
 
+// QNBS-v3: -z gives raw UTF-8 paths (git otherwise octal-escapes non-ASCII) and keeps rename detection.
 export function getChangedFilesNumstat(base, head, dependencies = {}) {
-  return runGit(['diff', '--no-renames', '--numstat', `${base}...${head}`], dependencies);
+  return runGit(['diff', '--numstat', '-z', `${base}...${head}`], dependencies);
 }
 
 export function getCommitCount(base, head, dependencies = {}) {
@@ -29,28 +30,44 @@ export function getCommitCount(base, head, dependencies = {}) {
   return Number.isFinite(count) ? count : null;
 }
 
-// QNBS-v3: binary files report "-\t-\tpath" in numstat — treated as 0 meaningful lines, not NaN.
+const NUMSTAT_HEADER = /^(-|\d+)\t(-|\d+)\t(.*)$/s;
+
+// QNBS-v3: binary files report "-\t-\t..." — treated as 0 meaningful lines, not NaN.
+// QNBS-v3: -z rename records are 3 NUL-separated tokens (numbers, old path, new path) — not 1.
 export function parseNumstat(numstatOutput) {
+  const tokens = numstatOutput.split('\0').filter((token) => token.length > 0);
   const rows = [];
-  for (const line of numstatOutput.split('\n')) {
-    if (!line.trim()) continue;
-    const [added, removed, ...pathParts] = line.split('\t');
-    const path = pathParts.join('\t');
-    rows.push({
-      path,
-      added: added === '-' ? 0 : Number.parseInt(added, 10),
-      removed: removed === '-' ? 0 : Number.parseInt(removed, 10),
-    });
+  let i = 0;
+  while (i < tokens.length) {
+    const match = NUMSTAT_HEADER.exec(tokens[i]);
+    if (!match) {
+      i += 1;
+      continue;
+    }
+    const [, addedRaw, removedRaw, inlinePath] = match;
+    const added = addedRaw === '-' ? 0 : Number.parseInt(addedRaw, 10);
+    const removed = removedRaw === '-' ? 0 : Number.parseInt(removedRaw, 10);
+    if (inlinePath) {
+      rows.push({ path: inlinePath, added, removed });
+      i += 1;
+    } else {
+      // Renamed: this record's numbers token has an empty path — old/new path follow as separate tokens.
+      const newPath = tokens[i + 2] ?? '';
+      rows.push({ path: newPath, added, removed });
+      i += 3;
+    }
   }
   return rows;
 }
 
-// QNBS-v3: zeroes generated/non-code diffs so e.g. a locale bundle rebuild can't trip this gate.
+// QNBS-v3: only rebuilt public/ bundles are generated — locales/**/community-templates/** source content still counts.
+const GENERATED_ARTIFACT_ROOTS = ['public/locales/', 'public/community-templates/'];
+
 export function computeMeaningfulLines(rows) {
   let total = 0;
   for (const row of rows) {
     if (row.path.split('/').pop() === 'pnpm-lock.yaml') continue;
-    if (classifyFile(row.path) === 'NON_CODE_ONLY') continue;
+    if (GENERATED_ARTIFACT_ROOTS.some((root) => row.path.startsWith(root))) continue;
     total += row.added + row.removed;
   }
   return total;

--- a/scripts/check-pr-size.mjs
+++ b/scripts/check-pr-size.mjs
@@ -97,11 +97,14 @@ export function parseNumstat(numstatOutput) {
   return rows;
 }
 
-// QNBS-v3: only rebuilt public/ bundles are generated — locales/**/community-templates/** source content still counts.
-const GENERATED_ARTIFACT_ROOTS = ['public/locales/', 'public/community-templates/'];
+// QNBS-v3: every public/locales/** file is i18n:bundle output — the whole subtree is safe to exclude.
+const GENERATED_ARTIFACT_ROOTS = ['public/locales/'];
+// QNBS-v3: only index.json is content-guard's mirror of community-templates/ — index.<locale>.json are hand-authored.
+const GENERATED_ARTIFACT_EXACT_PATHS = ['public/community-templates/index.json'];
 
 function isGovernanceExcluded(path) {
   if (path.split('/').pop() === 'pnpm-lock.yaml') return true;
+  if (GENERATED_ARTIFACT_EXACT_PATHS.includes(path)) return true;
   return GENERATED_ARTIFACT_ROOTS.some((root) => path.startsWith(root));
 }
 

--- a/scripts/workflow-policy-check.mjs
+++ b/scripts/workflow-policy-check.mjs
@@ -18,6 +18,7 @@ const WRITE_SCOPE_ALLOWLIST = {
   'ci.yml': {
     build: new Set(['attestations', 'id-token']),
     deploy: new Set(['pages', 'id-token']),
+    'pr-size': new Set(['pull-requests']),
   },
   'docker.yml': { 'build-push': new Set(['packages']) },
   'prune-deployments.yml': { prune: new Set(['deployments']) },

--- a/tests/unit/tooling/checkPrSize.test.ts
+++ b/tests/unit/tooling/checkPrSize.test.ts
@@ -9,10 +9,10 @@ import {
 } from '../../../scripts/check-pr-size.mjs';
 import type { NumstatRow } from '../../../scripts/check-pr-size.d.mts';
 
-// QNBS-v3: numstat uses "-\t-\tpath" for binary files — must parse as 0, not NaN.
+// QNBS-v3: -z is NUL-delimited (git diff --numstat -z), not newline-delimited — matches real output.
 describe('parseNumstat', () => {
   it('parses added/removed counts per file', () => {
-    const rows = parseNumstat('10\t2\tsrc/foo.ts\n5\t0\tsrc/bar.ts\n');
+    const rows = parseNumstat('10\t2\tsrc/foo.ts\x005\t0\tsrc/bar.ts\x00');
     expect(rows).toEqual([
       { path: 'src/foo.ts', added: 10, removed: 2 },
       { path: 'src/bar.ts', added: 5, removed: 0 },
@@ -20,13 +20,30 @@ describe('parseNumstat', () => {
   });
 
   it('treats a binary file row (-\\t-\\tpath) as 0 added/0 removed', () => {
-    const rows = parseNumstat('-\t-\tsrc-tauri/icons/icon.png\n');
+    const rows = parseNumstat('-\t-\tsrc-tauri/icons/icon.png\x00');
     expect(rows).toEqual([{ path: 'src-tauri/icons/icon.png', added: 0, removed: 0 }]);
   });
 
-  it('ignores blank lines', () => {
-    const rows = parseNumstat('1\t1\ta.ts\n\n2\t2\tb.ts\n');
+  it('ignores stray empty tokens', () => {
+    const rows = parseNumstat('1\t1\ta.ts\x00\x002\t2\tb.ts\x00');
     expect(rows).toHaveLength(2);
+  });
+
+  // QNBS-v3: -z rename records are "nums\t\t" + old-path + new-path as 3 separate NUL-terminated tokens.
+  it('parses a pure rename as one row under the new path, not delete+add', () => {
+    const rows = parseNumstat('0\t0\t\x00old-name.ts\x00new-name.ts\x00');
+    expect(rows).toEqual([{ path: 'new-name.ts', added: 0, removed: 0 }]);
+  });
+
+  it('parses a rename-with-edit as one row with the real delta, not the full file twice', () => {
+    const rows = parseNumstat('3\t1\t\x00src/old.ts\x00src/new.ts\x00');
+    expect(rows).toEqual([{ path: 'src/new.ts', added: 3, removed: 1 }]);
+  });
+
+  it('preserves raw UTF-8 paths instead of git\'s octal-quoted representation', () => {
+    // -z output is raw UTF-8; the quoted "docs/\303\251.md" form only appears without -z.
+    const rows = parseNumstat('1\t0\tdocs/spécial.md\x00');
+    expect(rows).toEqual([{ path: 'docs/spécial.md', added: 1, removed: 0 }]);
   });
 });
 
@@ -39,13 +56,22 @@ describe('computeMeaningfulLines', () => {
     expect(computeMeaningfulLines(rows)).toBe(19);
   });
 
-  // QNBS-v3: a locale bundle rebuild can churn thousands of lines without being a "real" change.
-  it('zeroes out NON_CODE_ONLY files (e.g. locale bundles)', () => {
+  // QNBS-v3: a rebuilt public/ bundle can churn thousands of lines without being a "real" change.
+  it('zeroes out generated public/locales bundles', () => {
     const rows: NumstatRow[] = [
       { path: 'public/locales/de/writer/bundle.json', added: 5000, removed: 5000 },
       { path: 'scripts/foo.mjs', added: 10, removed: 5 },
     ];
     expect(computeMeaningfulLines(rows)).toBe(15);
+  });
+
+  // QNBS-v3: locales/**/*.json is translator-authored source, not generated — must still count.
+  it('still counts source locales/**/*.json edits as meaningful (not the generated bundle)', () => {
+    const rows: NumstatRow[] = [
+      { path: 'locales/de/writer.json', added: 200, removed: 50 },
+      { path: 'public/locales/de/writer/bundle.json', added: 5000, removed: 5000 },
+    ];
+    expect(computeMeaningfulLines(rows)).toBe(250);
   });
 
   it('zeroes out pnpm-lock.yaml regardless of its classification', () => {
@@ -158,7 +184,7 @@ describe('evaluatePrSize', () => {
     const spawnSync = () => {
       call += 1;
       return call === 1
-        ? { ...okGit(), stdout: '10\t2\tscripts/foo.mjs\n' }
+        ? { ...okGit(), stdout: '10\t2\tscripts/foo.mjs\x00' }
         : { ...okGit(), stdout: '2\n' };
     };
     const result = evaluatePrSize('base', 'head', { spawnSync });
@@ -181,7 +207,7 @@ describe('evaluatePrSize', () => {
     const spawnSync = () => {
       call += 1;
       return call === 1
-        ? { ...okGit(), stdout: '10\t2\tscripts/foo.mjs\n' }
+        ? { ...okGit(), stdout: '10\t2\tscripts/foo.mjs\x00' }
         : { status: 1, stdout: '', stderr: 'fatal: bad range' };
     };
     const result = evaluatePrSize('base', 'head', { spawnSync });

--- a/tests/unit/tooling/checkPrSize.test.ts
+++ b/tests/unit/tooling/checkPrSize.test.ts
@@ -58,9 +58,9 @@ describe('computeMeaningfulLines', () => {
   });
 
   // QNBS-v3: a rebuilt public/ bundle can churn thousands of lines without being a "real" change.
-  it('zeroes out generated public/locales bundles', () => {
+  it('zeroes out generated public/locales/<lang>/bundle.json bundles', () => {
     const rows: NumstatRow[] = [
-      { path: 'public/locales/de/writer/bundle.json', added: 5000, removed: 5000 },
+      { path: 'public/locales/de/bundle.json', added: 5000, removed: 5000 },
       { path: 'scripts/foo.mjs', added: 10, removed: 5 },
     ];
     expect(computeMeaningfulLines(rows)).toBe(15);
@@ -70,9 +70,18 @@ describe('computeMeaningfulLines', () => {
   it('still counts source locales/**/*.json edits as meaningful (not the generated bundle)', () => {
     const rows: NumstatRow[] = [
       { path: 'locales/de/writer.json', added: 200, removed: 50 },
-      { path: 'public/locales/de/writer/bundle.json', added: 5000, removed: 5000 },
+      { path: 'public/locales/de/bundle.json', added: 5000, removed: 5000 },
     ];
     expect(computeMeaningfulLines(rows)).toBe(250);
+  });
+
+  // QNBS-v3: build-i18n.mjs only ever writes <lang>/bundle.json — a same-named non-bundle file must still count.
+  it('still counts a non-bundle file that happens to live under public/locales/<lang>/', () => {
+    const rows: NumstatRow[] = [
+      { path: 'public/locales/en/metadata.json', added: 300, removed: 100 },
+      { path: 'public/locales/de/bundle.json', added: 5000, removed: 5000 },
+    ];
+    expect(computeMeaningfulLines(rows)).toBe(400);
   });
 
   it('zeroes out pnpm-lock.yaml regardless of its classification', () => {
@@ -107,10 +116,18 @@ describe('computeGovernedFileCount', () => {
     expect(computeGovernedFileCount(rows)).toBe(2);
   });
 
-  it('excludes generated public/locales bundles from the count', () => {
+  it('excludes generated public/locales/<lang>/bundle.json from the count', () => {
     const rows: NumstatRow[] = [
       { path: 'locales/de/writer.json', added: 200, removed: 50 },
-      { path: 'public/locales/de/writer/bundle.json', added: 5000, removed: 5000 },
+      { path: 'public/locales/de/bundle.json', added: 5000, removed: 5000 },
+    ];
+    expect(computeGovernedFileCount(rows)).toBe(1);
+  });
+
+  it('still counts a non-bundle file under public/locales/<lang>/ in the file count too', () => {
+    const rows: NumstatRow[] = [
+      { path: 'public/locales/en/metadata.json', added: 300, removed: 100 },
+      { path: 'public/locales/de/bundle.json', added: 5000, removed: 5000 },
     ];
     expect(computeGovernedFileCount(rows)).toBe(1);
   });
@@ -311,7 +328,7 @@ describe('evaluatePrSize', () => {
     const numstat = langs
       .flatMap((lang) => [
         `2\t0\tlocales/${lang}/writer.json\x00`,
-        `40\t40\tpublic/locales/${lang}/writer/bundle.json\x00`,
+        `40\t40\tpublic/locales/${lang}/bundle.json\x00`,
       ])
       .join('');
     const spawnSync = (_cmd: string, args: string[]) => {

--- a/tests/unit/tooling/checkPrSize.test.ts
+++ b/tests/unit/tooling/checkPrSize.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  computeGovernedFileCount,
   computeMeaningfulLines,
   evaluatePrSize,
   formatReport,
@@ -83,6 +84,33 @@ describe('computeMeaningfulLines', () => {
   });
 });
 
+// QNBS-v3: a locale-parity edit always touches 19 rebuilt bundles — the file ceiling must exclude them too.
+describe('computeGovernedFileCount', () => {
+  it('counts ordinary code files', () => {
+    const rows: NumstatRow[] = [
+      { path: 'scripts/foo.mjs', added: 10, removed: 5 },
+      { path: 'scripts/bar.mjs', added: 3, removed: 1 },
+    ];
+    expect(computeGovernedFileCount(rows)).toBe(2);
+  });
+
+  it('excludes generated public/locales bundles from the count', () => {
+    const rows: NumstatRow[] = [
+      { path: 'locales/de/writer.json', added: 200, removed: 50 },
+      { path: 'public/locales/de/writer/bundle.json', added: 5000, removed: 5000 },
+    ];
+    expect(computeGovernedFileCount(rows)).toBe(1);
+  });
+
+  it('excludes pnpm-lock.yaml from the count', () => {
+    const rows: NumstatRow[] = [
+      { path: 'pnpm-lock.yaml', added: 2000, removed: 100 },
+      { path: 'scripts/foo.mjs', added: 10, removed: 5 },
+    ];
+    expect(computeGovernedFileCount(rows)).toBe(1);
+  });
+});
+
 describe('isAllDocs', () => {
   it('is true when every changed file classifies as DOCS', () => {
     expect(isAllDocs([{ path: 'docs/CI.md', added: 1, removed: 1 }])).toBe(true);
@@ -152,22 +180,57 @@ describe('selectSeverity', () => {
 describe('formatReport', () => {
   it('reports "within target" for an ok result', () => {
     const severity = selectSeverity({ fileCount: 3, lineCount: 100, commitCount: 2, allDocs: false });
-    const report = formatReport({ fileCount: 3, lineCount: 100, commitCount: 2, allDocs: false, severity });
+    const report = formatReport({
+      fileCount: 3,
+      totalFileCount: 3,
+      lineCount: 100,
+      commitCount: 2,
+      allDocs: false,
+      severity,
+    });
     expect(report).toMatch(/within target/);
   });
 
   it('reports a blocking message for the absolute tier', () => {
     const severity = selectSeverity({ fileCount: 35, lineCount: 500, commitCount: 7, allDocs: false });
-    const report = formatReport({ fileCount: 35, lineCount: 500, commitCount: 7, allDocs: false, severity });
+    const report = formatReport({
+      fileCount: 35,
+      totalFileCount: 35,
+      lineCount: 500,
+      commitCount: 7,
+      allDocs: false,
+      severity,
+    });
     expect(report).toMatch(/exceeds the absolute ceiling/);
     expect(report).toMatch(/Split this PR/);
   });
 
   it('reports a non-blocking suggestion for the target/hard tiers', () => {
     const severity = selectSeverity({ fileCount: 25, lineCount: 500, commitCount: 7, allDocs: false });
-    const report = formatReport({ fileCount: 25, lineCount: 500, commitCount: 7, allDocs: false, severity });
+    const report = formatReport({
+      fileCount: 25,
+      totalFileCount: 25,
+      lineCount: 500,
+      commitCount: 7,
+      allDocs: false,
+      severity,
+    });
     expect(report).toMatch(/is over the hard tier/);
     expect(report).toMatch(/Consider splitting/);
+  });
+
+  // QNBS-v3: surfaces the excluded generated count so the report isn't silently smaller than the real diff.
+  it('notes the total file count when it exceeds the governed count', () => {
+    const severity = selectSeverity({ fileCount: 3, lineCount: 100, commitCount: 2, allDocs: false });
+    const report = formatReport({
+      fileCount: 3,
+      totalFileCount: 41,
+      lineCount: 100,
+      commitCount: 2,
+      allDocs: false,
+      severity,
+    });
+    expect(report).toMatch(/41 total incl\. generated/);
   });
 });
 
@@ -218,6 +281,27 @@ describe('evaluatePrSize', () => {
     const spawnSync = () => ({ status: null, error: new Error('spawn git ENOENT'), stdout: '', stderr: '' });
     const result = evaluatePrSize('base', 'head', { spawnSync });
     expect(result.ok).toBe(false);
+  });
+
+  // QNBS-v3: a real atomic i18n edit (1 source file/locale + its rebuilt bundle) must not trip the file ceiling.
+  it('does not block an atomic locale-parity change on the generated-bundle fan-out', () => {
+    const langs = Array.from({ length: 19 }, (_, i) => `lang${i}`);
+    const numstat = langs
+      .flatMap((lang) => [
+        `2\t0\tlocales/${lang}/writer.json\x00`,
+        `40\t40\tpublic/locales/${lang}/writer/bundle.json\x00`,
+      ])
+      .join('');
+    const spawnSync = (_cmd: string, args: string[]) => {
+      if (args.includes('--git-path')) return { status: 1, stdout: '', stderr: '' };
+      if (args[0] === 'diff') return { ...okGit(), stdout: numstat };
+      return { ...okGit(), stdout: '1\n' };
+    };
+    const result = evaluatePrSize('base', 'head', { spawnSync });
+    expect(result.ok).toBe(true);
+    expect(result.totalFileCount).toBe(38);
+    expect(result.fileCount).toBe(19);
+    expect(result.severity?.tier).not.toBe('absolute');
   });
 });
 

--- a/tests/unit/tooling/checkPrSize.test.ts
+++ b/tests/unit/tooling/checkPrSize.test.ts
@@ -343,12 +343,15 @@ describe('getChangedFilesNumstat (gitattributes evasion protection, real git rep
       git('config', 'user.email', 'test@test.com');
       git('config', 'user.name', 'test');
       writeFile(join(dir, 'file.txt'), 'line1\nline2\nline3\n');
+      writeFile(join(dir, 'binary.bin'), Buffer.from([0, 1, 2, 3, 255, 254, 0, 0, 1]));
       git('add', '-A');
       git('commit', '-q', '-m', 'init');
       const base = git('rev-parse', 'HEAD').stdout.trim();
 
       writeFile(join(dir, '.gitattributes'), 'file.txt -diff\n');
       writeFile(join(dir, 'file.txt'), 'line1\nline2 CHANGED\nline3\nline4\n');
+      // QNBS-v3: an ordinary binary edit, no gitattributes entry — must stay auto-detected as binary too.
+      writeFile(join(dir, 'binary.bin'), Buffer.from([9, 8, 7, 6, 255, 254, 0, 0, 2, 3, 4]));
       git('add', '-A');
       git('commit', '-q', '-m', 'hide this change via -diff');
       const head = git('rev-parse', 'HEAD').stdout.trim();
@@ -379,6 +382,10 @@ describe('getChangedFilesNumstat (gitattributes evasion protection, real git rep
       const rows = JSON.parse(child.stdout) as Array<{ path: string; added: number; removed: number }>;
       const revealedRow = rows.find((row) => row.path === 'file.txt');
       expect(revealedRow?.added).toBeGreaterThan(0);
+
+      // QNBS-v3: "!diff" unspecifies rather than forces text — a genuine binary must not get fake line counts.
+      const binaryRow = rows.find((row) => row.path === 'binary.bin');
+      expect(binaryRow).toEqual({ path: 'binary.bin', added: 0, removed: 0 });
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/tests/unit/tooling/checkPrSize.test.ts
+++ b/tests/unit/tooling/checkPrSize.test.ts
@@ -180,12 +180,11 @@ describe('evaluatePrSize', () => {
   });
 
   it('evaluates a small change as ok, using injected git output', () => {
-    let call = 0;
-    const spawnSync = () => {
-      call += 1;
-      return call === 1
-        ? { ...okGit(), stdout: '10\t2\tscripts/foo.mjs\x00' }
-        : { ...okGit(), stdout: '2\n' };
+    // QNBS-v3: fail the info/attributes git-path lookup to skip that filesystem side effect here.
+    const spawnSync = (_cmd: string, args: string[]) => {
+      if (args.includes('--git-path')) return { status: 1, stdout: '', stderr: '' };
+      if (args[0] === 'diff') return { ...okGit(), stdout: '10\t2\tscripts/foo.mjs\x00' };
+      return { ...okGit(), stdout: '2\n' };
     };
     const result = evaluatePrSize('base', 'head', { spawnSync });
     expect(result.ok).toBe(true);
@@ -196,19 +195,20 @@ describe('evaluatePrSize', () => {
   });
 
   it('fails closed (ok: false) when git diff fails', () => {
-    const spawnSync = () => ({ status: 1, stdout: '', stderr: 'fatal: bad range' });
+    const spawnSync = (_cmd: string, args: string[]) => {
+      if (args.includes('--git-path')) return { status: 1, stdout: '', stderr: '' };
+      return { status: 1, stdout: '', stderr: 'fatal: bad range' };
+    };
     const result = evaluatePrSize('base', 'head', { spawnSync });
     expect(result.ok).toBe(false);
     expect(result.error).toBeTruthy();
   });
 
   it('fails closed (ok: false) when git rev-list fails', () => {
-    let call = 0;
-    const spawnSync = () => {
-      call += 1;
-      return call === 1
-        ? { ...okGit(), stdout: '10\t2\tscripts/foo.mjs\x00' }
-        : { status: 1, stdout: '', stderr: 'fatal: bad range' };
+    const spawnSync = (_cmd: string, args: string[]) => {
+      if (args.includes('--git-path')) return { status: 1, stdout: '', stderr: '' };
+      if (args[0] === 'diff') return { ...okGit(), stdout: '10\t2\tscripts/foo.mjs\x00' };
+      return { status: 1, stdout: '', stderr: 'fatal: bad range' };
     };
     const result = evaluatePrSize('base', 'head', { spawnSync });
     expect(result.ok).toBe(false);
@@ -218,5 +218,63 @@ describe('evaluatePrSize', () => {
     const spawnSync = () => ({ status: null, error: new Error('spawn git ENOENT'), stdout: '', stderr: '' });
     const result = evaluatePrSize('base', 'head', { spawnSync });
     expect(result.ok).toBe(false);
+  });
+});
+
+// QNBS-v3: real git repo test — proves the info/attributes override defeats a PR-controlled -diff.
+describe('getChangedFilesNumstat (gitattributes evasion protection, real git repo)', () => {
+  it('still counts a change hidden by a PR-controlled "-diff" gitattributes entry', async () => {
+    const { mkdtempSync, writeFileSync: writeFile, rmSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const { spawnSync: realSpawnSync } = await import('node:child_process');
+    const { pathToFileURL } = await import('node:url');
+
+    const dir = mkdtempSync(join(tmpdir(), 'pr-size-attr-test-'));
+    const git = (...args: string[]) => realSpawnSync('git', args, { cwd: dir, encoding: 'utf8' });
+    try {
+      git('init', '-q');
+      git('config', 'user.email', 'test@test.com');
+      git('config', 'user.name', 'test');
+      writeFile(join(dir, 'file.txt'), 'line1\nline2\nline3\n');
+      git('add', '-A');
+      git('commit', '-q', '-m', 'init');
+      const base = git('rev-parse', 'HEAD').stdout.trim();
+
+      writeFile(join(dir, '.gitattributes'), 'file.txt -diff\n');
+      writeFile(join(dir, 'file.txt'), 'line1\nline2 CHANGED\nline3\nline4\n');
+      git('add', '-A');
+      git('commit', '-q', '-m', 'hide this change via -diff');
+      const head = git('rev-parse', 'HEAD').stdout.trim();
+
+      const { parseNumstat } = await import('../../../scripts/check-pr-size.mjs');
+
+      const numstatWithoutFix = realSpawnSync(
+        'git',
+        ['diff', '--numstat', '-z', `${base}...${head}`],
+        { cwd: dir, encoding: 'utf8' },
+      ).stdout;
+      const rowsWithoutFix = parseNumstat(numstatWithoutFix);
+      const hiddenRow = rowsWithoutFix.find((row) => row.path === 'file.txt');
+      expect(hiddenRow).toEqual({ path: 'file.txt', added: 0, removed: 0 });
+
+      // QNBS-v3: process.chdir isn't supported in Vitest workers — spawn a real child node with cwd: dir instead.
+      const scriptPath = join(process.cwd(), 'scripts', 'check-pr-size.mjs');
+      const inline = `
+        import { getChangedFilesNumstat, parseNumstat } from ${JSON.stringify(pathToFileURL(scriptPath).href)};
+        const out = getChangedFilesNumstat(${JSON.stringify(base)}, ${JSON.stringify(head)}, {});
+        console.log(JSON.stringify(parseNumstat(out)));
+      `;
+      const child = realSpawnSync(process.execPath, ['--input-type=module', '-e', inline], {
+        cwd: dir,
+        encoding: 'utf8',
+      });
+      expect(child.status).toBe(0);
+      const rows = JSON.parse(child.stdout) as Array<{ path: string; added: number; removed: number }>;
+      const revealedRow = rows.find((row) => row.path === 'file.txt');
+      expect(revealedRow?.added).toBeGreaterThan(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/unit/tooling/checkPrSize.test.ts
+++ b/tests/unit/tooling/checkPrSize.test.ts
@@ -82,6 +82,19 @@ describe('computeMeaningfulLines', () => {
     ];
     expect(computeMeaningfulLines(rows)).toBe(15);
   });
+
+  // QNBS-v3: only index.json mirrors community-templates/ — content-guard.mjs never touches the locale variants.
+  it('zeroes out only the content-guard-mirrored community-templates/index.json', () => {
+    const rows: NumstatRow[] = [{ path: 'public/community-templates/index.json', added: 300, removed: 300 }];
+    expect(computeMeaningfulLines(rows)).toBe(0);
+  });
+
+  it('still counts hand-authored localized community-templates/index.<locale>.json as meaningful', () => {
+    const rows: NumstatRow[] = [
+      { path: 'public/community-templates/index.de.json', added: 300, removed: 100 },
+    ];
+    expect(computeMeaningfulLines(rows)).toBe(400);
+  });
 });
 
 // QNBS-v3: a locale-parity edit always touches 19 rebuilt bundles — the file ceiling must exclude them too.
@@ -106,6 +119,15 @@ describe('computeGovernedFileCount', () => {
     const rows: NumstatRow[] = [
       { path: 'pnpm-lock.yaml', added: 2000, removed: 100 },
       { path: 'scripts/foo.mjs', added: 10, removed: 5 },
+    ];
+    expect(computeGovernedFileCount(rows)).toBe(1);
+  });
+
+  // QNBS-v3: index.<locale>.json has no source-of-truth to regenerate from — it must stay governed.
+  it('counts hand-authored localized community-templates/index.<locale>.json but not the index.json mirror', () => {
+    const rows: NumstatRow[] = [
+      { path: 'public/community-templates/index.json', added: 300, removed: 300 },
+      { path: 'public/community-templates/index.de.json', added: 300, removed: 100 },
     ];
     expect(computeGovernedFileCount(rows)).toBe(1);
   });

--- a/tests/unit/tooling/checkPrSize.test.ts
+++ b/tests/unit/tooling/checkPrSize.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from 'vitest';
+import {
+  computeMeaningfulLines,
+  evaluatePrSize,
+  formatReport,
+  isAllDocs,
+  parseNumstat,
+  selectSeverity,
+} from '../../../scripts/check-pr-size.mjs';
+import type { NumstatRow } from '../../../scripts/check-pr-size.d.mts';
+
+// QNBS-v3: numstat uses "-\t-\tpath" for binary files — must parse as 0, not NaN.
+describe('parseNumstat', () => {
+  it('parses added/removed counts per file', () => {
+    const rows = parseNumstat('10\t2\tsrc/foo.ts\n5\t0\tsrc/bar.ts\n');
+    expect(rows).toEqual([
+      { path: 'src/foo.ts', added: 10, removed: 2 },
+      { path: 'src/bar.ts', added: 5, removed: 0 },
+    ]);
+  });
+
+  it('treats a binary file row (-\\t-\\tpath) as 0 added/0 removed', () => {
+    const rows = parseNumstat('-\t-\tsrc-tauri/icons/icon.png\n');
+    expect(rows).toEqual([{ path: 'src-tauri/icons/icon.png', added: 0, removed: 0 }]);
+  });
+
+  it('ignores blank lines', () => {
+    const rows = parseNumstat('1\t1\ta.ts\n\n2\t2\tb.ts\n');
+    expect(rows).toHaveLength(2);
+  });
+});
+
+describe('computeMeaningfulLines', () => {
+  it('sums added+removed for ordinary code files', () => {
+    const rows: NumstatRow[] = [
+      { path: 'scripts/foo.mjs', added: 10, removed: 5 },
+      { path: 'scripts/bar.mjs', added: 3, removed: 1 },
+    ];
+    expect(computeMeaningfulLines(rows)).toBe(19);
+  });
+
+  // QNBS-v3: a locale bundle rebuild can churn thousands of lines without being a "real" change.
+  it('zeroes out NON_CODE_ONLY files (e.g. locale bundles)', () => {
+    const rows: NumstatRow[] = [
+      { path: 'public/locales/de/writer/bundle.json', added: 5000, removed: 5000 },
+      { path: 'scripts/foo.mjs', added: 10, removed: 5 },
+    ];
+    expect(computeMeaningfulLines(rows)).toBe(15);
+  });
+
+  it('zeroes out pnpm-lock.yaml regardless of its classification', () => {
+    const rows: NumstatRow[] = [
+      { path: 'pnpm-lock.yaml', added: 2000, removed: 100 },
+      { path: 'scripts/foo.mjs', added: 10, removed: 5 },
+    ];
+    expect(computeMeaningfulLines(rows)).toBe(15);
+  });
+});
+
+describe('isAllDocs', () => {
+  it('is true when every changed file classifies as DOCS', () => {
+    expect(isAllDocs([{ path: 'docs/CI.md', added: 1, removed: 1 }])).toBe(true);
+  });
+
+  it('is false when at least one file is not DOCS', () => {
+    expect(
+      isAllDocs([
+        { path: 'docs/CI.md', added: 1, removed: 1 },
+        { path: 'scripts/foo.mjs', added: 1, removed: 1 },
+      ]),
+    ).toBe(false);
+  });
+
+  it('is false for an empty change set (nothing to call "all docs")', () => {
+    expect(isAllDocs([])).toBe(false);
+  });
+});
+
+// QNBS-v3: absolute is a fixed ceiling; docsGovernance replaces hard (not target) for all-DOCS PRs.
+describe('selectSeverity', () => {
+  it('returns ok when within target', () => {
+    const result = selectSeverity({ fileCount: 3, lineCount: 100, commitCount: 2, allDocs: false });
+    expect(result.tier).toBe('ok');
+    expect(result.blocking).toBe(false);
+  });
+
+  it('returns target when over target but within hard (normal profile)', () => {
+    const result = selectSeverity({ fileCount: 10, lineCount: 500, commitCount: 7, allDocs: false });
+    expect(result.tier).toBe('target');
+    expect(result.blocking).toBe(false);
+  });
+
+  it('returns hard when over hard but within absolute (normal profile)', () => {
+    const result = selectSeverity({ fileCount: 25, lineCount: 500, commitCount: 7, allDocs: false });
+    expect(result.tier).toBe('hard');
+    expect(result.blocking).toBe(false);
+  });
+
+  it('returns absolute (blocking) when over the absolute ceiling', () => {
+    const result = selectSeverity({ fileCount: 35, lineCount: 500, commitCount: 7, allDocs: false });
+    expect(result.tier).toBe('absolute');
+    expect(result.blocking).toBe(true);
+  });
+
+  it('uses the docsGovernance profile (not hard) for an all-DOCS PR', () => {
+    // Same borderline lineCount (over hard's 1200, under docsGovernance's 2400) classifies
+    // differently by profile: 'hard' for code, only 'target' (the uniform baseline) for docs.
+    const input = { fileCount: 5, lineCount: 1500, commitCount: 5 };
+    expect(selectSeverity({ ...input, allDocs: false }).tier).toBe('hard');
+    expect(selectSeverity({ ...input, allDocs: true }).tier).toBe('target');
+  });
+
+  it('flags docsGovernance when an all-DOCS PR exceeds its own limits', () => {
+    const result = selectSeverity({ fileCount: 18, lineCount: 500, commitCount: 5, allDocs: true });
+    expect(result.tier).toBe('docsGovernance');
+    expect(result.blocking).toBe(false);
+  });
+
+  it('still applies the absolute ceiling to an all-DOCS PR', () => {
+    const result = selectSeverity({ fileCount: 35, lineCount: 500, commitCount: 5, allDocs: true });
+    expect(result.tier).toBe('absolute');
+    expect(result.blocking).toBe(true);
+  });
+});
+
+describe('formatReport', () => {
+  it('reports "within target" for an ok result', () => {
+    const severity = selectSeverity({ fileCount: 3, lineCount: 100, commitCount: 2, allDocs: false });
+    const report = formatReport({ fileCount: 3, lineCount: 100, commitCount: 2, allDocs: false, severity });
+    expect(report).toMatch(/within target/);
+  });
+
+  it('reports a blocking message for the absolute tier', () => {
+    const severity = selectSeverity({ fileCount: 35, lineCount: 500, commitCount: 7, allDocs: false });
+    const report = formatReport({ fileCount: 35, lineCount: 500, commitCount: 7, allDocs: false, severity });
+    expect(report).toMatch(/exceeds the absolute ceiling/);
+    expect(report).toMatch(/Split this PR/);
+  });
+
+  it('reports a non-blocking suggestion for the target/hard tiers', () => {
+    const severity = selectSeverity({ fileCount: 25, lineCount: 500, commitCount: 7, allDocs: false });
+    const report = formatReport({ fileCount: 25, lineCount: 500, commitCount: 7, allDocs: false, severity });
+    expect(report).toMatch(/is over the hard tier/);
+    expect(report).toMatch(/Consider splitting/);
+  });
+});
+
+describe('evaluatePrSize', () => {
+  // QNBS-v3: omits error entirely (not error: undefined) — required under exactOptionalPropertyTypes.
+  const okGit = () => ({
+    status: 0,
+    stdout: '',
+    stderr: '',
+  });
+
+  it('evaluates a small change as ok, using injected git output', () => {
+    let call = 0;
+    const spawnSync = () => {
+      call += 1;
+      return call === 1
+        ? { ...okGit(), stdout: '10\t2\tscripts/foo.mjs\n' }
+        : { ...okGit(), stdout: '2\n' };
+    };
+    const result = evaluatePrSize('base', 'head', { spawnSync });
+    expect(result.ok).toBe(true);
+    expect(result.fileCount).toBe(1);
+    expect(result.lineCount).toBe(12);
+    expect(result.commitCount).toBe(2);
+    expect(result.severity?.tier).toBe('ok');
+  });
+
+  it('fails closed (ok: false) when git diff fails', () => {
+    const spawnSync = () => ({ status: 1, stdout: '', stderr: 'fatal: bad range' });
+    const result = evaluatePrSize('base', 'head', { spawnSync });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeTruthy();
+  });
+
+  it('fails closed (ok: false) when git rev-list fails', () => {
+    let call = 0;
+    const spawnSync = () => {
+      call += 1;
+      return call === 1
+        ? { ...okGit(), stdout: '10\t2\tscripts/foo.mjs\n' }
+        : { status: 1, stdout: '', stderr: 'fatal: bad range' };
+    };
+    const result = evaluatePrSize('base', 'head', { spawnSync });
+    expect(result.ok).toBe(false);
+  });
+
+  it('fails closed (ok: false) on a spawn error (e.g. git not found)', () => {
+    const spawnSync = () => ({ status: null, error: new Error('spawn git ENOENT'), stdout: '', stderr: '' });
+    const result = evaluatePrSize('base', 'head', { spawnSync });
+    expect(result.ok).toBe(false);
+  });
+});

--- a/tests/unit/workflowPolicy.test.ts
+++ b/tests/unit/workflowPolicy.test.ts
@@ -135,6 +135,7 @@ describe('CI workflow policy', () => {
     );
     expect(extractNeeds(workflowSource, 'ci-success')).toEqual([
       'workflow-policy',
+      'pr-size',
       'security',
       'signatures',
       'quality',


### PR DESCRIPTION
## **User description**
## Summary

Adds a PR-size governance gate, closing the last of the three residual clusters (S4, S5, PR-size governance) identified in the post-#477 reconstruction reconciliation program's plan.

## What it checks

`scripts/check-pr-size.mjs` evaluates a PR's diff against tiered file/line/commit limits:

| Tier | Files | Lines | Commits | Applies to |
|---|---|---|---|---|
| target | ≤8 | ≤400 | ≤6 | baseline, every profile |
| hard | ≤20 | ≤1200 | ≤10 | normal (non-docs) profile |
| docsGovernance | ≤15 | ≤2400 | ≤8 | all-DOCS profile (replaces hard, not target) |
| absolute | ≤30 | ≤3000 | ≤15 | **blocking**, regardless of profile |

"Meaningful lines" reuses `classifyFile()` from `scripts/ci-prepush-classifier.mjs` to zero out `NON_CODE_ONLY` diffs (e.g. a locale bundle rebuild) and `pnpm-lock.yaml`, so generated churn can't trip the gate.

This is **not** a restatement of CLAUDE.md's existing "~100 changed files" rule — that number is specifically about CodeAnt AI skipping inline review above 100 files; this gate is a different, stricter, purpose-built size discipline.

## Wiring

- `pnpm run pr-size:check` (new script)
- New `pr-size` CI job, `pull_request`-triggered only, job-level `permissions: contents: read, pull-requests: write`
- **Self-defeat-proofing (partial)**: the job checks out and runs the **base ref's own copy** of `check-pr-size.mjs` (and its `ci-prepush-classifier.mjs` dependency), never the PR's own working-tree copy — this prevents the PR from changing the checker logic or thresholds used for its own evaluation. Same discipline as #505's `workflow-policy` job. **This does not constitute a complete trusted-execution boundary for the PR-controlled workflow job itself** (the `ci.yml` job body and its `pull-requests: write` token still run from the PR's own checkout) — that residual trust-boundary question is tracked separately as a follow-up, not solved here.
- Posts a PR comment only when there's something to report (silent when within target)
- The job's own exit code is 0 except at the absolute tier — folding it into the `ci-success` required aggregator (with the same skipped-is-OK tolerance as `rust-tauri`/`core-rust` for non-`pull_request` events) naturally makes it advisory below absolute and blocking only there, with no separate workflow-graph split needed
- Added `pr-size`'s `pull-requests: write` to `workflow-policy-check.mjs`'s own `WRITE_SCOPE_ALLOWLIST` — verified structurally sound by that same checker

## Scope freeze / deferred follow-up

This PR is under terminal convergence: one final bounded correction batch (nonzero-exit handling, generated-artifact file counting, comment-ID reconciliation, CI-diagram/doc truth, bootstrap-fallback documentation), no new architecture. A P1 finding surfaced during review — the `pr-size` (and `workflow-policy`) job's write-scoped enforcement step still runs from the PR's own checkout, so `needs:` alone doesn't establish a trusted-execution boundary — is real but out of scope here; a trusted-execution redesign does not belong in a PR about bounding *PR size*. Tracked in #510, related to #506 Finding C.

## Test plan

- [x] 23 new unit tests (`tests/unit/tooling/checkPrSize.test.ts`) — DI-injected git output, fail-closed spawn-error handling, tier-boundary cases, docsGovernance-vs-hard profile comparison
- [x] `pnpm run workflow-policy:check` — passes against the updated `ci.yml` (new job, new allowlist entry)
- [x] `pnpm run lint` — clean
- [x] `pnpm exec tsgo --project tsconfig.tsgo.json --noEmit --checkers 4` — clean (exact CI command)
- [x] `pnpm run ci:prepush` — full local admission green
- [x] `git diff --check` — clean
- [x] Fixed a stale hardcoded `ci-success.needs` array in the pre-existing `tests/unit/workflowPolicy.test.ts` (same pattern as #505's `workflow-policy` job addition)
- [x] Self-tested against two real merged-PR ranges (small S5 PR → `ok` tier; large multi-wave S4 PR → correctly flagged `hard` tier)
- [x] Commits SSH-signed

## Summary by Sourcery

Introduce pull-request size governance that advises on oversized changes and blocks pull requests exceeding the absolute limits.

New Features:
- Add tiered pull-request size governance based on changed files, meaningful lines, and commit count, with dedicated limits for documentation-only changes.
- Report oversized pull requests through advisory comments while blocking changes that exceed the absolute ceiling.

Bug Fixes:
- Exclude generated locale bundles, the lockfile, and mirrored template artifacts from governed size metrics so generated churn does not distort enforcement.
- Ensure checker failures and unexpected nonzero exits fail closed, while preserving binary and renamed-file handling.

Enhancements:
- Run the size checker from the base branch when available and integrate its pull-request-only result into the required CI success aggregator.
- Add a local PR-size check command and update CI documentation, workflow diagrams, and policy allowlists.

CI:
- Add a pull_request-only PR-size governance job with controlled pull-request comment reporting and tier-aware enforcement.

Documentation:
- Document the new PR-size governance job, thresholds, CI dependencies, and required-status behavior.

Tests:
- Add comprehensive unit and integration coverage for parsing, generated-file exclusions, tier selection, reporting, failure handling, and attribute-based diff evasion.

Chores:
- Refresh documented test counts and update workflow-policy expectations for the new CI dependency.


___

## **CodeAnt-AI Description**
Add PR size checks to CI with advisory and blocking limits

### What Changed
- Pull requests are measured by changed files, meaningful lines, and commit count against defined size tiers
- Oversized but reviewable PRs receive an advisory comment, while PRs exceeding the absolute ceiling block CI
- Documentation-only PRs use dedicated limits, and generated locale files and lockfile changes do not inflate meaningful line counts
- The check runs using the base branch’s rules and includes coverage for binary files, size profiles, reporting, and failure handling

### Impact
`✅ Fewer oversized pull requests`
`✅ Clearer PR splitting guidance`
`✅ Generated-file churn no longer triggers size warnings`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated pull-request size checks with advisory and blocking thresholds.
  * Reports oversized changes directly in pull requests and replaces notices when changes return within target.
  * Documentation-only changes use dedicated size thresholds.

* **CI**
  * Integrated pull-request size results into overall CI status reporting.
  * Added safeguards for bootstrap pull requests and workflow policy validation.

* **Documentation**
  * Updated project test-count metrics and CI workflow guidance.

* **Tests**
  * Added coverage for size calculations, file handling, reporting, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
