### PR TITLE
chore: fix safe Biome useTemplate infos in workflow-policy tests

### DIFF
--- a/tests/unit/tooling/strykerWorkflowPolicy.test.ts
+++ b/tests/unit/tooling/strykerWorkflowPolicy.test.ts
@@ -18,6 +18,7 @@ const workflow = readFileSync(workflowPath, 'utf8');
 const scopeScriptPath = fileURLToPath(
   new URL('../../../scripts/stryker-scope.mjs', import.meta.url),
 );
+// QNBS-v3: stays string concat — a template literal here is `${{ ${expr} }}`, a JS SyntaxError, not just a style nit.
 const githubExpression = (expression: string) => '$' + '{{ ' + expression + ' }}';
 
 // QNBS-v3: Lock workflow/config invariants so mutation plumbing cannot silently drift.
@@ -61,17 +62,17 @@ describe('Stryker workflow policy', () => {
 
   it('uses supported incremental plumbing and preserves shard identity', () => {
     expect(workflow).toContain('--incrementalFile "$INCREMENTAL_FILE"');
-    expect(workflow).toContain('MATRIX_NAME: ' + githubExpression('matrix.name'));
-    expect(workflow).toContain('MATRIX_MUTATE: ' + githubExpression('matrix.mutate'));
+    expect(workflow).toContain(`MATRIX_NAME: ${githubExpression('matrix.name')}`);
+    expect(workflow).toContain(`MATRIX_MUTATE: ${githubExpression('matrix.mutate')}`);
     expect(workflow).toContain(
-      'MATRIX_TEST_FILES: ' + githubExpression("join(matrix.testFiles, ',')"),
+      `MATRIX_TEST_FILES: ${githubExpression("join(matrix.testFiles, ',')")}`,
     );
     expect(workflow).toContain('TEST_FILE_ARGS+=(--testFiles "$TEST_FILES")');
     expect(workflow).toContain('"${' + 'TEST_FILE_ARGS[@]}"');
     expect(workflow).not.toContain(
-      'rm -f reports/stryker-incremental-' + githubExpression('matrix.name') + '.json',
+      `rm -f reports/stryker-incremental-${githubExpression('matrix.name')}.json`,
     );
-    expect(workflow).not.toContain('--mutate "' + githubExpression('matrix.mutate') + '"');
+    expect(workflow).not.toContain(`--mutate "${githubExpression('matrix.mutate')}"`);
     expect(workflow).not.toContain('STRYKER_INCREMENTAL_FILE=');
     expect(workflow).toContain('merge-multiple: false');
     expect(workflow).toContain('if-no-files-found: error');

--- a/tests/unit/tooling/workflowPolicyCheck.test.ts
+++ b/tests/unit/tooling/workflowPolicyCheck.test.ts
@@ -17,7 +17,7 @@ import {
 import type { WorkflowPolicyFailure } from '../../../scripts/workflow-policy-check.d.mts';
 
 const doc = (yaml: string) => parseDocument(yaml, { uniqueKeys: true });
-// QNBS-v3: split like strykerWorkflowPolicy.test.ts's helper so Biome doesn't misread this as a JS template.
+// QNBS-v3: stays string concat — a template literal here is `${{ ${expr} }}`, a JS SyntaxError, not just a style nit.
 const githubExpression = (expression: string) => '$' + '{{ ' + expression + ' }}';
 
 // QNBS-v3: contents:read is the only safe top-level default — every other form is a policy gap.


### PR DESCRIPTION
## **User description**
## Summary

Small, standalone cleanup of 5 of the repo's 7 pre-existing Biome `lint/style/useTemplate` infos (informational only — `pnpm run lint` already exits 0 on these; not a CI-blocking finding). Split out as its own PR rather than folded into #509, which is under an explicit scope freeze.

## What changed

`tests/unit/tooling/strykerWorkflowPolicy.test.ts` and `tests/unit/tooling/workflowPolicyCheck.test.ts` both define a local `githubExpression()` test helper used to build GitHub Actions `${{ ... }}` expression strings for assertions against real workflow YAML.

- **5 call-site concatenations** (`'text ' + githubExpression(...)`) converted to template literals — mechanically safe, no behavior change, verified by running both affected test files.
- **2 remaining infos** — the `githubExpression` helper *definitions themselves* — are deliberately left as string concatenation. Biome's own suggested "unsafe fix" for these is:
  ```js
  const githubExpression = (expression) => `${{ ${expression} }}`;
  ```
  This is not just a style preference — it's a **JS SyntaxError** (verified empirically: `node -e` throws `Unexpected token '{'` on exactly this pattern), because the nested `${` inside `${{` gets parsed as a substitution start, and a bare `{` at expression position is an invalid object-literal-start followed by more `${...}`. Applying Biome's suggestion would break the file. Both definitions now carry a precise `// QNBS-v3:` comment explaining this, so it reads as an accepted, understood info rather than unaddressed debt.

## Test plan

- [x] `pnpm exec vitest run tests/unit/tooling/strykerWorkflowPolicy.test.ts tests/unit/tooling/workflowPolicyCheck.test.ts` — 74/74 pass
- [x] `pnpm run lint` — infos count 7 → 2 (both documented, exit code 0 either way — this was never a blocking finding)
- [x] `pnpm exec tsgo --project tsconfig.tsgo.json --noEmit --checkers 4` — clean
- [x] `pnpm run ci:prepush` — full local admission green
- [x] Empirically verified the "unsafe fix" for the 2 remaining infos is a SyntaxError before deciding not to apply it
- [x] Commit SSH-signed

## Summary by Sourcery

Clean up Biome template-literal findings in workflow policy tests without changing behavior.

Enhancements:
- Replace safe string-concatenation call sites with template literals in workflow policy tests and document the intentionally retained helper concatenations to prevent invalid syntax. 

Tests:
- Update workflow policy test assertions while preserving coverage of GitHub Actions expression handling.


___

## **CodeAnt-AI Description**
Clarify workflow policy tests while preserving their coverage

### What Changed
- Updated workflow assertions to use clearer string interpolation without changing the expected results
- Documented why the two GitHub expression helpers must retain their current form, preventing unsafe lint fixes that would break the tests

### Impact
`✅ Safer lint cleanup`
`✅ Preserved workflow policy coverage`
`✅ Fewer misleading lint findings`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test clarity when validating GitHub Actions workflow expressions.
  - Added documentation explaining intentional string-concatenation usage and syntax constraints.
  - Test behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->