### PR TITLE
fix(pwa): never delete a CacheStorage entry this app doesn't own

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2925_keys-0EA5E9" alt="i18n 19 locales — 2925 keys">
-  <img src="https://img.shields.io/badge/Tests-7121%2B_%2F_581_files-22C55E" alt="7121+ tests / 581 files">
+  <img src="https://img.shields.io/badge/Tests-7126%2B_%2F_582_files-22C55E" alt="7126+ tests / 582 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -512,7 +512,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2925 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7121+ tests / 581 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7126+ tests / 582 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -550,7 +550,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7121+ tests, 581 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7126+ tests, 582 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -712,7 +712,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-21, source-synchronized; CI remains authoritative for pass/fail):**
-- **7121+ unit tests** across **581 test files** — CI is authoritative for pass/fail
+- **7126+ unit tests** across **582 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2925 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2925_keys-0EA5E9" alt="i18n 19 locales — 2925 keys">
-  <img src="https://img.shields.io/badge/Tests-7114%2B_%2F_580_files-22C55E" alt="7114+ tests / 580 files">
+  <img src="https://img.shields.io/badge/Tests-7121%2B_%2F_581_files-22C55E" alt="7121+ tests / 581 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -512,7 +512,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2925 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7114+ tests / 580 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7121+ tests / 581 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -550,7 +550,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7114+ tests, 580 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7121+ tests, 581 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -712,7 +712,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-21, source-synchronized; CI remains authoritative for pass/fail):**
-- **7114+ unit tests** across **580 test files** — CI is authoritative for pass/fail
+- **7121+ unit tests** across **581 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2925 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -12,6 +12,13 @@ const CACHE_DYNAMIC = `worldscript-dynamic-v${APP_VERSION}`;
 const CACHE_IMAGES  = `worldscript-images-v${APP_VERSION}`;
 const ALL_CACHES    = [CACHE_STATIC, CACHE_DYNAMIC, CACHE_IMAGES];
 
+// QNBS-v3: exact owned families — a shared origin (qnbs.github.io) can host other apps' caches too.
+const OWNED_CACHE_FAMILIES = ['worldscript-static-v', 'worldscript-dynamic-v', 'worldscript-images-v'];
+
+function isWorldScriptOwnedCache(name) {
+  return OWNED_CACHE_FAMILIES.some((family) => name.startsWith(family));
+}
+
 const BASE = self.location.pathname.replace(/sw\.js$/, '');
 
 // QNBS-v3: Detect the Tauri desktop WebView (served from tauri://localhost or https://tauri.localhost).
@@ -131,8 +138,9 @@ self.addEventListener('activate', (event) => {
     event.waitUntil(
       (async () => {
         try {
+          // QNBS-v3: Tauri origin exclusivity is unproven here — apply the same ownership predicate.
           const keys = await caches.keys();
-          await Promise.all(keys.map((name) => caches.delete(name)));
+          await Promise.all(keys.filter(isWorldScriptOwnedCache).map((name) => caches.delete(name)));
         } catch (err) {
           swLogger.warn('Tauri cache cleanup failed (non-fatal):', err);
         }
@@ -151,7 +159,8 @@ self.addEventListener('activate', (event) => {
       .then((cacheNames) =>
         Promise.all(
           cacheNames
-            .filter((name) => !ALL_CACHES.includes(name))
+            // QNBS-v3: prune only owned-and-stale — never delete a cache we don't positively own.
+            .filter((name) => isWorldScriptOwnedCache(name) && !ALL_CACHES.includes(name))
             .map((name) => {
               swLogger.log('Pruning old cache:', name);
               return caches.delete(name);
@@ -319,8 +328,9 @@ self.addEventListener('message', (event) => {
   }
 
   if (type === 'CLEAR_CACHE') {
+    // QNBS-v3: clear only owned caches — a shared origin can host unrelated apps' caches too.
     caches.keys()
-      .then((keys) => Promise.all(keys.map((k) => caches.delete(k))))
+      .then((keys) => Promise.all(keys.filter(isWorldScriptOwnedCache).map((k) => caches.delete(k))))
       .then(() => event.source?.postMessage({ type: 'CACHE_CLEARED' }));
   }
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -12,11 +12,11 @@ const CACHE_DYNAMIC = `worldscript-dynamic-v${APP_VERSION}`;
 const CACHE_IMAGES  = `worldscript-images-v${APP_VERSION}`;
 const ALL_CACHES    = [CACHE_STATIC, CACHE_DYNAMIC, CACHE_IMAGES];
 
-// QNBS-v3: exact owned families — a shared origin (qnbs.github.io) can host other apps' caches too.
-const OWNED_CACHE_FAMILIES = ['worldscript-static-v', 'worldscript-dynamic-v', 'worldscript-images-v'];
+// QNBS-v3: anchored regex — startsWith('worldscript-static-v') also matched 'worldscript-static-vendor-cache'.
+const OWNED_CACHE_NAME_RE = /^worldscript-(?:static|dynamic|images)-v\d+\.\d+\.\d+(?:[-+][\w.-]+)?$/;
 
 function isWorldScriptOwnedCache(name) {
-  return OWNED_CACHE_FAMILIES.some((family) => name.startsWith(family));
+  return OWNED_CACHE_NAME_RE.test(name);
 }
 
 const BASE = self.location.pathname.replace(/sw\.js$/, '');

--- a/register-sw.ts
+++ b/register-sw.ts
@@ -102,6 +102,11 @@ const isTauriEnvironment = (): boolean => {
   );
 };
 
+// QNBS-v3: mirrors public/sw.js's isWorldScriptOwnedCache — duplicated since sw.js is a classic (non-module) script.
+const OWNED_CACHE_NAME_RE = /^worldscript-(?:static|dynamic|images)-v\d+\.\d+\.\d+(?:[-+][\w.-]+)?$/;
+
+export const isWorldScriptOwnedCacheName = (name: string): boolean => OWNED_CACHE_NAME_RE.test(name);
+
 // ── Core registration ─────────────────────────────────────────
 const registerServiceWorker = async (): Promise<void> => {
   // QNBS-v3: In Tauri, never register — and proactively tear down any SW + caches a prior build
@@ -114,7 +119,7 @@ const registerServiceWorker = async (): Promise<void> => {
         if (typeof caches !== 'undefined') {
           const keys = await caches.keys();
           await Promise.all(
-            keys.filter((k) => k.startsWith('worldscript-')).map((k) => caches.delete(k)),
+            keys.filter(isWorldScriptOwnedCacheName).map((k) => caches.delete(k)),
           );
         }
         appLogger.info(

--- a/tests/unit/registerSwCacheOwnership.test.ts
+++ b/tests/unit/registerSwCacheOwnership.test.ts
@@ -1,0 +1,82 @@
+// QNBS-v3: proves the Tauri-teardown cache cleanup in register-sw.ts never deletes an unowned cache.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../services/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { isWorldScriptOwnedCacheName, registerServiceWorker } from '../../register-sw';
+
+const CURRENT_STATIC = 'worldscript-static-v1.28.1';
+const FOREIGN_CACHE = 'some-other-github-pages-app-cache-v1';
+const COLLIDING_FOREIGN_CACHE = 'worldscript-static-vendor-cache';
+
+describe('register-sw — isWorldScriptOwnedCacheName', () => {
+  it('accepts real owned cache names', () => {
+    expect(isWorldScriptOwnedCacheName(CURRENT_STATIC)).toBe(true);
+    expect(isWorldScriptOwnedCacheName('worldscript-dynamic-v1.28.1')).toBe(true);
+    expect(isWorldScriptOwnedCacheName('worldscript-images-v1.28.1')).toBe(true);
+  });
+
+  it('rejects a foreign cache whose name merely shares the owned prefix', () => {
+    expect(isWorldScriptOwnedCacheName(COLLIDING_FOREIGN_CACHE)).toBe(false);
+    expect(isWorldScriptOwnedCacheName(FOREIGN_CACHE)).toBe(false);
+  });
+});
+
+describe('register-sw — Tauri teardown never deletes an unowned cache', () => {
+  let deletedNames: string[];
+  let cacheStore: Set<string>;
+
+  beforeEach(() => {
+    deletedNames = [];
+    cacheStore = new Set([CURRENT_STATIC, FOREIGN_CACHE, COLLIDING_FOREIGN_CACHE]);
+
+    Object.defineProperty(window, '__TAURI_INTERNALS__', {
+      value: {},
+      writable: true,
+      configurable: true,
+      enumerable: true,
+    });
+
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: {
+        getRegistrations: async () => [],
+      },
+      writable: true,
+      configurable: true,
+      enumerable: true,
+    });
+
+    Object.defineProperty(globalThis, 'caches', {
+      value: {
+        keys: async () => [...cacheStore],
+        delete: async (name: string) => {
+          deletedNames.push(name);
+          return cacheStore.delete(name);
+        },
+      },
+      writable: true,
+      configurable: true,
+      enumerable: true,
+    });
+  });
+
+  afterEach(() => {
+    // @ts-expect-error — test-only cleanup of a property this suite defines itself.
+    delete window.__TAURI_INTERNALS__;
+    // @ts-expect-error — jsdom's Navigator normally lacks serviceWorker; restore that absence.
+    delete navigator.serviceWorker;
+    // @ts-expect-error — jsdom lacks a global caches object by default; restore that absence.
+    delete globalThis.caches;
+  });
+
+  it('deletes the owned cache but never the foreign caches, including the colliding-prefix one', async () => {
+    await registerServiceWorker();
+    expect(deletedNames).toContain(CURRENT_STATIC);
+    expect(deletedNames).not.toContain(FOREIGN_CACHE);
+    expect(deletedNames).not.toContain(COLLIDING_FOREIGN_CACHE);
+    expect(cacheStore.has(FOREIGN_CACHE)).toBe(true);
+    expect(cacheStore.has(COLLIDING_FOREIGN_CACHE)).toBe(true);
+  });
+});

--- a/tests/unit/serviceWorkerCacheOwnership.test.ts
+++ b/tests/unit/serviceWorkerCacheOwnership.test.ts
@@ -1,0 +1,198 @@
+// @vitest-environment node
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import vm from 'node:vm';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+// QNBS-v3: proves the real activate/message handlers never delete a cache this app doesn't own.
+const swPath = fileURLToPath(new URL('../../public/sw.js', import.meta.url));
+const swSource = readFileSync(swPath, 'utf8');
+
+const appVersionMatch = swSource.match(/const APP_VERSION\s*=\s*'([^']+)'/);
+const extractedVersion = appVersionMatch?.[1];
+if (!extractedVersion) throw new Error('Could not extract APP_VERSION from public/sw.js');
+const APP_VERSION = extractedVersion;
+
+const CURRENT_STATIC = `worldscript-static-v${APP_VERSION}`;
+const CURRENT_DYNAMIC = `worldscript-dynamic-v${APP_VERSION}`;
+const CURRENT_IMAGES = `worldscript-images-v${APP_VERSION}`;
+const STALE_STATIC = 'worldscript-static-v0.0.0-stale-test';
+const FOREIGN_CACHE = 'some-other-github-pages-app-cache-v1';
+
+interface FakeCaches {
+  keys(): Promise<string[]>;
+  open(name: string): Promise<{
+    addAll: () => Promise<void>;
+    match: () => Promise<undefined>;
+    put: () => Promise<void>;
+    keys: () => Promise<never[]>;
+  }>;
+  delete(name: string): Promise<boolean>;
+  match(): Promise<undefined>;
+  attemptedDeletes: string[];
+  names(): string[];
+}
+
+function createFakeCaches(initialNames: string[], rejectOnDelete?: string): FakeCaches {
+  const store = new Set(initialNames);
+  const attemptedDeletes: string[] = [];
+  return {
+    async keys() {
+      return [...store];
+    },
+    async open() {
+      return {
+        addAll: async () => {},
+        match: async () => undefined,
+        put: async () => {},
+        keys: async () => [],
+      };
+    },
+    async delete(name: string) {
+      attemptedDeletes.push(name);
+      if (name === rejectOnDelete) throw new Error(`simulated delete failure for ${name}`);
+      return store.delete(name);
+    },
+    async match() {
+      return undefined;
+    },
+    attemptedDeletes,
+    names: () => [...store],
+  };
+}
+
+type SwHandler = (event: Record<string, unknown>) => unknown;
+
+function loadServiceWorker(opts: {
+  protocol: string;
+  hostname: string;
+  initialCacheNames: string[];
+  rejectOnDelete?: string;
+}) {
+  const handlers: Record<string, SwHandler> = {};
+  const fakeCaches = createFakeCaches(opts.initialCacheNames, opts.rejectOnDelete);
+  const selfMock = {
+    location: { protocol: opts.protocol, hostname: opts.hostname, pathname: '/WorldScript-Studio/sw.js' },
+    console: { log: () => {}, warn: () => {}, error: () => {} },
+    addEventListener: (type: string, handler: SwHandler) => {
+      handlers[type] = handler;
+    },
+    clients: { claim: async () => {} },
+    registration: { unregister: async () => {} },
+    skipWaiting: () => {},
+    __WB_MANIFEST: [],
+  };
+  const context = vm.createContext({ self: selfMock, caches: fakeCaches, console: selfMock.console });
+  vm.runInContext(swSource, context);
+  // QNBS-v3: bracket-index + explicit throw satisfies noUncheckedIndexedAccess and yields non-optional SwHandler.
+  const getHandler = (type: 'activate' | 'message'): SwHandler => {
+    const handler = handlers[type];
+    if (!handler) throw new Error(`sw.js never registered a "${type}" listener`);
+    return handler;
+  };
+  return { getHandler, fakeCaches };
+}
+
+async function runWaitUntil(handler: SwHandler, event: Record<string, unknown> = {}) {
+  let captured: unknown;
+  await handler({ ...event, waitUntil: (p: unknown) => { captured = p; } });
+  await captured;
+}
+
+describe('service worker — cache ownership (activate / CLEAR_CACHE never delete unowned caches)', () => {
+  beforeAll(() => {
+    expect(APP_VERSION.length).toBeGreaterThan(0);
+  });
+
+  it('non-Tauri activate: prunes stale owned generations, keeps current owned and foreign caches', async () => {
+    const { getHandler, fakeCaches } = loadServiceWorker({
+      protocol: 'https:',
+      hostname: 'qnbs.github.io',
+      initialCacheNames: [STALE_STATIC, CURRENT_STATIC, CURRENT_DYNAMIC, CURRENT_IMAGES, FOREIGN_CACHE],
+    });
+    await runWaitUntil(getHandler('activate'));
+    const remaining = fakeCaches.names();
+    expect(remaining).not.toContain(STALE_STATIC);
+    expect(remaining).toContain(CURRENT_STATIC);
+    expect(remaining).toContain(CURRENT_DYNAMIC);
+    expect(remaining).toContain(CURRENT_IMAGES);
+    expect(remaining).toContain(FOREIGN_CACHE);
+  });
+
+  it('non-Tauri activate: never attempts to delete a foreign cache', async () => {
+    const { getHandler, fakeCaches } = loadServiceWorker({
+      protocol: 'https:',
+      hostname: 'qnbs.github.io',
+      initialCacheNames: [STALE_STATIC, CURRENT_STATIC, FOREIGN_CACHE],
+    });
+    await runWaitUntil(getHandler('activate'));
+    expect(fakeCaches.attemptedDeletes).not.toContain(FOREIGN_CACHE);
+  });
+
+  it('Tauri activate: deletes owned caches of any generation, never a foreign cache', async () => {
+    const { getHandler, fakeCaches } = loadServiceWorker({
+      protocol: 'tauri:',
+      hostname: 'localhost',
+      initialCacheNames: [STALE_STATIC, CURRENT_STATIC, CURRENT_DYNAMIC, FOREIGN_CACHE],
+    });
+    await runWaitUntil(getHandler('activate'));
+    const remaining = fakeCaches.names();
+    expect(remaining).not.toContain(STALE_STATIC);
+    expect(remaining).not.toContain(CURRENT_STATIC);
+    expect(remaining).not.toContain(CURRENT_DYNAMIC);
+    expect(remaining).toContain(FOREIGN_CACHE);
+    expect(fakeCaches.attemptedDeletes).not.toContain(FOREIGN_CACHE);
+  });
+
+  it('CLEAR_CACHE: deletes owned caches of any generation, never a foreign cache', async () => {
+    const { getHandler, fakeCaches } = loadServiceWorker({
+      protocol: 'https:',
+      hostname: 'qnbs.github.io',
+      initialCacheNames: [STALE_STATIC, CURRENT_STATIC, CURRENT_IMAGES, FOREIGN_CACHE],
+    });
+    await getHandler('message')({ data: { type: 'CLEAR_CACHE' }, source: { postMessage: () => {} } });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const remaining = fakeCaches.names();
+    expect(remaining).not.toContain(STALE_STATIC);
+    expect(remaining).not.toContain(CURRENT_STATIC);
+    expect(remaining).not.toContain(CURRENT_IMAGES);
+    expect(remaining).toContain(FOREIGN_CACHE);
+  });
+
+  it('CLEAR_CACHE: never attempts to delete a foreign cache', async () => {
+    const { getHandler, fakeCaches } = loadServiceWorker({
+      protocol: 'https:',
+      hostname: 'qnbs.github.io',
+      initialCacheNames: [CURRENT_STATIC, FOREIGN_CACHE],
+    });
+    await getHandler('message')({ data: { type: 'CLEAR_CACHE' }, source: { postMessage: () => {} } });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(fakeCaches.attemptedDeletes).not.toContain(FOREIGN_CACHE);
+  });
+
+  it('non-Tauri activate: a failed owned-cache delete never causes a foreign cache to be deleted', async () => {
+    const { getHandler, fakeCaches } = loadServiceWorker({
+      protocol: 'https:',
+      hostname: 'qnbs.github.io',
+      initialCacheNames: [STALE_STATIC, CURRENT_STATIC, FOREIGN_CACHE],
+      rejectOnDelete: STALE_STATIC,
+    });
+    // QNBS-v3: Promise.all rejects on the simulated failure — activate's own promise chain rejects too.
+    await expect(runWaitUntil(getHandler('activate'))).rejects.toThrow();
+    expect(fakeCaches.attemptedDeletes).not.toContain(FOREIGN_CACHE);
+    expect(fakeCaches.names()).toContain(FOREIGN_CACHE);
+  });
+
+  it('Tauri activate: a failed owned-cache delete is caught and never causes a foreign cache delete', async () => {
+    const { getHandler, fakeCaches } = loadServiceWorker({
+      protocol: 'tauri:',
+      hostname: 'localhost',
+      initialCacheNames: [STALE_STATIC, FOREIGN_CACHE],
+      rejectOnDelete: STALE_STATIC,
+    });
+    // QNBS-v3: the Tauri branch wraps cleanup in try/catch, so this must resolve, not reject.
+    await runWaitUntil(getHandler('activate'));
+    expect(fakeCaches.attemptedDeletes).not.toContain(FOREIGN_CACHE);
+    expect(fakeCaches.names()).toContain(FOREIGN_CACHE);
+  });
+});

--- a/tests/unit/serviceWorkerCacheOwnership.test.ts
+++ b/tests/unit/serviceWorkerCacheOwnership.test.ts
@@ -18,6 +18,8 @@ const CURRENT_DYNAMIC = `worldscript-dynamic-v${APP_VERSION}`;
 const CURRENT_IMAGES = `worldscript-images-v${APP_VERSION}`;
 const STALE_STATIC = 'worldscript-static-v0.0.0-stale-test';
 const FOREIGN_CACHE = 'some-other-github-pages-app-cache-v1';
+// QNBS-v3: a startsWith('worldscript-static-v') predicate would wrongly treat this as owned.
+const COLLIDING_FOREIGN_CACHE = 'worldscript-static-vendor-cache';
 
 interface FakeCaches {
   keys(): Promise<string[]>;
@@ -194,5 +196,28 @@ describe('service worker — cache ownership (activate / CLEAR_CACHE never delet
     await runWaitUntil(getHandler('activate'));
     expect(fakeCaches.attemptedDeletes).not.toContain(FOREIGN_CACHE);
     expect(fakeCaches.names()).toContain(FOREIGN_CACHE);
+  });
+
+  it('non-Tauri activate: never deletes a foreign cache whose name shares the owned prefix', async () => {
+    const { getHandler, fakeCaches } = loadServiceWorker({
+      protocol: 'https:',
+      hostname: 'qnbs.github.io',
+      initialCacheNames: [CURRENT_STATIC, COLLIDING_FOREIGN_CACHE],
+    });
+    await runWaitUntil(getHandler('activate'));
+    expect(fakeCaches.attemptedDeletes).not.toContain(COLLIDING_FOREIGN_CACHE);
+    expect(fakeCaches.names()).toContain(COLLIDING_FOREIGN_CACHE);
+  });
+
+  it('CLEAR_CACHE: never deletes a foreign cache whose name shares the owned prefix', async () => {
+    const { getHandler, fakeCaches } = loadServiceWorker({
+      protocol: 'https:',
+      hostname: 'qnbs.github.io',
+      initialCacheNames: [CURRENT_STATIC, COLLIDING_FOREIGN_CACHE],
+    });
+    await getHandler('message')({ data: { type: 'CLEAR_CACHE' }, source: { postMessage: () => {} } });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(fakeCaches.attemptedDeletes).not.toContain(COLLIDING_FOREIGN_CACHE);
+    expect(fakeCaches.names()).toContain(COLLIDING_FOREIGN_CACHE);
   });
 });


### PR DESCRIPTION
## **User description**
## Summary

First implementation slice of a post-#512 deep audit (release-safety remediation program — see the audit findings labeled DA-01 through DA-06; this PR fixes the release-blocking cache-deletion finding).

`public/sw.js`'s cache cleanup was not positively ownership-scoped:
- **Non-Tauri `activate()`** deleted any cache **not exactly equal** to one of the 3 current-version names — not a prefix/ownership check.
- **`IS_TAURI` branch of `activate()`** deleted **every single cache on the origin, unconditionally**, justified only by an unverified assumption that Tauri's WebView origin is exclusive to this app.
- **`CLEAR_CACHE` message handler** also deleted every cache unconditionally.

The app is deployed to `https://qnbs.github.io/WorldScript-Studio/` — a **shared-origin** GitHub Pages project page. CacheStorage is origin-scoped, not path-scoped, so any other `qnbs.github.io/<other-repo>/` app's caches were deletable by all three paths. A version bump (exactly what a release does) changes `APP_VERSION`, which changes the "current" names, which triggers the over-broad `activate` cleanup on every returning client — making this directly release-relevant, not a theoretical edge case.

## Fix

Added `isWorldScriptOwnedCache(name)`, matching the **exact closed set** of cache-name families this SW actually creates (`worldscript-static-v`, `worldscript-dynamic-v`, `worldscript-images-v`) — deliberately narrower than a blanket `startsWith('worldscript-')`, which could still false-positive-match an unrelated cache from some other tool. Applied to all three deletion sites:
- non-Tauri `activate()`: prune only owned-and-stale (unchanged behavior for owned caches; foreign caches now always survive).
- `IS_TAURI` branch: no evidence the Tauri origin is exclusive, so the same predicate applies rather than assuming and deleting everything.
- `CLEAR_CACHE`: clears owned caches of any generation, never anything foreign.

## Test plan

- [x] New `tests/unit/serviceWorkerCacheOwnership.test.ts` — a Node `vm`-based harness loads the **real** `public/sw.js` source and executes its **real** `activate`/`message` handlers against a mocked `caches`/`self`, proving (both browser and Tauri code paths): current owned caches survive activation; stale owned generations are pruned; foreign caches always survive both `activate` and `CLEAR_CACHE`; owned caches are fully cleared by `CLEAR_CACHE`; a failed owned-cache deletion never causes a foreign cache to be deleted as a side effect.
- [x] **Verified all 7 assertions genuinely fail against the pre-fix code** (stashed the fix, re-ran, confirmed 7/7 failures, restored the fix) — proving the tests are real regression proof, not vacuous.
- [x] `pnpm run lint` — clean (2 pre-existing, already-documented infos, unrelated to this change)
- [x] `pnpm exec tsgo --project tsconfig.tsgo.json --noEmit --checkers 4` — clean (exact CI command)
- [x] `pnpm run ci:prepush` — full local admission green
- [x] `git diff --check` — clean
- [x] QNBS-v3 one-physical-line self-check — clean
- [x] Commits SSH-signed

## Summary by Sourcery

Protect unrelated CacheStorage entries by limiting all application cleanup paths to positively identified WorldScript Studio caches.

Bug Fixes:
- Restrict service worker and Tauri cache cleanup to the exact cache names owned by WorldScript Studio, preserving unrelated caches on shared origins.
- Prevent cache names that merely share an ownership prefix from being deleted.

Enhancements:
- Expose the cache ownership check for consistent use during Tauri teardown.

Documentation:
- Update documented test counts to reflect the added coverage.

Tests:
- Add regression coverage for browser and Tauri activation cleanup, clear-cache behavior, prefix collisions, and deletion failures.


___

## **CodeAnt-AI Description**
Protect unrelated app caches during service worker cleanup

### What Changed
- Service worker activation now removes only stale caches created by WorldScript Studio.
- Tauri cleanup and the “clear cache” action now preserve caches belonging to other apps on the same origin.
- Added coverage for browser and Tauri cleanup, including cache deletion failures, and updated documented test totals.

### Impact
`✅ Foreign app caches survive service worker updates`
`✅ Clear-cache actions no longer remove unrelated offline data`
`✅ Safer cache cleanup when a deletion fails`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved service worker cache cleanup to remove only application-owned caches.
  - Preserved caches belonging to other services during activation, cleanup, and cache-clearing actions.
  - Added safer handling when cache deletion fails.

- **Tests**
  - Added coverage for cache ownership, cleanup scenarios, foreign-cache preservation, and deletion failures.

- **Documentation**
  - Updated documented test metrics to reflect the latest totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->