### PR TITLE
fix(fs): fail closed on corrupt/unreadable desktop project data (DA-01)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2925_keys-0EA5E9" alt="i18n 19 locales — 2925 keys">
-  <img src="https://img.shields.io/badge/Tests-7133%2B_%2F_583_files-22C55E" alt="7133+ tests / 583 files">
+  <img src="https://img.shields.io/badge/Tests-7138%2B_%2F_583_files-22C55E" alt="7138+ tests / 583 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -512,7 +512,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2925 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7133+ tests / 583 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7138+ tests / 583 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -550,7 +550,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7133+ tests, 583 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7138+ tests, 583 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -712,7 +712,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-21, source-synchronized; CI remains authoritative for pass/fail):**
-- **7133+ unit tests** across **583 test files** — CI is authoritative for pass/fail
+- **7138+ unit tests** across **583 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2925 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2925_keys-0EA5E9" alt="i18n 19 locales — 2925 keys">
-  <img src="https://img.shields.io/badge/Tests-7126%2B_%2F_582_files-22C55E" alt="7126+ tests / 582 files">
+  <img src="https://img.shields.io/badge/Tests-7133%2B_%2F_583_files-22C55E" alt="7133+ tests / 583 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -512,7 +512,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2925 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7126+ tests / 582 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7133+ tests / 583 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -550,7 +550,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7126+ tests, 582 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7133+ tests, 583 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -712,7 +712,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-21, source-synchronized; CI remains authoritative for pass/fail):**
-- **7126+ unit tests** across **582 test files** — CI is authoritative for pass/fail
+- **7133+ unit tests** across **583 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2925 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/services/fs/fsCore.ts
+++ b/services/fs/fsCore.ts
@@ -148,15 +148,24 @@ export class DecompressionError extends Error {
   }
 }
 
+// QNBS-v3 (Amazon Q): JSON.parse also wrapped — a bare SyntaxError would break the DecompressionError-only contract callers rely on.
 export function decompressData<T>(raw: string): T {
   if (raw.startsWith(LZ_PREFIX)) {
     const decompressed = LZString.decompressFromUTF16(raw.slice(LZ_PREFIX.length));
     if (decompressed === null) {
       throw new DecompressionError();
     }
-    return JSON.parse(decompressed) as T;
+    try {
+      return JSON.parse(decompressed) as T;
+    } catch {
+      throw new DecompressionError('Failed to parse decompressed data as JSON — the payload is corrupt.');
+    }
   }
-  return JSON.parse(raw) as T;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    throw new DecompressionError('Failed to parse stored data as JSON — the payload is corrupt.');
+  }
 }
 
 // --- Crypto helpers ---

--- a/services/fs/fsCore.ts
+++ b/services/fs/fsCore.ts
@@ -140,10 +140,21 @@ export function compressData<T>(data: T): string {
   return LZ_PREFIX + LZString.compressToUTF16(json);
 }
 
+// QNBS-v3: lz-string returns null (never throws) on corrupt/truncated input — silently substituting '{}' masked real corruption as a valid empty object (DA-01); throw instead so callers can fail closed.
+export class DecompressionError extends Error {
+  constructor(message = 'Failed to decompress stored data — the payload is corrupt or truncated.') {
+    super(message);
+    this.name = 'DecompressionError';
+  }
+}
+
 export function decompressData<T>(raw: string): T {
   if (raw.startsWith(LZ_PREFIX)) {
     const decompressed = LZString.decompressFromUTF16(raw.slice(LZ_PREFIX.length));
-    return JSON.parse(decompressed ?? '{}') as T;
+    if (decompressed === null) {
+      throw new DecompressionError();
+    }
+    return JSON.parse(decompressed) as T;
   }
   return JSON.parse(raw) as T;
 }

--- a/services/fs/projectFsStore.ts
+++ b/services/fs/projectFsStore.ts
@@ -30,13 +30,27 @@ export class ProjectLoadError extends Error {
   }
 }
 
-// QNBS-v3 (DA-01): rejects parsed JSON that isn't project-shaped at all (e.g. an unrelated file, or a prior empty-object substitution bug) instead of silently hydrating a near-blank project.
-function looksLikeStoryProject(value: unknown): value is StoryProject {
+// QNBS-v3 (CodeAnt/CodeRabbit): array-or-EntityState — characters/worlds may be either shape in a real saved project.
+function isArrayOrEntityState(value: unknown): boolean {
+  if (Array.isArray(value)) return true;
   return (
     typeof value === 'object' &&
     value !== null &&
-    typeof (value as Record<string, unknown>)['title'] === 'string' &&
-    Array.isArray((value as Record<string, unknown>)['manuscript'])
+    Array.isArray((value as Record<string, unknown>)['ids']) &&
+    typeof (value as Record<string, unknown>)['entities'] === 'object'
+  );
+}
+
+// QNBS-v3 (DA-01): rejects parsed JSON that isn't project-shaped at all (e.g. an unrelated file, or a prior empty-object substitution bug) instead of silently hydrating a near-blank project.
+function looksLikeStoryProject(value: unknown): value is StoryProject {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v['title'] === 'string' &&
+    typeof v['logline'] === 'string' &&
+    Array.isArray(v['manuscript']) &&
+    isArrayOrEntityState(v['characters']) &&
+    isArrayOrEntityState(v['worlds'])
   );
 }
 
@@ -115,12 +129,12 @@ export class FsProjectStore extends FsAssetStore {
     const safeProjectId = sanitizePathSegment(projectId);
     const projectFile = await apis.join(appDataPath, 'projects', safeProjectId, 'project.json');
 
-    if (!(await apis.exists(projectFile))) {
-      return null;
-    }
-
+    // QNBS-v3 (CodeRabbit/codex): exists() rejecting is an I/O failure too, not absence — classify it the same as a readTextFile failure rather than letting it escape raw.
     let content: string;
     try {
+      if (!(await apis.exists(projectFile))) {
+        return null;
+      }
       content = await retryFs(() => apis.readTextFile(projectFile));
     } catch (error) {
       logger.error('Failed to read project file (I/O error):', error);

--- a/services/fs/projectFsStore.ts
+++ b/services/fs/projectFsStore.ts
@@ -19,6 +19,27 @@ import {
   writeTextFileAtomic,
 } from './fsCore';
 
+// QNBS-v3 (DA-01): distinguishes corrupt/unreadable saved data from genuine absence — callers must never treat this the same as "no project exists yet".
+export class ProjectLoadError extends Error {
+  constructor(
+    public readonly reason: 'corrupt' | 'io-error',
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ProjectLoadError';
+  }
+}
+
+// QNBS-v3 (DA-01): rejects parsed JSON that isn't project-shaped at all (e.g. an unrelated file, or a prior empty-object substitution bug) instead of silently hydrating a near-blank project.
+function looksLikeStoryProject(value: unknown): value is StoryProject {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as Record<string, unknown>)['title'] === 'string' &&
+    Array.isArray((value as Record<string, unknown>)['manuscript'])
+  );
+}
+
 export class FsProjectStore extends FsAssetStore {
   async saveProject(project: SaveProjectInput): Promise<void> {
     const flat = normalizeSaveProjectInputToStoryProject(project);
@@ -83,26 +104,50 @@ export class FsProjectStore extends FsAssetStore {
     }
   }
 
+  /**
+   * Genuine absence (no saved file for this ID) resolves to `null` — legitimate and unchanged.
+   * A corrupt or unreadable file throws `ProjectLoadError` instead: DA-01 requires that this never
+   * collapse into the same `null` a caller would read as "no project exists yet".
+   */
   async loadProject(projectId: string): Promise<StoryProject | null> {
-    try {
-      const apis = await this.getApis();
-      const appDataPath = await this.ensureAppDataPath();
-      const safeProjectId = sanitizePathSegment(projectId);
-      const projectFile = await apis.join(appDataPath, 'projects', safeProjectId, 'project.json');
+    const apis = await this.getApis();
+    const appDataPath = await this.ensureAppDataPath();
+    const safeProjectId = sanitizePathSegment(projectId);
+    const projectFile = await apis.join(appDataPath, 'projects', safeProjectId, 'project.json');
 
-      if (!(await apis.exists(projectFile))) {
-        return null;
-      }
-
-      const content = await retryFs(() => apis.readTextFile(projectFile));
-      const project = decompressData<StoryProject>(content);
-      // QNBS-v3: schedule observation after this async load resolves so validation cannot delay or alter the load result.
-      scheduleCoreProjectValidation(project);
-      return project;
-    } catch (error) {
-      logger.error('Failed to load project:', error);
+    if (!(await apis.exists(projectFile))) {
       return null;
     }
+
+    let content: string;
+    try {
+      content = await retryFs(() => apis.readTextFile(projectFile));
+    } catch (error) {
+      logger.error('Failed to read project file (I/O error):', error);
+      throw new ProjectLoadError(
+        'io-error',
+        `Could not read the project file for "${projectId}" — it may be locked, permission-denied, or otherwise inaccessible.`,
+      );
+    }
+
+    let project: StoryProject;
+    try {
+      const parsed = decompressData<unknown>(content);
+      if (!looksLikeStoryProject(parsed)) {
+        throw new Error('Parsed content is not project-shaped (missing title/manuscript).');
+      }
+      project = parsed;
+    } catch (error) {
+      logger.error('Failed to parse project file (corrupt data):', error);
+      throw new ProjectLoadError(
+        'corrupt',
+        `The saved project file for "${projectId}" appears to be corrupted and could not be read. The file has not been deleted.`,
+      );
+    }
+
+    // QNBS-v3: schedule observation after this async load resolves so validation cannot delay or alter the load result.
+    scheduleCoreProjectValidation(project);
+    return project;
   }
 
   async listProjects(): Promise<string[]> {

--- a/services/libraryBackupService.ts
+++ b/services/libraryBackupService.ts
@@ -4,6 +4,7 @@
  */
 import JSZip from 'jszip';
 import type { Settings, StoryProject } from '../types';
+import { ProjectLoadError } from './fs/projectFsStore';
 import { logger } from './logger';
 import type { BinderAssetPayload } from './storageBackend';
 import { storageService } from './storageService';
@@ -131,9 +132,12 @@ export async function collectLibraryBackupPayload(
     try {
       project = await storageService.loadProject(projectId);
     } catch (error) {
+      // QNBS-v3 (codex P1): only the expected corruption/I-O case is swallowed — an unexpected bug must still surface, not be silently absorbed as "skip this project".
+      if (!(error instanceof ProjectLoadError)) throw error;
       logger.warn('collectLibraryBackupPayload: skipping unreadable project', {
         projectId,
-        error: error instanceof Error ? error.message : String(error),
+        reason: error.reason,
+        error: error.message,
       });
       project = null;
     }

--- a/services/libraryBackupService.ts
+++ b/services/libraryBackupService.ts
@@ -4,6 +4,7 @@
  */
 import JSZip from 'jszip';
 import type { Settings, StoryProject } from '../types';
+import { logger } from './logger';
 import type { BinderAssetPayload } from './storageBackend';
 import { storageService } from './storageService';
 
@@ -125,7 +126,17 @@ export async function collectLibraryBackupPayload(
   onProgress?.('list', 0, total);
 
   for (const projectId of projectIds) {
-    const project = await storageService.loadProject(projectId);
+    // QNBS-v3 (DA-01): loadProject now throws on corrupt/unreadable data rather than returning null — one bad project must not abort the whole backup.
+    let project: StoryProject | null;
+    try {
+      project = await storageService.loadProject(projectId);
+    } catch (error) {
+      logger.warn('collectLibraryBackupPayload: skipping unreadable project', {
+        projectId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      project = null;
+    }
     const codex = await storageService.getStoryCodex(projectId);
     const ragVectors = await storageService.getRagVectors(projectId);
     const binderIds = await storageService.listBinderAssetIds(projectId);

--- a/tests/unit/libraryBackupService.test.ts
+++ b/tests/unit/libraryBackupService.test.ts
@@ -84,13 +84,6 @@ describe('libraryBackupService — partial corruption (DA-01)', () => {
     vi.clearAllMocks();
     const { storageService } = await import('../../services/storageService');
     vi.mocked(storageService.getStorageBackendKind).mockResolvedValue('filesystem');
-    vi.mocked(storageService.listProjects).mockResolvedValue(['good', 'corrupt']);
-    vi.mocked(storageService.loadProject).mockImplementation(async (projectId: string) => {
-      if (projectId === 'corrupt') {
-        throw new Error('The saved project file for "corrupt" appears to be corrupted.');
-      }
-      return minimalProject() as unknown as StoryProject;
-    });
     vi.mocked(storageService.getStoryCodex).mockResolvedValue(null);
     vi.mocked(storageService.getRagVectors).mockResolvedValue([]);
     vi.mocked(storageService.listBinderAssetIds).mockResolvedValue([]);
@@ -98,7 +91,16 @@ describe('libraryBackupService — partial corruption (DA-01)', () => {
     vi.mocked(storageService.listSnapshots).mockResolvedValue([]);
   });
 
-  it('does not abort the whole backup when one project fails to load — the good project still backs up', async () => {
+  it('does not abort the whole backup when one project is corrupt — the good project still backs up', async () => {
+    const { storageService } = await import('../../services/storageService');
+    const { ProjectLoadError } = await import('../../services/fs/projectFsStore');
+    vi.mocked(storageService.listProjects).mockResolvedValue(['good', 'corrupt']);
+    vi.mocked(storageService.loadProject).mockImplementation(async (projectId: string) => {
+      if (projectId === 'corrupt') {
+        throw new ProjectLoadError('corrupt', 'The saved project file for "corrupt" is corrupted.');
+      }
+      return minimalProject() as unknown as StoryProject;
+    });
     const { collectLibraryBackupPayload } = await import('../../services/libraryBackupService');
     const payload = await collectLibraryBackupPayload();
     expect(payload.projects).toHaveLength(2);
@@ -107,5 +109,19 @@ describe('libraryBackupService — partial corruption (DA-01)', () => {
     expect(good?.project).not.toBeNull();
     // QNBS-v3: the corrupt entry stays present with a null payload — the whole backup must not abort.
     expect(corrupt?.project).toBeNull();
+  });
+
+  // QNBS-v3 (codex P1): an unexpected (non-ProjectLoadError) failure must still surface, not be silently swallowed as if it were an ordinary corrupt project.
+  it('rethrows an unexpected (non-ProjectLoadError) failure instead of silently swallowing it', async () => {
+    const { storageService } = await import('../../services/storageService');
+    vi.mocked(storageService.listProjects).mockResolvedValue(['ok', 'buggy']);
+    vi.mocked(storageService.loadProject).mockImplementation(async (projectId: string) => {
+      if (projectId === 'buggy') {
+        throw new TypeError('Cannot read properties of undefined (a genuine programming bug)');
+      }
+      return minimalProject() as unknown as StoryProject;
+    });
+    const { collectLibraryBackupPayload } = await import('../../services/libraryBackupService');
+    await expect(collectLibraryBackupPayload()).rejects.toThrow(TypeError);
   });
 });

--- a/tests/unit/libraryBackupService.test.ts
+++ b/tests/unit/libraryBackupService.test.ts
@@ -78,3 +78,34 @@ describe('libraryBackupService zip roundtrip', () => {
     expect(parsed.projects[0]?.projectId).toBe('p1');
   });
 });
+
+describe('libraryBackupService — partial corruption (DA-01)', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const { storageService } = await import('../../services/storageService');
+    vi.mocked(storageService.getStorageBackendKind).mockResolvedValue('filesystem');
+    vi.mocked(storageService.listProjects).mockResolvedValue(['good', 'corrupt']);
+    vi.mocked(storageService.loadProject).mockImplementation(async (projectId: string) => {
+      if (projectId === 'corrupt') {
+        throw new Error('The saved project file for "corrupt" appears to be corrupted.');
+      }
+      return minimalProject() as unknown as StoryProject;
+    });
+    vi.mocked(storageService.getStoryCodex).mockResolvedValue(null);
+    vi.mocked(storageService.getRagVectors).mockResolvedValue([]);
+    vi.mocked(storageService.listBinderAssetIds).mockResolvedValue([]);
+    vi.mocked(storageService.loadSettings).mockResolvedValue(null);
+    vi.mocked(storageService.listSnapshots).mockResolvedValue([]);
+  });
+
+  it('does not abort the whole backup when one project fails to load — the good project still backs up', async () => {
+    const { collectLibraryBackupPayload } = await import('../../services/libraryBackupService');
+    const payload = await collectLibraryBackupPayload();
+    expect(payload.projects).toHaveLength(2);
+    const good = payload.projects.find((p) => p.projectId === 'good');
+    const corrupt = payload.projects.find((p) => p.projectId === 'corrupt');
+    expect(good?.project).not.toBeNull();
+    // QNBS-v3: the corrupt entry stays present with a null payload — the whole backup must not abort.
+    expect(corrupt?.project).toBeNull();
+  });
+});

--- a/tests/unit/services/fs/fsCore.test.ts
+++ b/tests/unit/services/fs/fsCore.test.ts
@@ -4,12 +4,14 @@
  * sanitization, and word counting — no Tauri APIs required.
  */
 
+import LZString from 'lz-string';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { TauriApis } from '../../../../services/fs/fsCore';
 import {
   compressData,
   countProjectWords,
   decompressData,
+  DecompressionError,
   decryptText,
   encryptText,
   retryFs,
@@ -137,8 +139,14 @@ describe('compressData / decompressData', () => {
     expect(decompressData(raw)).toEqual(data);
   });
 
-  it('decompresses a corrupt lz payload to an empty object', () => {
-    expect(decompressData('\x00lz1\x00@@not-valid@@')).toEqual({});
+  // QNBS-v3 (DA-01): was 'decompresses a corrupt lz payload to an empty object' — must fail closed instead.
+  it('throws DecompressionError on a corrupt/truncated lz payload instead of substituting {}', () => {
+    expect(() => decompressData('\x00lz1\x00@@not-valid@@')).toThrow(DecompressionError);
+  });
+
+  it('throws a native parse error when decompression succeeds but the result is not valid JSON', () => {
+    const raw = `\x00lz1\x00${LZString.compressToUTF16('this is not valid json {{{')}`;
+    expect(() => decompressData(raw)).toThrow(SyntaxError);
   });
 });
 

--- a/tests/unit/services/fs/fsCore.test.ts
+++ b/tests/unit/services/fs/fsCore.test.ts
@@ -144,9 +144,13 @@ describe('compressData / decompressData', () => {
     expect(() => decompressData('\x00lz1\x00@@not-valid@@')).toThrow(DecompressionError);
   });
 
-  it('throws a native parse error when decompression succeeds but the result is not valid JSON', () => {
+  it('throws DecompressionError (not a bare SyntaxError) when decompression succeeds but the result is not valid JSON', () => {
     const raw = `\x00lz1\x00${LZString.compressToUTF16('this is not valid json {{{')}`;
-    expect(() => decompressData(raw)).toThrow(SyntaxError);
+    expect(() => decompressData(raw)).toThrow(DecompressionError);
+  });
+
+  it('throws DecompressionError (not a bare SyntaxError) for malformed uncompressed JSON', () => {
+    expect(() => decompressData('this is not json {{{')).toThrow(DecompressionError);
   });
 });
 

--- a/tests/unit/services/fs/projectFsStore.test.ts
+++ b/tests/unit/services/fs/projectFsStore.test.ts
@@ -78,7 +78,7 @@ describe('FsProjectStore.loadProject — DA-01 fail-closed behavior', () => {
     await expect(promise).rejects.toMatchObject({ reason: 'corrupt' });
   });
 
-  it('throws ProjectLoadError("corrupt") on valid JSON that is not project-shaped', async () => {
+  it('throws ProjectLoadError("corrupt") on valid JSON that is not project-shaped at all', async () => {
     const { FsProjectStore, ProjectLoadError } = await import(
       '../../../../services/fs/projectFsStore'
     );
@@ -92,7 +92,34 @@ describe('FsProjectStore.loadProject — DA-01 fail-closed behavior', () => {
     await expect(promise).rejects.toMatchObject({ reason: 'corrupt' });
   });
 
-  it('resolves the real project on a valid save', async () => {
+  // QNBS-v3 (CodeAnt/CodeRabbit): the guard previously accepted this truncated shape — logline/characters/worlds are also required.
+  it('throws ProjectLoadError("corrupt") on a truncated project missing logline/characters/worlds', async () => {
+    const { FsProjectStore, ProjectLoadError } = await import(
+      '../../../../services/fs/projectFsStore'
+    );
+    mockDesktopPlatform.filesystem.exists.mockResolvedValue(true);
+    mockDesktopPlatform.filesystem.readTextFile.mockResolvedValue(
+      JSON.stringify({ title: 'x', manuscript: [] }),
+    );
+    const store = new FsProjectStore();
+    const promise = store.loadProject('truncated-id');
+    await expect(promise).rejects.toThrow(ProjectLoadError);
+    await expect(promise).rejects.toMatchObject({ reason: 'corrupt' });
+  });
+
+  // QNBS-v3 (codex/CodeRabbit): exists() rejecting (not just resolving false) must classify as io-error too.
+  it('throws ProjectLoadError("io-error") when the existence probe itself rejects', async () => {
+    const { FsProjectStore, ProjectLoadError } = await import(
+      '../../../../services/fs/projectFsStore'
+    );
+    mockDesktopPlatform.filesystem.exists.mockRejectedValue(new Error('EACCES: stat failed'));
+    const store = new FsProjectStore();
+    const promise = store.loadProject('unreadable-dir-id');
+    await expect(promise).rejects.toThrow(ProjectLoadError);
+    await expect(promise).rejects.toMatchObject({ reason: 'io-error' });
+  });
+
+  it('resolves the real project on a valid save with array-shaped characters/worlds', async () => {
     const { FsProjectStore } = await import('../../../../services/fs/projectFsStore');
     const validProject = {
       title: 'My Book',
@@ -105,5 +132,20 @@ describe('FsProjectStore.loadProject — DA-01 fail-closed behavior', () => {
     mockDesktopPlatform.filesystem.readTextFile.mockResolvedValue(compressData(validProject));
     const store = new FsProjectStore();
     await expect(store.loadProject('good-id')).resolves.toEqual(validProject);
+  });
+
+  it('resolves the real project on a valid save with EntityState-shaped characters/worlds', async () => {
+    const { FsProjectStore } = await import('../../../../services/fs/projectFsStore');
+    const validProject = {
+      title: 'My Book',
+      logline: 'L',
+      characters: { ids: [], entities: {} },
+      worlds: { ids: [], entities: {} },
+      manuscript: [],
+    };
+    mockDesktopPlatform.filesystem.exists.mockResolvedValue(true);
+    mockDesktopPlatform.filesystem.readTextFile.mockResolvedValue(compressData(validProject));
+    const store = new FsProjectStore();
+    await expect(store.loadProject('good-entity-state-id')).resolves.toEqual(validProject);
   });
 });

--- a/tests/unit/services/fs/projectFsStore.test.ts
+++ b/tests/unit/services/fs/projectFsStore.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for services/fs/projectFsStore.ts#loadProject — DA-01 fail-closed corruption/I-O semantics.
+ * Genuine absence must still resolve to null; corruption or I/O failure must throw ProjectLoadError
+ * instead of silently collapsing into the same null a caller could mistake for "no saved project".
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { compressData } from '../../../../services/fs/fsCore';
+
+// QNBS-v3: FsCore.getApis()'s own in-module loadTauriApis() call bypasses a mock of fsCore.ts — mock desktopPlatform one level down instead.
+const { mockDesktopPlatform } = vi.hoisted(() => ({
+  mockDesktopPlatform: {
+    runtime: { isDesktop: true },
+    filesystem: {
+      readTextFile: vi.fn(),
+      writeTextFile: vi.fn(),
+      readFile: vi.fn(),
+      writeFile: vi.fn(),
+      mkdir: vi.fn(),
+      exists: vi.fn(),
+      readDir: vi.fn(),
+      remove: vi.fn(),
+      rename: vi.fn(),
+    },
+    dialogs: { openFilePicker: vi.fn(), saveFilePicker: vi.fn() },
+    persistence: {
+      appDataDir: vi.fn().mockResolvedValue('/fake/appdata'),
+      join: vi.fn((...parts: string[]) => Promise.resolve(parts.join('/'))),
+    },
+  },
+}));
+
+vi.mock('../../../../services/desktopPlatform', () => ({ desktopPlatform: mockDesktopPlatform }));
+
+vi.mock('../../../../services/logger', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../../services/logger')>();
+  return { ...actual, logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() } };
+});
+
+vi.mock('../../../../features/project/coreValidationShadow', () => ({
+  scheduleCoreProjectValidation: vi.fn(),
+}));
+
+describe('FsProjectStore.loadProject — DA-01 fail-closed behavior', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null for a genuinely missing project file (legitimate absence, unchanged)', async () => {
+    const { FsProjectStore } = await import('../../../../services/fs/projectFsStore');
+    mockDesktopPlatform.filesystem.exists.mockResolvedValue(false);
+    const store = new FsProjectStore();
+    await expect(store.loadProject('missing-id')).resolves.toBeNull();
+  });
+
+  it('throws ProjectLoadError("io-error") on a read failure instead of returning null', async () => {
+    const { FsProjectStore, ProjectLoadError } = await import(
+      '../../../../services/fs/projectFsStore'
+    );
+    mockDesktopPlatform.filesystem.exists.mockResolvedValue(true);
+    mockDesktopPlatform.filesystem.readTextFile.mockRejectedValue(
+      new Error('EACCES: permission denied'),
+    );
+    const store = new FsProjectStore();
+    const promise = store.loadProject('locked-id');
+    await expect(promise).rejects.toThrow(ProjectLoadError);
+    await expect(promise).rejects.toMatchObject({ reason: 'io-error' });
+  });
+
+  it('throws ProjectLoadError("corrupt") on a corrupt/truncated compressed payload', async () => {
+    const { FsProjectStore, ProjectLoadError } = await import(
+      '../../../../services/fs/projectFsStore'
+    );
+    mockDesktopPlatform.filesystem.exists.mockResolvedValue(true);
+    mockDesktopPlatform.filesystem.readTextFile.mockResolvedValue('\x00lz1\x00@@not-valid@@');
+    const store = new FsProjectStore();
+    const promise = store.loadProject('corrupt-id');
+    await expect(promise).rejects.toThrow(ProjectLoadError);
+    await expect(promise).rejects.toMatchObject({ reason: 'corrupt' });
+  });
+
+  it('throws ProjectLoadError("corrupt") on valid JSON that is not project-shaped', async () => {
+    const { FsProjectStore, ProjectLoadError } = await import(
+      '../../../../services/fs/projectFsStore'
+    );
+    mockDesktopPlatform.filesystem.exists.mockResolvedValue(true);
+    mockDesktopPlatform.filesystem.readTextFile.mockResolvedValue(
+      JSON.stringify({ notAProject: true }),
+    );
+    const store = new FsProjectStore();
+    const promise = store.loadProject('wrong-shape-id');
+    await expect(promise).rejects.toThrow(ProjectLoadError);
+    await expect(promise).rejects.toMatchObject({ reason: 'corrupt' });
+  });
+
+  it('resolves the real project on a valid save', async () => {
+    const { FsProjectStore } = await import('../../../../services/fs/projectFsStore');
+    const validProject = {
+      title: 'My Book',
+      logline: 'L',
+      characters: [],
+      worlds: [],
+      manuscript: [],
+    };
+    mockDesktopPlatform.filesystem.exists.mockResolvedValue(true);
+    mockDesktopPlatform.filesystem.readTextFile.mockResolvedValue(compressData(validProject));
+    const store = new FsProjectStore();
+    await expect(store.loadProject('good-id')).resolves.toEqual(validProject);
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Part of the post-#512 deep audit program (DA-01, second slice after #513/DA-03). `services/fs/fsCore.ts#decompressData` silently substituted `{}` for a failed lz-string decompression (which returns `null`, never throws, on corrupt/truncated input) — masking real data corruption as a valid empty object. `FsProjectStore.loadProject()` then collapsed genuine absence, corruption, and I/O failure into the same `null` return, which every caller (including the desktop cold-boot path in `appBootstrap.ts`) reads as "no saved project" — risking a corrupted-but-recoverable file being silently treated as nonexistent and eventually overwritten by autosave.

## Changes

- `decompressData()` now throws `DecompressionError` instead of substituting `{}`.
- `FsProjectStore.loadProject()`: genuine absence (file doesn't exist) still resolves to `null`, unchanged. Corruption or I/O failure now throws `ProjectLoadError` with a `reason: 'corrupt' | 'io-error'` field. A minimal shape guard also rejects a payload that parses as valid JSON but isn't project-shaped at all (e.g. a stray `{}`).
- Neither `appBootstrap.ts` nor `index.tsx` needed changes — the throw propagates naturally into `bootApp()`'s existing catch block, which already renders `StorageErrorScreen` with an honest message instead of silently booting as a new user.
- `libraryBackupService.ts`'s per-project loop now catches the new throw so one corrupted project doesn't abort the whole library backup (it's recorded with a `null` payload + a logged warning, matching its prior null-tolerant shape — no format change).

## Deferred (tracked separately, not release-blocking on current evidence)

- #515 — `StorageErrorScreen`'s "Reset Database & Reload" button is IndexedDB-only; on desktop it doesn't clear the corrupted Tauri filesystem file, so a user hitting this new error is stuck in an honest-but-unactionable loop. The core safety invariant (fail closed, never silently overwrite) is fully closed by this PR regardless; the recovery-UX gap is a separate, smaller follow-up.

## Test plan

- [x] New regression tests in `tests/unit/services/fs/fsCore.test.ts`, `tests/unit/services/fs/projectFsStore.test.ts` (new file), `tests/unit/libraryBackupService.test.ts`
- [x] Every new assertion verified to fail against the pre-fix code (stash-based regression proof)
- [x] `pnpm run lint` / `pnpm run typecheck` / targeted vitest — all green locally
- [x] `pnpm run ci:prepush` — PASS

## Summary by Sourcery

Prevent corrupted or inaccessible desktop project data from being silently treated as absent and overwritten.

Bug Fixes:
- Fail closed when desktop project files are corrupt, malformed, or unreadable instead of treating them as missing projects.
- Preserve library backups when individual projects cannot be loaded by recording the affected project without its payload while continuing with the remaining projects.

Enhancements:
- Distinguish genuine project absence from corruption and I/O failures through explicit project load error reasons.
- Validate loaded project data sufficiently to reject valid JSON that is not shaped like a story project.

Tests:
- Add regression coverage for decompression failures, malformed JSON, invalid project shapes, missing files, read failures, valid project variants, and partial backup failures.


___

## **CodeAnt-AI Description**
Fail closed when desktop project files are corrupted or unreadable

### What Changed
- Corrupted, malformed, or inaccessible desktop project files now show an honest load error instead of being treated as a missing project.
- Valid project files continue to load normally, while genuinely missing files still indicate that no project exists.
- A malformed project cannot be mistaken for a near-empty project and silently overwritten.
- Library backups continue for other projects when one project cannot be read; the affected project remains in the backup with no project payload.
- Added coverage for missing files, read failures, corrupt data, invalid project shapes, valid loads, and partial backup failures.

### Impact
`✅ Fewer silent data overwrites`
`✅ Clearer desktop storage errors`
`✅ Complete backups despite one corrupt project`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of corrupted or truncated project data with clear load errors.
  * Distinguished missing files from read failures and invalid project content.
  * Library backups now continue when an individual project is unreadable, preserving valid project data.

* **Documentation**
  * Updated documented test metrics to reflect the latest coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->