### PR TITLE
fix(ci): admit GitHub Pages deploy despite legitimately-skipped upstream jobs (#522)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -615,7 +615,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [ci-success]
-    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && needs.ci-success.result == 'success'
+    # QNBS-v3 (#522): always()+!cancelled() overrides GHA's default skip-propagation from pr-size/rust-tauri/core-rust being legitimately skipped on push, without publishing from a cancelled run — ci-success.result is the real gate.
+    if: >-
+      ${{
+        always() &&
+        !cancelled() &&
+        github.ref == 'refs/heads/main' &&
+        github.event_name != 'pull_request' &&
+        needs.ci-success.result == 'success'
+      }}
     permissions:
       contents: read
       pages: write

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2925_keys-0EA5E9" alt="i18n 19 locales — 2925 keys">
-  <img src="https://img.shields.io/badge/Tests-7167%2B_%2F_588_files-22C55E" alt="7167+ tests / 588 files">
+  <img src="https://img.shields.io/badge/Tests-7168%2B_%2F_588_files-22C55E" alt="7168+ tests / 588 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -512,7 +512,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2925 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7167+ tests / 588 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7168+ tests / 588 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -550,7 +550,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7167+ tests, 588 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7168+ tests, 588 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -712,7 +712,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-21, source-synchronized; CI remains authoritative for pass/fail):**
-- **7167+ unit tests** across **588 test files** — CI is authoritative for pass/fail
+- **7168+ unit tests** across **588 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2925 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/tests/unit/workflowPolicy.test.ts
+++ b/tests/unit/workflowPolicy.test.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import {
   extractJobBlock,
+  extractJobIf,
   extractJobNames,
   extractLocalPathDependencies,
   extractNeeds,
@@ -130,14 +131,15 @@ describe('CI workflow policy', () => {
   // QNBS-v3 (#522): deploy's default success() gate inherits skip-propagation from pr-size/rust-tauri/core-rust being legitimately skipped on push, even though ci-success itself computed 'success' — always() overrides that and makes ci-success.result the real gate.
   it('gates deploy on ci-success.result explicitly via always()+!cancelled(), not implicit success()', () => {
     const deployBlock = extractJobBlock(workflowSource, 'deploy');
+    const deployIf = extractJobIf(deployBlock);
     expect(extractNeeds(workflowSource, 'deploy')).toEqual(['ci-success']);
     // QNBS-v3 (#522): main push has pr-size/rust-tauri/core-rust legitimately skipped and ci-success == success — deploy must still be eligible, not silently skipped by GHA's default chain propagation.
-    expect(deployBlock).toContain('always()');
-    expect(deployBlock).toContain('!cancelled()');
-    expect(deployBlock).toMatch(/github\.ref == 'refs\/heads\/main'/);
-    expect(deployBlock).toMatch(/github\.event_name != 'pull_request'/);
-    expect(deployBlock).toMatch(/needs\.ci-success\.result == 'success'/);
-    expect(deployBlock).toMatch(
+    expect(deployIf).toContain('always()');
+    expect(deployIf).toContain('!cancelled()');
+    expect(deployIf).toMatch(/github\.ref == 'refs\/heads\/main'/);
+    expect(deployIf).toMatch(/github\.event_name != 'pull_request'/);
+    expect(deployIf).toMatch(/needs\.ci-success\.result == 'success'/);
+    expect(deployIf).toMatch(
       /always\(\)[\s\S]+!cancelled\(\)[\s\S]+github\.ref == 'refs\/heads\/main'[\s\S]+github\.event_name != 'pull_request'[\s\S]+needs\.ci-success\.result == 'success'/,
     );
   });

--- a/tests/unit/workflowPolicy.test.ts
+++ b/tests/unit/workflowPolicy.test.ts
@@ -127,6 +127,21 @@ describe('CI workflow policy', () => {
     expect(visited).toContain('ci-success');
   });
 
+  // QNBS-v3 (#522): deploy's default success() gate inherits skip-propagation from pr-size/rust-tauri/core-rust being legitimately skipped on push, even though ci-success itself computed 'success' — always() overrides that and makes ci-success.result the real gate.
+  it('gates deploy on ci-success.result explicitly via always()+!cancelled(), not implicit success()', () => {
+    const deployBlock = extractJobBlock(workflowSource, 'deploy');
+    expect(extractNeeds(workflowSource, 'deploy')).toEqual(['ci-success']);
+    // QNBS-v3 (#522): main push has pr-size/rust-tauri/core-rust legitimately skipped and ci-success == success — deploy must still be eligible, not silently skipped by GHA's default chain propagation.
+    expect(deployBlock).toContain('always()');
+    expect(deployBlock).toContain('!cancelled()');
+    expect(deployBlock).toMatch(/github\.ref == 'refs\/heads\/main'/);
+    expect(deployBlock).toMatch(/github\.event_name != 'pull_request'/);
+    expect(deployBlock).toMatch(/needs\.ci-success\.result == 'success'/);
+    expect(deployBlock).toMatch(
+      /always\(\)[\s\S]+!cancelled\(\)[\s\S]+github\.ref == 'refs\/heads\/main'[\s\S]+github\.event_name != 'pull_request'[\s\S]+needs\.ci-success\.result == 'success'/,
+    );
+  });
+
   // QNBS-v3: Keep every unconditional CI job explicitly required or advisory so deploy cannot false-green.
   it('keeps required and advisory job authority explicit', () => {
     const ciSuccessBlock = extractJobBlock(workflowSource, 'ci-success');

--- a/tests/utils/workflowPolicyParsers.ts
+++ b/tests/utils/workflowPolicyParsers.ts
@@ -8,6 +8,17 @@ export function extractJobBlock(workflowSource: string, jobName: string): string
   return lines.slice(start, end === -1 ? lines.length : end).join('\n');
 }
 
+// QNBS-v3 (#522): scoped to the job's own if: value, not the whole block — a QNBS-v3 comment on the preceding line can otherwise contain the same tokens an assertion is checking for, letting a regressed if: expression still pass.
+export function extractJobIf(jobBlock: string): string {
+  const lines = jobBlock.split('\n');
+  const start = lines.findIndex((line) => /^ {4}if: ?/.test(line));
+  if (start === -1) throw new Error('Could not find an if: field in this job block');
+  const firstLine = lines[start] as string;
+  if (!/^ {4}if: >-?\s*$/.test(firstLine)) return firstLine.replace(/^ {4}if: /, '');
+  const end = lines.findIndex((line, index) => index > start && !/^ {5,}/.test(line));
+  return lines.slice(start + 1, end === -1 ? lines.length : end).join('\n');
+}
+
 // QNBS-v3: Named step extraction keeps policy assertions scoped to the active workflow step.
 export function extractStepBlock(jobBlock: string, stepName: string): string {
   const lines = jobBlock.split('\n');


### PR DESCRIPTION
## **User description**
## Summary

Fixes #522 — the GitHub Pages deploy job has been silently skipping on main pushes.

**Root cause:** `deploy`'s `if:` condition (`github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && needs.ci-success.result == 'success'`) has no status-check function, so GitHub Actions applies its default implicit `success()` gate — which is affected by *any* legitimately-skipped job in the dependency graph, not just `deploy`'s direct need (`ci-success`). Three jobs are intentionally skip-tolerated by `ci-success`'s own logic: `pr-size` (skipped on every non-`pull_request` event, by design — it's PR-only governance), and `rust-tauri`/`core-rust` (skipped when their paths aren't touched). `ci-success` itself correctly computes `success` in these cases (it has its own `if: always()` plus explicit per-job tolerance), but `deploy`'s bare `if:` inherits GHA's default skip-propagation regardless.

**Verified via real run history**, not just the reported symptom:
- #427 (2026-08-20) introduced `deploy: needs: [ci-success]` (previously `[build, e2e]`) — its own merge run happened to touch Rust paths, so Rust gates ran and deploy succeeded, hiding the bug.
- #428, 86 minutes later, was the first reproducible skip (no Rust-path changes → Rust gates skipped → deploy skipped).
- #509 (2026-08-26, PR-size governance) made this apply to *every* main push once `pr-size` joined `ci-success`'s tolerated-skip set — `pr-size` is unconditionally skipped off `pull_request` events.
- Confirmed empirically: runs where Rust gates actually ran (e.g. #505) deployed successfully; runs where they were skipped (recent DA-05/DA-06 merges) did not — `Deploy to GitHub Pages` shows `conclusion: skipped` with zero steps, not a failure.

**Fix:** `always() && !cancelled() && <existing explicit conditions>` — matches the identical proven pattern already used in `tauri-build.yml`'s `bundle` job for the same class of problem. Forces GitHub to evaluate `deploy`'s own explicit condition (main, non-PR, `ci-success.result == 'success'`) instead of deriving admission from whether any upstream job was skipped, while `!cancelled()` still refuses to publish from a genuinely cancelled workflow run.

## Test plan

- [x] New regression test in `tests/unit/workflowPolicy.test.ts` asserts `deploy`'s `needs`/`if:` structure directly against the broken scenario (`pr-size`/`rust-tauri`/`core-rust` skipped, `ci-success` success → deploy must still be admitted).
- [x] `pnpm run workflow-policy:check` — structural YAML validator passes.
- [x] YAML parse-verified the new `if: >-` block scalar resolves to the intended `${{ always() && !cancelled() && ... }}` expression (no `!`-as-tag-indicator ambiguity).
- [x] `pnpm run typecheck:single` — clean.
- [x] `pnpm run ci:prepush` — `MIXED` classification, all local checks pass.

**Note on what this PR *can't* prove:** `deploy` never runs on a `pull_request` event by design (`github.event_name != 'pull_request'` is one of its own conditions), so this PR's own CI cannot exercise the actual fix. The real acceptance evidence is a genuine post-merge main-push run showing real `Deploy to GitHub Pages` steps (`Set up job` / `Deploy to GitHub Pages` / `Complete job`), not `conclusion: skipped` — will verify that directly after merge before considering #522 closed.

## Summary by Sourcery

Allow approved main-branch builds to reach GitHub Pages despite legitimately skipped upstream jobs.

Bug Fixes:
- Ensure eligible GitHub Pages deployments on main-branch pushes are not skipped when optional upstream jobs are legitimately skipped.

Enhancements:
- Keep cancelled workflows and pull-request events excluded while making ci-success the explicit deployment gate.

Documentation:
- Update documented test counts to reflect the added workflow regression test.

Tests:
- Add regression coverage verifying the deploy condition handles skipped optional jobs and requires a successful ci-success result.


___

## **CodeAnt-AI Description**
Ensure approved main-branch builds reach GitHub Pages

### What Changed
- GitHub Pages deployment now proceeds on eligible main-branch pushes when required checks pass, even if unrelated jobs were legitimately skipped
- Cancelled workflows and pull requests remain excluded from deployment
- Added a regression test covering skipped optional jobs and the successful deployment path
- Updated documentation to reflect the new test count

### Impact
`✅ Fewer skipped GitHub Pages deployments`
`✅ Fresher main-branch documentation`
`✅ Protected deployments from cancelled workflows`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment workflow handling so valid deployments proceed after skipped prerequisite jobs while cancelled runs remain blocked.
  * Deployment continues to require successful checks on pushes to the main branch and excludes pull requests.

* **Documentation**
  * Updated project metrics to reflect more than 7,168 tests across 588 files.

* **Tests**
  * Added coverage to verify deployment workflow conditions and branch restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->