### PR TITLE
fix: close a bootstrap-effect race that can skip the welcome portal

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -55,12 +55,12 @@ import {
   selectAllWorlds,
   selectProjectData,
 } from './features/project/projectSelectors';
-import { projectActions } from './features/project/projectSlice';
 import { statusActions } from './features/status/statusSlice';
 import { useApp } from './hooks/useApp';
 import { useGlobalKeyboardShortcuts } from './hooks/useGlobalKeyboardShortcuts';
 import { useIdbUnlockStartupGuard } from './hooks/useIdbUnlockStartupGuard';
 import { useNativeNotifications } from './hooks/useNativeNotifications';
+import { useProjectBootstrapEffect } from './hooks/useProjectBootstrapEffect';
 import { usePushToTalk } from './hooks/usePushToTalk';
 import { useTranslation } from './hooks/useTranslation';
 import { runCommandById } from './services/commands/commandBuilder';
@@ -72,7 +72,6 @@ import { installCloseToTray, installDesktopTray } from './services/desktop/deskt
 import { desktopPlatform } from './services/desktopPlatform';
 import { logger } from './services/logger';
 import { pluginRegistry } from './services/pluginRegistry';
-import { repairProjectI18nFields } from './services/projectI18nRepair';
 import { loadScenarioWorkspaceView } from './services/scenarioWorkspaceLoader';
 import { hasCompletedSpotlightTour, startSpotlightTour } from './services/spotlightTour';
 import {
@@ -445,28 +444,7 @@ const App: FC<AppProps> = ({ isNewUser }) => {
     requestAnimationFrame(() => mainRef.current?.focus());
   }, [currentView, announce, t, isInitialLoad, isPortalActive]);
 
-  useEffect(() => {
-    if (!isI18nReady || isPortalActive || !project) return;
-
-    const repair = repairProjectI18nFields(project, t);
-    if (repair) {
-      if (repair.title !== undefined) dispatch(projectActions.updateTitle(repair.title));
-      if (repair.logline !== undefined) dispatch(projectActions.updateLogline(repair.logline));
-      if (repair.manuscript !== undefined)
-        dispatch(projectActions.setManuscript(repair.manuscript));
-      return;
-    }
-
-    if (project.title === '' && project.manuscript.length === 0) {
-      dispatch(
-        projectActions.resetProject({
-          title: t('initialProject.title'),
-          logline: t('initialProject.logline'),
-          chapter1Title: t('initialProject.chapter1'),
-        }),
-      );
-    }
-  }, [project, isPortalActive, isI18nReady, dispatch, t]);
+  useProjectBootstrapEffect({ project, isInitialLoad, isPortalActive, isI18nReady, t });
 
   // QNBS-v3: PR3 — auto-launch the product tour once for first-run installs, after the welcome
   // portal closes and the nav has rendered. Returning users (or anyone who already finished/closed

--- a/App.tsx
+++ b/App.tsx
@@ -444,6 +444,7 @@ const App: FC<AppProps> = ({ isNewUser }) => {
     requestAnimationFrame(() => mainRef.current?.focus());
   }, [currentView, announce, t, isInitialLoad, isPortalActive]);
 
+  // QNBS-v3: gates on isInitialLoad too (not just isPortalActive) so a same-commit stale read can't auto-seed a project before the welcome portal shows.
   useProjectBootstrapEffect({ project, isInitialLoad, isPortalActive, isI18nReady, t });
 
   // QNBS-v3: PR3 — auto-launch the product tour once for first-run installs, after the welcome

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`33064552219`) that gated this release didn't trigger it; only the separate, later tag-triggered
   CI/CD run did).
 
+### Fixed
+
+- **Onboarding bootstrap-effect race that could skip the welcome portal:** `hooks/useApp.ts`
+  initialized `isPortalActive` to `false` and only flipped it `true` via a mount effect, even
+  though `isNewUser` is already resolved synchronously before `<App>` mounts. A separate
+  project-bootstrap effect (repairs raw-i18n-key project fields, or seeds a fresh blank project)
+  only guarded on `isPortalActive`/`isI18nReady`/`project`, missing the `isInitialLoad` guard a
+  sibling effect in the same file already uses — occasionally letting a blank project get
+  auto-seeded before the portal-activation state change landed, skipping the welcome portal for a
+  new user. Fixed both: synchronous `isPortalActive` initialization, and the missing
+  `isInitialLoad` guard (extracted into `hooks/useProjectBootstrapEffect.ts` for direct test
+  coverage). See issue #527.
+
 ## [1.28.2] — 2026-08-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2925_keys-0EA5E9" alt="i18n 19 locales — 2925 keys">
-  <img src="https://img.shields.io/badge/Tests-7180%2B_%2F_589_files-22C55E" alt="7180+ tests / 589 files">
+  <img src="https://img.shields.io/badge/Tests-7181%2B_%2F_589_files-22C55E" alt="7181+ tests / 589 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2925 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7180+ tests / 589 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7181+ tests / 589 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7180+ tests, 589 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7181+ tests, 589 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -711,7 +711,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-27, source-synchronized; CI remains authoritative for pass/fail):**
-- **7180+ unit tests** across **589 test files** — CI is authoritative for pass/fail
+- **7181+ unit tests** across **589 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2925 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2925_keys-0EA5E9" alt="i18n 19 locales — 2925 keys">
-  <img src="https://img.shields.io/badge/Tests-7181%2B_%2F_589_files-22C55E" alt="7181+ tests / 589 files">
+  <img src="https://img.shields.io/badge/Tests-7183%2B_%2F_589_files-22C55E" alt="7183+ tests / 589 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2925 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7181+ tests / 589 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7183+ tests / 589 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7181+ tests, 589 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7183+ tests, 589 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -711,7 +711,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-27, source-synchronized; CI remains authoritative for pass/fail):**
-- **7181+ unit tests** across **589 test files** — CI is authoritative for pass/fail
+- **7183+ unit tests** across **589 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2925 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2925_keys-0EA5E9" alt="i18n 19 locales — 2925 keys">
-  <img src="https://img.shields.io/badge/Tests-7171%2B_%2F_588_files-22C55E" alt="7171+ tests / 588 files">
+  <img src="https://img.shields.io/badge/Tests-7180%2B_%2F_589_files-22C55E" alt="7180+ tests / 589 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2925 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7171+ tests / 588 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7180+ tests / 589 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7171+ tests, 588 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7180+ tests, 589 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -711,7 +711,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-27, source-synchronized; CI remains authoritative for pass/fail):**
-- **7171+ unit tests** across **588 test files** — CI is authoritative for pass/fail
+- **7180+ unit tests** across **589 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2925 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/hooks/useApp.ts
+++ b/hooks/useApp.ts
@@ -67,7 +67,8 @@ export const useApp = ({ isNewUser }: { isNewUser: boolean }) => {
   // category (once inside Help, currentView is 'help' and no longer tells us where the user was).
   const previousViewRef = useRef<View>('dashboard');
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
-  const [isPortalActive, setIsPortalActive] = useState(false);
+  // QNBS-v3: initialize from isNewUser (already stable pre-mount) instead of a hardcoded false, so no transient first commit exposes a stale value to a sibling effect.
+  const [isPortalActive, setIsPortalActive] = useState(isNewUser);
   const [isInitialLoad, setIsInitialLoad] = useState(true);
 
   // QNBS-v3 (CodeAnt): the single place that mutates currentView, so previousView is tracked on

--- a/hooks/useProjectBootstrapEffect.ts
+++ b/hooks/useProjectBootstrapEffect.ts
@@ -1,0 +1,61 @@
+import { useEffect } from 'react';
+import { useAppDispatch } from '../app/hooks';
+import { projectActions } from '../features/project/projectSlice';
+import type { ProjectMetaSlice, TranslateFn } from '../services/projectI18nRepair';
+import { repairProjectI18nFields } from '../services/projectI18nRepair';
+
+export interface ProjectBootstrapGateState {
+  project: ProjectMetaSlice | null;
+  isInitialLoad: boolean;
+  isPortalActive: boolean;
+  isI18nReady: boolean;
+}
+
+// QNBS-v3: pure guard, exported for direct unit testing — gates on isInitialLoad (not just isPortalActive) so a same-commit stale read of isPortalActive can't let a blank project auto-seed before the welcome portal shows.
+export function shouldRunProjectBootstrap({
+  project,
+  isInitialLoad,
+  isPortalActive,
+  isI18nReady,
+}: ProjectBootstrapGateState): boolean {
+  return !isInitialLoad && !isPortalActive && isI18nReady && project !== null;
+}
+
+export interface UseProjectBootstrapEffectParams extends ProjectBootstrapGateState {
+  t: TranslateFn;
+}
+
+/** Repairs raw-i18n-key project fields, or seeds a fresh blank project, once bootstrap has settled. */
+export function useProjectBootstrapEffect({
+  project,
+  isInitialLoad,
+  isPortalActive,
+  isI18nReady,
+  t,
+}: UseProjectBootstrapEffectParams): void {
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    if (!shouldRunProjectBootstrap({ project, isInitialLoad, isPortalActive, isI18nReady })) return;
+    if (!project) return;
+
+    const repair = repairProjectI18nFields(project, t);
+    if (repair) {
+      if (repair.title !== undefined) dispatch(projectActions.updateTitle(repair.title));
+      if (repair.logline !== undefined) dispatch(projectActions.updateLogline(repair.logline));
+      if (repair.manuscript !== undefined)
+        dispatch(projectActions.setManuscript(repair.manuscript));
+      return;
+    }
+
+    if (project.title === '' && project.manuscript.length === 0) {
+      dispatch(
+        projectActions.resetProject({
+          title: t('initialProject.title'),
+          logline: t('initialProject.logline'),
+          chapter1Title: t('initialProject.chapter1'),
+        }),
+      );
+    }
+  }, [project, isInitialLoad, isPortalActive, isI18nReady, dispatch, t]);
+}

--- a/hooks/useProjectBootstrapEffect.ts
+++ b/hooks/useProjectBootstrapEffect.ts
@@ -45,17 +45,7 @@ export function useProjectBootstrapEffect({
       if (repair.logline !== undefined) dispatch(projectActions.updateLogline(repair.logline));
       if (repair.manuscript !== undefined)
         dispatch(projectActions.setManuscript(repair.manuscript));
-      return;
     }
-
-    if (project.title === '' && project.manuscript.length === 0) {
-      dispatch(
-        projectActions.resetProject({
-          title: t('initialProject.title'),
-          logline: t('initialProject.logline'),
-          chapter1Title: t('initialProject.chapter1'),
-        }),
-      );
-    }
+    // QNBS-v3: no further branch here — repairProjectI18nFields already treats any blank title/logline/manuscript as needing repair, so it always returns non-null for a blank project; a separate resetProject dispatch for that same condition was unreachable dead code, removed rather than tested around.
   }, [project, isInitialLoad, isPortalActive, isI18nReady, dispatch, t]);
 }

--- a/hooks/useProjectBootstrapEffect.ts
+++ b/hooks/useProjectBootstrapEffect.ts
@@ -36,8 +36,9 @@ export function useProjectBootstrapEffect({
   const dispatch = useAppDispatch();
 
   useEffect(() => {
-    if (!shouldRunProjectBootstrap({ project, isInitialLoad, isPortalActive, isI18nReady })) return;
-    if (!project) return;
+    // QNBS-v3: narrows project directly (not via the predicate's own return type) so the redundant post-check codecov flagged as dead code isn't needed.
+    if (!project || !shouldRunProjectBootstrap({ project, isInitialLoad, isPortalActive, isI18nReady }))
+      return;
 
     const repair = repairProjectI18nFields(project, t);
     if (repair) {

--- a/tests/unit/useProjectBootstrapEffect.test.ts
+++ b/tests/unit/useProjectBootstrapEffect.test.ts
@@ -156,4 +156,43 @@ describe('useProjectBootstrapEffect', () => {
     );
     expect(dispatch).not.toHaveBeenCalled();
   });
+
+  it('repairs only the fields that actually need it, leaving already-valid fields alone', () => {
+    renderHook(() =>
+      useProjectBootstrapEffect({
+        project: {
+          title: '',
+          logline: 'A real logline',
+          manuscript: [{ id: 'sec-1', title: 'Real Chapter', content: 'real' }],
+        },
+        isInitialLoad: false,
+        isPortalActive: false,
+        isI18nReady: true,
+        t,
+      }),
+    );
+    expect(dispatch).toHaveBeenCalledWith(projectActions.updateTitle('initialProject.title'));
+    expect(dispatch).not.toHaveBeenCalledWith(projectActions.updateLogline(expect.anything()));
+    expect(dispatch).not.toHaveBeenCalledWith(projectActions.setManuscript(expect.anything()));
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('repairs only the logline when the title is already valid', () => {
+    renderHook(() =>
+      useProjectBootstrapEffect({
+        project: {
+          title: 'A Real Title',
+          logline: '',
+          manuscript: [{ id: 'sec-1', title: 'Real Chapter', content: 'real' }],
+        },
+        isInitialLoad: false,
+        isPortalActive: false,
+        isI18nReady: true,
+        t,
+      }),
+    );
+    expect(dispatch).not.toHaveBeenCalledWith(projectActions.updateTitle(expect.anything()));
+    expect(dispatch).toHaveBeenCalledWith(projectActions.updateLogline('initialProject.logline'));
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
 });

--- a/tests/unit/useProjectBootstrapEffect.test.ts
+++ b/tests/unit/useProjectBootstrapEffect.test.ts
@@ -1,0 +1,146 @@
+// QNBS-v3: locks in the new isInitialLoad guard invariant on shouldRunProjectBootstrap/useProjectBootstrapEffect — proves the guard logic, not a live reproduction of the React effect-ordering race itself (that evidence is the CI runs, documented in the tracking issue).
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const dispatch = vi.fn();
+vi.mock('../../app/hooks', () => ({
+  useAppDispatch: () => dispatch,
+}));
+
+import { projectActions } from '../../features/project/projectSlice';
+import {
+  shouldRunProjectBootstrap,
+  useProjectBootstrapEffect,
+} from '../../hooks/useProjectBootstrapEffect';
+
+const blankProject = { title: '', logline: '', manuscript: [] };
+const t = (key: string) => key;
+
+beforeEach(() => {
+  dispatch.mockClear();
+});
+
+describe('shouldRunProjectBootstrap', () => {
+  it('blocks during the exact race window: isInitialLoad still true, isPortalActive stale-false', () => {
+    // This is the reproduced race: on the first commit, useApp's mount effect has scheduled
+    // isPortalActive=true but it has not landed yet — isInitialLoad, set in the SAME batched
+    // update, is the reliable signal that the bootstrap decision has not settled.
+    expect(
+      shouldRunProjectBootstrap({
+        project: blankProject,
+        isInitialLoad: true,
+        isPortalActive: false,
+        isI18nReady: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('allows once bootstrap has settled and the portal is not active', () => {
+    expect(
+      shouldRunProjectBootstrap({
+        project: blankProject,
+        isInitialLoad: false,
+        isPortalActive: false,
+        isI18nReady: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('blocks while the portal is active, even after bootstrap settles', () => {
+    expect(
+      shouldRunProjectBootstrap({
+        project: blankProject,
+        isInitialLoad: false,
+        isPortalActive: true,
+        isI18nReady: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('blocks while i18n is not ready', () => {
+    expect(
+      shouldRunProjectBootstrap({
+        project: blankProject,
+        isInitialLoad: false,
+        isPortalActive: false,
+        isI18nReady: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('blocks when there is no project yet', () => {
+    expect(
+      shouldRunProjectBootstrap({
+        project: null,
+        isInitialLoad: false,
+        isPortalActive: false,
+        isI18nReady: true,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('useProjectBootstrapEffect', () => {
+  it('never dispatches during the race window (isInitialLoad still true)', () => {
+    renderHook(() =>
+      useProjectBootstrapEffect({
+        project: blankProject,
+        isInitialLoad: true,
+        isPortalActive: false,
+        isI18nReady: true,
+        t,
+      }),
+    );
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('seeds a blank project via the repair path once bootstrap has settled', () => {
+    // QNBS-v3: repairProjectI18nFields treats a blank title/logline/manuscript as "needs repair" too, so it — not the resetProject branch — is what actually seeds a brand-new blank project in practice.
+    renderHook(() =>
+      useProjectBootstrapEffect({
+        project: blankProject,
+        isInitialLoad: false,
+        isPortalActive: false,
+        isI18nReady: true,
+        t,
+      }),
+    );
+    expect(dispatch).toHaveBeenCalledWith(projectActions.updateTitle('initialProject.title'));
+    expect(dispatch).toHaveBeenCalledWith(projectActions.updateLogline('initialProject.logline'));
+    expect(dispatch).toHaveBeenCalledWith(
+      projectActions.setManuscript([
+        expect.objectContaining({ title: 'initialProject.chapter1', content: '' }),
+      ]),
+    );
+  });
+
+  it('dispatches nothing for a project that already has real content', () => {
+    renderHook(() =>
+      useProjectBootstrapEffect({
+        project: {
+          title: 'My Real Story',
+          logline: 'A real logline',
+          manuscript: [{ id: 'sec-1', title: 'Ch1', content: 'Real content' }],
+        },
+        isInitialLoad: false,
+        isPortalActive: false,
+        isI18nReady: true,
+        t,
+      }),
+    );
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('does not dispatch anything while the portal is active', () => {
+    renderHook(() =>
+      useProjectBootstrapEffect({
+        project: blankProject,
+        isInitialLoad: false,
+        isPortalActive: true,
+        isI18nReady: true,
+        t,
+      }),
+    );
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/useProjectBootstrapEffect.test.ts
+++ b/tests/unit/useProjectBootstrapEffect.test.ts
@@ -143,4 +143,17 @@ describe('useProjectBootstrapEffect', () => {
     );
     expect(dispatch).not.toHaveBeenCalled();
   });
+
+  it('does not dispatch anything before a project has loaded', () => {
+    renderHook(() =>
+      useProjectBootstrapEffect({
+        project: null,
+        isInitialLoad: false,
+        isPortalActive: false,
+        isI18nReady: true,
+        t,
+      }),
+    );
+    expect(dispatch).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## **User description**
## Summary

Fixes #527. Root cause: `hooks/useApp.ts` initialized `isPortalActive` to `false`, only flipping it `true` via a mount effect — but `isNewUser` (the value deciding this) is already resolved synchronously before `<App>` mounts (`index.tsx`: `const isNewUser = !preloadedState`), so there's no correctness reason to start with a known-wrong transient value.

Defense in depth: `App.tsx`'s separate project-bootstrap effect (repairs raw-i18n-key project fields, or seeds a fresh blank project) only guarded on `isPortalActive`/`isI18nReady`/`project` — a sibling effect in the same file already uses the identical `isInitialLoad` guard pattern; this one was just missing it. Without it, if both effects fire in the same React commit, the bootstrap effect could read `isPortalActive`'s stale pre-update value and fire before the portal-activation state change landed — occasionally skipping the welcome portal for a new user and auto-creating a default project instead.

## Changes

- `hooks/useApp.ts`: `useState(isNewUser)` instead of `useState(false)` for `isPortalActive`.
- Extracted the bootstrap effect into `hooks/useProjectBootstrapEffect.ts` (out of `App.tsx`, which had no prior component-level test coverage), adding the missing `isInitialLoad` guard.
- `shouldRunProjectBootstrap` — pure predicate, directly unit-tested across the guard's full input space, including the exact reproduced race-window inputs. These tests prove the new guard invariant; they do not themselves reproduce React's effect-ordering timing live — that evidence is the two CI runs documented in #527.
- `tests/unit/useProjectBootstrapEffect.test.ts` — 9 new tests.

## Test plan
- [x] `pnpm exec vitest run tests/unit/useProjectBootstrapEffect.test.ts tests/unit/useApp.test.ts` — 23/23 pass
- [x] `pnpm run lint` — clean (0 errors on changed files)
- [x] `pnpm run typecheck:single` — clean
- [x] `pnpm run ci:prepush` — MIXED classification, all local checks pass
- [ ] CI green, especially `tests/e2e/export.spec.ts` on `[Mobile Chrome]`/`[chromium]` and `a11y.spec.ts`'s welcome-state check — the ones that flaked on the v1.28.2 tag-triggered CI run

## Release relevance

Pre-existing, not introduced by v1.28.2. Targets the next release (v1.28.3), not amending the already-published v1.28.2 tag.

## Summary by Sourcery

Prevent the onboarding race from auto-initializing a project before the welcome portal is displayed.

Bug Fixes:
- Prevent new users from skipping the welcome portal by initializing portal state synchronously and delaying project bootstrap until startup has settled.

Enhancements:
- Extract project bootstrap behavior into a reusable hook with centralized startup guards and preserve i18n field repair for existing projects.

Documentation:
- Update documented test counts and record the onboarding race fix in the changelog.

Tests:
- Add unit coverage for project-bootstrap guard conditions, the reproduced race window, blank-project initialization, and selective field repair.


___

## **CodeAnt-AI Description**
Prevent new users from skipping the welcome portal during startup

### What Changed
- New users now enter the welcome portal immediately, without a transient state that can trigger project setup first
- Project translation repair and blank-project setup wait until initial startup has settled, preventing automatic project creation while the welcome portal is opening
- Added coverage for the startup race and the valid project-bootstrap scenarios

### Impact
`✅ Fewer skipped welcome portals`
`✅ No unwanted default projects during onboarding`
`✅ Reliable startup project initialization`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved onboarding and project initialization to prevent startup race conditions.
  * Ensured localization and portal state are ready before project setup begins.
  * Improved handling of blank projects and translated project content.
  * Improved initial portal activation for new users.

* **Documentation**
  * Updated release notes and project metrics, including documented test totals.

* **Tests**
  * Added coverage for startup timing, localization readiness, blank projects, and project updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->