### PR TITLE
fix(e2e): establish a deterministic WelcomePortal entry precondition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   new user. Fixed both: synchronous `isPortalActive` initialization, and the missing
   `isInitialLoad` guard (extracted into `hooks/useProjectBootstrapEffect.ts` for direct test
   coverage). See issue #527.
+- **`export.spec.ts` E2E precondition assumed WelcomePortal unconditionally:** `waitForSpaReady()`
+  succeeds on either WelcomePortal or an already-mounted main shell, but the test's `beforeEach`
+  clicked "Start a New Project" unconditionally, causing spurious CI failures whenever a cold boot
+  landed in the main shell instead (a startup-state precondition gap, not a #527/#530 regression —
+  see issue #532). Added `ensureWelcomePortalEntry()` (`tests/e2e/helpers.ts`), which recovers via
+  the real Settings → Data & Backups → Factory Reset flow when needed, with regression coverage for
+  both startup shapes.
 
 ## [1.28.2] — 2026-08-27
 

--- a/components/WelcomePortal.tsx
+++ b/components/WelcomePortal.tsx
@@ -366,11 +366,15 @@ export const WelcomePortal: React.FC<WelcomePortalProps> = ({ onExit }) => {
   };
 
   return (
-    <div className="fixed inset-0 z-50 overflow-y-auto overscroll-contain bg-[var(--sc-surface-base)] animate-fade-in">
+    <div
+      data-testid="welcome-portal"
+      className="fixed inset-0 z-50 overflow-y-auto overscroll-contain bg-[var(--sc-surface-base)] animate-fade-in"
+    >
       {/* QNBS-v3: shell is now scrollable (overflow-y-auto) with min-h-full centering — content
           taller than the viewport (e.g. the feature grid on mobile) scrolls instead of being
           clipped by the old fixed `flex items-center` shell. Fixes Mobile-Chrome E2E click
           timeouts where the bottom action buttons were unreachable. */}
+      {/* QNBS-v3: stable, locale-independent selector for E2E readiness checks — the primary action button's label is translated, but this attribute is not. */}
       {/* LanguageSelector now imported from ui/LanguageSelector.tsx with search functionality */}
       <LanguageSelector value={language} onChange={setLanguage} />
       <div className="flex min-h-full items-center justify-center p-4 pt-16 sm:pt-4">

--- a/tests/e2e/export.spec.ts
+++ b/tests/e2e/export.spec.ts
@@ -52,17 +52,14 @@ test.describe('End-to-end project flow (CI-only)', () => {
   test.beforeEach(async ({ page }) => {
     test.skip(!isCI, 'CI-only E2E suite');
     await page.route('**/generativelanguage.googleapis.com/**', mockGemini);
+    // QNBS-v3: seeds English before boot — ensureWelcomePortalEntry's contract is locale-independent, and the LanguageSelector trigger's accessible name isn't a reliable /EN/i click target (its aria-label can itself contain "en" as a substring in other locales, e.g. Spanish "bienvenida").
+    await page.addInitScript(() => localStorage.setItem('worldscript-language', 'en'));
     await page.goto('/');
     // QNBS-v3: a cold CI boot can already be in the main shell instead of WelcomePortal — this guarantees the precondition below assumes.
     await ensureWelcomePortalEntry(page);
   });
 
   test('full project flow navigates from AI outline to export and settings', async ({ page }) => {
-    const englishButton = page.getByRole('button', { name: /EN/i }).first();
-    if (await englishButton.isVisible()) {
-      await englishButton.click();
-    }
-
     await page.getByRole('button', { name: /Start a New Project/i }).click();
     await page.getByRole('button', { name: /Generate with AI/i }).click();
 

--- a/tests/e2e/export.spec.ts
+++ b/tests/e2e/export.spec.ts
@@ -2,10 +2,10 @@ import { expect, type Route, test } from '@playwright/test';
 
 import {
   clickNavItem,
+  ensureWelcomePortalEntry,
   flushWriterDebounce,
   seedGeminiApiKey,
   selectFirstEnabledWriterSection,
-  waitForSpaReady,
 } from './helpers';
 
 const isCI = process.env['CI'] === 'true';
@@ -53,7 +53,8 @@ test.describe('End-to-end project flow (CI-only)', () => {
     test.skip(!isCI, 'CI-only E2E suite');
     await page.route('**/generativelanguage.googleapis.com/**', mockGemini);
     await page.goto('/');
-    await waitForSpaReady(page);
+    // QNBS-v3: a cold CI boot can already be in the main shell instead of WelcomePortal — this guarantees the precondition below assumes.
+    await ensureWelcomePortalEntry(page);
   });
 
   test('full project flow navigates from AI outline to export and settings', async ({ page }) => {

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -172,6 +172,33 @@ export async function ensureBlankProject(page: Page): Promise<void> {
   await waitForMainChrome(page);
 }
 
+/**
+ * Deterministically reach the WelcomePortal "Start a New Project" entry point regardless of
+ * which of waitForSpaReady()'s two success shapes the app actually booted into. A cold CI boot
+ * has landed in an already-mounted main shell with a persisted project instead of the portal —
+ * a startup-state precondition gap distinct from the (fixed) portal-activation auto-seed race.
+ * Recovers via the real Settings → Data & Backups → Factory Reset flow so no React/Redux/storage
+ * internals are touched — only supported app behavior.
+ */
+export async function ensureWelcomePortalEntry(page: Page): Promise<void> {
+  await waitForSpaReady(page);
+  const startBtn = page.getByRole('button', { name: /Start a New Project/i });
+  if (await startBtn.isVisible({ timeout: 3000 }).catch(() => false)) {
+    return;
+  }
+  await clickNavItem(page, /Settings/i);
+  await page
+    .getByRole('button', { name: /Data & Backups|Daten & Backups/i })
+    .first()
+    .click();
+  await page.getByRole('button', { name: /Factory Reset|Werkseinstellungen/i }).click();
+  await page
+    .getByRole('button', { name: /Delete everything & restart|Alles löschen & neu starten/i })
+    .click();
+  await waitForSpaReady(page);
+  await expect(startBtn).toBeVisible({ timeout: 15000 });
+}
+
 /** Desktop sidebar (`md:`); avoids duplicate nav controls vs mobile tab bar. */
 export function sidebar(page: Page) {
   return page.locator('#sidebar');

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -137,9 +137,11 @@ export async function waitForSpaReady(page: Page): Promise<void> {
 }
 
 /**
- * Main shell is ready (desktop sidebar or mobile bottom tab bar).
+ * Main shell is ready (desktop sidebar or mobile bottom tab bar). Exported so callers proving
+ * "main shell is visible" don't reach for `locA.or(locB)` — both elements exist in the DOM at
+ * once (only one is CSS-visible per viewport), which trips Playwright's strict-mode violation.
  */
-async function waitForMainChrome(page: Page): Promise<void> {
+export async function waitForMainChrome(page: Page): Promise<void> {
   await Promise.race([
     page.locator('#sidebar').waitFor({ state: 'visible', timeout: 25000 }),
     page.locator('[data-tour="nav-mobile"]').waitFor({ state: 'visible', timeout: 25000 }),

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -187,6 +187,10 @@ export async function ensureWelcomePortalEntry(page: Page): Promise<void> {
   if (await startBtn.isVisible({ timeout: 3000 }).catch(() => false)) {
     return;
   }
+  // QNBS-v3: force English before the locale-dependent recovery flow below, or a persisted non-EN/DE language would hang it.
+  await page.evaluate(() => localStorage.setItem('worldscript-language', 'en'));
+  await page.reload();
+  await waitForMainChrome(page);
   await clickNavItem(page, /Settings/i);
   await page
     .getByRole('button', { name: /Data & Backups|Daten & Backups/i })

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -172,6 +172,7 @@ export async function ensureBlankProject(page: Page): Promise<void> {
   await waitForMainChrome(page);
 }
 
+// QNBS-v3: guarantees a deterministic WelcomePortal entry precondition when CI cold-boots into the main shell instead.
 /**
  * Deterministically reach the WelcomePortal "Start a New Project" entry point regardless of
  * which of waitForSpaReady()'s two success shapes the app actually booted into. A cold CI boot

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -175,28 +175,30 @@ export async function ensureBlankProject(page: Page): Promise<void> {
 
 // QNBS-v3: guarantees a deterministic WelcomePortal entry precondition when CI cold-boots into the main shell instead.
 /**
- * Deterministically reach the WelcomePortal "Start a New Project" entry point regardless of
- * which of waitForSpaReady()'s two success shapes the app actually booted into. A cold CI boot
- * has landed in an already-mounted main shell with a persisted project instead of the portal —
- * a startup-state precondition gap distinct from the (fixed) portal-activation auto-seed race.
- * Recovers via the real Settings → Data & Backups → Factory Reset flow so no React/Redux/storage
- * internals are touched — only supported app behavior.
+ * Deterministically reach the WelcomePortal entry point regardless of which of
+ * waitForSpaReady()'s two success shapes the app actually booted into. A cold CI boot has landed
+ * in an already-mounted main shell with a persisted project instead of the portal — a startup-
+ * state precondition gap distinct from the (fixed) portal-activation auto-seed race.
+ * Contract: guarantees the portal is reached, locale-independently — it does NOT guarantee
+ * English. A caller needing English selects it itself (export.spec.ts already does this for the
+ * fresh-boot case). Recovers via the real Settings → Data & Backups → Factory Reset flow when
+ * main chrome is active so no React/Redux/storage internals are touched — only supported app
+ * behavior.
  */
 export async function ensureWelcomePortalEntry(page: Page): Promise<void> {
   await waitForSpaReady(page);
-  const startBtn = page.getByRole('button', { name: /Start a New Project/i });
-  // QNBS-v3: check the locale-independent testid, not the translated button text — a non-English WelcomePortal must also early-return here, not fall through into the main-chrome-only recovery flow below.
-  if (
-    await page
-      .getByTestId('welcome-portal')
-      .isVisible({ timeout: 3000 })
-      .catch(() => false)
-  ) {
+  const portal = page.getByTestId('welcome-portal');
+  if (await portal.isVisible({ timeout: 3000 }).catch(() => false)) {
     return;
   }
   // QNBS-v3: force English before the locale-dependent recovery flow below, or a persisted non-EN/DE language would hang it.
   await page.evaluate(() => localStorage.setItem('worldscript-language', 'en'));
   await page.reload();
+  await waitForSpaReady(page);
+  // QNBS-v3: this reload can itself race a pending debounced autosave and land back in WelcomePortal instead of main chrome — accept either state again rather than assuming main chrome.
+  if (await portal.isVisible({ timeout: 3000 }).catch(() => false)) {
+    return;
+  }
   await waitForMainChrome(page);
   await clickNavItem(page, /Settings/i);
   await page
@@ -208,7 +210,7 @@ export async function ensureWelcomePortalEntry(page: Page): Promise<void> {
     .getByRole('button', { name: /Delete everything & restart|Alles löschen & neu starten/i })
     .click();
   await waitForSpaReady(page);
-  await expect(startBtn).toBeVisible({ timeout: 15000 });
+  await expect(portal).toBeVisible({ timeout: 15000 });
 }
 
 /** Desktop sidebar (`md:`); avoids duplicate nav controls vs mobile tab bar. */

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -185,7 +185,13 @@ export async function ensureBlankProject(page: Page): Promise<void> {
 export async function ensureWelcomePortalEntry(page: Page): Promise<void> {
   await waitForSpaReady(page);
   const startBtn = page.getByRole('button', { name: /Start a New Project/i });
-  if (await startBtn.isVisible({ timeout: 3000 }).catch(() => false)) {
+  // QNBS-v3: check the locale-independent testid, not the translated button text — a non-English WelcomePortal must also early-return here, not fall through into the main-chrome-only recovery flow below.
+  if (
+    await page
+      .getByTestId('welcome-portal')
+      .isVisible({ timeout: 3000 })
+      .catch(() => false)
+  ) {
     return;
   }
   // QNBS-v3: force English before the locale-dependent recovery flow below, or a persisted non-EN/DE language would hang it.

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -109,19 +109,18 @@ export async function seedGeminiApiKey(page: Page): Promise<void> {
 
 /**
  * Vite dev server keeps the HMR/WebSocket busy → `networkidle` often never settles.
- * Wait for either the welcome portal primary action or the desktop sidebar shell.
+ * Wait for either the welcome portal or the desktop/mobile sidebar shell.
  * QNBS-v3: Also waits for the body theme class to be applied by the App useEffect so
  *          that CSS custom properties (--sc-text-primary, etc.) are fully resolved before
  *          axe or visual checks run — without this, variables resolve to intermediate values.
  */
 export async function waitForSpaReady(page: Page): Promise<void> {
   await page.waitForLoadState('domcontentloaded');
+  // QNBS-v3: welcome-portal is a stable data-testid, not the translated button label — a non-English boot no longer times out this race.
   await Promise.race([
     page.locator('#sidebar').waitFor({ state: 'visible', timeout: 25000 }),
     page.locator('[data-tour="nav-mobile"]').waitFor({ state: 'visible', timeout: 25000 }),
-    page
-      .getByRole('button', { name: /Start a New Project/i })
-      .waitFor({ state: 'visible', timeout: 25000 }),
+    page.getByTestId('welcome-portal').waitFor({ state: 'visible', timeout: 25000 }),
   ]);
   // QNBS-v3: theme class is applied in App useEffect after first render — wait for it so
   //          CSS variable values are stable (avoids axe false-positives on mid-transition colors).

--- a/tests/e2e/onboarding-entry-precondition.spec.ts
+++ b/tests/e2e/onboarding-entry-precondition.spec.ts
@@ -15,6 +15,17 @@ test.describe('WelcomePortal entry precondition (CI-only)', () => {
     await expect(page.getByRole('button', { name: /Start a New Project/i })).toBeVisible();
   });
 
+  test('reaches the entry point when a non-English language is already persisted', async ({
+    page,
+  }) => {
+    // QNBS-v3: proves waitForSpaReady's stable welcome-portal selector survives a non-English boot, not just the translated button label.
+    await page.addInitScript(() => localStorage.setItem('worldscript-language', 'es'));
+    await page.goto('/');
+    await expect(page.getByTestId('welcome-portal')).toBeVisible();
+    await ensureWelcomePortalEntry(page);
+    await expect(page.getByRole('button', { name: /Start a New Project/i })).toBeVisible();
+  });
+
   test('reaches the entry point from an already-mounted main shell with a persisted project', async ({
     page,
   }) => {

--- a/tests/e2e/onboarding-entry-precondition.spec.ts
+++ b/tests/e2e/onboarding-entry-precondition.spec.ts
@@ -20,7 +20,17 @@ test.describe('WelcomePortal entry precondition (CI-only)', () => {
   }) => {
     await page.goto('/');
     await ensureBlankProject(page);
+    // QNBS-v3: the 1s debounced autosave must genuinely land before reload or this scenario passes without ever exercising the Factory Reset fallback.
+    await expect(page.getByText(/All changes saved|Alle Änderungen gespeichert/i)).toBeVisible({
+      timeout: 10000,
+    });
     await page.reload();
+    // Prove this reload really landed back in the main shell, not a fresh WelcomePortal —
+    // otherwise ensureWelcomePortalEntry's early-return branch would make the assertion below vacuous.
+    await expect(page.locator('#sidebar').or(page.locator('[data-tour="nav-mobile"]'))).toBeVisible(
+      { timeout: 25000 },
+    );
+    await expect(page.getByRole('button', { name: /Start a New Project/i })).not.toBeVisible();
     await ensureWelcomePortalEntry(page);
     await expect(page.getByRole('button', { name: /Start a New Project/i })).toBeVisible();
   });

--- a/tests/e2e/onboarding-entry-precondition.spec.ts
+++ b/tests/e2e/onboarding-entry-precondition.spec.ts
@@ -36,8 +36,7 @@ test.describe('WelcomePortal entry precondition (CI-only)', () => {
       timeout: 10000,
     });
     await page.reload();
-    // Prove this reload really landed back in the main shell, not a fresh WelcomePortal —
-    // otherwise ensureWelcomePortalEntry's early-return branch would make the assertion below vacuous.
+    // QNBS-v3: proves the reload landed in the main shell, not a fresh WelcomePortal, or the assertion below would be vacuous.
     await waitForMainChrome(page);
     await expect(page.getByRole('button', { name: /Start a New Project/i })).not.toBeVisible();
     await ensureWelcomePortalEntry(page);

--- a/tests/e2e/onboarding-entry-precondition.spec.ts
+++ b/tests/e2e/onboarding-entry-precondition.spec.ts
@@ -3,7 +3,7 @@ import { ensureBlankProject, ensureWelcomePortalEntry, waitForMainChrome } from 
 
 const isCI = process.env['CI'] === 'true';
 
-// QNBS-v3: proves ensureWelcomePortalEntry reaches "Start a New Project" from both startup shapes waitForSpaReady() accepts.
+// QNBS-v3: proves ensureWelcomePortalEntry's contract (portal reached, locale-independent) holds from every startup shape waitForSpaReady() accepts, including its own internal-reload race.
 test.describe('WelcomePortal entry precondition (CI-only)', () => {
   test.beforeEach(() => {
     test.skip(!isCI, 'CI-only E2E suite');
@@ -12,18 +12,18 @@ test.describe('WelcomePortal entry precondition (CI-only)', () => {
   test('reaches the entry point on a fresh WelcomePortal boot', async ({ page }) => {
     await page.goto('/');
     await ensureWelcomePortalEntry(page);
-    await expect(page.getByRole('button', { name: /Start a New Project/i })).toBeVisible();
+    await expect(page.getByTestId('welcome-portal')).toBeVisible();
   });
 
   test('reaches the entry point when a non-English language is already persisted', async ({
     page,
   }) => {
-    // QNBS-v3: proves waitForSpaReady's stable welcome-portal selector survives a non-English boot, not just the translated button label.
+    // QNBS-v3: the helper's contract is locale-independent portal-reached, not English — assert the stable testid, not the translated button label.
     await page.addInitScript(() => localStorage.setItem('worldscript-language', 'es'));
     await page.goto('/');
     await expect(page.getByTestId('welcome-portal')).toBeVisible();
     await ensureWelcomePortalEntry(page);
-    await expect(page.getByRole('button', { name: /Start a New Project/i })).toBeVisible();
+    await expect(page.getByTestId('welcome-portal')).toBeVisible();
   });
 
   test('reaches the entry point from an already-mounted main shell with a persisted project', async ({
@@ -31,7 +31,7 @@ test.describe('WelcomePortal entry precondition (CI-only)', () => {
   }) => {
     await page.goto('/');
     await ensureBlankProject(page);
-    // QNBS-v3: the 1s debounced autosave must genuinely land before reload or this scenario passes without ever exercising the Factory Reset fallback.
+    // QNBS-v3: waits for the debounced autosave to land so this scenario specifically exercises the full Settings/Factory Reset fallback, which does normalize to English as an implementation detail.
     await expect(page.getByText(/All changes saved|Alle Änderungen gespeichert/i)).toBeVisible({
       timeout: 10000,
     });
@@ -41,5 +41,15 @@ test.describe('WelcomePortal entry precondition (CI-only)', () => {
     await expect(page.getByRole('button', { name: /Start a New Project/i })).not.toBeVisible();
     await ensureWelcomePortalEntry(page);
     await expect(page.getByRole('button', { name: /Start a New Project/i })).toBeVisible();
+  });
+
+  test('reaches the entry point when its own internal reload can race a pending autosave', async ({
+    page,
+  }) => {
+    // QNBS-v3: deliberately does not wait for "All changes saved" — the helper's own English-normalization reload can race the pending debounced save either way, and it must end in the portal regardless.
+    await page.goto('/');
+    await ensureBlankProject(page);
+    await ensureWelcomePortalEntry(page);
+    await expect(page.getByTestId('welcome-portal')).toBeVisible();
   });
 });

--- a/tests/e2e/onboarding-entry-precondition.spec.ts
+++ b/tests/e2e/onboarding-entry-precondition.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { ensureBlankProject, ensureWelcomePortalEntry } from './helpers';
+import { ensureBlankProject, ensureWelcomePortalEntry, waitForMainChrome } from './helpers';
 
 const isCI = process.env['CI'] === 'true';
 
@@ -27,9 +27,7 @@ test.describe('WelcomePortal entry precondition (CI-only)', () => {
     await page.reload();
     // Prove this reload really landed back in the main shell, not a fresh WelcomePortal —
     // otherwise ensureWelcomePortalEntry's early-return branch would make the assertion below vacuous.
-    await expect(page.locator('#sidebar').or(page.locator('[data-tour="nav-mobile"]'))).toBeVisible(
-      { timeout: 25000 },
-    );
+    await waitForMainChrome(page);
     await expect(page.getByRole('button', { name: /Start a New Project/i })).not.toBeVisible();
     await ensureWelcomePortalEntry(page);
     await expect(page.getByRole('button', { name: /Start a New Project/i })).toBeVisible();

--- a/tests/e2e/onboarding-entry-precondition.spec.ts
+++ b/tests/e2e/onboarding-entry-precondition.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from '@playwright/test';
+import { ensureBlankProject, ensureWelcomePortalEntry } from './helpers';
+
+const isCI = process.env['CI'] === 'true';
+
+// QNBS-v3: proves ensureWelcomePortalEntry reaches "Start a New Project" from both startup shapes waitForSpaReady() accepts.
+test.describe('WelcomePortal entry precondition (CI-only)', () => {
+  test.beforeEach(() => {
+    test.skip(!isCI, 'CI-only E2E suite');
+  });
+
+  test('reaches the entry point on a fresh WelcomePortal boot', async ({ page }) => {
+    await page.goto('/');
+    await ensureWelcomePortalEntry(page);
+    await expect(page.getByRole('button', { name: /Start a New Project/i })).toBeVisible();
+  });
+
+  test('reaches the entry point from an already-mounted main shell with a persisted project', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    await ensureBlankProject(page);
+    await page.reload();
+    await ensureWelcomePortalEntry(page);
+    await expect(page.getByRole('button', { name: /Start a New Project/i })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

- `export.spec.ts`'s `beforeEach` assumed `waitForSpaReady()` always resolves via WelcomePortal and clicked "Start a New Project" unconditionally — but that helper's `Promise.race` also succeeds when the app boots straight into an already-mounted main shell.
- On the `main` post-merge run for PR #530 (run `33088546994`, job `98579015311`), this caused all 3 Playwright retries to fail identically — the app had booted into the main shell (Outline Generator view), not WelcomePortal. A same-SHA rerun (job `98582879363`) passed cleanly, confirming this is a startup-state precondition gap, distinct from the already-fixed #527 portal-activation auto-seed race — **not reopening #527**.
- Adds `ensureWelcomePortalEntry()` (`tests/e2e/helpers.ts`), which falls back to the real Settings → Data & Backups → Factory Reset flow when the portal isn't already showing — no storage/React internals touched, only supported app behavior — and wires it into `export.spec.ts`.

## Evidence

Full trace analysis (URL hash timeline, console boot-sequence, `waitForSpaReady()` race resolution) and the still-open root-cause question (how a persisted project reached IndexedDB before any test action ran) are documented in #532. **This PR does not resolve that root cause — #532 stays open.** This PR only fixes the test-harness precondition bug (the test's own faulty assumption), which is a real, independent defect regardless of the root cause.

## Test plan

- [x] `pnpm run typecheck` — pass
- [x] `pnpm exec biome check` on touched files — pass
- [x] `pnpm run ci:prepush` — local admission PASS
- [x] New regression spec (`tests/e2e/onboarding-entry-precondition.spec.ts`) proves `ensureWelcomePortalEntry()` reaches "Start a New Project" from both a fresh WelcomePortal boot and an already-mounted main-shell boot (with an explicit wait for the debounced autosave to land and an explicit post-reload main-shell assertion, so the second case can't pass without actually exercising the Factory Reset fallback)
- [ ] CI E2E job green on this PR (including `export.spec.ts` itself)

## Summary by Sourcery

Ensure E2E tests establish a deterministic WelcomePortal entry state regardless of the application's startup condition.

Bug Fixes:
- Make CI E2E project-flow setup reliably reach the WelcomePortal even when the application boots into an existing main shell.
- Handle locale-independent SPA readiness and portal detection to prevent false startup-state assumptions.

Enhancements:
- Add a supported Settings-based factory-reset fallback for recovering the WelcomePortal entry state without relying on application internals.
- Add stable WelcomePortal test identification and expose main-shell readiness for reusable E2E precondition checks.

Tests:
- Add regression coverage for fresh portal boots, persisted non-English locales, existing projects, and reloads racing pending autosaves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved startup reliability for export and onboarding flows across different initial app states.
  - Added automatic recovery to return to the Welcome Portal when needed, including after persisted sessions, cold starts, and pending saves.
  - Ensured reset and restart flows consistently present the expected start experience.
  - Improved startup handling across supported languages.

- **Tests**
  - Added regression coverage for fresh, persisted, and interrupted startup scenarios.
  - Added validation for reliable Welcome Portal entry during save-related timing conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->