### PR TITLE
chore(release): bump version to v1.28.3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
 - **Primary deploy target:** Static SPA on GitHub Pages (`/WorldScript-Studio/` base path)
 - **Secondary targets:** Vercel (root base) and Cloudflare Pages via edge builds (`pnpm run build:edge`)
 - **Desktop:** Tauri 2 bundles for Linux (AppImage), macOS (DMG), and Windows (MSI); auto-updater enabled via `latest.json`
-- **Version:** `1.28.2`
+- **Version:** `1.28.3`
 - **License:** MIT
 
 The app supports a multi-provider AI stack (Gemini, OpenAI, Claude, Grok, OpenRouter, Ollama, WebLLM, ONNX Runtime Web, Transformers.js), four AI execution modes (Hybrid / Cloud / Local / Eco), real-time collaboration with E2E encryption, a Plot Board v2 with swimlane/canvas/timeline modes, character/world management, manuscript export, voice dictation, and a 19-locale i18n layer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+<!-- release-candidate: v1.28.3 -->
+## [1.28.3] — 2026-08-27
+
 ### Documentation
 
 - **Post-release v1.28.2 truth sync:** removed the now-stale release-candidate markers from
@@ -32,9 +35,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   succeeds on either WelcomePortal or an already-mounted main shell, but the test's `beforeEach`
   clicked "Start a New Project" unconditionally, causing spurious CI failures whenever a cold boot
   landed in the main shell instead (a startup-state precondition gap, not a #527/#530 regression —
-  see issue #532). Added `ensureWelcomePortalEntry()` (`tests/e2e/helpers.ts`), which recovers via
-  the real Settings → Data & Backups → Factory Reset flow when needed, with regression coverage for
-  both startup shapes.
+  see issue #532, still open for the unexplained root cause). Added `ensureWelcomePortalEntry()`
+  (`tests/e2e/helpers.ts`), which recovers via the real Settings → Data & Backups → Factory Reset
+  flow when needed — including re-checking both startup shapes after its own internal reload,
+  since that reload can itself race a pending ~1s debounced autosave — and a stable
+  `data-testid="welcome-portal"` on `WelcomePortal.tsx`'s root so portal detection no longer
+  depends on translated button text. Regression coverage for both startup shapes, a non-English
+  persisted-language boot, and the internal-reload race.
 
 ## [1.28.2] — 2026-08-27
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
   <img src="https://img.shields.io/badge/TypeScript-7.x_(tsgo)-3178C6?logo=typescript&logoColor=white" alt="TypeScript 7 (tsgo)">
   <img src="https://img.shields.io/badge/AI-Gemini_%7C_OpenAI_%7C_OpenRouter_%7C_Ollama_%7C_WebLLM-4285F4?logo=google" alt="Gemini · OpenAI · OpenRouter · Ollama · WebLLM">
   <img src="https://img.shields.io/badge/Local_AI-WebGPU_%7C_ONNX_%7C_Transformers.js-8B5CF6" alt="WebGPU · ONNX · Transformers.js">
-  <img src="https://img.shields.io/badge/Release-v1.28.2-6366F1" alt="Release v1.28.2">
+  <!-- release-candidate: v1.28.3 -->
+  <img src="https://img.shields.io/badge/Release-v1.28.3-6366F1" alt="Release v1.28.3">
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2925_keys-0EA5E9" alt="i18n 19 locales — 2925 keys">

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "worldscript-studio",
   "private": true,
-  "version": "1.28.2",
+  "version": "1.28.3",
   "description": "WorldScript Studio — offline-first, AI-powered creative writing application.",
   "author": "QNBS",
   "keywords": [

--- a/public/sw.js
+++ b/public/sw.js
@@ -6,7 +6,7 @@
 // ============================================================
 
 // QNBS-v3 (CodeRabbit): version bump auto-synced from package.json by scripts/sync-sw-version.mjs — every CACHE_STATIC/CACHE_DYNAMIC name changes too, so this alone invalidates all prior caches on next activate.
-const APP_VERSION   = '1.28.2';
+const APP_VERSION   = '1.28.3';
 const CACHE_STATIC  = `worldscript-static-v${APP_VERSION}`;
 const CACHE_DYNAMIC = `worldscript-dynamic-v${APP_VERSION}`;
 const CACHE_IMAGES  = `worldscript-images-v${APP_VERSION}`;

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6685,7 +6685,7 @@ dependencies = [
 
 [[package]]
 name = "worldscript-studio"
-version = "1.28.2"
+version = "1.28.3"
 dependencies = [
  "base64 0.23.1",
  "candle-core",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "worldscript-studio"
-version = "1.28.2"
+version = "1.28.3"
 description = "AI-powered creative writing and world-building application"
 authors = ["QNBS"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "WorldScript Studio",
-  "version": "1.28.2",
+  "version": "1.28.3",
   "identifier": "com.worldscript.studio",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

Patch release (v1.28.2 → v1.28.3) containing two fixes already merged to `main`:

- **#527 / PR #530** — onboarding bootstrap-effect race that could skip the welcome portal for new users (synchronous `isPortalActive` init + `isInitialLoad` guard).
- **#532 / PR #533** — `export.spec.ts`'s E2E precondition assumed WelcomePortal unconditionally; `ensureWelcomePortalEntry()` now deterministically reaches the portal regardless of startup shape, including its own internal-reload race and non-English locale handling. Issue #532's root cause (how a persisted project can appear before any test action runs) stays open — this PR does not close it.

This is a **release metadata / version synchronization** PR — `package.json`, `src-tauri/{Cargo.toml,Cargo.lock,tauri.conf.json}`, `public/sw.js`, `AGENTS.md` version strings, plus CHANGELOG/README release truth (release-candidate marker + badge, matching the v1.28.2/#524 precedent). No new functional application logic.

Two review findings on this PR: the README release badge (fixed — now advertises v1.28.3 with the matching `release-candidate` marker) and a CodeAnt finding on `public/sw.js`'s cache-generation/precache-failure interaction, which is the same risk class already tracked as its own issue (#525) since the v1.28.2 release-prep — acknowledged and left there, not folded into this release-prep PR.

## Test plan

- [x] `pnpm run ci:prepush` — local admission PASS
- [x] `node scripts/dependency-state.mjs reconcile` — lockfile in sync
- [x] `node scripts/sync-sw-version.mjs` / `sync-tauri-version.mjs` — propagated to `public/sw.js`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.lock`, `AGENTS.md`
- [x] `node scripts/sync-readme-metrics.mjs` — README metrics already in sync (this script does not own the release badge itself, which was fixed separately)
- [ ] CI green on this PR

## Release sequence after merge

1. Merge to `main`.
2. Re-bootstrap and fully verify post-merge `main` CI, including real GitHub Pages deploy evidence (not just the aggregator).
3. Only once confirmed green: create and push the signed `v1.28.3` tag on that exact `main` commit.
4. Verify every tag-triggered workflow with real job/asset evidence (Tauri desktop bundles, GitHub Release publication, `latest.json`, updater signatures, Docker/GHCR publish, tag-triggered CI/CodeQL).
5. Follow-up post-release truth-sync PR (mirroring #528): remove the `release-candidate` markers, record real release-gate evidence in `AUDIT.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the application to version 1.28.3.
  * Marked the 1.28.3 release candidate and date.
  * Refreshed the service worker cache version to support the new release.

* **Documentation**
  * Updated release markers and version references across the project documentation.
  * Expanded onboarding fix notes, including reload handling, startup scenarios, and persisted language coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->