### PR TITLE
fix(signing): isolate capability probe from ambient git state

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2925_keys-0EA5E9" alt="i18n 19 locales — 2925 keys">
-  <img src="https://img.shields.io/badge/Tests-7197%2B_%2F_589_files-22C55E" alt="7197+ tests / 589 files">
+  <img src="https://img.shields.io/badge/Tests-7205%2B_%2F_589_files-22C55E" alt="7205+ tests / 589 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2925 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7197+ tests / 589 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7205+ tests / 589 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7197+ tests, 589 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7205+ tests, 589 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -711,7 +711,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-27, source-synchronized; CI remains authoritative for pass/fail):**
-- **7197+ unit tests** across **589 test files** — CI is authoritative for pass/fail
+- **7205+ unit tests** across **589 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2925 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2925_keys-0EA5E9" alt="i18n 19 locales — 2925 keys">
-  <img src="https://img.shields.io/badge/Tests-7183%2B_%2F_589_files-22C55E" alt="7183+ tests / 589 files">
+  <img src="https://img.shields.io/badge/Tests-7197%2B_%2F_589_files-22C55E" alt="7197+ tests / 589 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2925 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7183+ tests / 589 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7197+ tests / 589 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7183+ tests, 589 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7197+ tests, 589 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -711,7 +711,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-27, source-synchronized; CI remains authoritative for pass/fail):**
-- **7183+ unit tests** across **589 test files** — CI is authoritative for pass/fail
+- **7197+ unit tests** across **589 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2925 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/scripts/signing/doctor.mjs
+++ b/scripts/signing/doctor.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import {
+  auditRepositoryPolicy,
   getIdentity,
   getSigningConfig,
   getUnsafeOverrides,
@@ -10,13 +11,31 @@ import {
 } from './signing-core.mjs';
 
 const jsonMode = process.argv.includes('--json');
+// REPOSITORY_POLICY_MODE (--hook, invoked by pre-commit.mjs): proves the effective signing
+// config matches WorldScript-Studio's persisted policy, unredefined by command-scope (`git -c`)
+// config. EFFECTIVE_INVOCATION_MODE (no --hook, plain `pnpm run signing:doctor`): diagnostic
+// only -- reports the actual effective config without treating any override as inherently
+// hostile, since a human running it interactively wants to see what would actually happen.
+const hookMode = process.argv.includes('--hook');
 const cwd = process.cwd();
 const signing = getSigningConfig(cwd);
 const identity = getIdentity(cwd);
 const unsafeOverrides = getUnsafeOverrides();
-const probe = runSigningProbe(cwd);
+const policyAudit = hookMode
+  ? auditRepositoryPolicy(cwd)
+  : { ok: true, reason: 'not audited (EFFECTIVE_INVOCATION_MODE)' };
+const fatalOverride = unsafeOverrides.length > 0 || !policyAudit.ok;
+
+// QNBS-v3: a fatal override must skip the probe entirely, not run it and discard the result.
+const probe = fatalOverride
+  ? {
+      ok: false,
+      reason: unsafeOverrides.length > 0 ? 'unsafe config override detected' : policyAudit.reason,
+    }
+  : runSigningProbe(cwd);
 const summary = {
   ...safeConfigSummary(cwd),
+  policyAudit: hookMode ? policyAudit : undefined,
   probe: { ok: probe.ok, reason: probe.reason ?? 'signed probe verified' },
 };
 
@@ -35,6 +54,11 @@ if (jsonMode) {
   console.log(
     `unsafe config overrides: ${unsafeOverrides.length ? unsafeOverrides.join(', ') : 'none detected'}`,
   );
+  if (hookMode) {
+    console.log(
+      `repository policy: ${policyAudit.ok ? 'matches persisted policy' : `mismatch — ${policyAudit.reason}`}`,
+    );
+  }
   console.log(`isolated signing probe: ${probe.ok ? 'passed' : `failed — ${probe.reason}`}`);
 }
 
@@ -43,6 +67,7 @@ const hookFailure =
   !signing.keyConfigured ||
   !identity.name ||
   !identity.email ||
-  unsafeOverrides.length > 0 ||
+  fatalOverride ||
   !probe.ok;
-process.exit(hookFailure ? 1 : 0);
+// QNBS-v3: process.exit() right after console.log can truncate output on POSIX pipes (git hooks are piped); exitCode lets stdout flush naturally.
+process.exitCode = hookFailure ? 1 : 0;

--- a/scripts/signing/doctor.mjs
+++ b/scripts/signing/doctor.mjs
@@ -11,11 +11,7 @@ import {
 } from './signing-core.mjs';
 
 const jsonMode = process.argv.includes('--json');
-// REPOSITORY_POLICY_MODE (--hook, invoked by pre-commit.mjs): proves the effective signing
-// config matches WorldScript-Studio's persisted policy, unredefined by command-scope (`git -c`)
-// config. EFFECTIVE_INVOCATION_MODE (no --hook, plain `pnpm run signing:doctor`): diagnostic
-// only -- reports the actual effective config without treating any override as inherently
-// hostile, since a human running it interactively wants to see what would actually happen.
+// QNBS-v3: --hook enforces fail-closed REPOSITORY_POLICY_MODE; without it, plain diagnostic mode never treats an override as fatal.
 const hookMode = process.argv.includes('--hook');
 const cwd = process.cwd();
 const signing = getSigningConfig(cwd);
@@ -24,7 +20,8 @@ const unsafeOverrides = getUnsafeOverrides();
 const policyAudit = hookMode
   ? auditRepositoryPolicy(cwd)
   : { ok: true, reason: 'not audited (EFFECTIVE_INVOCATION_MODE)' };
-const fatalOverride = unsafeOverrides.length > 0 || !policyAudit.ok;
+// QNBS-v3: gate both override classes on hookMode so plain `signing:doctor` never fails from override presence alone.
+const fatalOverride = hookMode && (unsafeOverrides.length > 0 || !policyAudit.ok);
 
 // QNBS-v3: a fatal override must skip the probe entirely, not run it and discard the result.
 const probe = fatalOverride

--- a/scripts/signing/signing-core.d.mts
+++ b/scripts/signing/signing-core.d.mts
@@ -28,9 +28,17 @@ export interface SigningConfig {
   config: Record<string, string>;
 }
 
+export type GitEnv = Record<string, string | undefined>;
+
 export interface GitOptions {
   cwd?: string;
   input?: string;
+  env?: GitEnv;
+}
+
+export interface RepositoryPolicyAudit {
+  ok: boolean;
+  reason: string;
 }
 
 export interface OutgoingReport {
@@ -51,9 +59,14 @@ export function isSha(value: unknown): boolean;
 export function isZeroSha(value: unknown): boolean;
 export function getRepositoryRoot(cwd?: string): string | null;
 export function getGitDirectory(cwd?: string): string | null;
+export const SIGNING_POLICY_KEYS: readonly string[];
 export function getConfig(cwd?: string): Record<string, string>;
 export function getIdentity(cwd?: string): { name: string; email: string };
-export function getUnsafeOverrides(env?: Record<string, string | undefined>): string[];
+export function getForeignRepoEnv(baseEnv?: GitEnv): GitEnv;
+export function getPolicyBaselineEnv(baseEnv?: GitEnv): GitEnv;
+export function foreignRepoGit(repo: string, args: string[], options?: GitOptions): GitResult;
+export function getUnsafeOverrides(env?: GitEnv): string[];
+export function auditRepositoryPolicy(cwd?: string, env?: GitEnv): RepositoryPolicyAudit;
 export function isSigningEnabled(config: Record<string, string>): boolean;
 
 export function classifyCommitObject(input: {
@@ -79,6 +92,7 @@ export function writePrePushEvidenceFile(
   file: string,
   input: string | string[] | RefUpdate[],
 ): void;
+
 import type { DependencyState } from '../dependency-state.d.mts';
 
 // QNBS-v3: diagnostic-only dimension, independent of evidenceState/pathEvidenceState validity.
@@ -116,7 +130,11 @@ export function resolvePushEvidence(
 ): PushEvidence;
 export function selectIntroducedCommits(commits: string[], reachableFromBase: string[]): string[];
 export function runSigningProbe(cwd?: string): { ok: boolean; reason?: string; commit?: string };
-export function verifyCommitObject(sha: string, cwd?: string): VerificationResult;
+export function verifyCommitObject(
+  sha: string,
+  cwd?: string,
+  dependencies?: { runGit?: (args: string[], options?: GitOptions) => GitResult },
+): VerificationResult;
 export function commitSubject(sha: string, cwd?: string): string;
 export function commitsInRange(range: string, cwd?: string): string[];
 export function verifyCommitRange(

--- a/scripts/signing/signing-core.mjs
+++ b/scripts/signing/signing-core.mjs
@@ -44,10 +44,7 @@ export function isZeroSha(value) {
   return ZERO_SHA.test(value);
 }
 
-// Git's own repository-selection variables (`git rev-parse --local-env-vars`, git 2.45.1).
-// Legitimate for ordinary calls against the real, current repo (git itself sets these for
-// hook subprocesses) -- but must never leak into an operation against a *different*,
-// disposable repository, since they override cwd-based repo discovery entirely.
+// QNBS-v3: git's own repo-selection vars (git rev-parse --local-env-vars, git 2.45.1); legitimate for the real repo, must never leak into a different disposable repository.
 const GIT_LOCAL_ENV_VARS = [
   'GIT_ALTERNATE_OBJECT_DIRECTORIES',
   'GIT_CONFIG',
@@ -66,9 +63,7 @@ const GIT_LOCAL_ENV_VARS = [
   'GIT_COMMON_DIR',
 ];
 
-// Coarse, wholesale config-source overrides: substitute or suppress an entire config layer.
-// None of these are what a normal `git -c key=value` invocation sets, so treating them as
-// always-unsafe carries negligible false-positive risk against real hook invocations.
+// QNBS-v3: wholesale config-source overrides a normal `git -c` never sets; safe to treat as always-unsafe in any mode.
 const GIT_COARSE_CONFIG_OVERRIDES = [
   'GIT_CONFIG',
   'GIT_CONFIG_SYSTEM',
@@ -94,9 +89,7 @@ function stripKeys(env, keys) {
   return copy;
 }
 
-// Foreign-repo (disposable probe) environment: strip everything that could redirect a git
-// invocation away from the probe repository, or inject arbitrary config into it, regardless
-// of whether the surrounding real-invocation context is itself considered safe.
+// QNBS-v3: strips everything that could redirect or config-inject the probe, independent of whether the real invocation is itself considered safe.
 export function getForeignRepoEnv(baseEnv = process.env) {
   return stripKeys(baseEnv, [
     ...GIT_LOCAL_ENV_VARS,
@@ -105,9 +98,7 @@ export function getForeignRepoEnv(baseEnv = process.env) {
   ]);
 }
 
-// Real-repo policy-baseline environment: strip ONLY command-scope config injection, keep
-// repository-routing vars (GIT_DIR etc.) intact so this still resolves the SAME repository --
-// used to compare "persisted policy" against "effective config" for REPOSITORY_POLICY_MODE.
+// QNBS-v3: strips only command-scope injection, keeping GIT_DIR etc. so this still resolves the same repo as the policy baseline.
 export function getPolicyBaselineEnv(baseEnv = process.env) {
   return stripKeys(baseEnv, [
     ...GIT_COARSE_CONFIG_OVERRIDES,
@@ -116,8 +107,7 @@ export function getPolicyBaselineEnv(baseEnv = process.env) {
   ]);
 }
 
-// Runs a git command against an explicitly-addressed, isolated repository: no ambient
-// environment variable can redirect it elsewhere, and `cwd`/`--git-dir` both name the target.
+// QNBS-v3: explicit -C/--git-dir addressing so no ambient env var can redirect this call elsewhere.
 export function foreignRepoGit(repo, args, options = {}) {
   return runGit(['-C', repo, '--git-dir', join(repo, '.git'), ...args], {
     ...options,
@@ -136,9 +126,7 @@ export function getGitDirectory(cwd = process.cwd()) {
   return gitDir ? resolve(cwd, gitDir) : null;
 }
 
-// Single source of truth for "which config keys make up WorldScript-Studio's signing/
-// verification policy" -- used both for normal config reporting (getConfig) and for the
-// REPOSITORY_POLICY_MODE persisted-vs-effective comparison (auditRepositoryPolicy) below.
+// QNBS-v3: single source of truth for signing/verification policy keys (getConfig, auditRepositoryPolicy); excludes gpg.ssh.defaultKeyCommand since it only applies when user.signingkey is unset, which the audited user.signingkey entry already catches.
 export const SIGNING_POLICY_KEYS = [
   'user.email',
   'user.name',
@@ -149,8 +137,20 @@ export const SIGNING_POLICY_KEYS = [
   'gpg.program',
   'gpg.ssh.program',
   'gpg.ssh.allowedSignersFile',
+  'gpg.ssh.revocationFile',
+  'gpg.minTrustLevel',
   'core.hooksPath',
 ];
+
+// QNBS-v3: canonicalize via git's own --type flag (git-config(1)) instead of ad-hoc string parsing, so e.g. "true" and "yes" compare equal.
+const SIGNING_POLICY_KEY_TYPES = {
+  'commit.gpgsign': 'bool',
+  'tag.gpgsign': 'bool',
+  'user.signingkey': 'path',
+  'gpg.ssh.allowedSignersFile': 'path',
+  'gpg.ssh.revocationFile': 'path',
+  'core.hooksPath': 'path',
+};
 
 export function getConfig(cwd = process.cwd()) {
   const values = Object.fromEntries(
@@ -168,18 +168,16 @@ export function isGitHubCompatibleEmail(email) {
   return /^\d+\+[^@\s]+@users\.noreply\.github\.com$/i.test(email);
 }
 
-// Coarse config-source overrides only -- unconditionally unsafe regardless of invocation mode,
-// since none of these are what a legitimate `git -c key=value` sets (see GIT_COARSE_CONFIG_
-// OVERRIDES above). Surgical, `-c`-style overrides (GIT_CONFIG_COUNT/PARAMETERS/KEY_n/VALUE_n)
-// are deliberately NOT reported here -- their mere presence must never be fatal; see
-// auditRepositoryPolicy() for the narrower, context-aware check that actually governs those.
+// QNBS-v3: only coarse overrides are reported here (unconditionally unsafe); surgical -c-style overrides are never fatal by mere presence -- see auditRepositoryPolicy().
 export function getUnsafeOverrides(env = process.env) {
   return GIT_COARSE_CONFIG_OVERRIDES.filter((name) => env[name] !== undefined);
 }
 
-// QNBS-v3: distinguishes "key genuinely unset" (status 1, silent) from "config source unreadable" (any other failure).
+// QNBS-v3: canonicalizes typed keys via git's own --type flag rather than raw strings, so "true"/"yes" or `~`-relative paths compare equal (see SIGNING_POLICY_KEY_TYPES).
 function readConfigValue(key, cwd, env) {
-  const result = runGit(['config', '--get', key], { cwd, env });
+  const type = SIGNING_POLICY_KEY_TYPES[key];
+  const args = type ? ['config', `--type=${type}`, '--get', key] : ['config', '--get', key];
+  const result = runGit(args, { cwd, env });
   if (result.status === 0) return { ok: true, value: result.stdout.trim() };
   if (result.status === 1 && !result.error && !result.stderr) return { ok: true, value: '' };
   return { ok: false, value: '' };
@@ -199,13 +197,7 @@ function commandScopeConfigIsWellFormed(env) {
   return numbered.length === count * 2;
 }
 
-// REPOSITORY_POLICY_MODE: proves the *effective* signing configuration (what git will actually
-// use for this invocation, command-scope overlays included) matches WorldScript-Studio's
-// *persistent* policy (the same repo, read with command-scope config injection stripped) --
-// i.e. that a `git -c ...` override has not semantically redefined it. A well-formed override
-// that happens to set the same value as the persisted policy is not fatal; only an actual
-// mismatch, or malformed command-scope config that makes the comparison itself unreliable, is.
-// Never logs values -- only key names and match/mismatch, mirroring getUnsafeOverrides().
+// QNBS-v3: REPOSITORY_POLICY_MODE -- fails only on an actual persisted-vs-effective mismatch or malformed command-scope config, never on override presence alone; never logs values.
 export function auditRepositoryPolicy(cwd = process.cwd(), env = process.env) {
   if (!commandScopeConfigIsWellFormed(env)) {
     return { ok: false, reason: 'command-scope configuration is malformed' };

--- a/scripts/signing/signing-core.mjs
+++ b/scripts/signing/signing-core.mjs
@@ -8,12 +8,12 @@ const SHA = /^[0-9a-f]{40}$/i;
 const ZERO_SHA = /^0{40}$/;
 const EMPTY_TREE = '4b825dc642cb6eb9a060e54bf8d69288fbee4904';
 
-export function runGit(args, { cwd = process.cwd(), input = '' } = {}) {
+export function runGit(args, { cwd = process.cwd(), input = '', env } = {}) {
   const result = spawnSync('git', args, {
     cwd,
     encoding: 'utf8',
     env: {
-      ...process.env,
+      ...(env ?? process.env),
       GIT_TERMINAL_PROMPT: '0',
       SSH_ASKPASS: '/bin/false',
       SSH_ASKPASS_REQUIRE: 'force',
@@ -44,6 +44,88 @@ export function isZeroSha(value) {
   return ZERO_SHA.test(value);
 }
 
+// Git's own repository-selection variables (`git rev-parse --local-env-vars`, git 2.45.1).
+// Legitimate for ordinary calls against the real, current repo (git itself sets these for
+// hook subprocesses) -- but must never leak into an operation against a *different*,
+// disposable repository, since they override cwd-based repo discovery entirely.
+const GIT_LOCAL_ENV_VARS = [
+  'GIT_ALTERNATE_OBJECT_DIRECTORIES',
+  'GIT_CONFIG',
+  'GIT_CONFIG_PARAMETERS',
+  'GIT_CONFIG_COUNT',
+  'GIT_OBJECT_DIRECTORY',
+  'GIT_DIR',
+  'GIT_WORK_TREE',
+  'GIT_IMPLICIT_WORK_TREE',
+  'GIT_GRAFT_FILE',
+  'GIT_INDEX_FILE',
+  'GIT_NO_REPLACE_OBJECTS',
+  'GIT_REPLACE_REF_BASE',
+  'GIT_PREFIX',
+  'GIT_SHALLOW_FILE',
+  'GIT_COMMON_DIR',
+];
+
+// Coarse, wholesale config-source overrides: substitute or suppress an entire config layer.
+// None of these are what a normal `git -c key=value` invocation sets, so treating them as
+// always-unsafe carries negligible false-positive risk against real hook invocations.
+const GIT_COARSE_CONFIG_OVERRIDES = [
+  'GIT_CONFIG',
+  'GIT_CONFIG_SYSTEM',
+  'GIT_CONFIG_GLOBAL',
+  'GIT_CONFIG_NOSYSTEM',
+];
+
+// QNBS-v3: the carrier pair for `-c`-style overrides; stripping only the numbered KEY_n/VALUE_n entries would leave a stale COUNT that git itself treats as malformed.
+const GIT_COMMAND_SCOPE_CARRIERS = ['GIT_CONFIG_COUNT', 'GIT_CONFIG_PARAMETERS'];
+
+// QNBS-v3: detect every GIT_CONFIG_KEY_n/VALUE_n pair present, independent of a possibly-wrong GIT_CONFIG_COUNT.
+function numberedConfigOverrideKeys(env) {
+  const names = new Set();
+  for (const name of Object.keys(env)) {
+    if (/^GIT_CONFIG_(?:KEY|VALUE)_\d+$/.test(name)) names.add(name);
+  }
+  return [...names];
+}
+
+function stripKeys(env, keys) {
+  const copy = { ...env };
+  for (const key of keys) delete copy[key];
+  return copy;
+}
+
+// Foreign-repo (disposable probe) environment: strip everything that could redirect a git
+// invocation away from the probe repository, or inject arbitrary config into it, regardless
+// of whether the surrounding real-invocation context is itself considered safe.
+export function getForeignRepoEnv(baseEnv = process.env) {
+  return stripKeys(baseEnv, [
+    ...GIT_LOCAL_ENV_VARS,
+    ...GIT_COARSE_CONFIG_OVERRIDES,
+    ...numberedConfigOverrideKeys(baseEnv),
+  ]);
+}
+
+// Real-repo policy-baseline environment: strip ONLY command-scope config injection, keep
+// repository-routing vars (GIT_DIR etc.) intact so this still resolves the SAME repository --
+// used to compare "persisted policy" against "effective config" for REPOSITORY_POLICY_MODE.
+export function getPolicyBaselineEnv(baseEnv = process.env) {
+  return stripKeys(baseEnv, [
+    ...GIT_COARSE_CONFIG_OVERRIDES,
+    ...GIT_COMMAND_SCOPE_CARRIERS,
+    ...numberedConfigOverrideKeys(baseEnv),
+  ]);
+}
+
+// Runs a git command against an explicitly-addressed, isolated repository: no ambient
+// environment variable can redirect it elsewhere, and `cwd`/`--git-dir` both name the target.
+export function foreignRepoGit(repo, args, options = {}) {
+  return runGit(['-C', repo, '--git-dir', join(repo, '.git'), ...args], {
+    ...options,
+    cwd: repo,
+    env: getForeignRepoEnv(),
+  });
+}
+
 export function getRepositoryRoot(cwd = process.cwd()) {
   const root = gitOutput(['rev-parse', '--show-toplevel'], { cwd });
   return root ? resolve(root) : null;
@@ -54,19 +136,25 @@ export function getGitDirectory(cwd = process.cwd()) {
   return gitDir ? resolve(cwd, gitDir) : null;
 }
 
+// Single source of truth for "which config keys make up WorldScript-Studio's signing/
+// verification policy" -- used both for normal config reporting (getConfig) and for the
+// REPOSITORY_POLICY_MODE persisted-vs-effective comparison (auditRepositoryPolicy) below.
+export const SIGNING_POLICY_KEYS = [
+  'user.email',
+  'user.name',
+  'user.signingkey',
+  'commit.gpgsign',
+  'tag.gpgsign',
+  'gpg.format',
+  'gpg.program',
+  'gpg.ssh.program',
+  'gpg.ssh.allowedSignersFile',
+  'core.hooksPath',
+];
+
 export function getConfig(cwd = process.cwd()) {
-  const keys = [
-    'user.email',
-    'user.name',
-    'user.signingkey',
-    'commit.gpgsign',
-    'gpg.format',
-    'gpg.program',
-    'gpg.ssh.allowedSignersFile',
-    'core.hooksPath',
-  ];
   const values = Object.fromEntries(
-    keys.map((key) => [key, gitOutput(['config', '--get', key], { cwd })]),
+    SIGNING_POLICY_KEYS.map((key) => [key, gitOutput(['config', '--get', key], { cwd })]),
   );
   return values;
 }
@@ -80,15 +168,60 @@ export function isGitHubCompatibleEmail(email) {
   return /^\d+\+[^@\s]+@users\.noreply\.github\.com$/i.test(email);
 }
 
+// Coarse config-source overrides only -- unconditionally unsafe regardless of invocation mode,
+// since none of these are what a legitimate `git -c key=value` sets (see GIT_COARSE_CONFIG_
+// OVERRIDES above). Surgical, `-c`-style overrides (GIT_CONFIG_COUNT/PARAMETERS/KEY_n/VALUE_n)
+// are deliberately NOT reported here -- their mere presence must never be fatal; see
+// auditRepositoryPolicy() for the narrower, context-aware check that actually governs those.
 export function getUnsafeOverrides(env = process.env) {
-  const names = [
-    'GIT_CONFIG_NOSYSTEM',
-    'GIT_CONFIG_SYSTEM',
-    'GIT_CONFIG_GLOBAL',
-    'GIT_CONFIG_COUNT',
-    'GIT_CONFIG_PARAMETERS',
-  ];
-  return names.filter((name) => env[name] !== undefined).map((name) => name);
+  return GIT_COARSE_CONFIG_OVERRIDES.filter((name) => env[name] !== undefined);
+}
+
+// QNBS-v3: distinguishes "key genuinely unset" (status 1, silent) from "config source unreadable" (any other failure).
+function readConfigValue(key, cwd, env) {
+  const result = runGit(['config', '--get', key], { cwd, env });
+  if (result.status === 0) return { ok: true, value: result.stdout.trim() };
+  if (result.status === 1 && !result.error && !result.stderr) return { ok: true, value: '' };
+  return { ok: false, value: '' };
+}
+
+// QNBS-v3: a wrong/missing GIT_CONFIG_COUNT or a stray numbered pair makes the override unverifiable, not merely absent.
+function commandScopeConfigIsWellFormed(env) {
+  const countRaw = env.GIT_CONFIG_COUNT;
+  const numbered = numberedConfigOverrideKeys(env);
+  if (countRaw === undefined) return numbered.length === 0;
+  const count = Number.parseInt(countRaw, 10);
+  if (!Number.isInteger(count) || count < 0 || String(count) !== countRaw) return false;
+  for (let i = 0; i < count; i += 1) {
+    if (env[`GIT_CONFIG_KEY_${i}`] === undefined || env[`GIT_CONFIG_VALUE_${i}`] === undefined)
+      return false;
+  }
+  return numbered.length === count * 2;
+}
+
+// REPOSITORY_POLICY_MODE: proves the *effective* signing configuration (what git will actually
+// use for this invocation, command-scope overlays included) matches WorldScript-Studio's
+// *persistent* policy (the same repo, read with command-scope config injection stripped) --
+// i.e. that a `git -c ...` override has not semantically redefined it. A well-formed override
+// that happens to set the same value as the persisted policy is not fatal; only an actual
+// mismatch, or malformed command-scope config that makes the comparison itself unreliable, is.
+// Never logs values -- only key names and match/mismatch, mirroring getUnsafeOverrides().
+export function auditRepositoryPolicy(cwd = process.cwd(), env = process.env) {
+  if (!commandScopeConfigIsWellFormed(env)) {
+    return { ok: false, reason: 'command-scope configuration is malformed' };
+  }
+  const baselineEnv = getPolicyBaselineEnv(env);
+  for (const key of SIGNING_POLICY_KEYS) {
+    const effective = readConfigValue(key, cwd, env);
+    const persistent = readConfigValue(key, cwd, baselineEnv);
+    if (!effective.ok || !persistent.ok) {
+      return { ok: false, reason: `policy source for ${key} could not be resolved` };
+    }
+    if (effective.value !== persistent.value) {
+      return { ok: false, reason: `command-scope override redefines persisted policy for ${key}` };
+    }
+  }
+  return { ok: true, reason: 'effective configuration matches persisted policy' };
 }
 
 export function isSigningEnabled(config) {
@@ -126,7 +259,8 @@ function configureProbeRepository(repo, signing, identity) {
   if (signing.allowedSignersFile)
     settings.push(['gpg.ssh.allowedSignersFile', signing.allowedSignersFile]);
   for (const [key, value] of settings) {
-    const result = runGit(['config', key, value], { cwd: repo });
+    // QNBS-v3: --local plus explicit repo addressing keeps every probe config write inside the disposable repo.
+    const result = foreignRepoGit(repo, ['config', '--local', key, value]);
     if (result.status !== 0) return false;
   }
   return true;
@@ -156,16 +290,20 @@ export function runSigningProbe(cwd = process.cwd()) {
     probe = mkdtempSync(join(cwd, '.worldscript-signing-probe-'));
   }
   try {
-    let result = runGit(['init', '--quiet', '--initial-branch=main', probe]);
+    // QNBS-v3: init's target is positional/explicit; the foreign-repo env still guards against a leaked GIT_DIR redirecting it.
+    let result = runGit(['init', '--quiet', '--initial-branch=main', probe], {
+      env: getForeignRepoEnv(),
+    });
     if (result.status !== 0 || !configureProbeRepository(probe, signing, identity)) {
       return { ok: false, reason: 'isolated probe repository could not be configured' };
     }
-    result = runGit(
-      ['commit-tree', '-S', '-m', 'WorldScript signing capability probe', EMPTY_TREE],
-      {
-        cwd: probe,
-      },
-    );
+    result = foreignRepoGit(probe, [
+      'commit-tree',
+      '-S',
+      '-m',
+      'WorldScript signing capability probe',
+      EMPTY_TREE,
+    ]);
     if (result.status !== 0 || !isSha(result.stdout.trim())) {
       return {
         ok: false,
@@ -173,7 +311,9 @@ export function runSigningProbe(cwd = process.cwd()) {
       };
     }
     const commit = result.stdout.trim();
-    const verification = verifyCommitObject(commit, probe);
+    const verification = verifyCommitObject(commit, probe, {
+      runGit: (args, options) => foreignRepoGit(probe, args, options),
+    });
     return verification.ok
       ? { ok: true, commit }
       : { ok: false, reason: `Git-native verification failed: ${verification.reason}` };
@@ -194,11 +334,12 @@ export function classifyCommitObject({ objectType, contents, verificationStatus 
   return { ok: true, reason: 'Git-native signature verified' };
 }
 
-export function verifyCommitObject(sha, cwd = process.cwd()) {
+export function verifyCommitObject(sha, cwd = process.cwd(), dependencies = {}) {
+  const runGitFn = dependencies.runGit ?? runGit;
   if (!isSha(sha)) return { ok: false, reason: 'invalid commit SHA' };
-  const object = runGit(['cat-file', '-t', sha], { cwd });
-  const contents = runGit(['cat-file', '-p', sha], { cwd });
-  const verified = runGit(['verify-commit', '--raw', sha], { cwd });
+  const object = runGitFn(['cat-file', '-t', sha], { cwd });
+  const contents = runGitFn(['cat-file', '-p', sha], { cwd });
+  const verified = runGitFn(['verify-commit', '--raw', sha], { cwd });
   return classifyCommitObject({
     objectType: object.status === 0 ? object.stdout.trim() : '',
     contents: contents.status === 0 ? contents.stdout : '',

--- a/tests/unit/signing.test.ts
+++ b/tests/unit/signing.test.ts
@@ -1,7 +1,15 @@
 import { execFileSync, spawn, spawnSync } from 'node:child_process';
-import { mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { basename, join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import {
@@ -9,6 +17,7 @@ import {
   classifyCommitObject,
   classifyTagVerification,
   computeWorkingTreeState,
+  getForeignRepoEnv,
   getSigningConfig,
   hasCommitSignature,
   isGitHubCompatibleEmail,
@@ -812,14 +821,17 @@ describe('signing probe isolation (foreign-repo environment leak hardening)', ()
     return dir;
   }
 
+  // QNBS-v3: fixture setup/snapshot commands must not themselves be redirectable by an ambient hostile env.
   function gitConfigLocal(dir: string, key: string, value: string) {
-    execFileSync('git', ['-C', dir, 'config', '--local', key, value]);
+    execFileSync('git', ['-C', dir, 'config', '--local', key, value], { env: getForeignRepoEnv() });
   }
 
   // QNBS-v3: real SSH-format signing/verification, matching this repo's own gpg.format=ssh setup.
   function createSigningFixture(): { dir: string; email: string } {
     const dir = scratchDir('worldscript-signing-fixture-');
-    execFileSync('git', ['init', '--quiet', '--initial-branch=main', dir]);
+    execFileSync('git', ['init', '--quiet', '--initial-branch=main', dir], {
+      env: getForeignRepoEnv(),
+    });
     const email = 'fixture@users.noreply.github.com';
     const keyPath = join(dir, 'id_ed25519');
     execFileSync('ssh-keygen', ['-q', '-t', 'ed25519', '-N', '', '-f', keyPath, '-C', email]);
@@ -835,8 +847,10 @@ describe('signing probe isolation (foreign-repo environment leak hardening)', ()
     gitConfigLocal(dir, 'gpg.ssh.allowedSignersFile', allowedSignersFile);
     // QNBS-v3: an empty repo has no refs at all, which makes `git show-ref` exit non-zero -- give it real history.
     writeFileSync(join(dir, 'README.md'), 'fixture\n');
-    execFileSync('git', ['-C', dir, 'add', 'README.md']);
-    execFileSync('git', ['-C', dir, 'commit', '--quiet', '-m', 'initial commit']);
+    execFileSync('git', ['-C', dir, 'add', 'README.md'], { env: getForeignRepoEnv() });
+    execFileSync('git', ['-C', dir, 'commit', '--quiet', '-m', 'initial commit'], {
+      env: getForeignRepoEnv(),
+    });
     return { dir, email };
   }
 
@@ -844,12 +858,22 @@ describe('signing probe isolation (foreign-repo environment leak hardening)', ()
     return {
       config: readFileSync(join(dir, '.git', 'config'), 'utf8'),
       head: readFileSync(join(dir, '.git', 'HEAD'), 'utf8'),
-      refs: execFileSync('git', ['-C', dir, 'show-ref'], { encoding: 'utf8' }),
+      refs: execFileSync('git', ['-C', dir, 'show-ref'], {
+        encoding: 'utf8',
+        env: getForeignRepoEnv(),
+      }),
     };
   }
 
+  // QNBS-v3: sorted, before/after-diffed rather than order- or concurrency-dependent full equality.
   function probeTempDirs(): string[] {
-    return readdirSync(tmpdir()).filter((name) => name.startsWith('worldscript-signing-probe-'));
+    return readdirSync(tmpdir())
+      .filter((name) => name.startsWith('worldscript-signing-probe-'))
+      .sort();
+  }
+
+  function newProbeTempDirsSince(before: string[]): string[] {
+    return probeTempDirs().filter((name) => !before.includes(name));
   }
 
   afterEach(() => {
@@ -873,6 +897,7 @@ describe('signing probe isolation (foreign-repo environment leak hardening)', ()
           expect(() =>
             execFileSync('git', ['-C', dir, 'cat-file', '-e', result.commit as string], {
               stdio: 'ignore',
+              env: getForeignRepoEnv(),
             }),
           ).toThrow();
         } finally {
@@ -889,7 +914,7 @@ describe('signing probe isolation (foreign-repo environment leak hardening)', ()
     const before = probeTempDirs();
     const result = runSigningProbe(dir);
     expect(result.ok).toBe(true);
-    expect(probeTempDirs()).toEqual(before);
+    expect(newProbeTempDirsSince(before)).toEqual([]);
   });
 
   it('cleans up the disposable probe directory even when a probe step fails mid-way', () => {
@@ -899,7 +924,19 @@ describe('signing probe isolation (foreign-repo environment leak hardening)', ()
     const before = probeTempDirs();
     const result = runSigningProbe(dir);
     expect(result.ok).toBe(false);
-    expect(probeTempDirs()).toEqual(before);
+    expect(newProbeTempDirsSince(before)).toEqual([]);
+  });
+
+  // QNBS-v3: regression for the CodeRabbit finding -- an unrelated same-prefixed directory must not defeat the cleanup assertion.
+  it('cleanup assertion ignores an unrelated pre-existing probe-prefixed directory', () => {
+    const { dir } = createSigningFixture();
+    const decoy = scratchDir('worldscript-signing-probe-decoy-');
+    const before = probeTempDirs();
+    expect(before).toContain(basename(decoy));
+    const result = runSigningProbe(dir);
+    expect(result.ok).toBe(true);
+    expect(newProbeTempDirsSince(before)).toEqual([]);
+    expect(existsSync(decoy)).toBe(true);
   });
 
   it('runs two probes concurrently in separate OS processes without interference', async () => {
@@ -967,7 +1004,8 @@ describe('signing probe isolation (foreign-repo environment leak hardening)', ()
       fileCounter += 1;
       const file = join(fixture.dir, `file-${fileCounter}.txt`);
       writeFileSync(file, `content-${fileCounter}`);
-      execFileSync('git', ['-C', fixture.dir, 'add', file]);
+      // QNBS-v3: setup is sanitized, but the commit itself deliberately keeps the ambient/-c env under test.
+      execFileSync('git', ['-C', fixture.dir, 'add', file], { env: getForeignRepoEnv() });
       return spawnSync(
         'git',
         ['-C', fixture.dir, ...extraGitArgs, 'commit', '-m', `test commit ${fileCounter}`],
@@ -999,6 +1037,18 @@ describe('signing probe isolation (foreign-repo environment leak hardening)', ()
       );
       expect(result.stderr).toMatch(
         /isolated signing probe: failed — command-scope override redefines persisted policy for commit\.gpgsign/,
+      );
+    });
+
+    // QNBS-v3: regression for the Codex P1 finding -- a verification-affecting key outside the old 4-key list must also fail closed.
+    it('fails closed on a -c override to gpg.ssh.revocationFile, a verification-affecting key', () => {
+      const result = attemptCommit([
+        '-c',
+        `gpg.ssh.revocationFile=${join(fixture.dir, 'revoked')}`,
+      ]);
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toMatch(
+        /repository policy: mismatch — command-scope override redefines persisted policy for gpg\.ssh\.revocationFile/,
       );
     });
   });
@@ -1054,6 +1104,119 @@ describe('signing probe isolation (foreign-repo environment leak hardening)', ()
         ok: false,
         reason: 'command-scope configuration is malformed',
       });
+    });
+
+    // QNBS-v3: regression for the Codex P2 finding -- git-boolean-equivalent overrides of a persisted "true" must not be treated as raw-string mismatches.
+    it.each(['yes', 'on', '1', 'True', 'YES'])(
+      'is not fatal for a git-boolean-true-equivalent override (%s) against a persisted true',
+      (equivalent) => {
+        const env = {
+          ...process.env,
+          GIT_CONFIG_COUNT: '1',
+          GIT_CONFIG_KEY_0: 'commit.gpgsign',
+          GIT_CONFIG_VALUE_0: equivalent,
+        };
+        expect(auditRepositoryPolicy(fixture.dir, env)).toMatchObject({ ok: true });
+      },
+    );
+
+    // QNBS-v3: git-boolean-false-equivalent overrides of a persisted "false" must likewise not be treated as raw-string mismatches.
+    it.each(['no', 'off', '0', 'False'])(
+      'is not fatal for a git-boolean-false-equivalent override (%s) against a persisted false',
+      (equivalent) => {
+        gitConfigLocal(fixture.dir, 'commit.gpgsign', 'false');
+        const env = {
+          ...process.env,
+          GIT_CONFIG_COUNT: '1',
+          GIT_CONFIG_KEY_0: 'commit.gpgsign',
+          GIT_CONFIG_VALUE_0: equivalent,
+        };
+        expect(auditRepositoryPolicy(fixture.dir, env)).toMatchObject({ ok: true });
+      },
+    );
+
+    it('still fails when a boolean override genuinely flips the persisted value', () => {
+      const env = {
+        ...process.env,
+        GIT_CONFIG_COUNT: '1',
+        GIT_CONFIG_KEY_0: 'commit.gpgsign',
+        GIT_CONFIG_VALUE_0: 'no',
+      };
+      expect(auditRepositoryPolicy(fixture.dir, env)).toMatchObject({
+        ok: false,
+        reason: 'command-scope override redefines persisted policy for commit.gpgsign',
+      });
+    });
+
+    // QNBS-v3: a ~-relative override resolving to the same file as the persisted absolute path must not be a mismatch.
+    it('is not fatal for a semantically equivalent (~-relative) path override', () => {
+      const env = {
+        ...process.env,
+        HOME: fixture.dir,
+        GIT_CONFIG_COUNT: '1',
+        GIT_CONFIG_KEY_0: 'user.signingkey',
+        GIT_CONFIG_VALUE_0: '~/id_ed25519',
+      };
+      expect(auditRepositoryPolicy(fixture.dir, env)).toMatchObject({ ok: true });
+    });
+
+    it('still fails when a path override genuinely points elsewhere', () => {
+      const env = {
+        ...process.env,
+        GIT_CONFIG_COUNT: '1',
+        GIT_CONFIG_KEY_0: 'user.signingkey',
+        GIT_CONFIG_VALUE_0: join(fixture.dir, 'a-different-key'),
+      };
+      expect(auditRepositoryPolicy(fixture.dir, env)).toMatchObject({
+        ok: false,
+        reason: 'command-scope override redefines persisted policy for user.signingkey',
+      });
+    });
+  });
+
+  describe('doctor.mjs mode contract (--hook vs. plain EFFECTIVE_INVOCATION_MODE)', () => {
+    // QNBS-v3: regression for the CodeAnt finding -- a coarse override must not turn the plain diagnostic mode fatal.
+    it('does not fail plain `signing:doctor` (no --hook) merely because a coarse override is present', () => {
+      const { dir } = createSigningFixture();
+      const result = spawnSync(process.execPath, [doctorPath], {
+        cwd: dir,
+        env: { ...process.env, GIT_CONFIG_NOSYSTEM: '1' },
+        encoding: 'utf8',
+      });
+      expect(result.status).toBe(0);
+      expect(result.stdout).toMatch(/isolated signing probe: passed/);
+    });
+
+    it('still fails `signing:doctor --hook` when the same coarse override is present', () => {
+      const { dir } = createSigningFixture();
+      const result = spawnSync(process.execPath, [doctorPath, '--hook'], {
+        cwd: dir,
+        env: { ...process.env, GIT_CONFIG_NOSYSTEM: '1' },
+        encoding: 'utf8',
+      });
+      expect(result.status).not.toBe(0);
+      expect(result.stdout).toMatch(
+        /isolated signing probe: failed — unsafe config override detected/,
+      );
+    });
+  });
+
+  describe('fixture helper isolation (CodeRabbit finding)', () => {
+    // QNBS-v3: the fixture helpers that stand in for "the real repo" must not themselves be redirectable by an ambient hostile env.
+    it('creates the fixture at its real path even under an inherited GIT_DIR pointing elsewhere', () => {
+      const decoy = scratchDir('worldscript-signing-decoy-');
+      const gitDirVar = 'GIT_DIR';
+      const original = process.env[gitDirVar];
+      process.env[gitDirVar] = join(decoy, '.git');
+      let fixture: { dir: string; email: string };
+      try {
+        fixture = createSigningFixture();
+      } finally {
+        if (original === undefined) delete process.env[gitDirVar];
+        else process.env[gitDirVar] = original;
+      }
+      expect(readFileSync(join(fixture.dir, '.git', 'config'), 'utf8')).toContain(fixture.email);
+      expect(existsSync(join(decoy, '.git'))).toBe(false);
     });
   });
 });

--- a/tests/unit/signing.test.ts
+++ b/tests/unit/signing.test.ts
@@ -1,8 +1,11 @@
-import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { execFileSync, spawn, spawnSync } from 'node:child_process';
+import { mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import {
+  auditRepositoryPolicy,
   classifyCommitObject,
   classifyTagVerification,
   computeWorkingTreeState,
@@ -17,6 +20,7 @@ import {
   pushEventRange,
   readPrePushEvidenceFile,
   resolvePushEvidence,
+  runSigningProbe,
   selectIntroducedCommits,
   serializePrePushEvidence,
   verifyOutgoingUpdates,
@@ -794,5 +798,262 @@ describe('GitHub signature API controls', () => {
     });
     expect(lightweight.ok).toBe(false);
     expect(lightweight.reason).toContain('not an annotated tag object');
+  });
+});
+
+// QNBS-v3: real disposable git fixtures, not mocks -- the defect class is about real git subprocess env/resolution behavior.
+describe('signing probe isolation (foreign-repo environment leak hardening)', () => {
+  const doctorPath = resolve(process.cwd(), 'scripts/signing/doctor.mjs');
+  const scratchDirs: string[] = [];
+
+  function scratchDir(prefix: string): string {
+    const dir = mkdtempSync(join(tmpdir(), prefix));
+    scratchDirs.push(dir);
+    return dir;
+  }
+
+  function gitConfigLocal(dir: string, key: string, value: string) {
+    execFileSync('git', ['-C', dir, 'config', '--local', key, value]);
+  }
+
+  // QNBS-v3: real SSH-format signing/verification, matching this repo's own gpg.format=ssh setup.
+  function createSigningFixture(): { dir: string; email: string } {
+    const dir = scratchDir('worldscript-signing-fixture-');
+    execFileSync('git', ['init', '--quiet', '--initial-branch=main', dir]);
+    const email = 'fixture@users.noreply.github.com';
+    const keyPath = join(dir, 'id_ed25519');
+    execFileSync('ssh-keygen', ['-q', '-t', 'ed25519', '-N', '', '-f', keyPath, '-C', email]);
+    const publicKey = readFileSync(`${keyPath}.pub`, 'utf8').trim();
+    const allowedSignersFile = join(dir, 'allowed_signers');
+    writeFileSync(allowedSignersFile, `${email} ${publicKey}\n`);
+    gitConfigLocal(dir, 'user.name', 'Fixture User');
+    gitConfigLocal(dir, 'user.email', email);
+    gitConfigLocal(dir, 'commit.gpgsign', 'true');
+    gitConfigLocal(dir, 'tag.gpgsign', 'true');
+    gitConfigLocal(dir, 'gpg.format', 'ssh');
+    gitConfigLocal(dir, 'user.signingkey', keyPath);
+    gitConfigLocal(dir, 'gpg.ssh.allowedSignersFile', allowedSignersFile);
+    // QNBS-v3: an empty repo has no refs at all, which makes `git show-ref` exit non-zero -- give it real history.
+    writeFileSync(join(dir, 'README.md'), 'fixture\n');
+    execFileSync('git', ['-C', dir, 'add', 'README.md']);
+    execFileSync('git', ['-C', dir, 'commit', '--quiet', '-m', 'initial commit']);
+    return { dir, email };
+  }
+
+  function snapshotRepo(dir: string) {
+    return {
+      config: readFileSync(join(dir, '.git', 'config'), 'utf8'),
+      head: readFileSync(join(dir, '.git', 'HEAD'), 'utf8'),
+      refs: execFileSync('git', ['-C', dir, 'show-ref'], { encoding: 'utf8' }),
+    };
+  }
+
+  function probeTempDirs(): string[] {
+    return readdirSync(tmpdir()).filter((name) => name.startsWith('worldscript-signing-probe-'));
+  }
+
+  afterEach(() => {
+    for (const dir of scratchDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  describe('foreign-repo env leak vectors (probe stays isolated under a hostile ambient env)', () => {
+    const hostileVars = ['GIT_DIR', 'GIT_WORK_TREE', 'GIT_COMMON_DIR', 'GIT_INDEX_FILE'] as const;
+
+    for (const varName of hostileVars) {
+      it(`does not let an inherited ${varName} redirect the probe into the real repo`, () => {
+        const { dir } = createSigningFixture();
+        const before = snapshotRepo(dir);
+        const original = process.env[varName];
+        process.env[varName] =
+          varName === 'GIT_INDEX_FILE' ? join(dir, '.git', 'index') : join(dir, '.git');
+        try {
+          const result = runSigningProbe(dir);
+          expect(result.ok).toBe(true);
+          // QNBS-v3: proves the commit object never touched the fixture's own object database.
+          expect(() =>
+            execFileSync('git', ['-C', dir, 'cat-file', '-e', result.commit as string], {
+              stdio: 'ignore',
+            }),
+          ).toThrow();
+        } finally {
+          if (original === undefined) delete process.env[varName];
+          else process.env[varName] = original;
+        }
+        expect(snapshotRepo(dir)).toEqual(before);
+      });
+    }
+  });
+
+  it('cleans up the disposable probe directory on success', () => {
+    const { dir } = createSigningFixture();
+    const before = probeTempDirs();
+    const result = runSigningProbe(dir);
+    expect(result.ok).toBe(true);
+    expect(probeTempDirs()).toEqual(before);
+  });
+
+  it('cleans up the disposable probe directory even when a probe step fails mid-way', () => {
+    const { dir } = createSigningFixture();
+    // QNBS-v3: an unusable signing key lets config succeed but makes the later commit-tree -S step genuinely fail.
+    gitConfigLocal(dir, 'user.signingkey', join(dir, 'no-such-key'));
+    const before = probeTempDirs();
+    const result = runSigningProbe(dir);
+    expect(result.ok).toBe(false);
+    expect(probeTempDirs()).toEqual(before);
+  });
+
+  it('runs two probes concurrently in separate OS processes without interference', async () => {
+    const { dir } = createSigningFixture();
+    const before = snapshotRepo(dir);
+    const runInChildProcess = (): Promise<{ ok: boolean; commit?: string; reason?: string }> =>
+      new Promise((resolvePromise, reject) => {
+        const moduleUrl = pathToFileURL(
+          resolve(process.cwd(), 'scripts/signing/signing-core.mjs'),
+        ).href;
+        const child = spawn(
+          process.execPath,
+          [
+            '-e',
+            `import(${JSON.stringify(moduleUrl)}).then(m => { process.stdout.write(JSON.stringify(m.runSigningProbe(${JSON.stringify(dir)}))); });`,
+          ],
+          { stdio: ['ignore', 'pipe', 'pipe'] },
+        );
+        let stdout = '';
+        child.stdout.on('data', (chunk) => {
+          stdout += chunk;
+        });
+        child.on('error', reject);
+        child.on('close', () => {
+          try {
+            resolvePromise(JSON.parse(stdout));
+          } catch (error) {
+            reject(error);
+          }
+        });
+      });
+    const [first, second] = await Promise.all([runInChildProcess(), runInChildProcess()]);
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(true);
+    // QNBS-v3: isolation means neither corrupted the outer repo, not that deterministic ed25519 signatures must differ.
+    expect(snapshotRepo(dir)).toEqual(before);
+  });
+
+  it('regresses none of the pre-existing signing.test.ts assertions', () => {
+    // QNBS-v3: explicit marker -- the full suite already re-runs on every invocation of this file.
+    expect(getSigningConfig()).toHaveProperty('enabled');
+  });
+
+  describe('REPOSITORY_POLICY_MODE (--hook path, real git commit through the real pre-commit hook)', () => {
+    let fixture: { dir: string; email: string };
+    let fileCounter = 0;
+
+    beforeAll(() => {
+      fixture = createSigningFixture();
+      // QNBS-v3: owned by this describe's own afterAll -- the shared afterEach must not wipe it between these tests.
+      scratchDirs.splice(scratchDirs.indexOf(fixture.dir), 1);
+      const hookPath = join(fixture.dir, '.git', 'hooks', 'pre-commit');
+      writeFileSync(
+        hookPath,
+        `#!/bin/sh\nexec ${JSON.stringify(process.execPath)} ${JSON.stringify(doctorPath)} --hook\n`,
+        { mode: 0o755 },
+      );
+    });
+
+    afterAll(() => {
+      rmSync(fixture.dir, { recursive: true, force: true });
+    });
+
+    function attemptCommit(extraGitArgs: string[] = []) {
+      fileCounter += 1;
+      const file = join(fixture.dir, `file-${fileCounter}.txt`);
+      writeFileSync(file, `content-${fileCounter}`);
+      execFileSync('git', ['-C', fixture.dir, 'add', file]);
+      return spawnSync(
+        'git',
+        ['-C', fixture.dir, ...extraGitArgs, 'commit', '-m', `test commit ${fileCounter}`],
+        { encoding: 'utf8' },
+      );
+    }
+
+    it('passes a normal commit through the real pre-commit hook', () => {
+      const result = attemptCommit();
+      expect(result.status).toBe(0);
+    });
+
+    it('does not regress a harmless -c override unrelated to the signing policy', () => {
+      const result = attemptCommit(['-c', 'core.editor=true']);
+      expect(result.status).toBe(0);
+    });
+
+    it('does not fail on a -c override that matches the persisted policy value', () => {
+      const result = attemptCommit(['-c', 'commit.gpgsign=true']);
+      expect(result.status).toBe(0);
+    });
+
+    it('fails closed before the probe runs when a -c override redefines the signing policy', () => {
+      const result = attemptCommit(['-c', 'commit.gpgsign=false']);
+      expect(result.status).not.toBe(0);
+      // QNBS-v3: git relays a FAILING hook's stdout through its own stderr; a passing hook's goes through stdout.
+      expect(result.stderr).toMatch(
+        /repository policy: mismatch — command-scope override redefines persisted policy for commit\.gpgsign/,
+      );
+      expect(result.stderr).toMatch(
+        /isolated signing probe: failed — command-scope override redefines persisted policy for commit\.gpgsign/,
+      );
+    });
+  });
+
+  describe('auditRepositoryPolicy (direct unit coverage for the comparison/validation logic)', () => {
+    let fixture: { dir: string; email: string };
+
+    beforeEach(() => {
+      fixture = createSigningFixture();
+    });
+
+    it('matches when no command-scope override is present', () => {
+      expect(auditRepositoryPolicy(fixture.dir, process.env)).toMatchObject({ ok: true });
+    });
+
+    it('is not fatal for a well-formed override outside the audited key set', () => {
+      const env = {
+        ...process.env,
+        GIT_CONFIG_COUNT: '1',
+        GIT_CONFIG_KEY_0: 'core.editor',
+        GIT_CONFIG_VALUE_0: 'true',
+      };
+      expect(auditRepositoryPolicy(fixture.dir, env)).toMatchObject({ ok: true });
+    });
+
+    it('is not fatal for an override equal to the persisted value', () => {
+      const env = {
+        ...process.env,
+        GIT_CONFIG_COUNT: '1',
+        GIT_CONFIG_KEY_0: 'commit.gpgsign',
+        GIT_CONFIG_VALUE_0: 'true',
+      };
+      expect(auditRepositoryPolicy(fixture.dir, env)).toMatchObject({ ok: true });
+    });
+
+    it('fails when an override redefines an audited policy key', () => {
+      const env = {
+        ...process.env,
+        GIT_CONFIG_COUNT: '1',
+        GIT_CONFIG_KEY_0: 'commit.gpgsign',
+        GIT_CONFIG_VALUE_0: 'false',
+      };
+      expect(auditRepositoryPolicy(fixture.dir, env)).toMatchObject({
+        ok: false,
+        reason: 'command-scope override redefines persisted policy for commit.gpgsign',
+      });
+    });
+
+    it('fails closed when command-scope config is internally malformed', () => {
+      // QNBS-v3: declares 1 override pair via COUNT but supplies neither KEY_0 nor VALUE_0.
+      const env = { ...process.env, GIT_CONFIG_COUNT: '1' };
+      expect(auditRepositoryPolicy(fixture.dir, env)).toMatchObject({
+        ok: false,
+        reason: 'command-scope configuration is malformed',
+      });
+    });
   });
 });


### PR DESCRIPTION
## **User description**
## Summary
- Isolates the disposable signing-capability probe (`runSigningProbe()`) from ambient git environment variables that could otherwise redirect its `git init`/`git config`/`commit-tree` calls into the real repository (`getForeignRepoEnv()`/`foreignRepoGit()`, based on git's own `git rev-parse --local-env-vars` list), while leaving `runGit()`'s normal real-repo semantics completely unchanged.
- Replaces the fixed 4-key `getUnsafeOverrides()` fatal list with `auditRepositoryPolicy()` (`REPOSITORY_POLICY_MODE`, `--hook`): compares *effective* vs. *persisted* config per-key for the keys that actually make up WorldScript-Studio's signing policy, so a legitimate `git -c ...` override is only fatal when it actually redefines policy — never merely because a git-internal-legitimate variable (`GIT_DIR`, `GIT_WORK_TREE`, etc.) is present, or because a harmless/equivalent `-c` override exists.
- Fixes a control-flow bug in `doctor.mjs`: a fatal override now skips `runSigningProbe()` entirely instead of running it under a known-hostile environment and discarding the result.
- Fixes a real, independently-caught bug: `process.exit()` immediately after `console.log` can truncate output on POSIX pipes (git hooks are piped); replaced with `process.exitCode`.
- Never logs config values or secrets — only key names and match/mismatch state, consistent with the existing `getUnsafeOverrides()` property.

## Test plan
- [x] 34 pre-existing `tests/unit/signing.test.ts` assertions pass unmodified (regression guard)
- [x] 17 new tests using real disposable git fixtures (not mocks) and real SSH-format signing:
  - All 4 foreign-repo env-leak vectors (`GIT_DIR`, `GIT_WORK_TREE`, `GIT_COMMON_DIR`, `GIT_INDEX_FILE`) individually proven unable to redirect the probe, with byte-identical outer-repo config/HEAD/refs before vs. after
  - Probe repo genuinely isolated (its commit object never lands in the outer repo's object store)
  - Cleanup verified on success and on a realistic mid-probe failure
  - Real concurrency via two separate OS processes (not `Promise.all` on a synchronous call)
  - `REPOSITORY_POLICY_MODE`: a real `git commit` through the actual installed pre-commit hook — normal commit passes, a harmless `-c` override passes, an equivalent-value `-c` override passes, a policy-redefining `-c` override fails closed *before* the probe runs
  - Malformed command-scope config (`GIT_CONFIG_COUNT` inconsistent with actual `KEY_n`/`VALUE_n` pairs) fails closed
- [x] `pnpm run signing:doctor` passes locally
- [x] This PR's own commit was created through the real, non-bypassed pre-commit hook under the hardened implementation (`git commit -> pre-commit -> signing:doctor --hook -> runSigningProbe()`), and is itself SSH-signed and `git verify-commit`-clean
- [x] Local `ci:prepush` admission gate green

## Summary by Sourcery

Harden signing diagnostics and pre-commit enforcement against ambient Git state while limiting failures to genuine signing-policy violations.

Bug Fixes:
- Isolate disposable signing probes from inherited Git repository and configuration environment variables, preventing changes to the real repository.
- Prevent fatal hook overrides from running the signing probe and preserve hook diagnostics by allowing output to flush before exit.
- Fail closed on malformed or policy-changing command-scope Git configuration while allowing unrelated and semantically equivalent overrides.

Enhancements:
- Centralize signing policy keys and compare effective configuration with persisted repository policy using Git-aware value normalization.
- Expand signing tests with real disposable repositories, SSH signing, environment-leak, cleanup, concurrency, hook, and policy-audit coverage.

Documentation:
- Update README test-count metrics to reflect the expanded test suite.

Tests:
- Add integration coverage for probe isolation, cleanup, concurrent execution, policy enforcement, malformed configuration, and diagnostic versus hook modes.


___

## **CodeAnt-AI Description**
Isolate signing checks and reject only policy-changing Git overrides

### What Changed
- Signing capability checks now run in a disposable repository that cannot be redirected or modified by inherited Git environment settings.
- Probe directories are removed after successful and failed checks, including concurrent probes.
- Pre-commit checks now compare effective signing settings with the repository’s saved policy and block overrides that change signing behavior.
- Unrelated or matching `git -c` settings are allowed, while malformed command-scope configuration fails safely.
- Hook output is allowed to flush before failure, preventing missing diagnostic messages.

### Impact
`✅ No changes to the real repository during signing checks`
`✅ Fewer false failures from harmless Git overrides`
`✅ Clearer signing-policy failure messages`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added hook mode to the signing diagnostics tool for automated repository signing-policy checks.
  - Signing diagnostics now report policy results in both terminal and JSON output.
  - Signing verification is better isolated from repository configuration and unsafe environment overrides.

- **Documentation**
  - Updated project documentation and CI metrics to reflect 7,197+ tests across 589 files.

- **Tests**
  - Expanded coverage for signing checks, hook behavior, policy conflicts, isolation, cleanup, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->