### PR TITLE
fix: preserve intentionally cleared project metadata (#531-A)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -187,10 +187,12 @@ const ViewLoader: FC = () => {
 
 interface AppProps {
   isNewUser: boolean;
+  allowInitialMetadataSeed: boolean;
 }
 
-const App: FC<AppProps> = ({ isNewUser }) => {
-  const appState = useApp({ isNewUser });
+// QNBS-v3: keep boot project hydration authority separate from first-run portal semantics.
+const App: FC<AppProps> = ({ isNewUser, allowInitialMetadataSeed: initialSeedAuthority }) => {
+  const appState = useApp({ isNewUser, allowInitialMetadataSeed: initialSeedAuthority });
   const { currentView, handleNavigate, isPortalActive, isInitialLoad, allowInitialMetadataSeed } =
     appState;
   const settings = useAppSelector((state) => state.settings);

--- a/App.tsx
+++ b/App.tsx
@@ -445,7 +445,14 @@ const App: FC<AppProps> = ({ isNewUser }) => {
   }, [currentView, announce, t, isInitialLoad, isPortalActive]);
 
   // QNBS-v3: gates on isInitialLoad too (not just isPortalActive) so a same-commit stale read can't auto-seed a project before the welcome portal shows.
-  useProjectBootstrapEffect({ project, isInitialLoad, isPortalActive, isI18nReady, t });
+  useProjectBootstrapEffect({
+    project,
+    isNewUser,
+    isInitialLoad,
+    isPortalActive,
+    isI18nReady,
+    t,
+  });
 
   // QNBS-v3: PR3 — auto-launch the product tour once for first-run installs, after the welcome
   // portal closes and the nav has rendered. Returning users (or anyone who already finished/closed

--- a/App.tsx
+++ b/App.tsx
@@ -191,7 +191,8 @@ interface AppProps {
 
 const App: FC<AppProps> = ({ isNewUser }) => {
   const appState = useApp({ isNewUser });
-  const { currentView, handleNavigate, isPortalActive, isInitialLoad } = appState;
+  const { currentView, handleNavigate, isPortalActive, isInitialLoad, allowInitialMetadataSeed } =
+    appState;
   const settings = useAppSelector((state) => state.settings);
   const project = useAppSelector(selectProjectData);
   const featureFlags = useAppSelector(selectFeatureFlags);
@@ -447,7 +448,7 @@ const App: FC<AppProps> = ({ isNewUser }) => {
   // QNBS-v3: gates on isInitialLoad too (not just isPortalActive) so a same-commit stale read can't auto-seed a project before the welcome portal shows.
   useProjectBootstrapEffect({
     project,
-    isNewUser,
+    allowInitialMetadataSeed,
     isInitialLoad,
     isPortalActive,
     isI18nReady,

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2937_keys-0EA5E9" alt="i18n 19 locales — 2937 keys">
-  <img src="https://img.shields.io/badge/Tests-7317%2B_%2F_594_files-22C55E" alt="7317+ tests / 594 files">
+  <img src="https://img.shields.io/badge/Tests-7320%2B_%2F_594_files-22C55E" alt="7320+ tests / 594 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2937 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7317+ tests / 594 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7320+ tests / 594 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7317+ tests, 594 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7320+ tests, 594 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -711,7 +711,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-30, source-synchronized; CI remains authoritative for pass/fail):**
-- **7317+ unit tests** across **594 test files** — CI is authoritative for pass/fail
+- **7320+ unit tests** across **594 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2937 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2937_keys-0EA5E9" alt="i18n 19 locales — 2937 keys">
-  <img src="https://img.shields.io/badge/Tests-7320%2B_%2F_594_files-22C55E" alt="7320+ tests / 594 files">
+  <img src="https://img.shields.io/badge/Tests-7322%2B_%2F_594_files-22C55E" alt="7322+ tests / 594 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2937 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7320+ tests / 594 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7322+ tests / 594 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7320+ tests, 594 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7322+ tests, 594 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -711,7 +711,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-30, source-synchronized; CI remains authoritative for pass/fail):**
-- **7320+ unit tests** across **594 test files** — CI is authoritative for pass/fail
+- **7322+ unit tests** across **594 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2937 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2937_keys-0EA5E9" alt="i18n 19 locales — 2937 keys">
-  <img src="https://img.shields.io/badge/Tests-7322%2B_%2F_594_files-22C55E" alt="7322+ tests / 594 files">
+  <img src="https://img.shields.io/badge/Tests-7326%2B_%2F_594_files-22C55E" alt="7326+ tests / 594 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2937 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7322+ tests / 594 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7326+ tests / 594 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7322+ tests, 594 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7326+ tests, 594 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -711,7 +711,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-30, source-synchronized; CI remains authoritative for pass/fail):**
-- **7322+ unit tests** across **594 test files** — CI is authoritative for pass/fail
+- **7326+ unit tests** across **594 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2937 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2937_keys-0EA5E9" alt="i18n 19 locales — 2937 keys">
-  <img src="https://img.shields.io/badge/Tests-7345%2B_%2F_595_files-22C55E" alt="7345+ tests / 595 files">
+  <img src="https://img.shields.io/badge/Tests-7350%2B_%2F_595_files-22C55E" alt="7350+ tests / 595 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2937 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7345+ tests / 595 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7350+ tests / 595 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7345+ tests, 595 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7350+ tests, 595 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -711,7 +711,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-30, source-synchronized; CI remains authoritative for pass/fail):**
-- **7345+ unit tests** across **595 test files** — CI is authoritative for pass/fail
+- **7350+ unit tests** across **595 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2937 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2937_keys-0EA5E9" alt="i18n 19 locales — 2937 keys">
-  <img src="https://img.shields.io/badge/Tests-7331%2B_%2F_595_files-22C55E" alt="7331+ tests / 595 files">
+  <img src="https://img.shields.io/badge/Tests-7336%2B_%2F_595_files-22C55E" alt="7336+ tests / 595 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2937 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7331+ tests / 595 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7336+ tests / 595 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7331+ tests, 595 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7336+ tests, 595 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -711,7 +711,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-30, source-synchronized; CI remains authoritative for pass/fail):**
-- **7331+ unit tests** across **595 test files** — CI is authoritative for pass/fail
+- **7336+ unit tests** across **595 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2937 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2937_keys-0EA5E9" alt="i18n 19 locales — 2937 keys">
-  <img src="https://img.shields.io/badge/Tests-7352%2B_%2F_595_files-22C55E" alt="7352+ tests / 595 files">
+  <img src="https://img.shields.io/badge/Tests-7355%2B_%2F_595_files-22C55E" alt="7355+ tests / 595 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2937 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7352+ tests / 595 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7355+ tests / 595 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7352+ tests, 595 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7355+ tests, 595 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -711,7 +711,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-30, source-synchronized; CI remains authoritative for pass/fail):**
-- **7352+ unit tests** across **595 test files** — CI is authoritative for pass/fail
+- **7355+ unit tests** across **595 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2937 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2937_keys-0EA5E9" alt="i18n 19 locales — 2937 keys">
-  <img src="https://img.shields.io/badge/Tests-7350%2B_%2F_595_files-22C55E" alt="7350+ tests / 595 files">
+  <img src="https://img.shields.io/badge/Tests-7352%2B_%2F_595_files-22C55E" alt="7352+ tests / 595 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2937 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7350+ tests / 595 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7352+ tests / 595 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7350+ tests, 595 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7352+ tests, 595 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -711,7 +711,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-30, source-synchronized; CI remains authoritative for pass/fail):**
-- **7350+ unit tests** across **595 test files** — CI is authoritative for pass/fail
+- **7352+ unit tests** across **595 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2937 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2937_keys-0EA5E9" alt="i18n 19 locales — 2937 keys">
-  <img src="https://img.shields.io/badge/Tests-7330%2B_%2F_594_files-22C55E" alt="7330+ tests / 594 files">
+  <img src="https://img.shields.io/badge/Tests-7331%2B_%2F_595_files-22C55E" alt="7331+ tests / 595 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2937 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7330+ tests / 594 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7331+ tests / 595 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7330+ tests, 594 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7331+ tests, 595 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -711,7 +711,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-30, source-synchronized; CI remains authoritative for pass/fail):**
-- **7330+ unit tests** across **594 test files** — CI is authoritative for pass/fail
+- **7331+ unit tests** across **595 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2937 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2937_keys-0EA5E9" alt="i18n 19 locales — 2937 keys">
-  <img src="https://img.shields.io/badge/Tests-7326%2B_%2F_594_files-22C55E" alt="7326+ tests / 594 files">
+  <img src="https://img.shields.io/badge/Tests-7330%2B_%2F_594_files-22C55E" alt="7330+ tests / 594 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2937 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7326+ tests / 594 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7330+ tests / 594 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7326+ tests, 594 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7330+ tests, 594 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -711,7 +711,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-30, source-synchronized; CI remains authoritative for pass/fail):**
-- **7326+ unit tests** across **594 test files** — CI is authoritative for pass/fail
+- **7330+ unit tests** across **594 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2937 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2937_keys-0EA5E9" alt="i18n 19 locales — 2937 keys">
-  <img src="https://img.shields.io/badge/Tests-7336%2B_%2F_595_files-22C55E" alt="7336+ tests / 595 files">
+  <img src="https://img.shields.io/badge/Tests-7345%2B_%2F_595_files-22C55E" alt="7345+ tests / 595 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2937 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7336+ tests / 595 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7345+ tests / 595 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7336+ tests, 595 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7345+ tests, 595 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -711,7 +711,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-30, source-synchronized; CI remains authoritative for pass/fail):**
-- **7336+ unit tests** across **595 test files** — CI is authoritative for pass/fail
+- **7345+ unit tests** across **595 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2937 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2937_keys-0EA5E9" alt="i18n 19 locales — 2937 keys">
-  <img src="https://img.shields.io/badge/Tests-7355%2B_%2F_595_files-22C55E" alt="7355+ tests / 595 files">
+  <img src="https://img.shields.io/badge/Tests-7356%2B_%2F_595_files-22C55E" alt="7356+ tests / 595 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2937 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7355+ tests / 595 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7356+ tests / 595 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7355+ tests, 595 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7356+ tests, 595 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -711,7 +711,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-30, source-synchronized; CI remains authoritative for pass/fail):**
-- **7355+ unit tests** across **595 test files** — CI is authoritative for pass/fail
+- **7356+ unit tests** across **595 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2937 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/components/WelcomePortal.tsx
+++ b/components/WelcomePortal.tsx
@@ -13,6 +13,7 @@ import { Button } from './ui/Button';
 import { CustomIcon } from './ui/Icon';
 import { LanguageSelector } from './ui/LanguageSelector';
 
+// QNBS-v3: imported/demo portal exits revoke boot seed authority so external content keeps intentional blank metadata.
 interface WelcomePortalProps {
   onExit: (view?: View, options?: PortalExitOptions) => void;
 }
@@ -119,6 +120,7 @@ export const WelcomePortal: React.FC<WelcomePortalProps> = ({ onExit }) => {
             title: t('settings.data.importSuccess'),
           }),
         );
+        // QNBS-v3: imported project content must revoke fresh-project metadata seeding before bootstrap runs.
         onExit('manuscript', { allowInitialMetadataSeed: false });
       } else {
         dispatch(
@@ -174,6 +176,7 @@ export const WelcomePortal: React.FC<WelcomePortalProps> = ({ onExit }) => {
           title: t('settings.data.importSuccess'),
         }),
       );
+      // QNBS-v3: demo content is imported content, so it must not be overwritten by fresh-project seeding.
       onExit('manuscript', { allowInitialMetadataSeed: false });
     } else {
       dispatch(

--- a/components/WelcomePortal.tsx
+++ b/components/WelcomePortal.tsx
@@ -5,6 +5,7 @@ import { ICONS } from '../constants';
 import { projectActions } from '../features/project/projectSlice';
 import { importProjectThunk } from '../features/project/thunks/projectManagementThunks';
 import { statusActions } from '../features/status/statusSlice';
+import type { PortalExitOptions } from '../hooks/useApp';
 import { useTranslation } from '../hooks/useTranslation';
 import { storageService } from '../services/storageService';
 import type { View } from '../types';
@@ -13,7 +14,7 @@ import { CustomIcon } from './ui/Icon';
 import { LanguageSelector } from './ui/LanguageSelector';
 
 interface WelcomePortalProps {
-  onExit: (view?: View) => void;
+  onExit: (view?: View, options?: PortalExitOptions) => void;
 }
 
 type PortalView = 'main' | 'new_project' | 'open_project';
@@ -118,7 +119,7 @@ export const WelcomePortal: React.FC<WelcomePortalProps> = ({ onExit }) => {
             title: t('settings.data.importSuccess'),
           }),
         );
-        onExit('manuscript');
+        onExit('manuscript', { allowInitialMetadataSeed: false });
       } else {
         dispatch(
           statusActions.addNotification({
@@ -173,7 +174,7 @@ export const WelcomePortal: React.FC<WelcomePortalProps> = ({ onExit }) => {
           title: t('settings.data.importSuccess'),
         }),
       );
-      onExit('manuscript');
+      onExit('manuscript', { allowInitialMetadataSeed: false });
     } else {
       dispatch(
         statusActions.addNotification({

--- a/features/project/adapters.ts
+++ b/features/project/adapters.ts
@@ -1,8 +1,23 @@
+import type { EntityState } from '@reduxjs/toolkit';
 import { createEntityAdapter } from '@reduxjs/toolkit';
 import type { Character, World } from '../../types';
 
 // QNBS-v3: the stable no-op comparer selects RTK's object-safe update path without changing entity insertion order.
 const preserveEntityOrder = () => 0;
+
+// QNBS-v3: imported string IDs must survive EntityState construction even when they collide with Object.prototype.
+export function createPrototypeSafeEntityState<T extends { id: string }>(
+  items: readonly T[],
+): EntityState<T, string> | undefined {
+  const ids: string[] = [];
+  const entities = Object.create(null) as Record<string, T>;
+  for (const item of items) {
+    if (Object.hasOwn(entities, item.id)) return undefined;
+    ids.push(item.id);
+    entities[item.id] = item;
+  }
+  return { ids, entities };
+}
 
 export const charactersAdapter = createEntityAdapter<Character>({
   sortComparer: preserveEntityOrder,

--- a/features/project/adapters.ts
+++ b/features/project/adapters.ts
@@ -1,5 +1,10 @@
 import { createEntityAdapter } from '@reduxjs/toolkit';
 import type { Character, World } from '../../types';
 
-export const charactersAdapter = createEntityAdapter<Character>();
-export const worldsAdapter = createEntityAdapter<World>();
+// QNBS-v3: the stable no-op comparer selects RTK's object-safe update path without changing entity insertion order.
+const preserveEntityOrder = () => 0;
+
+export const charactersAdapter = createEntityAdapter<Character>({
+  sortComparer: preserveEntityOrder,
+});
+export const worldsAdapter = createEntityAdapter<World>({ sortComparer: preserveEntityOrder });

--- a/features/project/adapters.ts
+++ b/features/project/adapters.ts
@@ -6,6 +6,7 @@ import type { Character, World } from '../../types';
 const preserveEntityOrder = () => 0;
 
 // QNBS-v3: imported string IDs must survive EntityState construction even when they collide with Object.prototype.
+/** Builds a JSON-safe EntityState without treating prototype names as inherited properties. */
 export function createPrototypeSafeEntityState<T extends { id: string }>(
   items: readonly T[],
 ): EntityState<T, string> | undefined {

--- a/features/project/thunks/projectManagementThunks.ts
+++ b/features/project/thunks/projectManagementThunks.ts
@@ -3,10 +3,47 @@ import type { RootState } from '../../../app/store';
 import { parseImportedProjectJson } from '../../../services/projectImportSchema';
 import { storageService } from '../../../services/storageService';
 import type { Character, World } from '../../../types';
-import { charactersAdapter, worldsAdapter } from '../adapters';
+import { createPrototypeSafeEntityState } from '../adapters';
 import type { ProjectData } from '../projectSlice';
 
 const LEGACY_PROJECT_DIRECTORY_METADATA_KEY = '__worldscriptLegacyProjectDirectory';
+
+type ImportedEntityCollection<T extends { id: string }> =
+  | readonly T[]
+  | { ids: readonly string[]; entities: Record<string, T> };
+
+// QNBS-v3: validate normalized import correspondence before image I/O so malformed collections cannot create partial imports.
+function extractImportedEntities<T extends { id: string }>(
+  collection: ImportedEntityCollection<T> | undefined,
+): T[] | undefined {
+  if (collection === undefined) return [];
+  if (!('ids' in collection)) return [...collection];
+  if (
+    !Array.isArray(collection.ids) ||
+    typeof collection.entities !== 'object' ||
+    collection.entities === null
+  ) {
+    return undefined;
+  }
+
+  const seenIds = new Set<string>();
+  const importedEntities: T[] = [];
+  for (const id of collection.ids) {
+    if (typeof id !== 'string' || seenIds.has(id) || !Object.hasOwn(collection.entities, id)) {
+      return undefined;
+    }
+    const entity = collection.entities[id];
+    if (!entity || typeof entity !== 'object' || entity.id !== id) return undefined;
+    seenIds.add(id);
+    importedEntities.push(entity);
+  }
+
+  const entityKeys = Object.keys(collection.entities);
+  if (entityKeys.length !== seenIds.size || entityKeys.some((id) => !seenIds.has(id))) {
+    return undefined;
+  }
+  return importedEntities;
+}
 
 // QNBS-v3: compare only storage-owned target identity so mutable snapshot content cannot hide a project switch.
 function restoreTargetIdentity(project: unknown): string | null {
@@ -23,20 +60,28 @@ export const importProjectThunk = createAsyncThunk('project/importProject', asyn
   const text = await file.text();
   const projectDataJson = parseImportedProjectJson(text);
 
-  // QNBS-v3: setAll returns a new Immer-produced state — capture the return value, do not rely on in-place mutation
-  let charactersState = charactersAdapter.getInitialState();
-  let worldsState = worldsAdapter.getInitialState();
   const charactersToSet: Character[] = [];
   const worldsToSet: World[] = [];
 
-  let characterArray: (Character & { avatarBase64?: string })[] = [];
-  if (Array.isArray(projectDataJson.characters)) {
-    characterArray = projectDataJson.characters as (Character & { avatarBase64?: string })[];
-  } else if (projectDataJson.characters && 'ids' in projectDataJson.characters) {
-    const { ids, entities } = projectDataJson.characters;
-    characterArray = ids
-      .map((id: string) => entities[id])
-      .filter((item): item is Character & { avatarBase64?: string } => Boolean(item));
+  const characterArray = extractImportedEntities(
+    projectDataJson.characters as
+      | ImportedEntityCollection<Character & { avatarBase64?: string }>
+      | undefined,
+  );
+  const worldArray = extractImportedEntities(
+    projectDataJson.worlds as
+      | ImportedEntityCollection<World & { ambianceImageBase64?: string }>
+      | undefined,
+  );
+  if (!characterArray || !worldArray) {
+    throw new Error('Invalid project file: entity IDs do not match their collection entries.');
+  }
+
+  if (
+    !createPrototypeSafeEntityState(characterArray) ||
+    !createPrototypeSafeEntityState(worldArray)
+  ) {
+    throw new Error('Invalid project file: duplicate character or world entity ID.');
   }
 
   for (const char of characterArray) {
@@ -48,17 +93,6 @@ export const importProjectThunk = createAsyncThunk('project/importProject', asyn
     }
     charactersToSet.push(newChar);
   }
-  charactersState = charactersAdapter.setAll(charactersState, charactersToSet);
-
-  let worldArray: (World & { ambianceImageBase64?: string })[] = [];
-  if (Array.isArray(projectDataJson.worlds)) {
-    worldArray = projectDataJson.worlds as (World & { ambianceImageBase64?: string })[];
-  } else if (projectDataJson.worlds && 'ids' in projectDataJson.worlds) {
-    const { ids, entities } = projectDataJson.worlds;
-    worldArray = ids
-      .map((id: string) => entities[id])
-      .filter((item): item is World & { ambianceImageBase64?: string } => Boolean(item));
-  }
 
   for (const world of worldArray) {
     const newWorld = { ...world };
@@ -69,7 +103,11 @@ export const importProjectThunk = createAsyncThunk('project/importProject', asyn
     }
     worldsToSet.push(newWorld);
   }
-  worldsState = worldsAdapter.setAll(worldsState, worldsToSet);
+  const charactersState = createPrototypeSafeEntityState(charactersToSet);
+  const worldsState = createPrototypeSafeEntityState(worldsToSet);
+  if (!charactersState || !worldsState) {
+    throw new Error('Invalid project file: duplicate character or world entity ID.');
+  }
 
   const manuscript = projectDataJson.manuscript ?? [];
 

--- a/features/project/thunks/projectManagementThunks.ts
+++ b/features/project/thunks/projectManagementThunks.ts
@@ -13,6 +13,7 @@ type ImportedEntityCollection<T extends { id: string }> =
   | { ids: readonly string[]; entities: Record<string, T> };
 
 // QNBS-v3: validate normalized import correspondence before image I/O so malformed collections cannot create partial imports.
+/** Extracts imported entities while requiring exact ids-to-own-entities correspondence. */
 function extractImportedEntities<T extends { id: string }>(
   collection: ImportedEntityCollection<T> | undefined,
 ): T[] | undefined {

--- a/hooks/useApp.ts
+++ b/hooks/useApp.ts
@@ -66,14 +66,20 @@ export interface PortalExitOptions {
   allowInitialMetadataSeed?: boolean;
 }
 
-export const useApp = ({ isNewUser }: { isNewUser: boolean }) => {
+export const useApp = ({
+  isNewUser,
+  allowInitialMetadataSeed: initialSeedAuthority = isNewUser,
+}: {
+  isNewUser: boolean;
+  allowInitialMetadataSeed?: boolean;
+}) => {
   const [currentView, setCurrentView] = useState<View>(() => readInitialView());
   // QNBS-v3: remember the view navigated away from, so view-aware Help can open to the matching
   // category (once inside Help, currentView is 'help' and no longer tells us where the user was).
   const previousViewRef = useRef<View>('dashboard');
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
-  const [allowInitialMetadataSeed, setAllowInitialMetadataSeed] = useState(isNewUser);
-  // QNBS-v3: initialize from isNewUser (already stable pre-mount) instead of a hardcoded false, so no transient first commit exposes a stale value to a sibling effect.
+  const [allowInitialMetadataSeed, setAllowInitialMetadataSeed] = useState(initialSeedAuthority);
+  // QNBS-v3: initialize from boot project authority, with the legacy first-run fallback retained for direct hook consumers.
   const [isPortalActive, setIsPortalActive] = useState(isNewUser);
   const [isInitialLoad, setIsInitialLoad] = useState(true);
 
@@ -138,6 +144,7 @@ export const useApp = ({ isNewUser }: { isNewUser: boolean }) => {
 
   const handlePortalExit = useCallback(
     (view?: View, options?: PortalExitOptions) => {
+      // QNBS-v3: imported/demo content revokes seed authority before bootstrap can treat it as fresh project data.
       if (options?.allowInitialMetadataSeed === false) setAllowInitialMetadataSeed(false);
       if (view) {
         switchView(view);
@@ -163,6 +170,7 @@ export const useApp = ({ isNewUser }: { isNewUser: boolean }) => {
     isSidebarOpen,
     isPortalActive,
     isInitialLoad,
+    // QNBS-v3: expose transient boot/import authority without persisting a new project-state field.
     allowInitialMetadataSeed,
     handlePortalExit,
     handleNavigate,

--- a/hooks/useApp.ts
+++ b/hooks/useApp.ts
@@ -61,12 +61,18 @@ function readInitialView(): View {
   return 'dashboard';
 }
 
+// QNBS-v3: portal exit context distinguishes imported content from a project created in this app.
+export interface PortalExitOptions {
+  allowInitialMetadataSeed?: boolean;
+}
+
 export const useApp = ({ isNewUser }: { isNewUser: boolean }) => {
   const [currentView, setCurrentView] = useState<View>(() => readInitialView());
   // QNBS-v3: remember the view navigated away from, so view-aware Help can open to the matching
   // category (once inside Help, currentView is 'help' and no longer tells us where the user was).
   const previousViewRef = useRef<View>('dashboard');
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const [allowInitialMetadataSeed, setAllowInitialMetadataSeed] = useState(isNewUser);
   // QNBS-v3: initialize from isNewUser (already stable pre-mount) instead of a hardcoded false, so no transient first commit exposes a stale value to a sibling effect.
   const [isPortalActive, setIsPortalActive] = useState(isNewUser);
   const [isInitialLoad, setIsInitialLoad] = useState(true);
@@ -131,7 +137,8 @@ export const useApp = ({ isNewUser }: { isNewUser: boolean }) => {
   }, [currentView]);
 
   const handlePortalExit = useCallback(
-    (view?: View) => {
+    (view?: View, options?: PortalExitOptions) => {
+      if (options?.allowInitialMetadataSeed === false) setAllowInitialMetadataSeed(false);
       if (view) {
         switchView(view);
         pushHash(view);
@@ -156,6 +163,7 @@ export const useApp = ({ isNewUser }: { isNewUser: boolean }) => {
     isSidebarOpen,
     isPortalActive,
     isInitialLoad,
+    allowInitialMetadataSeed,
     handlePortalExit,
     handleNavigate,
     setIsSidebarOpen,

--- a/hooks/useProjectBootstrapEffect.ts
+++ b/hooks/useProjectBootstrapEffect.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useAppDispatch } from '../app/hooks';
 import { projectActions } from '../features/project/projectSlice';
 import type { ProjectMetaSlice, TranslateFn } from '../services/projectI18nRepair';
@@ -6,6 +6,8 @@ import { repairProjectI18nFields } from '../services/projectI18nRepair';
 
 export interface ProjectBootstrapGateState {
   project: ProjectMetaSlice | null;
+  // QNBS-v3: pre-hydration new-user state is the only authority allowed to seed blank metadata.
+  isNewUser: boolean;
   isInitialLoad: boolean;
   isPortalActive: boolean;
   isI18nReady: boolean;
@@ -28,25 +30,39 @@ export interface UseProjectBootstrapEffectParams extends ProjectBootstrapGateSta
 /** Repairs raw-i18n-key project fields, or seeds a fresh blank project, once bootstrap has settled. */
 export function useProjectBootstrapEffect({
   project,
+  isNewUser,
   isInitialLoad,
   isPortalActive,
   isI18nReady,
   t,
 }: UseProjectBootstrapEffectParams): void {
   const dispatch = useAppDispatch();
+  const hasCompletedFreshUserBootstrap = useRef(false);
 
   useEffect(() => {
     // QNBS-v3: narrows project directly (not via the predicate's own return type) so the redundant post-check codecov flagged as dead code isn't needed.
-    if (!project || !shouldRunProjectBootstrap({ project, isInitialLoad, isPortalActive, isI18nReady }))
+    if (
+      !project ||
+      !shouldRunProjectBootstrap({
+        project,
+        isNewUser,
+        isInitialLoad,
+        isPortalActive,
+        isI18nReady,
+      })
+    )
       return;
 
-    const repair = repairProjectI18nFields(project, t);
+    const repair = repairProjectI18nFields(project, t, {
+      seedInitialMetadata: isNewUser && !hasCompletedFreshUserBootstrap.current,
+    });
+    if (isNewUser) hasCompletedFreshUserBootstrap.current = true;
     if (repair) {
       if (repair.title !== undefined) dispatch(projectActions.updateTitle(repair.title));
       if (repair.logline !== undefined) dispatch(projectActions.updateLogline(repair.logline));
       if (repair.manuscript !== undefined)
         dispatch(projectActions.setManuscript(repair.manuscript));
     }
-    // QNBS-v3: no further branch here — repairProjectI18nFields already treats any blank title/logline/manuscript as needing repair, so it always returns non-null for a blank project; a separate resetProject dispatch for that same condition was unreachable dead code, removed rather than tested around.
-  }, [project, isInitialLoad, isPortalActive, isI18nReady, dispatch, t]);
+    // QNBS-v3: blank metadata is seeded only once for a fresh user; later empty strings remain user intent.
+  }, [project, isNewUser, isInitialLoad, isPortalActive, isI18nReady, dispatch, t]);
 }

--- a/hooks/useProjectBootstrapEffect.ts
+++ b/hooks/useProjectBootstrapEffect.ts
@@ -6,8 +6,6 @@ import { repairProjectI18nFields } from '../services/projectI18nRepair';
 
 export interface ProjectBootstrapGateState {
   project: ProjectMetaSlice | null;
-  // QNBS-v3: pre-hydration new-user state is the only authority allowed to seed blank metadata.
-  isNewUser: boolean;
   isInitialLoad: boolean;
   isPortalActive: boolean;
   isI18nReady: boolean;
@@ -24,13 +22,15 @@ export function shouldRunProjectBootstrap({
 }
 
 export interface UseProjectBootstrapEffectParams extends ProjectBootstrapGateState {
+  // QNBS-v3: explicit portal intent controls one-time metadata seeding without persisting schema state.
+  allowInitialMetadataSeed: boolean;
   t: TranslateFn;
 }
 
 /** Repairs raw-i18n-key project fields, or seeds a fresh blank project, once bootstrap has settled. */
 export function useProjectBootstrapEffect({
   project,
-  isNewUser,
+  allowInitialMetadataSeed,
   isInitialLoad,
   isPortalActive,
   isI18nReady,
@@ -45,7 +45,6 @@ export function useProjectBootstrapEffect({
       !project ||
       !shouldRunProjectBootstrap({
         project,
-        isNewUser,
         isInitialLoad,
         isPortalActive,
         isI18nReady,
@@ -54,9 +53,9 @@ export function useProjectBootstrapEffect({
       return;
 
     const repair = repairProjectI18nFields(project, t, {
-      seedInitialMetadata: isNewUser && !hasCompletedFreshUserBootstrap.current,
+      seedInitialMetadata: allowInitialMetadataSeed && !hasCompletedFreshUserBootstrap.current,
     });
-    if (isNewUser) hasCompletedFreshUserBootstrap.current = true;
+    if (allowInitialMetadataSeed) hasCompletedFreshUserBootstrap.current = true;
     if (repair) {
       if (repair.title !== undefined) dispatch(projectActions.updateTitle(repair.title));
       if (repair.logline !== undefined) dispatch(projectActions.updateLogline(repair.logline));
@@ -64,5 +63,5 @@ export function useProjectBootstrapEffect({
         dispatch(projectActions.setManuscript(repair.manuscript));
     }
     // QNBS-v3: blank metadata is seeded only once for a fresh user; later empty strings remain user intent.
-  }, [project, isNewUser, isInitialLoad, isPortalActive, isI18nReady, dispatch, t]);
+  }, [project, allowInitialMetadataSeed, isInitialLoad, isPortalActive, isI18nReady, dispatch, t]);
 }

--- a/index.tsx
+++ b/index.tsx
@@ -7,7 +7,11 @@ import { type AppDispatch, appStoreRef, type RootState, setupStore } from './app
 import { IdbUnlockModal } from './components/settings/IdbUnlockModal';
 import { I18nProvider } from './contexts/I18nContext';
 import { versionControlActions } from './features/versionControl/versionControlSlice';
-import { loadPersistedRootState, shouldAllowInitialMetadataSeed } from './services/appBootstrap';
+import {
+  getPersistedProjectPayload,
+  loadPersistedRootState,
+  shouldAllowInitialMetadataSeed,
+} from './services/appBootstrap';
 import { initializeStorage } from './services/dbInitialization';
 import { logger } from './services/logger';
 import {
@@ -128,19 +132,20 @@ async function bootApp(): Promise<void> {
     // We must manually reconstruct the undo envelope if we loaded flat data.
     if (preloadedState?.project) {
       const projectPart = preloadedState.project;
+      const persistedProjectData = getPersistedProjectPayload(projectPart);
+      const hasUndoPayload =
+        projectPart.present !== undefined &&
+        getPersistedProjectPayload({ present: projectPart.present }) !== undefined;
 
-      // Check if the loaded project is "flat" (i.e., it doesn't have a 'present' key, but HAS 'data')
-      const isFlatData = !projectPart.present && projectPart.data;
-
-      if (isFlatData && projectPart.data) {
+      if (persistedProjectData && !hasUndoPayload) {
         logger.debug('Hydrating flat project state into Redux-Undo envelope.');
         preloadedState.project = {
           past: [],
-          present: { data: projectPart.data }, // Reconstruct the slice structure
+          present: { data: persistedProjectData }, // Reconstruct the slice structure
           future: [],
-          _latestUnfiltered: projectPart.data, // Helper for redux-undo if needed
+          _latestUnfiltered: persistedProjectData, // Helper for redux-undo if needed
         };
-      } else if (!projectPart.present && !projectPart.data) {
+      } else if (!persistedProjectData) {
         // Fallback: Corrupt or empty project state
         logger.warn('Project state corrupted. Resetting project.');
         delete (preloadedState as Record<string, unknown>)['project'];

--- a/index.tsx
+++ b/index.tsx
@@ -8,8 +8,8 @@ import { IdbUnlockModal } from './components/settings/IdbUnlockModal';
 import { I18nProvider } from './contexts/I18nContext';
 import { versionControlActions } from './features/versionControl/versionControlSlice';
 import {
-  getPersistedProjectPayload,
   loadPersistedRootState,
+  normalizePersistedProjectForStore,
   shouldAllowInitialMetadataSeed,
 } from './services/appBootstrap';
 import { initializeStorage } from './services/dbInitialization';
@@ -132,20 +132,12 @@ async function bootApp(): Promise<void> {
     // We must manually reconstruct the undo envelope if we loaded flat data.
     if (preloadedState?.project) {
       const projectPart = preloadedState.project;
-      const persistedProjectData = getPersistedProjectPayload(projectPart);
-      const hasUndoPayload =
-        projectPart.present !== undefined &&
-        getPersistedProjectPayload({ present: projectPart.present }) !== undefined;
+      const normalizedProject = normalizePersistedProjectForStore(projectPart);
 
-      if (persistedProjectData && !hasUndoPayload) {
-        logger.debug('Hydrating flat project state into Redux-Undo envelope.');
-        preloadedState.project = {
-          past: [],
-          present: { data: persistedProjectData }, // Reconstruct the slice structure
-          future: [],
-          _latestUnfiltered: persistedProjectData, // Helper for redux-undo if needed
-        };
-      } else if (!persistedProjectData) {
+      if (normalizedProject) {
+        logger.debug('Hydrating persisted project state into Redux-Undo envelope.');
+        preloadedState.project = normalizedProject;
+      } else {
         // Fallback: Corrupt or empty project state
         logger.warn('Project state corrupted. Resetting project.');
         delete (preloadedState as Record<string, unknown>)['project'];

--- a/index.tsx
+++ b/index.tsx
@@ -7,7 +7,7 @@ import { type AppDispatch, appStoreRef, type RootState, setupStore } from './app
 import { IdbUnlockModal } from './components/settings/IdbUnlockModal';
 import { I18nProvider } from './contexts/I18nContext';
 import { versionControlActions } from './features/versionControl/versionControlSlice';
-import { loadPersistedRootState } from './services/appBootstrap';
+import { loadPersistedRootState, shouldAllowInitialMetadataSeed } from './services/appBootstrap';
 import { initializeStorage } from './services/dbInitialization';
 import { logger } from './services/logger';
 import {
@@ -148,6 +148,9 @@ async function bootApp(): Promise<void> {
     }
     // --------------------------------
 
+    // QNBS-v3: derive metadata seeding from the normalized persisted-project boundary, not the broader first-run flag.
+    const allowInitialMetadataSeed = shouldAllowInitialMetadataSeed(preloadedState);
+
     const store = setupStore(preloadedState);
     appStoreRef.current = store as unknown as { getState(): RootState; dispatch: AppDispatch };
 
@@ -184,7 +187,7 @@ async function bootApp(): Promise<void> {
     root.render(
       <React.StrictMode>
         <Provider store={store}>
-          <App isNewUser={isNewUser} />
+          <App isNewUser={isNewUser} allowInitialMetadataSeed={allowInitialMetadataSeed} />
         </Provider>
       </React.StrictMode>,
     );

--- a/services/appBootstrap.ts
+++ b/services/appBootstrap.ts
@@ -43,34 +43,49 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+function hasOwn(value: object, key: PropertyKey): boolean {
+  return Object.hasOwn(value, key);
+}
+
+// QNBS-v3: null-prototype entity records preserve legal persisted IDs that collide with Object.prototype during bootstrap.
 function normalizeEntityCollection<T>(
   value: unknown,
   adapter: EntityAdapter<T, string>,
 ): EntityState<T, string> | undefined {
   if (Array.isArray(value)) {
-    const ids = new Set<string>();
+    const ids: string[] = [];
+    const entities = Object.create(null) as Record<string, T>;
     for (const entity of value) {
       if (!isRecord(entity) || typeof entity['id'] !== 'string' || !entity['id'].trim())
         return undefined;
-      if (ids.has(entity['id'])) return undefined;
-      ids.add(entity['id']);
+      const id = entity['id'];
+      if (hasOwn(entities, id)) return undefined;
+      ids.push(id);
+      entities[id] = entity as T;
     }
-    const state = adapter.getInitialState();
-    return adapter.setAll(state, value as T[]);
+    return { ...adapter.getInitialState(), ids, entities };
   }
 
   if (!isRecord(value) || !Array.isArray(value['ids']) || !isRecord(value['entities']))
     return undefined;
-  const ids = value['ids'];
-  const entities = value['entities'];
+  const sourceIds = value['ids'];
+  const sourceEntities = value['entities'];
+  const ids: string[] = [];
+  const entities = Object.create(null) as Record<string, T>;
   const seenIds = new Set<string>();
-  for (const id of ids) {
+  for (const id of sourceIds) {
     if (typeof id !== 'string' || !id.trim() || seenIds.has(id)) return undefined;
-    const entity = entities[id];
+    if (!hasOwn(sourceEntities, id)) return undefined;
+    const entity = sourceEntities[id];
     if (!isRecord(entity) || entity['id'] !== id) return undefined;
     seenIds.add(id);
+    ids.push(id);
+    entities[id] = entity as T;
   }
-  return value as unknown as EntityState<T, string>;
+  for (const key of Reflect.ownKeys(sourceEntities)) {
+    if (typeof key !== 'string' || !seenIds.has(key)) return undefined;
+  }
+  return { ...adapter.getInitialState(), ids, entities };
 }
 
 // QNBS-v3: canonical desktop collections prevent valid filesystem projects from being discarded while malformed envelopes remain non-authoritative.
@@ -90,6 +105,36 @@ export function getPersistedProjectPayload(
     worlds,
     outline: outline ?? [],
   } as unknown as ProjectData;
+}
+
+// QNBS-v3: the active payload is normalized before Redux-Undo sees it, preventing desktop array data from bypassing the canonical Redux state boundary.
+export function normalizePersistedProjectForStore(
+  project: PersistedRootState['project'] | undefined,
+): PersistedRootState['project'] | undefined {
+  const payload = getPersistedProjectPayload(project);
+  if (!payload) return undefined;
+
+  if (
+    project &&
+    isRecord(project.present) &&
+    Array.isArray(project.past) &&
+    Array.isArray(project.future)
+  ) {
+    const present = { ...project.present, data: payload };
+    return {
+      ...project,
+      present,
+      _latestUnfiltered: present,
+    };
+  }
+
+  const present = { data: payload };
+  return {
+    past: [],
+    present,
+    future: [],
+    _latestUnfiltered: present,
+  };
 }
 
 // QNBS-v3: seed authority follows hydrated project presence, so settings-only state can still initialize the synthetic project without overwriting real user intent.

--- a/services/appBootstrap.ts
+++ b/services/appBootstrap.ts
@@ -1,3 +1,5 @@
+import type { EntityAdapter, EntityState } from '@reduxjs/toolkit';
+import { charactersAdapter, worldsAdapter } from '../features/project/adapters';
 import type { ProjectData } from '../features/project/projectSlice';
 import type { PersistedRootState } from '../types';
 import { dbService } from './dbService';
@@ -41,26 +43,53 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-function hasEntityStateShape(value: unknown): boolean {
+function normalizeEntityCollection<T>(
+  value: unknown,
+  adapter: EntityAdapter<T, string>,
+): EntityState<T, string> | undefined {
+  if (Array.isArray(value)) {
+    const ids = new Set<string>();
+    for (const entity of value) {
+      if (!isRecord(entity) || typeof entity['id'] !== 'string' || !entity['id'].trim())
+        return undefined;
+      if (ids.has(entity['id'])) return undefined;
+      ids.add(entity['id']);
+    }
+    const state = adapter.getInitialState();
+    return adapter.setAll(state, value as T[]);
+  }
+
   if (!isRecord(value) || !Array.isArray(value['ids']) || !isRecord(value['entities']))
-    return false;
-  return value['ids'].every((id: unknown) => typeof id === 'string');
+    return undefined;
+  const ids = value['ids'];
+  const entities = value['entities'];
+  const seenIds = new Set<string>();
+  for (const id of ids) {
+    if (typeof id !== 'string' || !id.trim() || seenIds.has(id)) return undefined;
+    const entity = entities[id];
+    if (!isRecord(entity) || entity['id'] !== id) return undefined;
+    seenIds.add(id);
+  }
+  return value as unknown as EntityState<T, string>;
 }
 
-// QNBS-v3: structural project evidence prevents malformed envelopes from suppressing fresh seeding while preserving partial metadata repair.
+// QNBS-v3: canonical desktop collections prevent valid filesystem projects from being discarded while malformed envelopes remain non-authoritative.
 export function getPersistedProjectPayload(
   project: PersistedRootState['project'] | undefined,
 ): ProjectData | undefined {
   const payload = project?.present?.data ?? project?.data;
   if (!isRecord(payload)) return undefined;
-  if (
-    !hasEntityStateShape(payload.characters) ||
-    !hasEntityStateShape(payload.worlds) ||
-    !Array.isArray(payload.outline) ||
-    !Array.isArray(payload.manuscript)
-  )
-    return undefined;
-  return payload as ProjectData;
+  const characters = normalizeEntityCollection(payload['characters'], charactersAdapter);
+  const worlds = normalizeEntityCollection(payload['worlds'], worldsAdapter);
+  if (!characters || !worlds || !Array.isArray(payload['manuscript'])) return undefined;
+  const outline = payload['outline'];
+  if (outline !== undefined && !Array.isArray(outline)) return undefined;
+  return {
+    ...payload,
+    characters,
+    worlds,
+    outline: outline ?? [],
+  } as unknown as ProjectData;
 }
 
 // QNBS-v3: seed authority follows hydrated project presence, so settings-only state can still initialize the synthetic project without overwriting real user intent.

--- a/services/appBootstrap.ts
+++ b/services/appBootstrap.ts
@@ -56,8 +56,7 @@ function normalizeEntityCollection<T>(
     const ids: string[] = [];
     const entities = Object.create(null) as Record<string, T>;
     for (const entity of value) {
-      if (!isRecord(entity) || typeof entity['id'] !== 'string' || !entity['id'].trim())
-        return undefined;
+      if (!isRecord(entity) || typeof entity['id'] !== 'string') return undefined;
       const id = entity['id'];
       if (hasOwn(entities, id)) return undefined;
       ids.push(id);
@@ -74,7 +73,7 @@ function normalizeEntityCollection<T>(
   const entities = Object.create(null) as Record<string, T>;
   const seenIds = new Set<string>();
   for (const id of sourceIds) {
-    if (typeof id !== 'string' || !id.trim() || seenIds.has(id)) return undefined;
+    if (typeof id !== 'string' || seenIds.has(id)) return undefined;
     if (!hasOwn(sourceEntities, id)) return undefined;
     const entity = sourceEntities[id];
     if (!isRecord(entity) || entity['id'] !== id) return undefined;

--- a/services/appBootstrap.ts
+++ b/services/appBootstrap.ts
@@ -37,9 +37,19 @@ export async function loadPersistedRootState(): Promise<PersistedRootState | und
   return result;
 }
 
+// QNBS-v3: only an actual persisted payload grants project authority; malformed envelopes must still seed the synthetic project.
+export function getPersistedProjectPayload(
+  project: PersistedRootState['project'] | undefined,
+): ProjectData | undefined {
+  const payload = project?.present?.data ?? project?.data;
+  return typeof payload === 'object' && payload !== null && !Array.isArray(payload)
+    ? payload
+    : undefined;
+}
+
 // QNBS-v3: seed authority follows hydrated project presence, so settings-only state can still initialize the synthetic project without overwriting real user intent.
 export function shouldAllowInitialMetadataSeed(
   preloadedState: PersistedRootState | undefined,
 ): boolean {
-  return preloadedState?.project === undefined;
+  return getPersistedProjectPayload(preloadedState?.project) === undefined;
 }

--- a/services/appBootstrap.ts
+++ b/services/appBootstrap.ts
@@ -36,3 +36,10 @@ export async function loadPersistedRootState(): Promise<PersistedRootState | und
   if (project) result.project = { data: project as unknown as ProjectData };
   return result;
 }
+
+// QNBS-v3: seed authority follows hydrated project presence, so settings-only state can still initialize the synthetic project without overwriting real user intent.
+export function shouldAllowInitialMetadataSeed(
+  preloadedState: PersistedRootState | undefined,
+): boolean {
+  return preloadedState?.project === undefined;
+}

--- a/services/appBootstrap.ts
+++ b/services/appBootstrap.ts
@@ -37,14 +37,30 @@ export async function loadPersistedRootState(): Promise<PersistedRootState | und
   return result;
 }
 
-// QNBS-v3: only an actual persisted payload grants project authority; malformed envelopes must still seed the synthetic project.
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasEntityStateShape(value: unknown): boolean {
+  if (!isRecord(value) || !Array.isArray(value['ids']) || !isRecord(value['entities']))
+    return false;
+  return value['ids'].every((id: unknown) => typeof id === 'string');
+}
+
+// QNBS-v3: structural project evidence prevents malformed envelopes from suppressing fresh seeding while preserving partial metadata repair.
 export function getPersistedProjectPayload(
   project: PersistedRootState['project'] | undefined,
 ): ProjectData | undefined {
   const payload = project?.present?.data ?? project?.data;
-  return typeof payload === 'object' && payload !== null && !Array.isArray(payload)
-    ? payload
-    : undefined;
+  if (!isRecord(payload)) return undefined;
+  if (
+    !hasEntityStateShape(payload.characters) ||
+    !hasEntityStateShape(payload.worlds) ||
+    !Array.isArray(payload.outline) ||
+    !Array.isArray(payload.manuscript)
+  )
+    return undefined;
+  return payload as ProjectData;
 }
 
 // QNBS-v3: seed authority follows hydrated project presence, so settings-only state can still initialize the synthetic project without overwriting real user intent.

--- a/services/projectI18nRepair.ts
+++ b/services/projectI18nRepair.ts
@@ -15,6 +15,12 @@ export type ProjectI18nRepair = {
   manuscript?: StorySection[];
 };
 
+// QNBS-v3: missing metadata is repairable while empty strings remain valid user intent.
+function shouldRepairMetadata(value: unknown, seedInitialMetadata: boolean): boolean {
+  if (typeof value !== 'string') return true;
+  return (seedInitialMetadata && value === '') || isKnownPersistedTranslationKey(value);
+}
+
 /** Repair raw i18n keys, optionally seeding metadata only for the first fresh-user bootstrap. */
 export function repairProjectI18nFields(
   project: ProjectMetaSlice,
@@ -25,14 +31,11 @@ export function repairProjectI18nFields(
   let changed = false;
 
   // QNBS-v3: only explicit fresh-project authority may fill blanks; raw persisted keys remain independently repairable.
-  if ((seedInitialMetadata && !project.title) || isKnownPersistedTranslationKey(project.title)) {
+  if (shouldRepairMetadata(project.title, seedInitialMetadata)) {
     repair.title = t('initialProject.title');
     changed = true;
   }
-  if (
-    (seedInitialMetadata && !project.logline) ||
-    isKnownPersistedTranslationKey(project.logline)
-  ) {
+  if (shouldRepairMetadata(project.logline, seedInitialMetadata)) {
     repair.logline = t('initialProject.logline');
     changed = true;
   }

--- a/services/projectI18nRepair.ts
+++ b/services/projectI18nRepair.ts
@@ -24,6 +24,7 @@ export function repairProjectI18nFields(
   const repair: ProjectI18nRepair = {};
   let changed = false;
 
+  // QNBS-v3: only explicit fresh-project authority may fill blanks; raw persisted keys remain independently repairable.
   if ((seedInitialMetadata && !project.title) || isKnownPersistedTranslationKey(project.title)) {
     repair.title = t('initialProject.title');
     changed = true;

--- a/services/projectI18nRepair.ts
+++ b/services/projectI18nRepair.ts
@@ -15,19 +15,23 @@ export type ProjectI18nRepair = {
   manuscript?: StorySection[];
 };
 
-/** Repair project fields that were saved as raw i18n keys during cold start. */
+/** Repair raw i18n keys, optionally seeding metadata only for the first fresh-user bootstrap. */
 export function repairProjectI18nFields(
   project: ProjectMetaSlice,
   t: TranslateFn,
+  { seedInitialMetadata = false }: { seedInitialMetadata?: boolean } = {},
 ): ProjectI18nRepair | null {
   const repair: ProjectI18nRepair = {};
   let changed = false;
 
-  if (!project.title || isKnownPersistedTranslationKey(project.title)) {
+  if ((seedInitialMetadata && !project.title) || isKnownPersistedTranslationKey(project.title)) {
     repair.title = t('initialProject.title');
     changed = true;
   }
-  if (!project.logline || isKnownPersistedTranslationKey(project.logline)) {
+  if (
+    (seedInitialMetadata && !project.logline) ||
+    isKnownPersistedTranslationKey(project.logline)
+  ) {
     repair.logline = t('initialProject.logline');
     changed = true;
   }

--- a/services/projectImportSchema.ts
+++ b/services/projectImportSchema.ts
@@ -135,10 +135,23 @@ const outlineSectionSchema = z.object({
   isTwist: z.boolean().optional(),
 });
 
+// QNBS-v3: entry-based parsing preserves legal prototype-named entity IDs as own keys for hydration.
+/** Parses record entries without letting special property names alter object prototypes. */
+function prototypeSafeEntityRecordSchema<T extends z.ZodTypeAny>(item: T) {
+  return z.preprocess(
+    (value) => {
+      if (typeof value !== 'object' || value === null || Array.isArray(value)) return value;
+      const record = value as Record<string, unknown>;
+      return Object.keys(record).map((key) => [key, record[key]]);
+    },
+    z.array(z.tuple([z.string(), item])).transform((entries) => Object.fromEntries(entries)),
+  );
+}
+
 const entityStateSchema = <T extends z.ZodTypeAny>(item: T) =>
   z.object({
     ids: z.array(z.string()),
-    entities: z.record(z.string(), item),
+    entities: prototypeSafeEntityRecordSchema(item),
   });
 
 const charactersFieldSchema = z.union([

--- a/tests/e2e/onboarding-entry-precondition.spec.ts
+++ b/tests/e2e/onboarding-entry-precondition.spec.ts
@@ -21,7 +21,6 @@ test.describe('WelcomePortal entry precondition (CI-only)', () => {
     // QNBS-v3: the helper's contract is locale-independent portal-reached, not English — assert the stable testid, not the translated button label.
     await page.addInitScript(() => localStorage.setItem('worldscript-language', 'es'));
     await page.goto('/');
-    await expect(page.getByTestId('welcome-portal')).toBeVisible();
     await ensureWelcomePortalEntry(page);
     await expect(page.getByTestId('welcome-portal')).toBeVisible();
   });

--- a/tests/unit/App.test.tsx
+++ b/tests/unit/App.test.tsx
@@ -1,0 +1,185 @@
+import { render } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockUseApp,
+  mockProjectBootstrapEffect,
+  mockDispatch,
+  mockStore,
+  selectorState,
+  project,
+  featureFlags,
+} = vi.hoisted(() => ({
+  mockUseApp: vi.fn(),
+  mockProjectBootstrapEffect: vi.fn(),
+  mockDispatch: vi.fn(),
+  mockStore: {
+    getState: vi.fn(() => ({})),
+  },
+  selectorState: {
+    settings: {
+      theme: 'light',
+      appearancePreset: 'default',
+      writingSurfaceStyle: 'default',
+      keyboardShortcuts: [],
+      privacy: { analyticsEnabled: false },
+      aiMode: 'hybrid',
+      openRouter: { enabled: false },
+      advancedEditor: {
+        distractionFree: false,
+        typewriterMode: false,
+        zenMode: false,
+        focusMode: false,
+      },
+      accessibility: {
+        highContrast: false,
+        reducedMotion: false,
+        reducedTransparency: false,
+        largeText: false,
+        screenReader: false,
+        focusIndicators: false,
+        comfortableTargets: false,
+        colorBlindMode: 'none',
+      },
+      desktop: { minimizeToTray: false },
+    },
+  },
+  project: { id: 'test-project', title: 'Test project' },
+  featureFlags: {
+    enableRtlLayout: false,
+    enablePluginSystem: false,
+    enableDuckDbAnalytics: false,
+    enableWorkerBusV2: false,
+    enableLocalFirstSync: false,
+    enableIdbAtRestEncryption: false,
+    enableObjectsGroups: false,
+    enableMindMaps: false,
+    enableCharacterInterviews: false,
+    enableLoraAdapters: false,
+    enableGlobalCopilot: false,
+    enableVoiceSupport: false,
+  },
+}));
+
+vi.mock('react-redux', () => ({
+  Provider: ({ children }: { children: ReactNode }) => children,
+  useStore: () => mockStore,
+}));
+
+vi.mock('../../app/hooks', () => ({
+  useAppDispatch: () => mockDispatch,
+  useAppSelector: vi.fn((selector: (state: unknown) => unknown) => selector(selectorState)),
+}));
+
+vi.mock('../../features/project/projectSelectors', () => ({
+  selectProjectData: () => project,
+  selectAllCharacters: () => [],
+  selectAllWorlds: () => [],
+}));
+
+vi.mock('../../features/featureFlags/featureFlagsSlice', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../features/featureFlags/featureFlagsSlice')>();
+  return {
+    ...actual,
+    selectFeatureFlags: () => featureFlags,
+  };
+});
+
+vi.mock('../../hooks/useApp', () => ({ useApp: mockUseApp }));
+vi.mock('../../hooks/useProjectBootstrapEffect', () => ({
+  useProjectBootstrapEffect: mockProjectBootstrapEffect,
+}));
+vi.mock('../../hooks/useGlobalKeyboardShortcuts', () => ({
+  useGlobalKeyboardShortcuts: vi.fn(),
+}));
+vi.mock('../../hooks/useIdbUnlockStartupGuard', () => ({
+  useIdbUnlockStartupGuard: vi.fn(),
+}));
+vi.mock('../../hooks/useNativeNotifications', () => ({ useNativeNotifications: vi.fn() }));
+vi.mock('../../hooks/usePushToTalk', () => ({ usePushToTalk: vi.fn() }));
+vi.mock('../../hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    language: 'en',
+    setLanguage: vi.fn(),
+    isReady: true,
+  }),
+}));
+
+vi.mock('../../contexts/I18nContext', () => ({
+  I18nProvider: ({ children }: { children: ReactNode }) => children,
+  RTL_LOCALES: new Set<string>(),
+}));
+vi.mock('../../contexts/LiveRegionContext', () => ({
+  LiveRegionProvider: ({ children }: { children: ReactNode }) => children,
+  useAnnounce: () => vi.fn(),
+}));
+
+vi.mock('../../app/listenerMiddleware', () => ({
+  initAdaptiveAiOnStartup: vi.fn(),
+  initLocalFirstSyncOnStartup: vi.fn(),
+  initWorkerBusOnStartup: vi.fn(),
+}));
+vi.mock('../../services/storage/encryptionMigrationJournal', () => ({
+  readEncryptionMigrationJournal: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('../../services/storage/storageEncryptionService', () => ({
+  isIdbEncryptionReady: vi.fn(() => false),
+}));
+vi.mock('../../services/desktop/desktopMenu', () => ({
+  installDesktopMenu: vi.fn().mockResolvedValue(false),
+}));
+vi.mock('../../services/desktop/desktopTray', () => ({
+  installCloseToTray: vi.fn().mockResolvedValue(undefined),
+  installDesktopTray: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../../services/tauriDeepLink', () => ({
+  initTauriDeepLink: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../../services/tauriRuntime', () => ({
+  applyDesktopRuntimeFlags: vi.fn(),
+  isTauriRuntime: vi.fn(() => false),
+}));
+vi.mock('../../services/desktopPlatform', () => ({
+  desktopPlatform: {
+    runtime: { isDesktop: false },
+    lifecycle: { quit: vi.fn().mockResolvedValue(undefined) },
+  },
+}));
+
+import App from '../../App';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseApp.mockReturnValue({
+    currentView: 'dashboard',
+    previousView: 'dashboard',
+    handleNavigate: vi.fn(),
+    handlePortalExit: vi.fn(),
+    isPortalActive: false,
+    isInitialLoad: true,
+    allowInitialMetadataSeed: true,
+    isSidebarOpen: false,
+    setIsSidebarOpen: vi.fn(),
+  });
+});
+
+describe('App seed-authority wiring', () => {
+  // QNBS-v3: protects the boot authority boundary so synthetic-project seeding cannot drift from the hydrated runtime decision.
+  it('forwards boot authority into useApp and runtime authority into project bootstrap', () => {
+    render(<App isNewUser={false} allowInitialMetadataSeed={false} />);
+
+    expect(mockUseApp).toHaveBeenCalledWith({
+      isNewUser: false,
+      allowInitialMetadataSeed: false,
+    });
+    expect(mockProjectBootstrapEffect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        project,
+        allowInitialMetadataSeed: true,
+      }),
+    );
+  });
+});

--- a/tests/unit/App.test.tsx
+++ b/tests/unit/App.test.tsx
@@ -2,65 +2,44 @@ import { render } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const {
-  mockUseApp,
-  mockProjectBootstrapEffect,
-  mockDispatch,
-  mockStore,
-  selectorState,
-  project,
-  featureFlags,
-} = vi.hoisted(() => ({
-  mockUseApp: vi.fn(),
-  mockProjectBootstrapEffect: vi.fn(),
-  mockDispatch: vi.fn(),
-  mockStore: {
-    getState: vi.fn(() => ({})),
-  },
-  selectorState: {
-    settings: {
-      theme: 'light',
-      appearancePreset: 'default',
-      writingSurfaceStyle: 'default',
-      keyboardShortcuts: [],
-      privacy: { analyticsEnabled: false },
-      aiMode: 'hybrid',
-      openRouter: { enabled: false },
-      advancedEditor: {
-        distractionFree: false,
-        typewriterMode: false,
-        zenMode: false,
-        focusMode: false,
-      },
-      accessibility: {
-        highContrast: false,
-        reducedMotion: false,
-        reducedTransparency: false,
-        largeText: false,
-        screenReader: false,
-        focusIndicators: false,
-        comfortableTargets: false,
-        colorBlindMode: 'none',
-      },
-      desktop: { minimizeToTray: false },
+const { mockUseApp, mockProjectBootstrapEffect, mockDispatch, mockStore, selectorState, project } =
+  vi.hoisted(() => ({
+    mockUseApp: vi.fn(),
+    mockProjectBootstrapEffect: vi.fn(),
+    mockDispatch: vi.fn(),
+    mockStore: {
+      getState: vi.fn(() => ({})),
     },
-  },
-  project: { id: 'test-project', title: 'Test project' },
-  featureFlags: {
-    enableRtlLayout: false,
-    enablePluginSystem: false,
-    enableDuckDbAnalytics: false,
-    enableWorkerBusV2: false,
-    enableLocalFirstSync: false,
-    enableIdbAtRestEncryption: false,
-    enableObjectsGroups: false,
-    enableMindMaps: false,
-    enableCharacterInterviews: false,
-    enableLoraAdapters: false,
-    enableGlobalCopilot: false,
-    enableVoiceSupport: false,
-  },
-}));
+    selectorState: {
+      settings: {
+        theme: 'light',
+        appearancePreset: 'default',
+        writingSurfaceStyle: 'default',
+        keyboardShortcuts: [],
+        privacy: { analyticsEnabled: false },
+        aiMode: 'hybrid',
+        openRouter: { enabled: false },
+        advancedEditor: {
+          distractionFree: false,
+          typewriterMode: false,
+          zenMode: false,
+          focusMode: false,
+        },
+        accessibility: {
+          highContrast: false,
+          reducedMotion: false,
+          reducedTransparency: false,
+          largeText: false,
+          screenReader: false,
+          focusIndicators: false,
+          comfortableTargets: false,
+          colorBlindMode: 'none',
+        },
+        desktop: { minimizeToTray: false },
+      },
+    },
+    project: { id: 'test-project', title: 'Test project' },
+  }));
 
 vi.mock('react-redux', () => ({
   Provider: ({ children }: { children: ReactNode }) => children,
@@ -83,7 +62,21 @@ vi.mock('../../features/featureFlags/featureFlagsSlice', async (importOriginal) 
     await importOriginal<typeof import('../../features/featureFlags/featureFlagsSlice')>();
   return {
     ...actual,
-    selectFeatureFlags: () => featureFlags,
+    selectFeatureFlags: () => ({
+      ...actual.defaultFeatureFlagsState,
+      enableRtlLayout: false,
+      enablePluginSystem: false,
+      enableDuckDbAnalytics: false,
+      enableWorkerBusV2: false,
+      enableLocalFirstSync: false,
+      enableIdbAtRestEncryption: false,
+      enableObjectsGroups: false,
+      enableMindMaps: false,
+      enableCharacterInterviews: false,
+      enableLoraAdapters: false,
+      enableGlobalCopilot: false,
+      enableVoiceSupport: false,
+    }),
   };
 });
 

--- a/tests/unit/WelcomePortal.test.tsx
+++ b/tests/unit/WelcomePortal.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { WelcomePortal } from '../../components/WelcomePortal';
 
@@ -49,7 +49,17 @@ vi.mock('../../features/status/statusSlice', () => ({
 }));
 
 vi.mock('../../features/project/thunks/projectManagementThunks', () => ({
-  importProjectThunk: vi.fn(() => async () => undefined),
+  importProjectThunk: Object.assign(
+    vi.fn(() => ({ type: 'project/importProject/pending' })),
+    {
+      fulfilled: {
+        match: (action: unknown) =>
+          typeof action === 'object' &&
+          action !== null &&
+          (action as { type?: string }).type === 'project/importProject/fulfilled',
+      },
+    },
+  ),
 }));
 
 vi.mock('../../services/storageService', () => ({
@@ -115,5 +125,17 @@ describe('WelcomePortal', () => {
     render(<WelcomePortal onExit={vi.fn()} />);
     fireEvent.click(screen.getByRole('button', { name: 'portal.welcome.openProject' }));
     expect(screen.getByText('portal.open.title')).toBeTruthy();
+  });
+
+  it('marks a welcome-portal import as ineligible for fresh metadata seeding', async () => {
+    mockDispatch.mockResolvedValue({ type: 'project/importProject/fulfilled' });
+    const onExit = vi.fn();
+    render(<WelcomePortal onExit={onExit} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'portal.welcome.tryDemo' }));
+
+    await waitFor(() =>
+      expect(onExit).toHaveBeenCalledWith('manuscript', { allowInitialMetadataSeed: false }),
+    );
   });
 });

--- a/tests/unit/WelcomePortal.test.tsx
+++ b/tests/unit/WelcomePortal.test.tsx
@@ -143,4 +143,20 @@ describe('WelcomePortal', () => {
       expect(onExit).toHaveBeenCalledWith('manuscript', { allowInitialMetadataSeed: false }),
     );
   });
+
+  it('revokes fresh metadata seeding after importing a project file', async () => {
+    mockDispatch.mockResolvedValue({ type: 'project/importProject/fulfilled' });
+    const onExit = vi.fn();
+    const user = userEvent.setup();
+    render(<WelcomePortal onExit={onExit} />);
+
+    await user.click(screen.getByRole('button', { name: 'portal.welcome.openProject' }));
+    const input = document.querySelector('input[type="file"]');
+    expect(input).not.toBeNull();
+    await user.upload(input as HTMLInputElement, new File(['{}'], 'project.json'));
+
+    await waitFor(() =>
+      expect(onExit).toHaveBeenCalledWith('manuscript', { allowInitialMetadataSeed: false }),
+    );
+  });
 });

--- a/tests/unit/WelcomePortal.test.tsx
+++ b/tests/unit/WelcomePortal.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { WelcomePortal } from '../../components/WelcomePortal';
 
@@ -115,24 +116,28 @@ describe('WelcomePortal', () => {
     expect(screen.getByText('portal.welcome.privacyBadge')).toBeTruthy();
   });
 
-  it('navigates to new project view on newProject button click', () => {
+  it('navigates to new project view on newProject button click', async () => {
+    const user = userEvent.setup();
     render(<WelcomePortal onExit={vi.fn()} />);
-    fireEvent.click(screen.getByRole('button', { name: 'portal.welcome.newProject' }));
+    await user.click(screen.getByRole('button', { name: 'portal.welcome.newProject' }));
     expect(screen.getByText('portal.new.title')).toBeTruthy();
   });
 
-  it('navigates to open project view on openProject button click', () => {
+  it('navigates to open project view on openProject button click', async () => {
+    const user = userEvent.setup();
     render(<WelcomePortal onExit={vi.fn()} />);
-    fireEvent.click(screen.getByRole('button', { name: 'portal.welcome.openProject' }));
+    await user.click(screen.getByRole('button', { name: 'portal.welcome.openProject' }));
     expect(screen.getByText('portal.open.title')).toBeTruthy();
   });
 
+  // QNBS-v3: locks the portal transition that revokes fresh-metadata seed authority after import.
   it('marks a welcome-portal import as ineligible for fresh metadata seeding', async () => {
     mockDispatch.mockResolvedValue({ type: 'project/importProject/fulfilled' });
     const onExit = vi.fn();
+    const user = userEvent.setup();
     render(<WelcomePortal onExit={onExit} />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'portal.welcome.tryDemo' }));
+    await user.click(screen.getByRole('button', { name: 'portal.welcome.tryDemo' }));
 
     await waitFor(() =>
       expect(onExit).toHaveBeenCalledWith('manuscript', { allowInitialMetadataSeed: false }),

--- a/tests/unit/projectI18nRepair.test.ts
+++ b/tests/unit/projectI18nRepair.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { repairProjectI18nFields } from '../../services/projectI18nRepair';
+import { type ProjectMetaSlice, repairProjectI18nFields } from '../../services/projectI18nRepair';
 
 describe('repairProjectI18nFields', () => {
   const t = vi.fn((key: string) => {
@@ -52,6 +52,28 @@ describe('repairProjectI18nFields', () => {
       t,
     );
     expect(repair).toBeNull();
+  });
+
+  it('repairs missing title without replacing the persisted project content', () => {
+    const repair = repairProjectI18nFields(
+      {
+        logline: 'Existing logline',
+        manuscript: [{ id: '1', title: 'Chapter 1', content: 'Existing work' }],
+      } as unknown as ProjectMetaSlice,
+      t,
+    );
+    expect(repair).toEqual({ title: 'My Untitled Story' });
+  });
+
+  it('repairs missing logline without replacing the persisted project content', () => {
+    const repair = repairProjectI18nFields(
+      {
+        title: 'Existing title',
+        manuscript: [{ id: '1', title: 'Chapter 1', content: 'Existing work' }],
+      } as unknown as ProjectMetaSlice,
+      t,
+    );
+    expect(repair).toEqual({ logline: 'A journey...' });
   });
 
   it('returns null when project metadata is already human-readable', () => {

--- a/tests/unit/projectI18nRepair.test.ts
+++ b/tests/unit/projectI18nRepair.test.ts
@@ -65,6 +65,7 @@ describe('repairProjectI18nFields', () => {
     expect(repair).toEqual({ title: 'My Untitled Story' });
   });
 
+  // QNBS-v3: missing presentation metadata is repaired without discarding the genuine persisted project.
   it('repairs missing logline without replacing the persisted project content', () => {
     const repair = repairProjectI18nFields(
       {

--- a/tests/unit/projectI18nRepair.test.ts
+++ b/tests/unit/projectI18nRepair.test.ts
@@ -25,6 +25,7 @@ describe('repairProjectI18nFields', () => {
     expect(repair?.manuscript?.[0]?.title).toBe('Chapter 1');
   });
 
+  // QNBS-v3: separates user-intent preservation from explicit fresh-project metadata seeding.
   it('preserves intentionally empty title and logline while still seeding an empty manuscript', () => {
     const repair = repairProjectI18nFields({ title: '', logline: '', manuscript: [] }, t);
     expect(repair?.title).toBeUndefined();

--- a/tests/unit/projectI18nRepair.test.ts
+++ b/tests/unit/projectI18nRepair.test.ts
@@ -25,10 +25,32 @@ describe('repairProjectI18nFields', () => {
     expect(repair?.manuscript?.[0]?.title).toBe('Chapter 1');
   });
 
-  it('seeds manuscript when empty', () => {
+  it('preserves intentionally empty title and logline while still seeding an empty manuscript', () => {
     const repair = repairProjectI18nFields({ title: '', logline: '', manuscript: [] }, t);
-    expect(repair?.title).toBe('My Untitled Story');
+    expect(repair?.title).toBeUndefined();
+    expect(repair?.logline).toBeUndefined();
     expect(repair?.manuscript).toHaveLength(1);
+  });
+
+  it('seeds blank metadata only when fresh-user bootstrap explicitly authorizes it', () => {
+    const repair = repairProjectI18nFields({ title: '', logline: '', manuscript: [] }, t, {
+      seedInitialMetadata: true,
+    });
+    expect(repair?.title).toBe('My Untitled Story');
+    expect(repair?.logline).toBe('A journey...');
+    expect(repair?.manuscript).toHaveLength(1);
+  });
+
+  it('leaves intentionally empty metadata untouched when the project has real content', () => {
+    const repair = repairProjectI18nFields(
+      {
+        title: '',
+        logline: '',
+        manuscript: [{ id: '1', title: 'Chapter 1', content: 'Existing work' }],
+      },
+      t,
+    );
+    expect(repair).toBeNull();
   });
 
   it('returns null when project metadata is already human-readable', () => {

--- a/tests/unit/projectImportSchema.test.ts
+++ b/tests/unit/projectImportSchema.test.ts
@@ -45,6 +45,34 @@ describe('projectImportSchema', () => {
     expect(parsed.worlds).toMatchObject([{ id: ' ', name: 'Whitespace world' }]);
   });
 
+  // QNBS-v3: import parsing must retain prototype-named entity keys before hydration correspondence checks.
+  it('preserves prototype-named IDs in normalized entity records', () => {
+    const raw = JSON.stringify({
+      title: 'T',
+      logline: 'L',
+      characters: {
+        ids: ['__proto__'],
+        entities: Object.fromEntries([['__proto__', { id: '__proto__', name: 'Prototype' }]]),
+      },
+      worlds: {
+        ids: ['constructor'],
+        entities: Object.fromEntries([['constructor', { id: 'constructor', name: 'Constructor' }]]),
+      },
+      manuscript: [],
+    });
+    const parsed = parseImportedProjectJson(raw);
+    const characters = parsed.characters;
+    const worlds = parsed.worlds;
+
+    expect(Array.isArray(characters)).toBe(false);
+    expect(Array.isArray(worlds)).toBe(false);
+    if (Array.isArray(characters) || Array.isArray(worlds) || !characters || !worlds) return;
+    expect(Object.hasOwn(characters.entities, '__proto__')).toBe(true);
+    expect(Reflect.get(characters.entities, '__proto__')?.id).toBe('__proto__');
+    expect(Object.hasOwn(worlds.entities, 'constructor')).toBe(true);
+    expect(worlds.entities.constructor?.id).toBe('constructor');
+  });
+
   it('rejects invalid JSON shape', () => {
     expect(() => parseImportedProjectJson(JSON.stringify([]))).toThrow(/Invalid project file/);
   });

--- a/tests/unit/projectImportSchema.test.ts
+++ b/tests/unit/projectImportSchema.test.ts
@@ -30,6 +30,21 @@ describe('projectImportSchema', () => {
     expect(parsed.binderNodes?.[0]?.title).toBe('Research');
   });
 
+  // QNBS-v3: the bootstrap boundary must preserve string IDs already accepted by project imports.
+  it('accepts empty and whitespace entity IDs in imported projects', () => {
+    const raw = JSON.stringify({
+      title: 'T',
+      logline: 'L',
+      characters: [{ id: '', name: 'Unnamed' }],
+      worlds: [{ id: ' ', name: 'Whitespace world' }],
+      manuscript: [],
+    });
+    const parsed = parseImportedProjectJson(raw);
+
+    expect(parsed.characters).toMatchObject([{ id: '', name: 'Unnamed' }]);
+    expect(parsed.worlds).toMatchObject([{ id: ' ', name: 'Whitespace world' }]);
+  });
+
   it('rejects invalid JSON shape', () => {
     expect(() => parseImportedProjectJson(JSON.stringify([]))).toThrow(/Invalid project file/);
   });

--- a/tests/unit/services/appBootstrap.test.ts
+++ b/tests/unit/services/appBootstrap.test.ts
@@ -9,6 +9,7 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { charactersAdapter } from '../../../features/project/adapters';
 import type { PersistedRootState } from '../../../types';
 
 const createPersistedProject = (overrides: Record<string, unknown> = {}) => ({
@@ -59,6 +60,7 @@ vi.mock('../../../services/storageService', () => ({
 import {
   getPersistedProjectPayload,
   loadPersistedRootState,
+  normalizePersistedProjectForStore,
   shouldAllowInitialMetadataSeed,
 } from '../../../services/appBootstrap';
 
@@ -249,6 +251,71 @@ describe('shouldAllowInitialMetadataSeed', () => {
     expect(payload?.worlds).toEqual({ ids: ['world-1'], entities: { 'world-1': world } });
   });
 
+  it('preserves prototype-named array IDs in an adapter-compatible entity state', () => {
+    const ids = ['__proto__', 'constructor', 'toString'];
+    const project = createDesktopProject({
+      characters: ids.map((id) => ({ id, name: `Character ${id}` })),
+      worlds: ids.map((id) => ({ id, name: `World ${id}` })),
+    });
+    const state = { project: { data: project } } as unknown as PersistedRootState;
+    const payload = getPersistedProjectPayload(state.project);
+
+    expect(payload).toBeDefined();
+    if (!payload) return;
+    expect(Object.getPrototypeOf(payload.characters.entities)).toBeNull();
+    expect(Object.getPrototypeOf(payload.worlds.entities)).toBeNull();
+    for (const id of ids) {
+      expect(payload.characters.ids).toContain(id);
+      expect(Object.hasOwn(payload.characters.entities, id)).toBe(true);
+      expect(payload.characters.entities[id]?.id).toBe(id);
+      expect(payload.worlds.ids).toContain(id);
+      expect(Object.hasOwn(payload.worlds.entities, id)).toBe(true);
+      expect(payload.worlds.entities[id]?.id).toBe(id);
+    }
+
+    const updated = charactersAdapter.updateOne(payload.characters, {
+      id: '__proto__',
+      changes: { name: 'Updated' },
+    });
+    const updatedPrototypeCharacter = Object.getOwnPropertyDescriptor(updated.entities, '__proto__')
+      ?.value as { name: string } | undefined;
+    expect(updatedPrototypeCharacter?.name).toBe('Updated');
+    const selectCharacter = charactersAdapter.getSelectors().selectById;
+    expect(selectCharacter(payload.characters, '__proto__')?.name).toBe('Character __proto__');
+  });
+
+  it('rebuilds an EntityState input into a prototype-safe map without losing IDs', () => {
+    const sourceEntities = Object.create(null) as Record<string, { id: string; name: string }>;
+    sourceEntities['constructor'] = { id: 'constructor', name: 'Constructor' };
+    sourceEntities['toString'] = { id: 'toString', name: 'To String' };
+    const project = createDesktopProject({
+      characters: { ids: ['constructor', 'toString'], entities: sourceEntities },
+    });
+    const state = { project: { data: project } } as unknown as PersistedRootState;
+    const payload = getPersistedProjectPayload(state.project);
+
+    expect(payload).toBeDefined();
+    if (!payload) return;
+    expect(payload?.characters.ids).toEqual(['constructor', 'toString']);
+    expect(Object.getPrototypeOf(payload.characters.entities)).toBeNull();
+    expect(payload.characters.entities['constructor']?.name).toBe('Constructor');
+    expect(payload.characters.entities['toString']?.name).toBe('To String');
+  });
+
+  // QNBS-v3: orphaned entity entries must not masquerade as canonical state and suppress fresh-project fallback.
+  it('rejects EntityState entries that are not represented by ids', () => {
+    const project = createDesktopProject({
+      characters: {
+        ids: [],
+        entities: { orphan: { id: 'orphan', name: 'Orphan' } },
+      },
+    });
+    const state = { project: { data: project } } as unknown as PersistedRootState;
+
+    expect(getPersistedProjectPayload(state.project)).toBeUndefined();
+    expect(shouldAllowInitialMetadataSeed(state)).toBe(true);
+  });
+
   it('normalizes mixed array and EntityState desktop collections', () => {
     const world = { id: 'world-1', name: 'Arcadia' };
     const project = createDesktopProject({
@@ -325,5 +392,32 @@ describe('shouldAllowInitialMetadataSeed', () => {
 
     expect(getPersistedProjectPayload(state.project)).toBeUndefined();
     expect(shouldAllowInitialMetadataSeed(state)).toBe(true);
+  });
+
+  it('writes the normalized active payload back into an existing undo envelope', () => {
+    const project = createDesktopProject({
+      characters: [{ id: 'character-1', name: 'Ada' }],
+      worlds: [{ id: 'world-1', name: 'Arcadia' }],
+    });
+    const past = [{ data: createPersistedProject({ title: 'Past' }) }];
+    const future = [{ data: createPersistedProject({ title: 'Future' }) }];
+    const envelope = {
+      past,
+      present: { data: project },
+      future,
+      group: 'project-edit',
+      _latestUnfiltered: { data: project },
+    } as unknown as PersistedRootState['project'];
+
+    const normalized = normalizePersistedProjectForStore(envelope);
+
+    expect(normalized?.past).toBe(past);
+    expect(normalized?.future).toBe(future);
+    expect(normalized?.present?.data.characters).toEqual({
+      ids: ['character-1'],
+      entities: { 'character-1': { id: 'character-1', name: 'Ada' } },
+    });
+    expect(normalized?.present?.data.outline).toEqual([]);
+    expect(normalized?._latestUnfiltered).toEqual({ data: normalized?.present?.data });
   });
 });

--- a/tests/unit/services/appBootstrap.test.ts
+++ b/tests/unit/services/appBootstrap.test.ts
@@ -21,6 +21,15 @@ const createPersistedProject = (overrides: Record<string, unknown> = {}) => ({
   ...overrides,
 });
 
+const createDesktopProject = (overrides: Record<string, unknown> = {}) => ({
+  title: '',
+  logline: '',
+  characters: [],
+  worlds: [],
+  manuscript: [],
+  ...overrides,
+});
+
 const h = vi.hoisted(() => ({
   isTauri: { value: false },
   dbLoadState: vi.fn(),
@@ -209,5 +218,112 @@ describe('shouldAllowInitialMetadataSeed', () => {
     const state = { project: { data: project } } as unknown as PersistedRootState;
     expect(getPersistedProjectPayload(state.project)).toEqual(project);
     expect(shouldAllowInitialMetadataSeed(state)).toBe(false);
+  });
+
+  // QNBS-v3: canonicalizes supported desktop persistence shapes before hydration authority can suppress fresh-project seeding.
+  it('normalizes desktop arrays and an omitted outline into the Redux shape', () => {
+    const project = createDesktopProject();
+    const state = { project: { data: project } } as unknown as PersistedRootState;
+    const payload = getPersistedProjectPayload(state.project);
+
+    expect(payload).toMatchObject({
+      outline: [],
+      manuscript: [],
+    });
+    expect(payload?.characters).toEqual({ ids: [], entities: {} });
+    expect(payload?.worlds).toEqual({ ids: [], entities: {} });
+    expect(shouldAllowInitialMetadataSeed(state)).toBe(false);
+  });
+
+  it('preserves all entities when normalizing desktop character and world arrays', () => {
+    const character = { id: 'character-1', name: 'Ada' };
+    const world = { id: 'world-1', name: 'Arcadia' };
+    const project = createDesktopProject({ characters: [character], worlds: [world] });
+    const state = { project: { data: project } } as unknown as PersistedRootState;
+    const payload = getPersistedProjectPayload(state.project);
+
+    expect(payload?.characters).toEqual({
+      ids: ['character-1'],
+      entities: { 'character-1': character },
+    });
+    expect(payload?.worlds).toEqual({ ids: ['world-1'], entities: { 'world-1': world } });
+  });
+
+  it('normalizes mixed array and EntityState desktop collections', () => {
+    const world = { id: 'world-1', name: 'Arcadia' };
+    const project = createDesktopProject({
+      characters: [{ id: 'character-1', name: 'Ada' }],
+      worlds: { ids: ['world-1'], entities: { 'world-1': world } },
+    });
+    const state = { project: { data: project } } as unknown as PersistedRootState;
+    const payload = getPersistedProjectPayload(state.project);
+
+    expect(payload?.characters.ids).toEqual(['character-1']);
+    expect(payload?.worlds).toEqual({ ids: ['world-1'], entities: { 'world-1': world } });
+  });
+
+  it('accepts the inverse mixed EntityState and array representation', () => {
+    const character = { id: 'character-1', name: 'Ada' };
+    const project = createDesktopProject({
+      characters: { ids: ['character-1'], entities: { 'character-1': character } },
+      worlds: [{ id: 'world-1', name: 'Arcadia' }],
+    });
+    const state = { project: { data: project } } as unknown as PersistedRootState;
+    const payload = getPersistedProjectPayload(state.project);
+
+    expect(payload?.characters).toEqual({
+      ids: ['character-1'],
+      entities: { 'character-1': character },
+    });
+    expect(payload?.worlds.ids).toEqual(['world-1']);
+  });
+
+  it('rejects array entities without stable IDs instead of dropping their content', () => {
+    const project = createDesktopProject({ characters: [{ name: 'Missing ID' }] });
+    const state = { project: { data: project } } as unknown as PersistedRootState;
+
+    expect(getPersistedProjectPayload(state.project)).toBeUndefined();
+    expect(shouldAllowInitialMetadataSeed(state)).toBe(true);
+  });
+
+  it('preserves an already canonical Redux project without changing its content', () => {
+    const project = createPersistedProject({
+      title: 'A story',
+      logline: 'A premise',
+      manuscript: [{ id: 'section-1', title: 'Chapter 1', content: 'Existing work' }],
+    });
+    const state = { project: { data: project } } as unknown as PersistedRootState;
+
+    expect(getPersistedProjectPayload(state.project)).toEqual(project);
+  });
+
+  it('keeps a structurally genuine project authoritative when title is absent', () => {
+    const project = createDesktopProject({
+      manuscript: [{ id: 'section-1', title: 'Existing', content: 'Work' }],
+    });
+    Reflect.deleteProperty(project, 'title');
+    const state = { project: { data: project } } as unknown as PersistedRootState;
+
+    expect(getPersistedProjectPayload(state.project)).toBeDefined();
+    expect(shouldAllowInitialMetadataSeed(state)).toBe(false);
+  });
+
+  it('keeps a structurally genuine project authoritative when logline is absent', () => {
+    const project = createDesktopProject({
+      manuscript: [{ id: 'section-1', title: 'Existing', content: 'Work' }],
+    });
+    Reflect.deleteProperty(project, 'logline');
+    const state = { project: { data: project } } as unknown as PersistedRootState;
+
+    expect(getPersistedProjectPayload(state.project)).toBeDefined();
+    expect(shouldAllowInitialMetadataSeed(state)).toBe(false);
+  });
+
+  it('rejects a present non-array outline instead of hiding malformed structure', () => {
+    const project = createDesktopProject({ outline: {} });
+    const state = { project: { data: project } } as unknown as PersistedRootState;
+
+    expect(getPersistedProjectPayload(state.project)).toBeUndefined();
+    expect(shouldAllowInitialMetadataSeed(state)).toBe(true);
   });
 });

--- a/tests/unit/services/appBootstrap.test.ts
+++ b/tests/unit/services/appBootstrap.test.ts
@@ -303,6 +303,33 @@ describe('shouldAllowInitialMetadataSeed', () => {
     expect(payload.characters.entities['toString']?.name).toBe('To String');
   });
 
+  // QNBS-v3: imported string IDs remain hydratable so valid project content cannot be discarded at cold boot.
+  it('preserves empty and whitespace entity IDs accepted by project imports', () => {
+    const characters = [
+      { id: '', name: 'Empty ID' },
+      { id: ' ', name: 'Whitespace ID' },
+    ];
+    const worlds = [
+      { id: '', name: 'Empty world ID' },
+      { id: ' ', name: 'Whitespace world ID' },
+    ];
+    const project = createDesktopProject({ characters, worlds });
+    const state = { project: { data: project } } as unknown as PersistedRootState;
+    const payload = getPersistedProjectPayload(state.project);
+
+    expect(payload?.characters?.ids).toEqual(['', ' ']);
+    expect(payload?.worlds?.ids).toEqual(['', ' ']);
+    expect(Object.hasOwn(payload?.characters?.entities ?? {}, '')).toBe(true);
+    expect(Object.hasOwn(payload?.characters?.entities ?? {}, ' ')).toBe(true);
+    expect(Object.hasOwn(payload?.worlds?.entities ?? {}, '')).toBe(true);
+    expect(Object.hasOwn(payload?.worlds?.entities ?? {}, ' ')).toBe(true);
+    expect(payload?.characters?.entities['']?.name).toBe('Empty ID');
+    expect(payload?.characters?.entities[' ']?.name).toBe('Whitespace ID');
+    expect(payload?.worlds?.entities['']?.name).toBe('Empty world ID');
+    expect(payload?.worlds?.entities[' ']?.name).toBe('Whitespace world ID');
+    expect(shouldAllowInitialMetadataSeed(state)).toBe(false);
+  });
+
   // QNBS-v3: orphaned entity entries must not masquerade as canonical state and suppress fresh-project fallback.
   it('rejects EntityState entries that are not represented by ids', () => {
     const project = createDesktopProject({

--- a/tests/unit/services/appBootstrap.test.ts
+++ b/tests/unit/services/appBootstrap.test.ts
@@ -38,6 +38,7 @@ vi.mock('../../../services/storageService', () => ({
 }));
 
 import {
+  getPersistedProjectPayload,
   loadPersistedRootState,
   shouldAllowInitialMetadataSeed,
 } from '../../../services/appBootstrap';
@@ -136,6 +137,15 @@ describe('shouldAllowInitialMetadataSeed', () => {
   it('allows seeding when settings were restored without a project', () => {
     const settingsOnlyState = { settings: {} } as unknown as PersistedRootState;
     expect(shouldAllowInitialMetadataSeed(settingsOnlyState)).toBe(true);
+  });
+
+  it('allows seeding when a persisted project envelope has no actual payload', () => {
+    const malformedState = {
+      project: { present: {} },
+      settings: {},
+    } as unknown as PersistedRootState;
+    expect(getPersistedProjectPayload(malformedState.project)).toBeUndefined();
+    expect(shouldAllowInitialMetadataSeed(malformedState)).toBe(true);
   });
 
   it('does not allow seeding after a persisted project was hydrated', () => {

--- a/tests/unit/services/appBootstrap.test.ts
+++ b/tests/unit/services/appBootstrap.test.ts
@@ -11,6 +11,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { PersistedRootState } from '../../../types';
 
+const createPersistedProject = (overrides: Record<string, unknown> = {}) => ({
+  title: '',
+  logline: '',
+  characters: { ids: [], entities: {} },
+  worlds: { ids: [], entities: {} },
+  outline: [],
+  manuscript: [],
+  ...overrides,
+});
+
 const h = vi.hoisted(() => ({
   isTauri: { value: false },
   dbLoadState: vi.fn(),
@@ -141,17 +151,63 @@ describe('shouldAllowInitialMetadataSeed', () => {
 
   it('allows seeding when a persisted project envelope has no actual payload', () => {
     const malformedState = {
-      project: { present: {} },
+      project: { present: { data: {} } },
       settings: {},
     } as unknown as PersistedRootState;
     expect(getPersistedProjectPayload(malformedState.project)).toBeUndefined();
     expect(shouldAllowInitialMetadataSeed(malformedState)).toBe(true);
   });
 
+  it('allows seeding when flat persisted project data is an empty object', () => {
+    const malformedState = {
+      project: { data: {} },
+    } as unknown as PersistedRootState;
+    expect(getPersistedProjectPayload(malformedState.project)).toBeUndefined();
+    expect(shouldAllowInitialMetadataSeed(malformedState)).toBe(true);
+  });
+
+  it('rejects flat arbitrary object-shaped project data as non-hydratable', () => {
+    const malformedState = {
+      project: { data: { foo: 'bar' } },
+    } as unknown as PersistedRootState;
+    expect(getPersistedProjectPayload(malformedState.project)).toBeUndefined();
+    expect(shouldAllowInitialMetadataSeed(malformedState)).toBe(true);
+  });
+
+  it('accepts a structurally genuine empty project without requiring metadata content', () => {
+    const project = createPersistedProject();
+    const state = { project: { data: project } } as unknown as PersistedRootState;
+    expect(getPersistedProjectPayload(state.project)).toEqual(project);
+    expect(shouldAllowInitialMetadataSeed(state)).toBe(false);
+  });
+
   it('does not allow seeding after a persisted project was hydrated', () => {
+    const project = createPersistedProject({
+      manuscript: [{ id: 'section-1', title: 'Existing', content: 'Valuable work' }],
+    });
     const hydratedProjectState = {
-      project: { present: { data: {} } },
+      project: { present: { data: project } },
     } as unknown as PersistedRootState;
     expect(shouldAllowInitialMetadataSeed(hydratedProjectState)).toBe(false);
+  });
+
+  it('keeps a genuine project authoritative when title is missing', () => {
+    const project = createPersistedProject({
+      title: undefined,
+      manuscript: [{ id: 'section-1', title: 'Existing', content: 'Valuable work' }],
+    });
+    const state = { project: { data: project } } as unknown as PersistedRootState;
+    expect(getPersistedProjectPayload(state.project)).toEqual(project);
+    expect(shouldAllowInitialMetadataSeed(state)).toBe(false);
+  });
+
+  it('keeps a genuine project authoritative when logline is missing', () => {
+    const project = createPersistedProject({
+      logline: undefined,
+      manuscript: [{ id: 'section-1', title: 'Existing', content: 'Valuable work' }],
+    });
+    const state = { project: { data: project } } as unknown as PersistedRootState;
+    expect(getPersistedProjectPayload(state.project)).toEqual(project);
+    expect(shouldAllowInitialMetadataSeed(state)).toBe(false);
   });
 });

--- a/tests/unit/services/appBootstrap.test.ts
+++ b/tests/unit/services/appBootstrap.test.ts
@@ -160,6 +160,7 @@ describe('shouldAllowInitialMetadataSeed', () => {
     expect(shouldAllowInitialMetadataSeed(settingsOnlyState)).toBe(true);
   });
 
+  // QNBS-v3: payload absence must keep malformed envelopes from suppressing fresh-project initialization.
   it('allows seeding when a persisted project envelope has no actual payload', () => {
     const malformedState = {
       project: { present: { data: {} } },

--- a/tests/unit/services/appBootstrap.test.ts
+++ b/tests/unit/services/appBootstrap.test.ts
@@ -9,6 +9,7 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PersistedRootState } from '../../../types';
 
 const h = vi.hoisted(() => ({
   isTauri: { value: false },
@@ -36,7 +37,10 @@ vi.mock('../../../services/storageService', () => ({
   },
 }));
 
-import { loadPersistedRootState } from '../../../services/appBootstrap';
+import {
+  loadPersistedRootState,
+  shouldAllowInitialMetadataSeed,
+} from '../../../services/appBootstrap';
 
 describe('loadPersistedRootState', () => {
   beforeEach(() => {
@@ -120,5 +124,24 @@ describe('loadPersistedRootState', () => {
     await loadPersistedRootState();
     expect(h.loadProject).toHaveBeenCalledTimes(1);
     expect(h.loadProject).toHaveBeenCalledWith('proj-1');
+  });
+});
+
+describe('shouldAllowInitialMetadataSeed', () => {
+  // QNBS-v3: verifies metadata seeding follows hydrated project presence instead of any persisted root state.
+  it('allows seeding when no persisted root state exists', () => {
+    expect(shouldAllowInitialMetadataSeed(undefined)).toBe(true);
+  });
+
+  it('allows seeding when settings were restored without a project', () => {
+    const settingsOnlyState = { settings: {} } as unknown as PersistedRootState;
+    expect(shouldAllowInitialMetadataSeed(settingsOnlyState)).toBe(true);
+  });
+
+  it('does not allow seeding after a persisted project was hydrated', () => {
+    const hydratedProjectState = {
+      project: { present: { data: {} } },
+    } as unknown as PersistedRootState;
+    expect(shouldAllowInitialMetadataSeed(hydratedProjectState)).toBe(false);
   });
 });

--- a/tests/unit/store.test.ts
+++ b/tests/unit/store.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
+import { normalizePersistedProjectForStore } from '../../services/appBootstrap';
+import type { PersistedRootState } from '../../types';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -73,6 +75,49 @@ describe('setupStore', () => {
     expect(Array.isArray(state['project']?.past)).toBe(true);
     expect(Array.isArray(state['project']?.future)).toBe(true);
     expect(state['project']?.present).toBeTruthy();
+  });
+
+  // QNBS-v3: the store must receive the canonical active payload so desktop arrays cannot bypass EntityState selectors after undo hydration.
+  it('hydrates normalized active data inside an existing undo envelope', async () => {
+    const { setupStore } = await import('../../app/store');
+    const project = {
+      title: '',
+      logline: '',
+      characters: [{ id: '__proto__', name: 'Ada' }],
+      worlds: [{ id: 'constructor', name: 'Arcadia' }],
+      manuscript: [],
+    };
+    const normalizedProject = normalizePersistedProjectForStore({
+      past: [],
+      present: { data: project },
+      future: [],
+    } as unknown as PersistedRootState['project']);
+
+    expect(normalizedProject).toBeDefined();
+    if (!normalizedProject) return;
+    const store = setupStore({ project: normalizedProject } as PersistedRootState);
+    const state = store.getState() as unknown as {
+      project: {
+        present: {
+          data: {
+            characters: { entities: Record<string, { id: string }> };
+            worlds: { entities: Record<string, { id: string }> };
+          };
+        };
+      };
+    };
+
+    const prototypeCharacter = Object.getOwnPropertyDescriptor(
+      state.project.present.data.characters.entities,
+      '__proto__',
+    )?.value as { id: string } | undefined;
+    const constructorWorld = Object.getOwnPropertyDescriptor(
+      state.project.present.data.worlds.entities,
+      'constructor',
+    )?.value as { id: string } | undefined;
+    expect(prototypeCharacter?.id).toBe('__proto__');
+    expect(constructorWorld?.id).toBe('constructor');
+    expect(Object.getPrototypeOf(state.project.present.data.characters.entities)).toBeNull();
   });
 });
 

--- a/tests/unit/thunks/binderAndManagementThunks.test.ts
+++ b/tests/unit/thunks/binderAndManagementThunks.test.ts
@@ -431,7 +431,10 @@ describe('importProjectThunk', () => {
         entities: Object.fromEntries([['toString', { id: 'toString', name: 'ToString World' }]]),
       },
     };
-    vi.mocked(parseImportedProjectJson).mockReturnValue(projectWithNormalizedPrototypeIds as never);
+    const actualSchema = await vi.importActual<
+      typeof import('../../../services/projectImportSchema')
+    >('../../../services/projectImportSchema');
+    vi.mocked(parseImportedProjectJson).mockImplementation(actualSchema.parseImportedProjectJson);
 
     const store = makeStore();
     const file = new File([JSON.stringify(projectWithNormalizedPrototypeIds)], 'novel.json', {

--- a/tests/unit/thunks/binderAndManagementThunks.test.ts
+++ b/tests/unit/thunks/binderAndManagementThunks.test.ts
@@ -18,6 +18,7 @@ vi.mock('../../../services/projectImportSchema', () => ({
 }));
 
 import featureFlagsReducer from '../../../features/featureFlags/featureFlagsSlice';
+import { charactersAdapter, worldsAdapter } from '../../../features/project/adapters';
 import projectReducer, { projectActions } from '../../../features/project/projectSlice';
 import {
   importBinderFileThunk,
@@ -353,6 +354,143 @@ describe('importProjectThunk', () => {
     const action = await store.dispatch(importProjectThunk(file));
 
     expect(action.type).toBe('project/importProject/fulfilled');
+  });
+
+  // QNBS-v3: imported prototype-named IDs must remain own properties through canonicalization and persistence.
+  it('preserves prototype-named imported character and world IDs', async () => {
+    const projectWithPrototypeIds = {
+      ...minimalProject,
+      characters: [
+        { id: '__proto__', name: 'Prototype Character' },
+        { id: 'constructor', name: 'Constructor Character' },
+        { id: 'toString', name: 'ToString Character' },
+      ],
+      worlds: [
+        { id: '__proto__', name: 'Prototype World' },
+        { id: 'constructor', name: 'Constructor World' },
+        { id: 'toString', name: 'ToString World' },
+      ],
+    };
+    vi.mocked(parseImportedProjectJson).mockReturnValue(projectWithPrototypeIds as never);
+
+    const store = makeStore();
+    const file = new File([JSON.stringify(projectWithPrototypeIds)], 'novel.json', {
+      type: 'application/json',
+    });
+    const action = await store.dispatch(importProjectThunk(file));
+    const payload = (
+      action as {
+        payload: {
+          characters: { ids: string[]; entities: Record<string, { id: string; name: string }> };
+          worlds: { ids: string[]; entities: Record<string, { id: string; name: string }> };
+        };
+      }
+    ).payload;
+
+    for (const id of ['__proto__', 'constructor', 'toString']) {
+      expect(payload.characters.ids).toContain(id);
+      expect(Object.hasOwn(payload.characters.entities, id)).toBe(true);
+      expect(Object.hasOwn(payload.worlds.entities, id)).toBe(true);
+    }
+    expect(JSON.stringify(payload.characters.entities)).toContain('Prototype Character');
+    expect(JSON.stringify(payload.worlds.entities)).toContain('Prototype World');
+
+    const state = store.getState().project.present.data;
+    expect(Object.getPrototypeOf(state.characters.entities)).toBeNull();
+    expect(Object.getPrototypeOf(state.worlds.entities)).toBeNull();
+    expect(charactersAdapter.getSelectors().selectById(state.characters, '__proto__')?.name).toBe(
+      'Prototype Character',
+    );
+    expect(worldsAdapter.getSelectors().selectById(state.worlds, 'constructor')?.name).toBe(
+      'Constructor World',
+    );
+
+    store.dispatch(
+      projectActions.updateCharacter({ id: '__proto__', changes: { name: 'Updated Character' } }),
+    );
+    const updatedCharacter = Reflect.get(
+      store.getState().project.present.data.characters.entities,
+      '__proto__',
+    ) as { name?: string };
+    expect(updatedCharacter.name).toBe('Updated Character');
+  });
+
+  // QNBS-v3: normalized imports must preserve own-ID correspondence instead of filtering malformed entries silently.
+  it('preserves prototype-named IDs in normalized imported collections', async () => {
+    const projectWithNormalizedPrototypeIds = {
+      ...minimalProject,
+      characters: {
+        ids: ['__proto__', 'constructor'],
+        entities: Object.fromEntries([
+          ['__proto__', { id: '__proto__', name: 'Prototype Character' }],
+          ['constructor', { id: 'constructor', name: 'Constructor Character' }],
+        ]),
+      },
+      worlds: {
+        ids: ['toString'],
+        entities: Object.fromEntries([['toString', { id: 'toString', name: 'ToString World' }]]),
+      },
+    };
+    vi.mocked(parseImportedProjectJson).mockReturnValue(projectWithNormalizedPrototypeIds as never);
+
+    const store = makeStore();
+    const file = new File([JSON.stringify(projectWithNormalizedPrototypeIds)], 'novel.json', {
+      type: 'application/json',
+    });
+    const action = await store.dispatch(importProjectThunk(file));
+
+    expect(action.type).toBe('project/importProject/fulfilled');
+    expect(store.getState().project.present.data.characters.ids).toEqual([
+      '__proto__',
+      'constructor',
+    ]);
+    expect(store.getState().project.present.data.worlds.ids).toEqual(['toString']);
+  });
+
+  // QNBS-v3: malformed normalized collections must fail before import side effects can create partial state.
+  it.each([
+    {
+      name: 'missing entity',
+      characters: { ids: ['missing'], entities: {} },
+    },
+    {
+      name: 'orphan entity',
+      characters: { ids: ['c1'], entities: { c1: { id: 'c1' }, orphan: { id: 'orphan' } } },
+    },
+  ])('rejects normalized collections with $name', async ({ characters }) => {
+    const malformedProject = { ...minimalProject, characters };
+    vi.mocked(parseImportedProjectJson).mockReturnValue(malformedProject as never);
+
+    const store = makeStore();
+    const file = new File([JSON.stringify(malformedProject)], 'novel.json', {
+      type: 'application/json',
+    });
+    const action = await store.dispatch(importProjectThunk(file));
+
+    expect(action.type).toBe('project/importProject/rejected');
+    expect(store.getState().project.present.data.title).toBe('');
+    expect(storageService.saveImage).not.toHaveBeenCalled();
+  });
+
+  // QNBS-v3: duplicate imported IDs are rejected instead of silently discarding project entities.
+  it('rejects duplicate imported entity IDs without creating a partial project', async () => {
+    const projectWithDuplicateIds = {
+      ...minimalProject,
+      characters: [
+        { id: 'duplicate', name: 'First Character' },
+        { id: 'duplicate', name: 'Second Character' },
+      ],
+    };
+    vi.mocked(parseImportedProjectJson).mockReturnValue(projectWithDuplicateIds as never);
+
+    const store = makeStore();
+    const file = new File([JSON.stringify(projectWithDuplicateIds)], 'novel.json', {
+      type: 'application/json',
+    });
+    const action = await store.dispatch(importProjectThunk(file));
+
+    expect(action.type).toBe('project/importProject/rejected');
+    expect(store.getState().project.present.data.title).toBe('');
   });
 });
 

--- a/tests/unit/useApp.test.ts
+++ b/tests/unit/useApp.test.ts
@@ -126,6 +126,14 @@ describe('useApp', () => {
     expect(result.current.allowInitialMetadataSeed).toBe(false);
   });
 
+  // QNBS-v3: proves boot-derived seed authority can differ from first-run portal state.
+  it('uses explicit boot seed authority independently from isNewUser', () => {
+    const { result } = renderHook(() =>
+      useApp({ isNewUser: false, allowInitialMetadataSeed: true }),
+    );
+    expect(result.current.allowInitialMetadataSeed).toBe(true);
+  });
+
   it('activates portal for new users', () => {
     const { result } = renderHook(() => useApp({ isNewUser: true }));
     expect(result.current.isPortalActive).toBe(true);

--- a/tests/unit/useApp.test.ts
+++ b/tests/unit/useApp.test.ts
@@ -115,6 +115,17 @@ describe('useApp', () => {
     expect(result.current.isPortalActive).toBe(false);
   });
 
+  it('disables fresh metadata seeding when the portal exits after an import', () => {
+    const { result } = renderHook(() => useApp({ isNewUser: true }));
+    expect(result.current.allowInitialMetadataSeed).toBe(true);
+
+    act(() => {
+      result.current.handlePortalExit('manuscript', { allowInitialMetadataSeed: false });
+    });
+
+    expect(result.current.allowInitialMetadataSeed).toBe(false);
+  });
+
   it('activates portal for new users', () => {
     const { result } = renderHook(() => useApp({ isNewUser: true }));
     expect(result.current.isPortalActive).toBe(true);

--- a/tests/unit/useProjectBootstrapEffect.test.ts
+++ b/tests/unit/useProjectBootstrapEffect.test.ts
@@ -28,6 +28,7 @@ describe('shouldRunProjectBootstrap', () => {
     expect(
       shouldRunProjectBootstrap({
         project: blankProject,
+        isNewUser: false,
         isInitialLoad: true,
         isPortalActive: false,
         isI18nReady: true,
@@ -39,6 +40,7 @@ describe('shouldRunProjectBootstrap', () => {
     expect(
       shouldRunProjectBootstrap({
         project: blankProject,
+        isNewUser: false,
         isInitialLoad: false,
         isPortalActive: false,
         isI18nReady: true,
@@ -50,6 +52,7 @@ describe('shouldRunProjectBootstrap', () => {
     expect(
       shouldRunProjectBootstrap({
         project: blankProject,
+        isNewUser: false,
         isInitialLoad: false,
         isPortalActive: true,
         isI18nReady: true,
@@ -61,6 +64,7 @@ describe('shouldRunProjectBootstrap', () => {
     expect(
       shouldRunProjectBootstrap({
         project: blankProject,
+        isNewUser: false,
         isInitialLoad: false,
         isPortalActive: false,
         isI18nReady: false,
@@ -72,6 +76,7 @@ describe('shouldRunProjectBootstrap', () => {
     expect(
       shouldRunProjectBootstrap({
         project: null,
+        isNewUser: false,
         isInitialLoad: false,
         isPortalActive: false,
         isI18nReady: true,
@@ -85,6 +90,7 @@ describe('useProjectBootstrapEffect', () => {
     renderHook(() =>
       useProjectBootstrapEffect({
         project: blankProject,
+        isNewUser: false,
         isInitialLoad: true,
         isPortalActive: false,
         isI18nReady: true,
@@ -94,24 +100,46 @@ describe('useProjectBootstrapEffect', () => {
     expect(dispatch).not.toHaveBeenCalled();
   });
 
-  it('seeds a blank project via the repair path once bootstrap has settled', () => {
-    // QNBS-v3: repairProjectI18nFields treats a blank title/logline/manuscript as "needs repair" too, so it — not the resetProject branch — is what actually seeds a brand-new blank project in practice.
+  it('preserves blank metadata for a returning project while still seeding its empty manuscript', () => {
     renderHook(() =>
       useProjectBootstrapEffect({
         project: blankProject,
+        isNewUser: false,
         isInitialLoad: false,
         isPortalActive: false,
         isI18nReady: true,
         t,
       }),
     );
-    expect(dispatch).toHaveBeenCalledWith(projectActions.updateTitle('initialProject.title'));
-    expect(dispatch).toHaveBeenCalledWith(projectActions.updateLogline('initialProject.logline'));
+    expect(dispatch).not.toHaveBeenCalledWith(projectActions.updateTitle(expect.anything()));
+    expect(dispatch).not.toHaveBeenCalledWith(projectActions.updateLogline(expect.anything()));
     expect(dispatch).toHaveBeenCalledWith(
       projectActions.setManuscript([
         expect.objectContaining({ title: 'initialProject.chapter1', content: '' }),
       ]),
     );
+  });
+
+  it('seeds blank metadata only once for a fresh user', () => {
+    const { rerender } = renderHook(
+      ({ project }) =>
+        useProjectBootstrapEffect({
+          project,
+          isNewUser: true,
+          isInitialLoad: false,
+          isPortalActive: false,
+          isI18nReady: true,
+          t,
+        }),
+      { initialProps: { project: blankProject } },
+    );
+    expect(dispatch).toHaveBeenCalledWith(projectActions.updateTitle('initialProject.title'));
+    expect(dispatch).toHaveBeenCalledWith(projectActions.updateLogline('initialProject.logline'));
+
+    dispatch.mockClear();
+    rerender({ project: { ...blankProject } });
+    expect(dispatch).not.toHaveBeenCalledWith(projectActions.updateTitle(expect.anything()));
+    expect(dispatch).not.toHaveBeenCalledWith(projectActions.updateLogline(expect.anything()));
   });
 
   it('dispatches nothing for a project that already has real content', () => {
@@ -122,6 +150,7 @@ describe('useProjectBootstrapEffect', () => {
           logline: 'A real logline',
           manuscript: [{ id: 'sec-1', title: 'Ch1', content: 'Real content' }],
         },
+        isNewUser: false,
         isInitialLoad: false,
         isPortalActive: false,
         isI18nReady: true,
@@ -135,6 +164,7 @@ describe('useProjectBootstrapEffect', () => {
     renderHook(() =>
       useProjectBootstrapEffect({
         project: blankProject,
+        isNewUser: false,
         isInitialLoad: false,
         isPortalActive: true,
         isI18nReady: true,
@@ -148,6 +178,7 @@ describe('useProjectBootstrapEffect', () => {
     renderHook(() =>
       useProjectBootstrapEffect({
         project: null,
+        isNewUser: false,
         isInitialLoad: false,
         isPortalActive: false,
         isI18nReady: true,
@@ -161,10 +192,11 @@ describe('useProjectBootstrapEffect', () => {
     renderHook(() =>
       useProjectBootstrapEffect({
         project: {
-          title: '',
+          title: 'initialProject.title',
           logline: 'A real logline',
           manuscript: [{ id: 'sec-1', title: 'Real Chapter', content: 'real' }],
         },
+        isNewUser: false,
         isInitialLoad: false,
         isPortalActive: false,
         isI18nReady: true,
@@ -182,9 +214,10 @@ describe('useProjectBootstrapEffect', () => {
       useProjectBootstrapEffect({
         project: {
           title: 'A Real Title',
-          logline: '',
+          logline: 'initialProject.logline',
           manuscript: [{ id: 'sec-1', title: 'Real Chapter', content: 'real' }],
         },
+        isNewUser: false,
         isInitialLoad: false,
         isPortalActive: false,
         isI18nReady: true,

--- a/tests/unit/useProjectBootstrapEffect.test.ts
+++ b/tests/unit/useProjectBootstrapEffect.test.ts
@@ -80,6 +80,7 @@ describe('shouldRunProjectBootstrap', () => {
   });
 });
 
+// QNBS-v3: verifies bootstrap applies explicit seed authority without changing raw-key repair behavior.
 describe('useProjectBootstrapEffect', () => {
   it('never dispatches during the race window (isInitialLoad still true)', () => {
     renderHook(() =>

--- a/tests/unit/useProjectBootstrapEffect.test.ts
+++ b/tests/unit/useProjectBootstrapEffect.test.ts
@@ -28,7 +28,6 @@ describe('shouldRunProjectBootstrap', () => {
     expect(
       shouldRunProjectBootstrap({
         project: blankProject,
-        isNewUser: false,
         isInitialLoad: true,
         isPortalActive: false,
         isI18nReady: true,
@@ -40,7 +39,6 @@ describe('shouldRunProjectBootstrap', () => {
     expect(
       shouldRunProjectBootstrap({
         project: blankProject,
-        isNewUser: false,
         isInitialLoad: false,
         isPortalActive: false,
         isI18nReady: true,
@@ -52,7 +50,6 @@ describe('shouldRunProjectBootstrap', () => {
     expect(
       shouldRunProjectBootstrap({
         project: blankProject,
-        isNewUser: false,
         isInitialLoad: false,
         isPortalActive: true,
         isI18nReady: true,
@@ -64,7 +61,6 @@ describe('shouldRunProjectBootstrap', () => {
     expect(
       shouldRunProjectBootstrap({
         project: blankProject,
-        isNewUser: false,
         isInitialLoad: false,
         isPortalActive: false,
         isI18nReady: false,
@@ -76,7 +72,6 @@ describe('shouldRunProjectBootstrap', () => {
     expect(
       shouldRunProjectBootstrap({
         project: null,
-        isNewUser: false,
         isInitialLoad: false,
         isPortalActive: false,
         isI18nReady: true,
@@ -90,7 +85,7 @@ describe('useProjectBootstrapEffect', () => {
     renderHook(() =>
       useProjectBootstrapEffect({
         project: blankProject,
-        isNewUser: false,
+        allowInitialMetadataSeed: false,
         isInitialLoad: true,
         isPortalActive: false,
         isI18nReady: true,
@@ -104,7 +99,7 @@ describe('useProjectBootstrapEffect', () => {
     renderHook(() =>
       useProjectBootstrapEffect({
         project: blankProject,
-        isNewUser: false,
+        allowInitialMetadataSeed: false,
         isInitialLoad: false,
         isPortalActive: false,
         isI18nReady: true,
@@ -125,7 +120,7 @@ describe('useProjectBootstrapEffect', () => {
       ({ project }) =>
         useProjectBootstrapEffect({
           project,
-          isNewUser: true,
+          allowInitialMetadataSeed: true,
           isInitialLoad: false,
           isPortalActive: false,
           isI18nReady: true,
@@ -150,7 +145,7 @@ describe('useProjectBootstrapEffect', () => {
           logline: 'A real logline',
           manuscript: [{ id: 'sec-1', title: 'Ch1', content: 'Real content' }],
         },
-        isNewUser: false,
+        allowInitialMetadataSeed: false,
         isInitialLoad: false,
         isPortalActive: false,
         isI18nReady: true,
@@ -164,7 +159,7 @@ describe('useProjectBootstrapEffect', () => {
     renderHook(() =>
       useProjectBootstrapEffect({
         project: blankProject,
-        isNewUser: false,
+        allowInitialMetadataSeed: false,
         isInitialLoad: false,
         isPortalActive: true,
         isI18nReady: true,
@@ -178,7 +173,7 @@ describe('useProjectBootstrapEffect', () => {
     renderHook(() =>
       useProjectBootstrapEffect({
         project: null,
-        isNewUser: false,
+        allowInitialMetadataSeed: false,
         isInitialLoad: false,
         isPortalActive: false,
         isI18nReady: true,
@@ -196,7 +191,7 @@ describe('useProjectBootstrapEffect', () => {
           logline: 'A real logline',
           manuscript: [{ id: 'sec-1', title: 'Real Chapter', content: 'real' }],
         },
-        isNewUser: false,
+        allowInitialMetadataSeed: false,
         isInitialLoad: false,
         isPortalActive: false,
         isI18nReady: true,
@@ -217,7 +212,7 @@ describe('useProjectBootstrapEffect', () => {
           logline: 'initialProject.logline',
           manuscript: [{ id: 'sec-1', title: 'Real Chapter', content: 'real' }],
         },
-        isNewUser: false,
+        allowInitialMetadataSeed: false,
         isInitialLoad: false,
         isPortalActive: false,
         isI18nReady: true,


### PR DESCRIPTION
## **User description**
## S2 / #531-A only

This PR implements only the intent-preservation portion of Issue #531.

### Fixed
- Preserve intentionally empty project title and logline during returning-user bootstrap.
- Preserve raw persisted i18n-key repair for title, logline, and manuscript section titles.
- Keep fresh-user blank metadata initialization bounded to its existing one-time lifecycle signal.

### Explicitly preserved / not included
- #531 Gap 1 (translation-readiness fallback) is not fixed here.
- #531 Gap 3 (atomic redux-undo startup repair) is not fixed here.
- No persisted project schema, undo-history, locale-readiness, Storage-Core, or roadmap changes are included.

This is a bounded S2 continuation from #531-A. It does not claim to close the complete issue.

## Summary by Sourcery

Preserve user-cleared project metadata and safely validate project data during startup and import.

Bug Fixes:
- Preserve intentionally blank project titles and loglines for returning, imported, and demo projects while continuing to repair persisted translation keys.
- Prevent malformed or partially valid project imports from altering the current project state.
- Preserve imported and persisted entities with empty, whitespace, or prototype-colliding IDs.

Enhancements:
- Make fresh-project metadata initialization dependent on explicit, one-time bootstrap authority rather than general first-run state.
- Normalize and validate persisted project data before Redux hydration, including collection formats, outlines, and undo envelopes.

Documentation:
- Update documented test counts to reflect the expanded test suite.

Tests:
- Add coverage for metadata intent preservation, seed-authority transitions, persisted-state normalization, safe entity IDs, and malformed import rejection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved project setup so imported and demo projects preserve intentionally blank titles and loglines.
  - Prevented repeated automatic metadata seeding while continuing to repair missing localized fields.
  - Improved startup handling for incomplete or malformed saved projects while preserving valid content and history.
  - Preserved entity ordering and safely retained unusual character and world identifiers.
  - Added validation to prevent malformed or duplicate project entities during import.

- **Documentation**
  - Updated README test-count references to reflect 7,355+ tests across 595 files.

- **Tests**
  - Expanded coverage for onboarding, portal exits, metadata handling, project imports, and bootstrap scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Preserve project metadata and imported content during startup and import

### What Changed
- Intentionally blank project titles and loglines now remain blank for returning, imported, and demo projects.
- Fresh projects seed default metadata only during an authorized first-time setup.
- Saved desktop projects are validated and normalized before loading, including array-based collections, missing outlines, undo history, and unusual entity IDs.
- Invalid or inconsistent imports are rejected before they can partially change the current project.

### Impact
`✅ Cleared project metadata stays cleared`
`✅ Imported and demo content is not overwritten`
`✅ Fewer lost or partially imported project entities`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>