### PR TITLE
fix: harden Writer Studio readability (#341)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2937_keys-0EA5E9" alt="i18n 19 locales — 2937 keys">
-  <img src="https://img.shields.io/badge/Tests-7356%2B_%2F_595_files-22C55E" alt="7356+ tests / 595 files">
+  <img src="https://img.shields.io/badge/Tests-7357%2B_%2F_595_files-22C55E" alt="7357+ tests / 595 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2937 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7356+ tests / 595 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7357+ tests / 595 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7356+ tests, 595 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7357+ tests, 595 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -711,7 +711,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-30, source-synchronized; CI remains authoritative for pass/fail):**
-- **7356+ unit tests** across **595 test files** — CI is authoritative for pass/fail
+- **7357+ unit tests** across **595 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2937 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/components/manuscript/ManuscriptEditor.tsx
+++ b/components/manuscript/ManuscriptEditor.tsx
@@ -97,7 +97,7 @@ export const ManuscriptEditor: FC<{ isFocusMode: boolean }> = React.memo(({ isFo
   // QNBS-v3: Defer highlight computation so keystroke → textarea updates stay synchronous even for long scenes.
   const deferredContent = useDeferredValue(activeSection?.content ?? '');
   const isHighlightPending = deferredContent !== (activeSection?.content ?? '');
-  // QNBS-v3 (#341): retain a visible pending cue without dropping light-sepia mirror contrast below 4.5:1.
+  // QNBS-v3: Pending mirror opacity preserves WCAG contrast while retaining the deferred-state cue.
 
   // QNBS-v3 (#341): shared with components/ui/Textarea.tsx and ContextPanel.tsx — the raw enum
   // value (e.g. 'custom') is not a valid font-family, and the highlight overlay must render the

--- a/components/manuscript/ManuscriptEditor.tsx
+++ b/components/manuscript/ManuscriptEditor.tsx
@@ -97,6 +97,7 @@ export const ManuscriptEditor: FC<{ isFocusMode: boolean }> = React.memo(({ isFo
   // QNBS-v3: Defer highlight computation so keystroke → textarea updates stay synchronous even for long scenes.
   const deferredContent = useDeferredValue(activeSection?.content ?? '');
   const isHighlightPending = deferredContent !== (activeSection?.content ?? '');
+  // QNBS-v3 (#341): retain a visible pending cue without dropping light-sepia mirror contrast below 4.5:1.
 
   // QNBS-v3 (#341): shared with components/ui/Textarea.tsx and ContextPanel.tsx — the raw enum
   // value (e.g. 'custom') is not a valid font-family, and the highlight overlay must render the
@@ -398,7 +399,7 @@ export const ManuscriptEditor: FC<{ isFocusMode: boolean }> = React.memo(({ isFo
           ref={highlightRef}
           data-testid="manuscript-editor-mirror"
           dir={dir}
-          className={`absolute inset-0 p-4 sm:p-6 md:p-12 pt-2 leading-relaxed pointer-events-none overflow-auto max-w-3xl mx-auto transition-all duration-500 ${isFocusMode ? 'max-w-4xl pt-12' : ''} ${isHighlightPending ? 'opacity-70' : 'opacity-100'}`}
+          className={`absolute inset-0 p-4 sm:p-6 md:p-12 pt-2 leading-relaxed pointer-events-none overflow-auto max-w-3xl mx-auto transition-all duration-500 ${isFocusMode ? 'max-w-4xl pt-12' : ''} ${isHighlightPending ? 'opacity-75' : 'opacity-100'}`}
           style={editorStyles}
           aria-hidden="true"
         >

--- a/tests/unit/manuscript/ManuscriptEditor.test.tsx
+++ b/tests/unit/manuscript/ManuscriptEditor.test.tsx
@@ -8,12 +8,21 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const reactDeferredMock = vi.hoisted(() => ({ forceStaleValue: false }));
+// QNBS-v3: Retain the previous deferred value so pending-state coverage models React's stale render contract.
+const reactDeferredMock = vi.hoisted(() => ({
+  forceStaleValue: false,
+  previousValue: undefined as unknown,
+}));
 
 vi.mock('react', async () => {
   const actual = await vi.importActual<typeof import('react')>('react');
-  const useDeferredValue = <T,>(value: T): T =>
-    reactDeferredMock.forceStaleValue ? ('' as T) : value;
+  const useDeferredValue = <T,>(value: T): T => {
+    if (reactDeferredMock.forceStaleValue && reactDeferredMock.previousValue !== undefined) {
+      return reactDeferredMock.previousValue as T;
+    }
+    reactDeferredMock.previousValue = value;
+    return value;
+  };
   return { ...actual, useDeferredValue };
 });
 
@@ -189,7 +198,9 @@ describe('ManuscriptEditor', () => {
     ltMock.available = false;
     ltMock.matches = [];
     ltMock.applySuggestion.mockReset();
+    // QNBS-v3: Reset deferred mock state so each test observes an isolated render timeline.
     reactDeferredMock.forceStaleValue = false;
+    reactDeferredMock.previousValue = undefined;
   });
 
   it('shows empty state when no section is selected', () => {
@@ -332,12 +343,19 @@ describe('ManuscriptEditor', () => {
       expect(mirror.scrollTop).toBe(360);
     });
 
-    // QNBS-v3 (#341): deferred mirror content must retain WCAG contrast while a long edit settles.
-    it('does not dim the visible mirror below the contrast contract while deferred', () => {
+    // QNBS-v3: A stale mirror must retain content and the WCAG-safe pending opacity during edits.
+    it('applies opacity-75 while retaining stale mirror content during deferred rendering', () => {
+      const { rerender } = render(<ManuscriptEditor isFocusMode={false} />);
+      mockActiveSection = {
+        id: 'sec-1',
+        title: 'Chapter One',
+        content: 'Updated content while the edit settles',
+      };
       reactDeferredMock.forceStaleValue = true;
-      render(<ManuscriptEditor isFocusMode={false} />);
+      rerender(<ManuscriptEditor isFocusMode />);
       const mirror = screen.getByTestId('manuscript-editor-mirror');
-      expect(mirror).not.toHaveClass('opacity-70');
+      expect(mirror).toHaveClass('opacity-75');
+      expect(mirror).toHaveTextContent('Hello world teh quick brown fox');
     });
   });
 });

--- a/tests/unit/manuscript/ManuscriptEditor.test.tsx
+++ b/tests/unit/manuscript/ManuscriptEditor.test.tsx
@@ -8,6 +8,15 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+const reactDeferredMock = vi.hoisted(() => ({ forceStaleValue: false }));
+
+vi.mock('react', async () => {
+  const actual = await vi.importActual<typeof import('react')>('react');
+  const useDeferredValue = <T,>(value: T): T =>
+    reactDeferredMock.forceStaleValue ? ('' as T) : value;
+  return { ...actual, useDeferredValue };
+});
+
 // ---------------------------------------------------------------------------
 // Mocks
 // ---------------------------------------------------------------------------
@@ -180,6 +189,7 @@ describe('ManuscriptEditor', () => {
     ltMock.available = false;
     ltMock.matches = [];
     ltMock.applySuggestion.mockReset();
+    reactDeferredMock.forceStaleValue = false;
   });
 
   it('shows empty state when no section is selected', () => {
@@ -320,6 +330,14 @@ describe('ManuscriptEditor', () => {
         currentTarget: { scrollTop: 360, scrollLeft: 0 },
       } as unknown as React.UIEvent<HTMLTextAreaElement>);
       expect(mirror.scrollTop).toBe(360);
+    });
+
+    // QNBS-v3 (#341): deferred mirror content must retain WCAG contrast while a long edit settles.
+    it('does not dim the visible mirror below the contrast contract while deferred', () => {
+      reactDeferredMock.forceStaleValue = true;
+      render(<ManuscriptEditor isFocusMode={false} />);
+      const mirror = screen.getByTestId('manuscript-editor-mirror');
+      expect(mirror).not.toHaveClass('opacity-70');
     });
   });
 });


### PR DESCRIPTION
## **User description**
S3 / #341 only. Historical #344 dual-layer, shared typography, scroll-sync, and contrast-oracle fixes remain authoritative. This bounded change raises the ManuscriptEditor deferred mirror opacity from 70% to 75%; the prior light-sepia pending state measured 4.4479:1 and the new state measures approximately 5.10:1 while retaining the pending cue. Includes focused regression coverage and the README test-count truth sync required by the local gate. Focused tests and ci:prepush pass; current main Chromium Readability/scroll-sync coverage passes. No Storage-Core, persistence, PWA lifecycle, Tauri lifecycle, WebKitGTK workaround, Alt-Tab, #332 performance, #478, or #557 work is included. #341 closure remains subject to exact-head cloud and packaged-runtime evidence; unavailable packaged Linux verification is not claimed.

## Summary by Sourcery

Harden manuscript editor readability during deferred highlighting while preserving pending-state feedback.

Bug Fixes:
- Improve manuscript editor readability while deferred highlighting is pending by increasing the mirror opacity from 70% to 75% without removing the pending-state cue.

Documentation:
- Synchronize README test-count references with the addition of the regression test.

Tests:
- Add regression coverage ensuring stale deferred mirror content retains the WCAG-safe opacity and pending rendering behavior.


___

## **CodeAnt-AI Description**
Preserve manuscript readability while deferred highlighting is pending

### What Changed
- The manuscript editor now keeps the deferred highlight mirror at a readable contrast level while still showing that updates are pending.
- Added regression coverage to prevent the mirror from returning to the lower-contrast pending state.
- Updated README test-count references to include the new regression test.

### Impact
`✅ Readable manuscript text during long edits`
`✅ Visible pending-state feedback`
`✅ Documented test counts match the suite`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved contrast for the manuscript editor’s pending highlight state, making deferred content easier to distinguish.

- **Documentation**
  - Updated project test metrics throughout the README to reflect 7,357+ tests across 595 files.

- **Tests**
  - Added coverage to verify consistent highlight contrast while manuscript content is still updating.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->