### PR TITLE
chore: ignore nested git worktree checkouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ coverage/
 reports/
 tests/bench/baseline/
 
+# Nested git worktree checkouts (git worktree add .worktrees/<name>) — never tracked
+.worktrees/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json


### PR DESCRIPTION
## Summary
- `.worktrees/` (the `git worktree add` target directory used throughout local development) was not in the root `.gitignore`, so the primary checkout's `git status` collapsed every nested worktree's full content into one opaque untracked-directory line.
- This is a real risk for an accidental `git add -A` picking up nested worktree checkouts (each with their own `.git` file, `node_modules`, etc.).

## Test plan
- [x] `git status` in the primary checkout no longer lists `.worktrees/` as untracked content.
- [x] No other tracked files affected (single-line addition to `.gitignore`).

## Summary by Sourcery

Enhancements:
- Exclude nested Git worktree checkouts from the primary repository’s untracked-file status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added ignore rules for nested Git worktree checkouts to keep them out of version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->