### PR TITLE
fix(e2e): make WelcomePortal recovery navigation locale-independent

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+coverage:
+  ignore:
+    - "tests/**"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,2 @@
-coverage:
-  ignore:
-    - "tests/**"
+ignore:
+  - "tests/**"

--- a/components/SettingsView.tsx
+++ b/components/SettingsView.tsx
@@ -38,14 +38,17 @@ import { ViewErrorBoundary } from './ui/ViewErrorBoundary';
 
 // --- SUB-COMPONENTS ---
 
+// QNBS-v3: stable data-testid lets E2E recovery navigation target a category without matching translated label text
 const NavButton: FC<{
+  id: string;
   icon: React.ReactNode;
   label: string;
   isActive: boolean;
   onClick: () => void;
-}> = React.memo(({ icon, label, isActive, onClick }) => (
+}> = React.memo(({ id, icon, label, isActive, onClick }) => (
   <button
     type="button"
+    data-testid={`settings-nav-${id}`}
     onClick={onClick}
     aria-current={isActive ? 'page' : undefined}
     className={`flex items-center flex-shrink-0 md:flex-shrink md:w-full px-3 py-2 text-left rounded-md transition-colors whitespace-nowrap md:whitespace-normal ${isActive ? 'bg-[var(--nav-background-active)] text-[var(--nav-text-active)]' : 'hover:bg-[var(--nav-background-hover)] text-[var(--sc-text-secondary)] hover:text-[var(--sc-text-primary)]'}`}
@@ -365,6 +368,7 @@ const SettingsViewUI: FC = () => {
               filteredNavCategories.map((cat) => (
                 <NavButton
                   key={cat.id}
+                  id={cat.id}
                   icon={cat.icon}
                   label={cat.label}
                   isActive={activeCategory === cat.id}
@@ -379,6 +383,7 @@ const SettingsViewUI: FC = () => {
                   .map((cat) => (
                     <NavButton
                       key={cat.id}
+                      id={cat.id}
                       icon={cat.icon}
                       label={cat.label}
                       isActive={activeCategory === cat.id}
@@ -396,6 +401,7 @@ const SettingsViewUI: FC = () => {
                       {groupCats.map((cat) => (
                         <NavButton
                           key={cat.id}
+                          id={cat.id}
                           icon={cat.icon}
                           label={cat.label}
                           isActive={activeCategory === cat.id}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -77,7 +77,7 @@ const BottomTabItem: React.FC<{
   isActive: boolean;
   onClick: () => void;
   sectionId?: string;
-  /** Spotlight tour / stable E2E anchor (`data-tour`) */
+  // QNBS-v3: stable data-tour anchor lets E2E recovery navigation find this button without matching translated label text
   dataTour?: string;
 }> = React.memo(({ icon, label, isActive, onClick, sectionId, dataTour }) => {
   // QNBS-v3: colored icon dot for mobile tab bar via section SSOT

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -77,7 +77,9 @@ const BottomTabItem: React.FC<{
   isActive: boolean;
   onClick: () => void;
   sectionId?: string;
-}> = React.memo(({ icon, label, isActive, onClick, sectionId }) => {
+  /** Spotlight tour / stable E2E anchor (`data-tour`) */
+  dataTour?: string;
+}> = React.memo(({ icon, label, isActive, onClick, sectionId, dataTour }) => {
   // QNBS-v3: colored icon dot for mobile tab bar via section SSOT
   const sectionConfig = sectionId ? APP_SECTIONS[sectionId as keyof typeof APP_SECTIONS] : null;
   const iconColor = sectionConfig && !isActive ? sectionConfig.textColor : '';
@@ -86,6 +88,7 @@ const BottomTabItem: React.FC<{
     <button
       type="button"
       onClick={onClick}
+      data-tour={dataTour}
       className={`relative flex flex-col items-center justify-center flex-1 min-h-[44px] py-2 transition-colors duration-200 touch-manipulation outline-none focus-visible:ring-2 focus-visible:ring-[var(--sc-ring-focus)] rounded-lg ${
         isActive ? 'text-[var(--nav-text-active)]' : 'text-[var(--sc-text-muted)]'
       }`}
@@ -201,6 +204,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
           label={t('common.more')}
           isActive={isSidebarOpen || !isTabBarView}
           onClick={() => setIsSidebarOpen(!isSidebarOpen)}
+          dataTour="nav-more"
         />
       </nav>
 

--- a/components/settings/DataSection.tsx
+++ b/components/settings/DataSection.tsx
@@ -418,6 +418,7 @@ export const DataSection: FC = () => {
                   {t('settings.data.dangerZone.factoryReset.hint')}
                 </p>
               </div>
+              {/* QNBS-v3: stable data-testid lets E2E recovery navigation target this button without matching translated label text */}
               <Button
                 variant="danger"
                 size="sm"

--- a/components/settings/DataSection.tsx
+++ b/components/settings/DataSection.tsx
@@ -421,6 +421,7 @@ export const DataSection: FC = () => {
               <Button
                 variant="danger"
                 size="sm"
+                data-testid="factory-reset-button"
                 onClick={() => setModal({ state: 'factoryReset', payload: {} })}
                 className="shrink-0"
               >

--- a/components/settings/SettingsModals.tsx
+++ b/components/settings/SettingsModals.tsx
@@ -138,7 +138,12 @@ export const SettingsModals: FC = () => {
             <Button variant="secondary" onClick={() => setModal({ state: 'closed', payload: {} })}>
               {t('common.cancel')}
             </Button>
-            <Button variant="danger" onClick={() => void handleFactoryReset()}>
+            {/* QNBS-v3: stable data-testid lets E2E recovery navigation target this button without matching translated label text */}
+            <Button
+              variant="danger"
+              onClick={() => void handleFactoryReset()}
+              data-testid="factory-reset-confirm-button"
+            >
               {t('settings.data.dangerZone.factoryReset.modalConfirm')}
             </Button>
           </div>

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -29,6 +29,21 @@ export async function clickNavItem(page: Page, name: RegExp): Promise<void> {
   await page.locator('#sidebar-mobile').getByRole('button', { name }).click();
 }
 
+/** Locale-independent Settings navigation: same mobile-aware fallback as clickNavItem, keyed on the stable `data-tour="nav-settings"` anchor instead of translated visible text. */
+async function clickSettingsNavItem(page: Page): Promise<void> {
+  const desktopBtn = page.locator('#sidebar [data-tour="nav-settings"]');
+  if (await desktopBtn.isVisible({ timeout: 1500 }).catch(() => false)) {
+    await desktopBtn.click();
+    return;
+  }
+  // QNBS-v3: data-tour="nav-more" (not a translated /More/i label) so this stays locale-independent on a non-English mobile boot.
+  const moreBtn = page.locator('[data-tour="nav-more"]');
+  await expect(moreBtn).toBeVisible({ timeout: 8000 });
+  await moreBtn.click();
+  await page.locator('#sidebar-mobile').waitFor({ state: 'visible' });
+  await page.locator('#sidebar-mobile [data-tour="nav-settings"]').click();
+}
+
 // QNBS-v3: Stable Writer `#writer-section-select` + option handling avoids Playwright strict-mode / native-<option> visibility pitfalls that broke CI E2E.
 
 /** Writer section `<Select>` — stable id to avoid picking tone/tool comboboxes elsewhere on the page. */
@@ -147,6 +162,19 @@ export async function waitForMainChrome(page: Page): Promise<void> {
   ]);
 }
 
+/** QNBS-v3: explicit discriminated startup state, not boolean soup — repeatedly asking "is the portal visible?" via isVisible().catch(()=>false) can't distinguish "main chrome" from "still loading" and silently swallows genuine errors as false. */
+export type StartupState = 'WELCOME_PORTAL' | 'MAIN_CHROME';
+
+/** Resolves which of waitForSpaReady()'s two shapes the current document actually reached. */
+export async function resolveStartupState(page: Page): Promise<StartupState> {
+  await waitForSpaReady(page);
+  const portal = page.getByTestId('welcome-portal');
+  if (await portal.isVisible().catch(() => false)) {
+    return 'WELCOME_PORTAL';
+  }
+  return 'MAIN_CHROME';
+}
+
 /** Language toggle on the welcome portal (EN must be active for English copy in assertions). */
 export async function selectEnglish(page: Page): Promise<void> {
   const enBtn = page.getByRole('button', { name: /^EN$/i }).first();
@@ -179,36 +207,20 @@ export async function ensureBlankProject(page: Page): Promise<void> {
  * waitForSpaReady()'s two success shapes the app actually booted into. A cold CI boot has landed
  * in an already-mounted main shell with a persisted project instead of the portal — a startup-
  * state precondition gap distinct from the (fixed) portal-activation auto-seed race.
- * Contract: guarantees the portal is reached, locale-independently — it does NOT guarantee
- * English. A caller needing English selects it itself (export.spec.ts already does this for the
- * fresh-boot case). Recovers via the real Settings → Data & Backups → Factory Reset flow when
- * main chrome is active so no React/Redux/storage internals are touched — only supported app
- * behavior.
+ * Contract: guarantees the portal is reached, locale-independently. Recovers via the real
+ * Settings → Data & Backups → Factory Reset flow when main chrome is active so no React/Redux/
+ * storage internals are touched — only supported app behavior.
  */
 export async function ensureWelcomePortalEntry(page: Page): Promise<void> {
-  await waitForSpaReady(page);
   const portal = page.getByTestId('welcome-portal');
-  if (await portal.isVisible({ timeout: 3000 }).catch(() => false)) {
+  if ((await resolveStartupState(page)) === 'WELCOME_PORTAL') {
     return;
   }
-  // QNBS-v3: force English before the locale-dependent recovery flow below, or a persisted non-EN/DE language would hang it.
-  await page.evaluate(() => localStorage.setItem('worldscript-language', 'en'));
-  await page.reload();
-  await waitForSpaReady(page);
-  // QNBS-v3: this reload can itself race a pending debounced autosave and land back in WelcomePortal instead of main chrome — accept either state again rather than assuming main chrome.
-  if (await portal.isVisible({ timeout: 3000 }).catch(() => false)) {
-    return;
-  }
-  await waitForMainChrome(page);
-  await clickNavItem(page, /Settings/i);
-  await page
-    .getByRole('button', { name: /Data & Backups|Daten & Backups/i })
-    .first()
-    .click();
-  await page.getByRole('button', { name: /Factory Reset|Werkseinstellungen/i }).click();
-  await page
-    .getByRole('button', { name: /Delete everything & restart|Alles löschen & neu starten/i })
-    .click();
+  // QNBS-v3: every step below uses a stable data-tour/data-testid anchor, never translated text — Playwright's own docs say addInitScript execution order across registrations is unspecified, so this cannot rely on forcing a language first.
+  await clickSettingsNavItem(page);
+  await page.getByTestId('settings-nav-data').click();
+  await page.getByTestId('factory-reset-button').click();
+  await page.getByTestId('factory-reset-confirm-button').click();
   await waitForSpaReady(page);
   await expect(portal).toBeVisible({ timeout: 15000 });
 }

--- a/tests/e2e/onboarding-entry-precondition.spec.ts
+++ b/tests/e2e/onboarding-entry-precondition.spec.ts
@@ -42,6 +42,22 @@ test.describe('WelcomePortal entry precondition (CI-only)', () => {
     await expect(page.getByRole('button', { name: /Start a New Project/i })).toBeVisible();
   });
 
+  test('reaches the entry point via the recovery flow with a persisted non-English language, on Mobile Chrome and desktop alike', async ({
+    page,
+  }) => {
+    // QNBS-v3: a fresh boot lands on the portal regardless of locale — this combines a persisted main-chrome project with a non-English language so a mobile "More"-button locale regression actually fails, on every project including Mobile Chrome.
+    await page.goto('/');
+    await ensureBlankProject(page);
+    await expect(page.getByText(/All changes saved/i)).toBeVisible({ timeout: 10000 });
+    await page.addInitScript(() => localStorage.setItem('worldscript-language', 'es'));
+    await page.reload();
+    await waitForMainChrome(page);
+    // QNBS-v3: proves the precondition actually took effect — without this, a broken addInitScript seed could pass this test vacuously in English, regardless of viewport/view.
+    expect(await page.evaluate(() => localStorage.getItem('worldscript-language'))).toBe('es');
+    await ensureWelcomePortalEntry(page);
+    await expect(page.getByTestId('welcome-portal')).toBeVisible();
+  });
+
   test('reaches the entry point when its own internal reload can race a pending autosave', async ({
     page,
   }) => {

--- a/tests/e2e/onboarding-entry-precondition.spec.ts
+++ b/tests/e2e/onboarding-entry-precondition.spec.ts
@@ -52,8 +52,8 @@ test.describe('WelcomePortal entry precondition (CI-only)', () => {
     await page.addInitScript(() => localStorage.setItem('worldscript-language', 'es'));
     await page.reload();
     await waitForMainChrome(page);
-    // QNBS-v3: proves the precondition actually took effect — without this, a broken addInitScript seed could pass this test vacuously in English, regardless of viewport/view.
-    expect(await page.evaluate(() => localStorage.getItem('worldscript-language'))).toBe('es');
+    // QNBS-v3: asserts the applied locale, not just the persisted seed — a broken addInitScript or a failed es bundle load could otherwise pass this test vacuously in English.
+    await expect(page.locator('html')).toHaveAttribute('lang', 'es');
     await ensureWelcomePortalEntry(page);
     await expect(page.getByTestId('welcome-portal')).toBeVisible();
   });


### PR DESCRIPTION
## **User description**
## Summary

`main`'s CI has been red on this commit chain twice in a row (post-#587-merge, then its rerun) on the same E2E test, which was root-caused via the Playwright accessibility snapshot as a real, deterministic bug — see #589. This PR extracts exactly the already-converged fix for this failure class from PR #583 (the broader startup/navigation nondeterminism work for #532), so `main` can go green again without waiting for #583's full convergence.

## The bug (#589)

`ensureWelcomePortalEntry()`'s Factory-Reset recovery fallback (used when a pre-existing/leftover project causes a cold boot to land in the main shell instead of the WelcomePortal — a known, low-probability "internal reload race" the helper already anticipated) tried to force English via `localStorage.setItem` + `page.reload()`, then drove Settings → Data & Backups → Factory Reset through **English/German-only** translated button-name regexes. The captured accessibility snapshot from the failing run proved the forced-English reload doesn't reliably take effect before the English-only lookup runs — the UI was still rendered in Spanish ("Más", not "More") — so the recovery path fails deterministically whenever the rare race triggers with any other persisted locale.

## The fix (extracted from #583)

Replaces the whole recovery flow with stable, locale-independent anchors end to end, matching how the rest of this same test file already treats `welcome-portal` as the stable success signal:

- `clickSettingsNavItem()` (`tests/e2e/helpers.ts`) — mobile-aware Settings navigation keyed on `data-tour="nav-settings"`/`"nav-more"`, never translated text.
- `resolveStartupState()` — explicit `'WELCOME_PORTAL' | 'MAIN_CHROME'` result instead of repeated `isVisible().catch(() => false)` boolean soup.
- `settings-nav-${id}` testid on `SettingsView`'s `NavButton`, and `factory-reset-button` / `factory-reset-confirm-button` testids on `DataSection` / `SettingsModals`.
- `Sidebar.tsx` gains the `data-tour="nav-more"` anchor the new helper needs — traced as a required dependency not otherwise present on `main` (not in the originally-expected file list; added after confirming via diff tracing it's genuinely necessary, nothing else).
- A new regression test in `onboarding-entry-precondition.spec.ts` deterministically reproduces the exact failure shape (persisted main-chrome project + non-English language, Mobile Chrome and desktop) instead of relying on the rare race to expose it.

## Deliberately excluded

- `hooks/useSettingsView.ts`'s `handleFactoryReset` error-toast refactor and its tests (`tests/unit/hooks/useSettingsView.test.ts`) — an orthogonal CodeScene hotspot-decline cleanup from #583, unrelated to locale independence.
- `tests/unit/settings/SettingsModals.test.tsx`'s new tests — general modal-rendering coverage from #583, not specific to this fix.
- No IDB reset-gate changes, no factory-reset production lifecycle redesign, no storage opener changes, no encryption-transition work, no #584/S5/R-15/S6/Qt work.

This is not a competing implementation — it's an urgent extraction because #589 is actively keeping `main` red and blocking the repository's Dependabot merge-sequencing policy. #583 remains the owner of the full startup/navigation nondeterminism fix and will be rebased to reconcile with this extraction once it merges (the extracted hunks should disappear from #583's effective diff, not be reintroduced differently).

Closes #589 once merged and post-merge `main` is validated. Does not close #532 (the broader nondeterminism issue #583 still owns).

## Test plan

- [x] `pnpm run lint` — pass (2 pre-existing, unrelated infos)
- [x] `pnpm run typecheck` — pass (exact CI command)
- [x] Targeted unit tests for every touched component (`SettingsView`, `Sidebar`, `DataSection`, `SettingsModals`, `useSettingsView`) — all pass unmodified, confirming the additive testid/data-tour attributes don't change existing behavior
- [x] `pnpm run ci:prepush` — pass
- [ ] Full GitHub CI, including a genuine first-attempt Chromium + Mobile Chrome E2E pass (no rerun-only acceptance for this fix specifically, since it directly owns an E2E nondeterminism defect)

## Summary by Sourcery

Make WelcomePortal recovery locale-independent by replacing translated-label navigation and English-forcing reloads with stable UI targets.

Bug Fixes:
- Make WelcomePortal recovery reliable when a persisted non-English locale opens the main shell, including desktop and mobile layouts.

Enhancements:
- Add explicit startup-state resolution and stable UI anchors for locale-independent Settings and factory-reset navigation.

Tests:
- Add regression coverage for persisted Spanish startup and recovery on desktop and Mobile Chrome.

Chores:
- Exclude test files from Codecov patch coverage reporting.

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
WelcomePortal recovery no longer forces English or matches translated labels when a leftover project opens the main shell. It now uses stable `data-tour`/`data-testid` targets, so recovery works with persisted non-English locales on desktop and mobile.

**Bug Fixes**
- Resolves startup explicitly as WelcomePortal or the main shell before selecting recovery.
- Adds stable targets for Settings, mobile More, Data & Backups, and factory-reset actions.
- Covers persisted Spanish startup and verifies the app applies the `es` locale on desktop and Mobile Chrome.
- Closes #589; does not close #532.

**CI**
- Adds `codecov.yml` with a top-level `ignore` key so `tests/**` is excluded from patch coverage and E2E helper changes don't cause false coverage failures.

<sup>Written for commit 9e80812aeb517bd625f0737fc028b1671c9d17d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/qnbs/WorldScript-Studio/pull/590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded end-to-end coverage for onboarding recovery after reloading saved projects.
  - Added validation for Spanish-language startup flows across desktop and mobile browsers.
  - Improved coverage for settings navigation, data backup, and factory-reset workflows.

- **Quality Improvements**
  - Improved reliability of navigation and reset-flow validation across screen sizes and locales.
  - Added checks confirming the selected language is applied when recovering from a saved session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Make WelcomePortal recovery work across saved languages and device layouts

### What Changed
- Recovery from an existing project now reaches the WelcomePortal without relying on translated navigation labels or forcing the app into English first
- Settings, data reset, confirmation, and mobile navigation can be located consistently on both desktop and mobile layouts
- Added a regression test covering a saved Spanish language on Mobile Chrome and desktop

### Impact
`✅ Reliable recovery in non-English locales`
`✅ Fewer CI failures from locale-dependent navigation`
`✅ Consistent recovery on mobile and desktop`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
