### PR TITLE
fix(storage): make factory-reset recovery deterministic (#591, #593)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2937_keys-0EA5E9" alt="i18n 19 locales — 2937 keys">
-  <img src="https://img.shields.io/badge/Tests-7357%2B_%2F_595_files-22C55E" alt="7357+ tests / 595 files">
+  <img src="https://img.shields.io/badge/Tests-7358%2B_%2F_595_files-22C55E" alt="7358+ tests / 595 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2937 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7357+ tests / 595 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7358+ tests / 595 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7357+ tests, 595 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7358+ tests, 595 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -711,7 +711,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-30, source-synchronized; CI remains authoritative for pass/fail):**
-- **7357+ unit tests** across **595 test files** — CI is authoritative for pass/fail
+- **7358+ unit tests** across **595 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2937 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2937_keys-0EA5E9" alt="i18n 19 locales — 2937 keys">
-  <img src="https://img.shields.io/badge/Tests-7364%2B_%2F_595_files-22C55E" alt="7364+ tests / 595 files">
+  <img src="https://img.shields.io/badge/Tests-7365%2B_%2F_595_files-22C55E" alt="7365+ tests / 595 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2937 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7364+ tests / 595 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7365+ tests / 595 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7364+ tests, 595 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7365+ tests, 595 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -711,7 +711,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-30, source-synchronized; CI remains authoritative for pass/fail):**
-- **7364+ unit tests** across **595 test files** — CI is authoritative for pass/fail
+- **7365+ unit tests** across **595 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2937 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2937_keys-0EA5E9" alt="i18n 19 locales — 2937 keys">
-  <img src="https://img.shields.io/badge/Tests-7368%2B_%2F_595_files-22C55E" alt="7368+ tests / 595 files">
+  <img src="https://img.shields.io/badge/Tests-7369%2B_%2F_595_files-22C55E" alt="7369+ tests / 595 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2937 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7368+ tests / 595 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7369+ tests / 595 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7368+ tests, 595 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7369+ tests, 595 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -711,7 +711,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-30, source-synchronized; CI remains authoritative for pass/fail):**
-- **7368+ unit tests** across **595 test files** — CI is authoritative for pass/fail
+- **7369+ unit tests** across **595 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2937 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2937_keys-0EA5E9" alt="i18n 19 locales — 2937 keys">
-  <img src="https://img.shields.io/badge/Tests-7358%2B_%2F_595_files-22C55E" alt="7358+ tests / 595 files">
+  <img src="https://img.shields.io/badge/Tests-7361%2B_%2F_595_files-22C55E" alt="7361+ tests / 595 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2937 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7358+ tests / 595 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7361+ tests / 595 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7358+ tests, 595 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7361+ tests, 595 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -711,7 +711,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-30, source-synchronized; CI remains authoritative for pass/fail):**
-- **7358+ unit tests** across **595 test files** — CI is authoritative for pass/fail
+- **7361+ unit tests** across **595 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2937 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2937_keys-0EA5E9" alt="i18n 19 locales — 2937 keys">
-  <img src="https://img.shields.io/badge/Tests-7365%2B_%2F_595_files-22C55E" alt="7365+ tests / 595 files">
+  <img src="https://img.shields.io/badge/Tests-7368%2B_%2F_595_files-22C55E" alt="7368+ tests / 595 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2937 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7365+ tests / 595 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7368+ tests / 595 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7365+ tests, 595 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7368+ tests, 595 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -711,7 +711,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-30, source-synchronized; CI remains authoritative for pass/fail):**
-- **7365+ unit tests** across **595 test files** — CI is authoritative for pass/fail
+- **7368+ unit tests** across **595 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2937 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2937_keys-0EA5E9" alt="i18n 19 locales — 2937 keys">
-  <img src="https://img.shields.io/badge/Tests-7361%2B_%2F_595_files-22C55E" alt="7361+ tests / 595 files">
+  <img src="https://img.shields.io/badge/Tests-7362%2B_%2F_595_files-22C55E" alt="7362+ tests / 595 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2937 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7361+ tests / 595 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7362+ tests / 595 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7361+ tests, 595 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7362+ tests, 595 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -711,7 +711,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-30, source-synchronized; CI remains authoritative for pass/fail):**
-- **7361+ unit tests** across **595 test files** — CI is authoritative for pass/fail
+- **7362+ unit tests** across **595 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2937 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2937_keys-0EA5E9" alt="i18n 19 locales — 2937 keys">
-  <img src="https://img.shields.io/badge/Tests-7362%2B_%2F_595_files-22C55E" alt="7362+ tests / 595 files">
+  <img src="https://img.shields.io/badge/Tests-7364%2B_%2F_595_files-22C55E" alt="7364+ tests / 595 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2937 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7362+ tests / 595 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7364+ tests / 595 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7362+ tests, 595 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7364+ tests, 595 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -711,7 +711,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-08-30, source-synchronized; CI remains authoritative for pass/fail):**
-- **7362+ unit tests** across **595 test files** — CI is authoritative for pass/fail
+- **7364+ unit tests** across **595 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2937 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/app/listenerMiddleware.ts
+++ b/app/listenerMiddleware.ts
@@ -16,13 +16,17 @@ import {
   loadLocalRagService,
   loadRagVectorMigration,
 } from '../services/duckdb/duckdbListenerLoader';
+import { isFactoryResetInProgress } from '../services/factoryResetService';
 import { logger } from '../services/logger';
 import { saveEnvelopeFromProjectData } from '../services/storageBackend';
 import { storageService } from '../services/storageService';
 import type { Character, StorySection, World } from '../types';
 import { isAnalyticsPersistenceAllowed } from './analyticsGate';
+import {
+  projectPersistenceCoordinator,
+  settingsPersistenceCoordinator,
+} from './persistenceCoordinator';
 import type { AppDispatch, RootState } from './store';
-import { projectPersistenceCoordinator, settingsPersistenceCoordinator } from './persistenceCoordinator';
 import { appStoreRef } from './storeRef';
 import { useTransientUiStore } from './transientUiStore';
 
@@ -70,6 +74,8 @@ function addDebouncedListener(
       // invocation runs after the delay window. Without this, 50 rapid dispatches produce 50 saves.
       listenerApi.cancelActiveListeners();
       await listenerApi.delay(delayMs);
+      // QNBS-v3: a debounce armed just before a factory reset began still fires after it -- this shared gate is the same one flushPersistedState checks, closing every autosave path (not just visibilitychange) that could otherwise repopulate the database the reset just deleted.
+      if (isFactoryResetInProgress()) return;
       await effect({
         getState: () => listenerApi.getState() as RootState,
         getOriginalState: () => originalState,

--- a/app/listenerMiddleware.ts
+++ b/app/listenerMiddleware.ts
@@ -23,7 +23,8 @@ import { storageService } from '../services/storageService';
 import type { Character, StorySection, World } from '../types';
 import { isAnalyticsPersistenceAllowed } from './analyticsGate';
 import {
-  backgroundWriteCoordinator,
+  crossProjectIndexCoordinator,
+  duckDbWriteCoordinator,
   projectPersistenceCoordinator,
   settingsPersistenceCoordinator,
 } from './persistenceCoordinator';
@@ -98,8 +99,8 @@ async function runCrossProjectIndexUpdate(
   const { indexProject } = await import('../services/crossProjectIndexService');
   // QNBS-v3: reset may start during the dynamic import's own await -- re-checked here with zero await before registering, mirroring the project-autosave TOCTOU fix below.
   if (isFactoryResetInProgress()) return;
-  // QNBS-v3: routed through backgroundWriteCoordinator (not awaited here) so wipeAllAppData()'s drain can still catch a reset starting while this write is in flight, without making a reset -- or the next project save -- wait on this non-critical write.
-  void backgroundWriteCoordinator.enqueue(() =>
+  // QNBS-v3: routed through its own coordinator (not awaited here) so wipeAllAppData()'s drain can still catch a reset starting while this write is in flight, without making a reset -- or the next project save -- wait on this non-critical write.
+  void crossProjectIndexCoordinator.enqueue(() =>
     // QNBS-v3: SEC — a thunk lets the gate re-evaluate at indexProject's DuckDB write site (after its async IDB work) instead of a snapshot here, so a mid-window opt-out can't slip a stale mirror write through.
     indexProject(projectId, enriched, () => isAnalyticsPersistenceAllowed(api.getState())).catch(
       (err: unknown) => logger.warn('Cross-project index update failed (non-critical):', err),
@@ -125,8 +126,8 @@ async function runDuckDbDualWrite(
   const { duckdbDualWrite, withDuckDbRetry } = await loadDuckdbAnalytics();
   // QNBS-v3: reset may start during loadDuckdbAnalytics()'s own await -- re-checked here with zero await before registering, mirroring the project-autosave TOCTOU fix below.
   if (isFactoryResetInProgress()) return;
-  // QNBS-v3: routed through backgroundWriteCoordinator (not awaited here) for the same reason as the cross-project index update above.
-  void backgroundWriteCoordinator.enqueue(() =>
+  // QNBS-v3: its own coordinator, not shared with crossProjectIndexCoordinator -- a shared single queue slot let one resource's write silently discard the other's still-pending write.
+  void duckDbWriteCoordinator.enqueue(() =>
     withDuckDbRetry(() => {
       // QNBS-v3: SEC — re-checked at write time since the opt-out may have toggled during the async loadDuckdbAnalytics()/retry window, making the outer gate's snapshot stale.
       if (!isAnalyticsPersistenceAllowed(api.getState())) return Promise.resolve();

--- a/app/listenerMiddleware.ts
+++ b/app/listenerMiddleware.ts
@@ -74,7 +74,7 @@ function addDebouncedListener(
       // invocation runs after the delay window. Without this, 50 rapid dispatches produce 50 saves.
       listenerApi.cancelActiveListeners();
       await listenerApi.delay(delayMs);
-      // QNBS-v3: a debounce armed just before a factory reset began still fires after it -- this shared gate is the same one flushPersistedState checks, closing every autosave path (not just visibilitychange) that could otherwise repopulate the database the reset just deleted.
+      // QNBS-v3: a debounce armed just before a factory reset began still fires after it -- blocks a new project/settings/codex write from starting once resetInProgress flips; project autosave re-checks again immediately before its own enqueue() since checkStorageHealth() is an await this gate already passed once.
       if (isFactoryResetInProgress()) return;
       await effect({
         getState: () => listenerApi.getState() as RootState,
@@ -151,6 +151,8 @@ addDebouncedListener(
         /* non-critical */
       }
 
+      // QNBS-v3: re-checked here, not just at the top of addDebouncedListener -- checkStorageHealth() above is an await this shared guard already passed before, so a reset started during that gap would otherwise still reach enqueue() unblocked. No await sits between this check and enqueue() itself, so nothing can interleave between them.
+      if (isFactoryResetInProgress()) return;
       // QNBS-v3 (#332): skip stale indexing after a newer project snapshot supersedes this save.
       const projectSaveResult = await projectPersistenceCoordinator.enqueue(() =>
         storageService.saveProject(projectDataToSave),
@@ -292,6 +294,7 @@ addDebouncedListener(
         { advanced: state.featureFlags?.enableStoryBibleAdvanced ?? false },
         binderResearchSections,
       );
+      // QNBS-v3: unlike project/settings, this write isn't drained by wipeAllAppData() before deletion -- accepted, since Codex is a regenerable index derived from the manuscript, not primary data whose staleness affects which boot screen the app shows.
       await saveStoryCodex(codex);
 
       // QNBS-v3: SEC — re-read live state at the gate (not the pre-await snapshot) so toggling the

--- a/app/listenerMiddleware.ts
+++ b/app/listenerMiddleware.ts
@@ -23,6 +23,7 @@ import { storageService } from '../services/storageService';
 import type { Character, StorySection, World } from '../types';
 import { isAnalyticsPersistenceAllowed } from './analyticsGate';
 import {
+  backgroundWriteCoordinator,
   projectPersistenceCoordinator,
   settingsPersistenceCoordinator,
 } from './persistenceCoordinator';
@@ -92,11 +93,17 @@ async function runCrossProjectIndexUpdate(
   presentData: ProjectData,
   enriched: ProjectData,
 ): Promise<void> {
-  if (!presentData.id) return;
+  const projectId = presentData.id;
+  if (!projectId) return;
   const { indexProject } = await import('../services/crossProjectIndexService');
-  // QNBS-v3: SEC — a thunk lets the gate re-evaluate at indexProject's DuckDB write site (after its async IDB work) instead of a snapshot here, so a mid-window opt-out can't slip a stale mirror write through.
-  indexProject(presentData.id, enriched, () => isAnalyticsPersistenceAllowed(api.getState())).catch(
-    (err: unknown) => logger.warn('Cross-project index update failed (non-critical):', err),
+  // QNBS-v3: reset may start during the dynamic import's own await -- re-checked here with zero await before registering, mirroring the project-autosave TOCTOU fix below.
+  if (isFactoryResetInProgress()) return;
+  // QNBS-v3: routed through backgroundWriteCoordinator (not awaited here) so wipeAllAppData()'s drain can still catch a reset starting while this write is in flight, without making a reset -- or the next project save -- wait on this non-critical write.
+  void backgroundWriteCoordinator.enqueue(() =>
+    // QNBS-v3: SEC — a thunk lets the gate re-evaluate at indexProject's DuckDB write site (after its async IDB work) instead of a snapshot here, so a mid-window opt-out can't slip a stale mirror write through.
+    indexProject(projectId, enriched, () => isAnalyticsPersistenceAllowed(api.getState())).catch(
+      (err: unknown) => logger.warn('Cross-project index update failed (non-critical):', err),
+    ),
   );
 }
 
@@ -116,21 +123,26 @@ async function runDuckDbDualWrite(
   }));
   const totalWordCount = sections.reduce((acc, s) => acc + s.wordCount, 0);
   const { duckdbDualWrite, withDuckDbRetry } = await loadDuckdbAnalytics();
-  void withDuckDbRetry(() => {
-    // QNBS-v3: SEC — re-checked at write time since the opt-out may have toggled during the async loadDuckdbAnalytics()/retry window, making the outer gate's snapshot stale.
-    if (!isAnalyticsPersistenceAllowed(api.getState())) return Promise.resolve();
-    return duckdbDualWrite(
-      projectId,
-      presentData.title,
-      presentData.logline,
-      totalWordCount,
-      presentData.projectGoals?.totalWordCount,
-      presentData.projectGoals?.targetDate,
-      presentData.writingHistory ?? [],
-      sections,
-    );
-  }).catch((err: unknown) =>
-    logger.warn('DuckDB dual-write failed after retries (non-critical):', err),
+  // QNBS-v3: reset may start during loadDuckdbAnalytics()'s own await -- re-checked here with zero await before registering, mirroring the project-autosave TOCTOU fix below.
+  if (isFactoryResetInProgress()) return;
+  // QNBS-v3: routed through backgroundWriteCoordinator (not awaited here) for the same reason as the cross-project index update above.
+  void backgroundWriteCoordinator.enqueue(() =>
+    withDuckDbRetry(() => {
+      // QNBS-v3: SEC — re-checked at write time since the opt-out may have toggled during the async loadDuckdbAnalytics()/retry window, making the outer gate's snapshot stale.
+      if (!isAnalyticsPersistenceAllowed(api.getState())) return Promise.resolve();
+      return duckdbDualWrite(
+        projectId,
+        presentData.title,
+        presentData.logline,
+        totalWordCount,
+        presentData.projectGoals?.totalWordCount,
+        presentData.projectGoals?.targetDate,
+        presentData.writingHistory ?? [],
+        sections,
+      );
+    }).catch((err: unknown) =>
+      logger.warn('DuckDB dual-write failed after retries (non-critical):', err),
+    ),
   );
 }
 

--- a/app/listenerMiddleware.ts
+++ b/app/listenerMiddleware.ts
@@ -86,6 +86,54 @@ function addDebouncedListener(
   });
 }
 
+// QNBS-v3: split from a single combined side-effects function -- CodeScene's hotspot gate flagged that one function too once it held both branches; each concern is simple alone.
+async function runCrossProjectIndexUpdate(
+  api: DebouncedEffectApi,
+  presentData: ProjectData,
+  enriched: ProjectData,
+): Promise<void> {
+  if (!presentData.id) return;
+  const { indexProject } = await import('../services/crossProjectIndexService');
+  // QNBS-v3: SEC — a thunk lets the gate re-evaluate at indexProject's DuckDB write site (after its async IDB work) instead of a snapshot here, so a mid-window opt-out can't slip a stale mirror write through.
+  indexProject(presentData.id, enriched, () => isAnalyticsPersistenceAllowed(api.getState())).catch(
+    (err: unknown) => logger.warn('Cross-project index update failed (non-critical):', err),
+  );
+}
+
+async function runDuckDbDualWrite(
+  api: DebouncedEffectApi,
+  presentData: ProjectData,
+): Promise<void> {
+  if (!isAnalyticsPersistenceAllowed(api.getState())) return;
+  const projectId = presentData.id ?? 'default';
+  const sections = presentData.manuscript.map((s, idx) => ({
+    id: s.id,
+    title: s.title,
+    wordCount: (s.content?.match(/\S+/g) ?? []).length,
+    status: s.status,
+    position: idx,
+    scene_start: s.sceneStart,
+  }));
+  const totalWordCount = sections.reduce((acc, s) => acc + s.wordCount, 0);
+  const { duckdbDualWrite, withDuckDbRetry } = await loadDuckdbAnalytics();
+  void withDuckDbRetry(() => {
+    // QNBS-v3: SEC — re-checked at write time since the opt-out may have toggled during the async loadDuckdbAnalytics()/retry window, making the outer gate's snapshot stale.
+    if (!isAnalyticsPersistenceAllowed(api.getState())) return Promise.resolve();
+    return duckdbDualWrite(
+      projectId,
+      presentData.title,
+      presentData.logline,
+      totalWordCount,
+      presentData.projectGoals?.totalWordCount,
+      presentData.projectGoals?.targetDate,
+      presentData.writingHistory ?? [],
+      sections,
+    );
+  }).catch((err: unknown) =>
+    logger.warn('DuckDB dual-write failed after retries (non-critical):', err),
+  );
+}
+
 // QNBS-v3: extracted out of the debounced project-save effect so CodeFactor's complexity gate on that already-large function doesn't keep climbing every time a cross-cutting concern (indexing, analytics) needs its own guard.
 async function runPostProjectSaveSideEffects(
   api: DebouncedEffectApi,
@@ -93,45 +141,8 @@ async function runPostProjectSaveSideEffects(
   enriched: ProjectData,
 ): Promise<void> {
   // QNBS-v3: the IDB search index always updates on save (enableCrossProjectSearch is permanent core); the DuckDB mirror honours the same analytics-privacy gate as other DuckDB writes.
-  if (presentData.id) {
-    const { indexProject } = await import('../services/crossProjectIndexService');
-    // QNBS-v3: SEC — a thunk lets the gate re-evaluate at indexProject's DuckDB write site (after its async IDB work) instead of a snapshot here, so a mid-window opt-out can't slip a stale mirror write through.
-    indexProject(presentData.id, enriched, () =>
-      isAnalyticsPersistenceAllowed(api.getState()),
-    ).catch((err: unknown) =>
-      logger.warn('Cross-project index update failed (non-critical):', err),
-    );
-  }
-
-  if (isAnalyticsPersistenceAllowed(api.getState())) {
-    const projectId = presentData.id ?? 'default';
-    const sections = presentData.manuscript.map((s, idx) => ({
-      id: s.id,
-      title: s.title,
-      wordCount: (s.content?.match(/\S+/g) ?? []).length,
-      status: s.status,
-      position: idx,
-      scene_start: s.sceneStart,
-    }));
-    const totalWordCount = sections.reduce((acc, s) => acc + s.wordCount, 0);
-    const { duckdbDualWrite, withDuckDbRetry } = await loadDuckdbAnalytics();
-    void withDuckDbRetry(() => {
-      // QNBS-v3: SEC — re-checked at write time since the opt-out may have toggled during the async loadDuckdbAnalytics()/retry window, making the outer gate's snapshot stale.
-      if (!isAnalyticsPersistenceAllowed(api.getState())) return Promise.resolve();
-      return duckdbDualWrite(
-        projectId,
-        presentData.title,
-        presentData.logline,
-        totalWordCount,
-        presentData.projectGoals?.totalWordCount,
-        presentData.projectGoals?.targetDate,
-        presentData.writingHistory ?? [],
-        sections,
-      );
-    }).catch((err: unknown) =>
-      logger.warn('DuckDB dual-write failed after retries (non-critical):', err),
-    );
-  }
+  await runCrossProjectIndexUpdate(api, presentData, enriched);
+  await runDuckDbDualWrite(api, presentData);
 }
 
 // --- 1a. Auto-Save: Project ---

--- a/app/listenerMiddleware.ts
+++ b/app/listenerMiddleware.ts
@@ -86,6 +86,54 @@ function addDebouncedListener(
   });
 }
 
+// QNBS-v3: extracted out of the debounced project-save effect so CodeFactor's complexity gate on that already-large function doesn't keep climbing every time a cross-cutting concern (indexing, analytics) needs its own guard.
+async function runPostProjectSaveSideEffects(
+  api: DebouncedEffectApi,
+  presentData: ProjectData,
+  enriched: ProjectData,
+): Promise<void> {
+  // QNBS-v3: the IDB search index always updates on save (enableCrossProjectSearch is permanent core); the DuckDB mirror honours the same analytics-privacy gate as other DuckDB writes.
+  if (presentData.id) {
+    const { indexProject } = await import('../services/crossProjectIndexService');
+    // QNBS-v3: SEC — a thunk lets the gate re-evaluate at indexProject's DuckDB write site (after its async IDB work) instead of a snapshot here, so a mid-window opt-out can't slip a stale mirror write through.
+    indexProject(presentData.id, enriched, () =>
+      isAnalyticsPersistenceAllowed(api.getState()),
+    ).catch((err: unknown) =>
+      logger.warn('Cross-project index update failed (non-critical):', err),
+    );
+  }
+
+  if (isAnalyticsPersistenceAllowed(api.getState())) {
+    const projectId = presentData.id ?? 'default';
+    const sections = presentData.manuscript.map((s, idx) => ({
+      id: s.id,
+      title: s.title,
+      wordCount: (s.content?.match(/\S+/g) ?? []).length,
+      status: s.status,
+      position: idx,
+      scene_start: s.sceneStart,
+    }));
+    const totalWordCount = sections.reduce((acc, s) => acc + s.wordCount, 0);
+    const { duckdbDualWrite, withDuckDbRetry } = await loadDuckdbAnalytics();
+    void withDuckDbRetry(() => {
+      // QNBS-v3: SEC — re-checked at write time since the opt-out may have toggled during the async loadDuckdbAnalytics()/retry window, making the outer gate's snapshot stale.
+      if (!isAnalyticsPersistenceAllowed(api.getState())) return Promise.resolve();
+      return duckdbDualWrite(
+        projectId,
+        presentData.title,
+        presentData.logline,
+        totalWordCount,
+        presentData.projectGoals?.totalWordCount,
+        presentData.projectGoals?.targetDate,
+        presentData.writingHistory ?? [],
+        sections,
+      );
+    }).catch((err: unknown) =>
+      logger.warn('DuckDB dual-write failed after retries (non-critical):', err),
+    );
+  }
+}
+
 // --- 1a. Auto-Save: Project ---
 addDebouncedListener(
   (curr, prev) => {
@@ -152,58 +200,18 @@ addDebouncedListener(
       }
 
       // QNBS-v3: re-checked here, not just at the top of addDebouncedListener -- checkStorageHealth() above is an await this shared guard already passed before, so a reset started during that gap would otherwise still reach enqueue() unblocked. No await sits between this check and enqueue() itself, so nothing can interleave between them.
-      if (isFactoryResetInProgress()) return;
+      if (isFactoryResetInProgress()) {
+        // QNBS-v3: this bails out after setSavingStatus('saving') above -- a reset that then fails and never reloads would otherwise leave the indicator spinning forever.
+        api.dispatch(statusActions.setSavingStatus('idle'));
+        return;
+      }
       // QNBS-v3 (#332): skip stale indexing after a newer project snapshot supersedes this save.
       const projectSaveResult = await projectPersistenceCoordinator.enqueue(() =>
         storageService.saveProject(projectDataToSave),
       );
       if (projectSaveResult.superseded) return;
 
-      // QNBS-v3: enableCrossProjectSearch promoted to permanent core — the IDB search index always
-      // updates on save. The DuckDB mirror is analytics persistence, so it honours the same privacy
-      // gate as the other DuckDB writes (search still works fully from the IDB index when off).
-      if (presentData.id) {
-        const { indexProject } = await import('../services/crossProjectIndexService');
-        // QNBS-v3: SEC — pass a thunk so the gate is re-evaluated at the DuckDB write site inside
-        // indexProject (after its async IDB work), not snapshotted here — an opt-out toggled during
-        // that window can't slip a stale mirror write through.
-        indexProject(presentData.id, enriched, () =>
-          isAnalyticsPersistenceAllowed(api.getState()),
-        ).catch((err: unknown) =>
-          logger.warn('Cross-project index update failed (non-critical):', err),
-        );
-      }
-
-      if (isAnalyticsPersistenceAllowed(api.getState())) {
-        const projectId = presentData.id ?? 'default';
-        const sections = presentData.manuscript.map((s, idx) => ({
-          id: s.id,
-          title: s.title,
-          wordCount: (s.content?.match(/\S+/g) ?? []).length,
-          status: s.status,
-          position: idx,
-          scene_start: s.sceneStart,
-        }));
-        const totalWordCount = sections.reduce((acc, s) => acc + s.wordCount, 0);
-        const { duckdbDualWrite, withDuckDbRetry } = await loadDuckdbAnalytics();
-        void withDuckDbRetry(() => {
-          // QNBS-v3: SEC — re-check at write time; the opt-out may have toggled during the async
-          // loadDuckdbAnalytics()/retry window, so a snapshot taken at the outer gate could go stale.
-          if (!isAnalyticsPersistenceAllowed(api.getState())) return Promise.resolve();
-          return duckdbDualWrite(
-            projectId,
-            presentData.title,
-            presentData.logline,
-            totalWordCount,
-            presentData.projectGoals?.totalWordCount,
-            presentData.projectGoals?.targetDate,
-            presentData.writingHistory ?? [],
-            sections,
-          );
-        }).catch((err: unknown) =>
-          logger.warn('DuckDB dual-write failed after retries (non-critical):', err),
-        );
-      }
+      await runPostProjectSaveSideEffects(api, presentData, enriched);
 
       api.dispatch(statusActions.setSavingStatus('saved'));
       await api.delay(2000);

--- a/app/persistedStateFlush.ts
+++ b/app/persistedStateFlush.ts
@@ -1,7 +1,11 @@
 import type { ProjectData } from '../features/project/projectSlice';
+import { isFactoryResetInProgress } from '../services/factoryResetService';
 import { saveEnvelopeFromProjectData, storageService } from '../services/storageService';
+import {
+  projectPersistenceCoordinator,
+  settingsPersistenceCoordinator,
+} from './persistenceCoordinator';
 import type { RootState } from './store';
-import { projectPersistenceCoordinator, settingsPersistenceCoordinator } from './persistenceCoordinator';
 
 /**
  * QNBS-v3 (#332/D3): shared, awaitable flush of pending project+settings state. Used by both the
@@ -12,6 +16,8 @@ import { projectPersistenceCoordinator, settingsPersistenceCoordinator } from '.
  * swallowed by Promise.allSettled — callers decide their own failure policy.
  */
 export async function flushPersistedState(state: RootState): Promise<void> {
+  // QNBS-v3: window.location.reload() fires visibilitychange before the page actually unloads -- without this, a factory reset's own reload races this flush, recreating the just-deleted database with stale pre-reset state.
+  if (isFactoryResetInProgress()) return;
   const presentData = state.project.present?.data;
   // QNBS-v3 (#332): make visibility and quit flushes wait behind both active and queued saves.
   const saves: Promise<unknown>[] = [

--- a/app/persistenceCoordinator.ts
+++ b/app/persistenceCoordinator.ts
@@ -93,5 +93,7 @@ export class PersistenceCoordinator {
 
 export const projectPersistenceCoordinator = new PersistenceCoordinator();
 export const settingsPersistenceCoordinator = new PersistenceCoordinator();
-// QNBS-v3: separate from projectPersistenceCoordinator so a slow non-critical index/analytics write can never queue behind (and delay) the next actual project save; a factory reset still drains it before deleting anything.
-export const backgroundWriteCoordinator = new PersistenceCoordinator();
+// QNBS-v3: separate from projectPersistenceCoordinator so a slow non-critical write can never queue behind (and delay) the next actual project save; a factory reset still drains both before deleting anything.
+// QNBS-v3: kept as two distinct coordinators, not one shared instance -- enqueue() retains only a single queued slot, so sharing one between indexing and DuckDB writes let a later write of one kind silently discard an already-queued write of the other.
+export const crossProjectIndexCoordinator = new PersistenceCoordinator();
+export const duckDbWriteCoordinator = new PersistenceCoordinator();

--- a/app/persistenceCoordinator.ts
+++ b/app/persistenceCoordinator.ts
@@ -93,3 +93,5 @@ export class PersistenceCoordinator {
 
 export const projectPersistenceCoordinator = new PersistenceCoordinator();
 export const settingsPersistenceCoordinator = new PersistenceCoordinator();
+// QNBS-v3: separate from projectPersistenceCoordinator so a slow non-critical index/analytics write can never queue behind (and delay) the next actual project save; a factory reset still drains it before deleting anything.
+export const backgroundWriteCoordinator = new PersistenceCoordinator();

--- a/services/crossProjectIndexService.ts
+++ b/services/crossProjectIndexService.ts
@@ -98,7 +98,8 @@ export async function indexProject(
   const gateAllows: () => boolean =
     typeof duckDbEnabled === 'function' ? duckDbEnabled : () => duckDbEnabled;
   if (gateAllows()) {
-    void loadDuckdbAnalytics()
+    // QNBS-v3: awaited, not fire-and-forget -- a caller draining indexProject()'s own promise (e.g. a factory reset's coordinator drain) must see this mirror write as part of what "done" means, not something still in flight after this function has already returned.
+    await loadDuckdbAnalytics()
       .then(({ duckdbCrossProjectWrite }) => {
         if (!gateAllows()) return undefined;
         return duckdbCrossProjectWrite({

--- a/services/factoryResetService.ts
+++ b/services/factoryResetService.ts
@@ -8,6 +8,10 @@
  * IDB store is added.
  */
 
+import {
+  projectPersistenceCoordinator,
+  settingsPersistenceCoordinator,
+} from '../app/persistenceCoordinator';
 import { logger } from './logger';
 import { isTauriRuntime } from './tauriRuntime';
 
@@ -71,6 +75,16 @@ async function clearServiceWorkerCaches(): Promise<void> {
   }
 }
 
+// QNBS-v3: readInitialView() reads via URLSearchParams.get('view'), which decodes -- comparing the raw key would let an encoded spelling like %76iew survive this filter and still restore Settings after reload.
+function isViewKey(rawKey: string): boolean {
+  if (rawKey === 'view') return true;
+  try {
+    return decodeURIComponent(rawKey.replace(/\+/g, ' ')) === 'view';
+  } catch {
+    return false;
+  }
+}
+
 // QNBS-v3: string-level removal, not URLSearchParams.delete() -- reserializing via searchParams.toString() would reserialize every retained parameter too, e.g. turning a raw %20 into + or a bare flag `?foo` into `?foo=`, silently rewriting unrelated URL state this reset has no business touching.
 function stripViewQueryParam(rawSearch: string): string {
   if (!rawSearch || rawSearch === '?') return '';
@@ -80,7 +94,7 @@ function stripViewQueryParam(rawSearch: string): string {
     .filter((pair) => {
       const eq = pair.indexOf('=');
       const key = eq === -1 ? pair : pair.slice(0, eq);
-      return key !== 'view';
+      return !isViewKey(key);
     });
   return pairs.length > 0 ? `?${pairs.join('&')}` : '';
 }
@@ -132,6 +146,11 @@ export async function wipeAllAppData(): Promise<void> {
   logger.warn('[factoryReset] Wiping all app data…');
   resetInProgress = true;
   try {
+    // QNBS-v3: a save enqueued (project or settings autosave, or a visibility/quit flush) before this flag flipped already passed its own guard check and will run regardless -- draining both coordinators here lets it finish before deletion starts, instead of racing it.
+    await Promise.all([
+      projectPersistenceCoordinator.idle(),
+      settingsPersistenceCoordinator.idle(),
+    ]);
     // QNBS-v3: clear fallible desktop data first so a failed desktop reset never leaves a mixed wipe.
     await clearTauriAppData();
     await deleteAllIndexedDBDatabases();

--- a/services/factoryResetService.ts
+++ b/services/factoryResetService.ts
@@ -16,6 +16,14 @@ const OWNED_CACHE_NAME_RE =
   /^worldscript-(?:static|dynamic|images)-v\d+\.\d+\.\d+(?:[-+][\w.-]+)?$/;
 const isWorldScriptOwnedCacheName = (name: string): boolean => OWNED_CACHE_NAME_RE.test(name);
 
+// QNBS-v3: set before any wipe work starts and never cleared -- the page is reloading regardless, and a false-negative window here is exactly the race (visibilitychange-triggered flush recreating a just-deleted database) this exists to close.
+let resetInProgress = false;
+
+/** True once a factory reset has started; stays true until the reload actually happens. */
+export function isFactoryResetInProgress(): boolean {
+  return resetInProgress;
+}
+
 /** All IDB databases the app may have created. */
 const KNOWN_DB_NAMES = [
   'worldscript-db', // legacy — migrated to worldscript-data-db
@@ -63,13 +71,25 @@ async function clearServiceWorkerCaches(): Promise<void> {
   }
 }
 
+// QNBS-v3: string-level removal, not URLSearchParams.delete() -- reserializing via searchParams.toString() would reserialize every retained parameter too, e.g. turning a raw %20 into + or a bare flag `?foo` into `?foo=`, silently rewriting unrelated URL state this reset has no business touching.
+function stripViewQueryParam(rawSearch: string): string {
+  if (!rawSearch || rawSearch === '?') return '';
+  const pairs = rawSearch
+    .slice(1)
+    .split('&')
+    .filter((pair) => {
+      const eq = pair.indexOf('=');
+      const key = eq === -1 ? pair : pair.slice(0, eq);
+      return key !== 'view';
+    });
+  return pairs.length > 0 ? `?${pairs.join('&')}` : '';
+}
+
 // QNBS-v3: the deep-link hash and `view` query param both survive a bare window.location.reload(), and useApp.ts's readInitialView() reads them before checking whether a project even exists -- without this, a reset triggered from Settings reboots straight back into Settings.
 function sanitizeViewCarryingUrlState(): void {
   try {
     const url = new URL(window.location.href);
-    url.hash = '';
-    url.searchParams.delete('view');
-    history.replaceState(null, '', `${url.pathname}${url.search}${url.hash}`);
+    history.replaceState(null, '', `${url.pathname}${stripViewQueryParam(url.search)}`);
   } catch {
     // Never let URL sanitization block the reset itself.
   }
@@ -110,18 +130,25 @@ async function clearTauriAppData(): Promise<void> {
  */
 export async function wipeAllAppData(): Promise<void> {
   logger.warn('[factoryReset] Wiping all app data…');
-  // QNBS-v3: clear fallible desktop data first so a failed desktop reset never leaves a mixed wipe.
-  await clearTauriAppData();
-  await deleteAllIndexedDBDatabases();
-  await clearServiceWorkerCaches();
+  resetInProgress = true;
   try {
-    localStorage.clear();
-    sessionStorage.clear();
-  } catch {
-    // Private browsing may throw
+    // QNBS-v3: clear fallible desktop data first so a failed desktop reset never leaves a mixed wipe.
+    await clearTauriAppData();
+    await deleteAllIndexedDBDatabases();
+    await clearServiceWorkerCaches();
+    try {
+      localStorage.clear();
+      sessionStorage.clear();
+    } catch {
+      // Private browsing may throw
+    }
+    // Small delay so async IDB deletions can settle before unload.
+    await new Promise((r) => setTimeout(r, 300));
+    sanitizeViewCarryingUrlState();
+    window.location.reload();
+  } catch (error) {
+    // QNBS-v3: a failed reset never reloads, so the app keeps running -- the in-progress flag must not stay permanently on and silently block every future save.
+    resetInProgress = false;
+    throw error;
   }
-  // Small delay so async IDB deletions can settle before unload.
-  await new Promise((r) => setTimeout(r, 300));
-  sanitizeViewCarryingUrlState();
-  window.location.reload();
 }

--- a/services/factoryResetService.ts
+++ b/services/factoryResetService.ts
@@ -12,7 +12,8 @@ import { logger } from './logger';
 import { isTauriRuntime } from './tauriRuntime';
 
 // QNBS-v3: mirrors public/sw.js's isWorldScriptOwnedCache/register-sw.ts's isWorldScriptOwnedCacheName — duplicated (not imported) since sw.js is a classic non-module script and register-sw.ts has its own load-time side effect.
-const OWNED_CACHE_NAME_RE = /^worldscript-(?:static|dynamic|images)-v\d+\.\d+\.\d+(?:[-+][\w.-]+)?$/;
+const OWNED_CACHE_NAME_RE =
+  /^worldscript-(?:static|dynamic|images)-v\d+\.\d+\.\d+(?:[-+][\w.-]+)?$/;
 const isWorldScriptOwnedCacheName = (name: string): boolean => OWNED_CACHE_NAME_RE.test(name);
 
 /** All IDB databases the app may have created. */
@@ -59,6 +60,18 @@ async function clearServiceWorkerCaches(): Promise<void> {
     await Promise.all(keys.filter(isWorldScriptOwnedCacheName).map((k) => caches.delete(k)));
   } catch {
     // Non-fatal — caches cleared on next SW registration
+  }
+}
+
+// QNBS-v3: the deep-link hash and `view` query param both survive a bare window.location.reload(), and useApp.ts's readInitialView() reads them before checking whether a project even exists -- without this, a reset triggered from Settings reboots straight back into Settings.
+function sanitizeViewCarryingUrlState(): void {
+  try {
+    const url = new URL(window.location.href);
+    url.hash = '';
+    url.searchParams.delete('view');
+    history.replaceState(null, '', `${url.pathname}${url.search}${url.hash}`);
+  } catch {
+    // Never let URL sanitization block the reset itself.
   }
 }
 
@@ -109,5 +122,6 @@ export async function wipeAllAppData(): Promise<void> {
   }
   // Small delay so async IDB deletions can settle before unload.
   await new Promise((r) => setTimeout(r, 300));
+  sanitizeViewCarryingUrlState();
   window.location.reload();
 }

--- a/services/factoryResetService.ts
+++ b/services/factoryResetService.ts
@@ -9,6 +9,7 @@
  */
 
 import {
+  backgroundWriteCoordinator,
   projectPersistenceCoordinator,
   settingsPersistenceCoordinator,
 } from '../app/persistenceCoordinator';
@@ -146,10 +147,11 @@ export async function wipeAllAppData(): Promise<void> {
   logger.warn('[factoryReset] Wiping all app data…');
   resetInProgress = true;
   try {
-    // QNBS-v3: a save enqueued (project or settings autosave, or a visibility/quit flush) before this flag flipped already passed its own guard check and will run regardless -- draining both coordinators here lets it finish before deletion starts, instead of racing it.
+    // QNBS-v3: a save enqueued (project or settings autosave, or a visibility/quit flush) before this flag flipped already passed its own guard check and will run regardless -- draining all three coordinators here lets it finish before deletion starts, instead of racing it. backgroundWriteCoordinator covers the non-critical cross-project-index/DuckDB writes a project save fires off after its own enqueue() already resolved.
     await Promise.all([
       projectPersistenceCoordinator.idle(),
       settingsPersistenceCoordinator.idle(),
+      backgroundWriteCoordinator.idle(),
     ]);
     // QNBS-v3: clear fallible desktop data first so a failed desktop reset never leaves a mixed wipe.
     await clearTauriAppData();

--- a/services/factoryResetService.ts
+++ b/services/factoryResetService.ts
@@ -9,7 +9,8 @@
  */
 
 import {
-  backgroundWriteCoordinator,
+  crossProjectIndexCoordinator,
+  duckDbWriteCoordinator,
   projectPersistenceCoordinator,
   settingsPersistenceCoordinator,
 } from '../app/persistenceCoordinator';
@@ -147,11 +148,12 @@ export async function wipeAllAppData(): Promise<void> {
   logger.warn('[factoryReset] Wiping all app data…');
   resetInProgress = true;
   try {
-    // QNBS-v3: a save enqueued (project or settings autosave, or a visibility/quit flush) before this flag flipped already passed its own guard check and will run regardless -- draining all three coordinators here lets it finish before deletion starts, instead of racing it. backgroundWriteCoordinator covers the non-critical cross-project-index/DuckDB writes a project save fires off after its own enqueue() already resolved.
+    // QNBS-v3: a save enqueued (project or settings autosave, or a visibility/quit flush) before this flag flipped already passed its own guard check and will run regardless -- draining all four coordinators here lets it finish before deletion starts, instead of racing it. The last two cover the non-critical cross-project-index/DuckDB writes a project save fires off after its own enqueue() already resolved.
     await Promise.all([
       projectPersistenceCoordinator.idle(),
       settingsPersistenceCoordinator.idle(),
-      backgroundWriteCoordinator.idle(),
+      crossProjectIndexCoordinator.idle(),
+      duckDbWriteCoordinator.idle(),
     ]);
     // QNBS-v3: clear fallible desktop data first so a failed desktop reset never leaves a mixed wipe.
     await clearTauriAppData();

--- a/tests/unit/crossProjectIndexService.test.ts
+++ b/tests/unit/crossProjectIndexService.test.ts
@@ -67,13 +67,6 @@ beforeEach(async () => {
   }
 });
 
-// Flush the fire-and-forget DuckDB write chain (loadDuckdbAnalytics().then(...)) deterministically —
-// it is a pure microtask chain (mocked loader resolves synchronously), so awaiting a few microtask
-// ticks settles it without depending on real timers / wall-clock scheduling.
-async function flushMicrotasks() {
-  for (let i = 0; i < 5; i++) await Promise.resolve();
-}
-
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 describe('crossProjectIndexService', () => {
@@ -160,7 +153,6 @@ describe('crossProjectIndexService', () => {
   // IDB put (so a mid-call opt-out is honoured). The IDB index itself is written regardless.
   it('indexProject writes the DuckDB mirror when the gate callback returns true', async () => {
     await indexProject('proj-1', makeProjectData(), () => true);
-    await flushMicrotasks();
     expect(mockCrossProjectWrite).toHaveBeenCalledWith(
       expect.objectContaining({ projectId: 'proj-1', title: 'My Novel' }),
     );
@@ -168,11 +160,31 @@ describe('crossProjectIndexService', () => {
 
   it('indexProject skips the DuckDB mirror when the gate callback returns false (IDB still written)', async () => {
     await indexProject('proj-1', makeProjectData(), () => false);
-    await flushMicrotasks();
     expect(mockCrossProjectWrite).not.toHaveBeenCalled();
     // IDB search index is still populated — search works regardless of analytics opt-out.
     const results = await listIndexedProjects();
     expect(results.find((r) => r.projectId === 'proj-1')).toBeDefined();
+  });
+
+  // QNBS-v3: closes a cubic P1 finding -- a caller awaiting indexProject() (e.g. a factory reset's coordinator drain) must see the mirror write as done, not still in flight after this call already resolved.
+  it("indexProject's own promise does not resolve until the DuckDB mirror write settles", async () => {
+    let resolveMirror: () => void = () => {};
+    mockCrossProjectWrite.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveMirror = resolve;
+      }),
+    );
+    let indexProjectSettled = false;
+    const pending = indexProject('proj-1', makeProjectData(), () => true).then(() => {
+      indexProjectSettled = true;
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(indexProjectSettled).toBe(false);
+
+    resolveMirror();
+    await pending;
+    expect(indexProjectSettled).toBe(true);
   });
 });
 

--- a/tests/unit/factoryResetService.test.ts
+++ b/tests/unit/factoryResetService.test.ts
@@ -3,7 +3,10 @@
  * QNBS-v3: covers the native indexedDB.databases() path, the known-list fallback, the Cache API branch, and the Tauri AppData clear branch (exists/missing/partial-failure).
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { projectPersistenceCoordinator } from '../../app/persistenceCoordinator';
+import {
+  backgroundWriteCoordinator,
+  projectPersistenceCoordinator,
+} from '../../app/persistenceCoordinator';
 import { isFactoryResetInProgress, wipeAllAppData } from '../../services/factoryResetService';
 import { logger } from '../../services/logger';
 
@@ -118,6 +121,38 @@ describe('wipeAllAppData', () => {
     } finally {
       // QNBS-v3: resolveSave() is idempotent (a no-op if the success path already called it) -- an assertion failing above must not leave this singleton coordinator permanently stuck, hanging every later test's own wipeAllAppData() at idle().
       resolveSave();
+      await vi.runAllTimersAsync();
+      vi.useRealTimers();
+      delSpy.mockRestore();
+    }
+  });
+
+  // QNBS-v3: the post-save index/DuckDB writes were previously untracked by any drain, so a reset could delete the database they were about to write to.
+  it('drains a background index/analytics write already enqueued before deleting any database', async () => {
+    await createDb('worldscript-data-db');
+    let resolveWrite: () => void = () => {};
+    const pendingWrite = new Promise<void>((resolve) => {
+      resolveWrite = resolve;
+    });
+    const enqueued = backgroundWriteCoordinator.enqueue(() => pendingWrite);
+
+    const delSpy = vi.spyOn(indexedDB, 'deleteDatabase');
+    vi.useFakeTimers();
+    try {
+      const done = wipeAllAppData();
+      // QNBS-v3: lets the idle()-await point run without letting the still-pending write resolve.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(delSpy).not.toHaveBeenCalled();
+
+      resolveWrite();
+      await enqueued;
+      await vi.runAllTimersAsync();
+      await done;
+      expect(delSpy).toHaveBeenCalled();
+    } finally {
+      // QNBS-v3: idempotent no-op if the success path already resolved it -- see the project-save drain test above for why this matters.
+      resolveWrite();
       await vi.runAllTimersAsync();
       vi.useRealTimers();
       delSpy.mockRestore();

--- a/tests/unit/factoryResetService.test.ts
+++ b/tests/unit/factoryResetService.test.ts
@@ -3,7 +3,7 @@
  * QNBS-v3: covers the native indexedDB.databases() path, the known-list fallback, the Cache API branch, and the Tauri AppData clear branch (exists/missing/partial-failure).
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { wipeAllAppData } from '../../services/factoryResetService';
+import { isFactoryResetInProgress, wipeAllAppData } from '../../services/factoryResetService';
 import { logger } from '../../services/logger';
 
 const mockIsTauriRuntime = vi.fn(() => false);
@@ -85,6 +85,12 @@ describe('wipeAllAppData', () => {
     delSpy.mockRestore();
   });
 
+  // QNBS-v3: guards flushPersistedState's visibilitychange/quit-flush call sites against racing this same reload and recreating a just-deleted database with stale state.
+  it('marks a reset in progress for the duration of a successful wipe', async () => {
+    await runWipe();
+    expect(isFactoryResetInProgress()).toBe(true);
+  });
+
   // QNBS-v3: a bare reload preserves the hash, and readInitialView() reads it before checking whether a project exists, rebooting a freshly wiped app straight back into the pre-reset view.
   it('sanitizes the view-carrying hash and view query param before reload, preserving other URL state', async () => {
     Object.defineProperty(window, 'location', {
@@ -104,6 +110,24 @@ describe('wipeAllAppData', () => {
     expect(replaceStateSpy.mock.invocationCallOrder[0]).toBeLessThan(
       reloadMock.mock.invocationCallOrder[0]!,
     );
+    replaceStateSpy.mockRestore();
+  });
+
+  // QNBS-v3: URLSearchParams.delete() + toString() would reserialize every retained parameter, silently turning a raw %20 into + or a bare flag into an explicit empty value -- proves the fix strips only `view` at the string level.
+  it('removes only the view query param without reserializing non-canonical unrelated query encoding', async () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        ...originalLocation,
+        href: 'http://localhost:3000/WorldScript-Studio/?foo=a%20b&flag&view=settings',
+        reload: reloadMock,
+      },
+    });
+    const replaceStateSpy = vi.spyOn(history, 'replaceState').mockImplementation(() => undefined);
+
+    await runWipe();
+
+    expect(replaceStateSpy).toHaveBeenCalledWith(null, '', '/WorldScript-Studio/?foo=a%20b&flag');
     replaceStateSpy.mockRestore();
   });
 
@@ -219,6 +243,8 @@ describe('wipeAllAppData', () => {
         'Failed to clear Tauri app data during factory reset:',
         expect.any(Error),
       );
+      // QNBS-v3: a failed reset never reloads, so the app keeps running -- the flag must not stay stuck on and silently block every future save.
+      expect(isFactoryResetInProgress()).toBe(false);
     });
 
     it('rejects and never reloads when readDir itself throws', async () => {

--- a/tests/unit/factoryResetService.test.ts
+++ b/tests/unit/factoryResetService.test.ts
@@ -85,6 +85,28 @@ describe('wipeAllAppData', () => {
     delSpy.mockRestore();
   });
 
+  // QNBS-v3: a bare reload preserves the hash, and readInitialView() reads it before checking whether a project exists, rebooting a freshly wiped app straight back into the pre-reset view.
+  it('sanitizes the view-carrying hash and view query param before reload, preserving other URL state', async () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        ...originalLocation,
+        href: 'http://localhost:3000/WorldScript-Studio/?foo=bar&view=settings#/settings',
+        reload: reloadMock,
+      },
+    });
+    const replaceStateSpy = vi.spyOn(history, 'replaceState').mockImplementation(() => undefined);
+
+    await runWipe();
+
+    expect(replaceStateSpy).toHaveBeenCalledWith(null, '', '/WorldScript-Studio/?foo=bar');
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+    expect(replaceStateSpy.mock.invocationCallOrder[0]).toBeLessThan(
+      reloadMock.mock.invocationCallOrder[0]!,
+    );
+    replaceStateSpy.mockRestore();
+  });
+
   it('falls back to the known database list when indexedDB.databases() fails', async () => {
     const dbSpy = vi.spyOn(indexedDB, 'databases').mockRejectedValueOnce(new Error('not allowed'));
     const delSpy = vi.spyOn(indexedDB, 'deleteDatabase');
@@ -98,10 +120,12 @@ describe('wipeAllAppData', () => {
     delSpy.mockRestore();
   });
 
-  it('clears this app\'s own service-worker caches when the Cache API is available', async () => {
+  it("clears this app's own service-worker caches when the Cache API is available", async () => {
     const del = vi.fn().mockResolvedValue(true);
     vi.stubGlobal('caches', {
-      keys: vi.fn().mockResolvedValue(['worldscript-static-v1.28.2', 'worldscript-dynamic-v1.28.2']),
+      keys: vi
+        .fn()
+        .mockResolvedValue(['worldscript-static-v1.28.2', 'worldscript-dynamic-v1.28.2']),
       delete: del,
     });
 

--- a/tests/unit/factoryResetService.test.ts
+++ b/tests/unit/factoryResetService.test.ts
@@ -3,6 +3,7 @@
  * QNBS-v3: covers the native indexedDB.databases() path, the known-list fallback, the Cache API branch, and the Tauri AppData clear branch (exists/missing/partial-failure).
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { projectPersistenceCoordinator } from '../../app/persistenceCoordinator';
 import { isFactoryResetInProgress, wipeAllAppData } from '../../services/factoryResetService';
 import { logger } from '../../services/logger';
 
@@ -91,6 +92,35 @@ describe('wipeAllAppData', () => {
     expect(isFactoryResetInProgress()).toBe(true);
   });
 
+  // QNBS-v3: a save already enqueued before resetInProgress flips has already passed its own guard check and will run regardless -- proves the reset waits for it to finish before deleting anything, instead of racing it.
+  it('drains a project save already enqueued before deleting any database', async () => {
+    await createDb('worldscript-data-db');
+    let resolveSave: () => void = () => {};
+    const pendingSave = new Promise<void>((resolve) => {
+      resolveSave = resolve;
+    });
+    const enqueued = projectPersistenceCoordinator.enqueue(() => pendingSave);
+
+    const delSpy = vi.spyOn(indexedDB, 'deleteDatabase');
+    vi.useFakeTimers();
+    try {
+      const done = wipeAllAppData();
+      // QNBS-v3: lets the idle()-await point run without letting the still-pending save resolve.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(delSpy).not.toHaveBeenCalled();
+
+      resolveSave();
+      await enqueued;
+      await vi.runAllTimersAsync();
+      await done;
+      expect(delSpy).toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+      delSpy.mockRestore();
+    }
+  });
+
   // QNBS-v3: a bare reload preserves the hash, and readInitialView() reads it before checking whether a project exists, rebooting a freshly wiped app straight back into the pre-reset view.
   it('sanitizes the view-carrying hash and view query param before reload, preserving other URL state', async () => {
     Object.defineProperty(window, 'location', {
@@ -128,6 +158,24 @@ describe('wipeAllAppData', () => {
     await runWipe();
 
     expect(replaceStateSpy).toHaveBeenCalledWith(null, '', '/WorldScript-Studio/?foo=a%20b&flag');
+    replaceStateSpy.mockRestore();
+  });
+
+  // QNBS-v3: readInitialView() reads via URLSearchParams.get('view'), which decodes -- an encoded spelling like %76iew would otherwise survive a raw-key comparison and still restore Settings after reload.
+  it('strips a percent-encoded view key, not just the literal spelling', async () => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        ...originalLocation,
+        href: 'http://localhost:3000/WorldScript-Studio/?%76iew=settings&foo=bar',
+        reload: reloadMock,
+      },
+    });
+    const replaceStateSpy = vi.spyOn(history, 'replaceState').mockImplementation(() => undefined);
+
+    await runWipe();
+
+    expect(replaceStateSpy).toHaveBeenCalledWith(null, '', '/WorldScript-Studio/?foo=bar');
     replaceStateSpy.mockRestore();
   });
 

--- a/tests/unit/factoryResetService.test.ts
+++ b/tests/unit/factoryResetService.test.ts
@@ -151,15 +151,15 @@ describe('wipeAllAppData', () => {
       await Promise.resolve();
       expect(delSpy).not.toHaveBeenCalled();
 
-      // QNBS-v3: resolving only one of the two must not be enough -- proves the drain genuinely waits on both, not just whichever settles first.
-      resolveIndexWrite();
-      await enqueuedIndex;
+      // QNBS-v3: DuckDB resolved first (not index) is the discriminating order -- if crossProjectIndexCoordinator.idle() were dropped from the drain, deletion would proceed right here since every other awaited promise is already settled.
+      resolveDuckDbWrite();
+      await enqueuedDuckDb;
       await Promise.resolve();
       await Promise.resolve();
       expect(delSpy).not.toHaveBeenCalled();
 
-      resolveDuckDbWrite();
-      await enqueuedDuckDb;
+      resolveIndexWrite();
+      await enqueuedIndex;
       await vi.runAllTimersAsync();
       await done;
       expect(delSpy).toHaveBeenCalled();

--- a/tests/unit/factoryResetService.test.ts
+++ b/tests/unit/factoryResetService.test.ts
@@ -116,6 +116,9 @@ describe('wipeAllAppData', () => {
       await done;
       expect(delSpy).toHaveBeenCalled();
     } finally {
+      // QNBS-v3: resolveSave() is idempotent (a no-op if the success path already called it) -- an assertion failing above must not leave this singleton coordinator permanently stuck, hanging every later test's own wipeAllAppData() at idle().
+      resolveSave();
+      await vi.runAllTimersAsync();
       vi.useRealTimers();
       delSpy.mockRestore();
     }

--- a/tests/unit/factoryResetService.test.ts
+++ b/tests/unit/factoryResetService.test.ts
@@ -4,7 +4,8 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
-  backgroundWriteCoordinator,
+  crossProjectIndexCoordinator,
+  duckDbWriteCoordinator,
   projectPersistenceCoordinator,
 } from '../../app/persistenceCoordinator';
 import { isFactoryResetInProgress, wipeAllAppData } from '../../services/factoryResetService';
@@ -127,32 +128,45 @@ describe('wipeAllAppData', () => {
     }
   });
 
-  // QNBS-v3: the post-save index/DuckDB writes were previously untracked by any drain, so a reset could delete the database they were about to write to.
-  it('drains a background index/analytics write already enqueued before deleting any database', async () => {
+  // QNBS-v3: the post-save index/DuckDB writes were previously untracked by any drain, so a reset could delete the database they were about to write to. Two separate coordinators (not one shared instance) since a shared single queue slot let one resource's write silently discard the other's.
+  it('drains both the cross-project-index and DuckDB write coordinators before deleting any database', async () => {
     await createDb('worldscript-data-db');
-    let resolveWrite: () => void = () => {};
-    const pendingWrite = new Promise<void>((resolve) => {
-      resolveWrite = resolve;
+    let resolveIndexWrite: () => void = () => {};
+    let resolveDuckDbWrite: () => void = () => {};
+    const pendingIndexWrite = new Promise<void>((resolve) => {
+      resolveIndexWrite = resolve;
     });
-    const enqueued = backgroundWriteCoordinator.enqueue(() => pendingWrite);
+    const pendingDuckDbWrite = new Promise<void>((resolve) => {
+      resolveDuckDbWrite = resolve;
+    });
+    const enqueuedIndex = crossProjectIndexCoordinator.enqueue(() => pendingIndexWrite);
+    const enqueuedDuckDb = duckDbWriteCoordinator.enqueue(() => pendingDuckDbWrite);
 
     const delSpy = vi.spyOn(indexedDB, 'deleteDatabase');
     vi.useFakeTimers();
     try {
       const done = wipeAllAppData();
-      // QNBS-v3: lets the idle()-await point run without letting the still-pending write resolve.
+      // QNBS-v3: lets the idle()-await point run without letting either still-pending write resolve.
       await Promise.resolve();
       await Promise.resolve();
       expect(delSpy).not.toHaveBeenCalled();
 
-      resolveWrite();
-      await enqueued;
+      // QNBS-v3: resolving only one of the two must not be enough -- proves the drain genuinely waits on both, not just whichever settles first.
+      resolveIndexWrite();
+      await enqueuedIndex;
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(delSpy).not.toHaveBeenCalled();
+
+      resolveDuckDbWrite();
+      await enqueuedDuckDb;
       await vi.runAllTimersAsync();
       await done;
       expect(delSpy).toHaveBeenCalled();
     } finally {
       // QNBS-v3: idempotent no-op if the success path already resolved it -- see the project-save drain test above for why this matters.
-      resolveWrite();
+      resolveIndexWrite();
+      resolveDuckDbWrite();
       await vi.runAllTimersAsync();
       vi.useRealTimers();
       delSpy.mockRestore();

--- a/tests/unit/listenerMiddleware.test.ts
+++ b/tests/unit/listenerMiddleware.test.ts
@@ -45,6 +45,12 @@ vi.mock('../../services/factoryResetService', () => ({
   isFactoryResetInProgress: () => mockIsFactoryResetInProgress(),
 }));
 
+// QNBS-v3: dynamically imported by listenerMiddleware's post-save side effects -- mocked so tests can assert on it directly instead of touching the real IDB store.
+const mockIndexProject = vi.fn().mockResolvedValue(undefined);
+vi.mock('../../services/crossProjectIndexService', () => ({
+  indexProject: (...args: unknown[]) => mockIndexProject(...args),
+}));
+
 const mockCheckStorageHealth = vi.fn().mockResolvedValue({ ok: true, warning: null });
 vi.mock('../../services/dbInitialization', () => ({
   checkStorageHealth: (...args: unknown[]) => mockCheckStorageHealth(...args),
@@ -393,6 +399,35 @@ describe('auto-save project listener', () => {
     await vi.advanceTimersByTimeAsync(0);
 
     expect(mockSaveProject).not.toHaveBeenCalled();
+  });
+
+  // QNBS-v3: enqueue() resolving already clears the coordinator's own active slot, so a reset starting right after is invisible to wipeAllAppData()'s drain -- the post-save writes need their own re-check.
+  it('skips the cross-project index update when a factory reset starts right after the save resolves', async () => {
+    let resolveSave: (value?: undefined) => void = () => {};
+    mockSaveProject.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveSave = resolve;
+      }),
+    );
+    const store = makeFullStore();
+    store.dispatch(projectActions.updateTitle('Post-Save Race'));
+    await vi.advanceTimersByTimeAsync(1000);
+    // QNBS-v3: the effect is now suspended awaiting the coordinator's enqueue(), which is itself awaiting this pending save.
+    expect(mockSaveProject).toHaveBeenCalled();
+
+    mockIsFactoryResetInProgress.mockReturnValue(true);
+    resolveSave();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(mockIndexProject).not.toHaveBeenCalled();
+  });
+
+  it('runs the cross-project index update when no reset is in progress', async () => {
+    const store = makeFullStore();
+    store.dispatch(projectActions.updateTitle('Normal Save'));
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(mockIndexProject).toHaveBeenCalled();
   });
 });
 

--- a/tests/unit/listenerMiddleware.test.ts
+++ b/tests/unit/listenerMiddleware.test.ts
@@ -40,6 +40,11 @@ vi.mock('../../services/storageService', () => ({
   },
 }));
 
+const mockIsFactoryResetInProgress = vi.fn(() => false);
+vi.mock('../../services/factoryResetService', () => ({
+  isFactoryResetInProgress: () => mockIsFactoryResetInProgress(),
+}));
+
 vi.mock('../../services/dbService', () => ({
   dbService: {
     initDB: vi.fn().mockResolvedValue(undefined),
@@ -350,6 +355,16 @@ describe('auto-save project listener', () => {
     // An error notification should be present
     const errorNote = notifications.find((n) => n.type === 'error');
     expect(errorNote).toBeTruthy();
+  });
+
+  // QNBS-v3: a debounce armed just before a factory reset began must not fire after it and repopulate the database the reset just deleted.
+  it('skips the debounced save entirely while a factory reset is in progress', async () => {
+    mockIsFactoryResetInProgress.mockReturnValue(true);
+    const store = makeFullStore();
+    store.dispatch(projectActions.updateTitle('Should Never Save'));
+    await vi.advanceTimersByTimeAsync(1500);
+    expect(mockSaveProject).not.toHaveBeenCalled();
+    mockIsFactoryResetInProgress.mockReturnValue(false);
   });
 });
 

--- a/tests/unit/listenerMiddleware.test.ts
+++ b/tests/unit/listenerMiddleware.test.ts
@@ -45,6 +45,11 @@ vi.mock('../../services/factoryResetService', () => ({
   isFactoryResetInProgress: () => mockIsFactoryResetInProgress(),
 }));
 
+const mockCheckStorageHealth = vi.fn().mockResolvedValue({ ok: true, warning: null });
+vi.mock('../../services/dbInitialization', () => ({
+  checkStorageHealth: (...args: unknown[]) => mockCheckStorageHealth(...args),
+}));
+
 vi.mock('../../services/dbService', () => ({
   dbService: {
     initDB: vi.fn().mockResolvedValue(undefined),
@@ -190,6 +195,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   // QNBS-v3: clearAllMocks resets call history, not a mockReturnValue override -- an assertion failure mid-test must not leave this true for every later test in the file.
   mockIsFactoryResetInProgress.mockReturnValue(false);
+  mockCheckStorageHealth.mockResolvedValue({ ok: true, warning: null });
   vi.useFakeTimers();
 });
 
@@ -365,6 +371,27 @@ describe('auto-save project listener', () => {
     const store = makeFullStore();
     store.dispatch(projectActions.updateTitle('Should Never Save'));
     await vi.advanceTimersByTimeAsync(1500);
+    expect(mockSaveProject).not.toHaveBeenCalled();
+  });
+
+  // QNBS-v3: the shared addDebouncedListener guard passes once before this effect's own checkStorageHealth() await -- a reset starting during that gap must still be caught by the re-check immediately before enqueue().
+  it('skips saveProject when a factory reset starts while checkStorageHealth is still pending', async () => {
+    let resolveHealth: (value: { ok: boolean; warning: string | null }) => void = () => {};
+    mockCheckStorageHealth.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveHealth = resolve;
+      }),
+    );
+    const store = makeFullStore();
+    store.dispatch(projectActions.updateTitle('Race Test'));
+    await vi.advanceTimersByTimeAsync(1000);
+    // QNBS-v3: the effect is now suspended inside its own checkStorageHealth() await, past the shared guard's first (already-false) check.
+    expect(mockCheckStorageHealth).toHaveBeenCalled();
+
+    mockIsFactoryResetInProgress.mockReturnValue(true);
+    resolveHealth({ ok: true, warning: null });
+    await vi.advanceTimersByTimeAsync(0);
+
     expect(mockSaveProject).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/listenerMiddleware.test.ts
+++ b/tests/unit/listenerMiddleware.test.ts
@@ -188,6 +188,8 @@ function getNotifications(store: MinimalStore) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // QNBS-v3: clearAllMocks resets call history, not a mockReturnValue override -- an assertion failure mid-test must not leave this true for every later test in the file.
+  mockIsFactoryResetInProgress.mockReturnValue(false);
   vi.useFakeTimers();
 });
 
@@ -364,7 +366,6 @@ describe('auto-save project listener', () => {
     store.dispatch(projectActions.updateTitle('Should Never Save'));
     await vi.advanceTimersByTimeAsync(1500);
     expect(mockSaveProject).not.toHaveBeenCalled();
-    mockIsFactoryResetInProgress.mockReturnValue(false);
   });
 });
 

--- a/tests/unit/persistedStateFlush.test.ts
+++ b/tests/unit/persistedStateFlush.test.ts
@@ -14,11 +14,16 @@ import type { RootState } from '../../app/store';
 const h = vi.hoisted(() => ({
   saveProject: vi.fn(async (_envelope: { envelope: Record<string, unknown> }) => {}),
   saveSettings: vi.fn(async (_settings: unknown) => {}),
+  isFactoryResetInProgress: vi.fn(() => false),
 }));
 
 vi.mock('../../services/storageService', () => ({
   storageService: { saveProject: h.saveProject, saveSettings: h.saveSettings },
   saveEnvelopeFromProjectData: (data: unknown) => ({ envelope: data }),
+}));
+
+vi.mock('../../services/factoryResetService', () => ({
+  isFactoryResetInProgress: () => h.isFactoryResetInProgress(),
 }));
 
 import { flushPersistedState } from '../../app/persistedStateFlush';
@@ -47,6 +52,15 @@ describe('flushPersistedState', () => {
   beforeEach(() => {
     h.saveProject.mockClear();
     h.saveSettings.mockClear();
+    h.isFactoryResetInProgress.mockReturnValue(false);
+  });
+
+  // QNBS-v3: window.location.reload() fires visibilitychange before the page actually unloads -- a factory reset's own reload must not race this flush into recreating the just-deleted database.
+  it('skips the flush entirely while a factory reset is in progress', async () => {
+    h.isFactoryResetInProgress.mockReturnValue(true);
+    await flushPersistedState(buildState());
+    expect(h.saveProject).not.toHaveBeenCalled();
+    expect(h.saveSettings).not.toHaveBeenCalled();
   });
 
   it('saves project (enriched with persistedVersionControl) and settings', async () => {

--- a/tests/unit/tooling/strykerWorkflowPolicy.test.ts
+++ b/tests/unit/tooling/strykerWorkflowPolicy.test.ts
@@ -18,8 +18,8 @@ const workflow = readFileSync(workflowPath, 'utf8');
 const scopeScriptPath = fileURLToPath(
   new URL('../../../scripts/stryker-scope.mjs', import.meta.url),
 );
-// QNBS-v3: stays string concat — a template literal here is `${{ ${expr} }}`, a JS SyntaxError, not just a style nit.
-const githubExpression = (expression: string) => '$' + '{{ ' + expression + ' }}';
+// QNBS-v3: the unescaped `${{ ${expr} }}` form Biome's own autofix suggests is a JS SyntaxError — `\$` escapes the literal dollar so only the inner `${expr}` interpolates.
+const githubExpression = (expression: string) => `\${{ ${expression} }}`;
 
 // QNBS-v3: Lock workflow/config invariants so mutation plumbing cannot silently drift.
 describe('Stryker workflow policy', () => {

--- a/tests/unit/tooling/workflowPolicyCheck.test.ts
+++ b/tests/unit/tooling/workflowPolicyCheck.test.ts
@@ -1,6 +1,7 @@
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { parseDocument } from 'yaml';
+import type { WorkflowPolicyFailure } from '../../../scripts/workflow-policy-check.d.mts';
 import {
   checkActionFile,
   checkActionPins,
@@ -14,11 +15,10 @@ import {
   getTriggers,
   listActionFiles,
 } from '../../../scripts/workflow-policy-check.mjs';
-import type { WorkflowPolicyFailure } from '../../../scripts/workflow-policy-check.d.mts';
 
 const doc = (yaml: string) => parseDocument(yaml, { uniqueKeys: true });
-// QNBS-v3: stays string concat — a template literal here is `${{ ${expr} }}`, a JS SyntaxError, not just a style nit.
-const githubExpression = (expression: string) => '$' + '{{ ' + expression + ' }}';
+// QNBS-v3: the unescaped `${{ ${expr} }}` form Biome's own autofix suggests is a JS SyntaxError — `\$` escapes the literal dollar so only the inner `${expr}` interpolates.
+const githubExpression = (expression: string) => `\${{ ${expression} }}`;
 
 // QNBS-v3: contents:read is the only safe top-level default — every other form is a policy gap.
 describe('checkTopLevelPermissions', () => {
@@ -36,11 +36,7 @@ describe('checkTopLevelPermissions', () => {
 
   it('fails when a top-level write permission is declared', () => {
     const failures: WorkflowPolicyFailure[] = [];
-    checkTopLevelPermissions(
-      'x.yml',
-      doc('permissions:\n  contents: write\njobs: {}\n'),
-      failures,
-    );
+    checkTopLevelPermissions('x.yml', doc('permissions:\n  contents: write\njobs: {}\n'), failures);
     expect(failures).toHaveLength(1);
     expect(failures[0]?.message).toMatch(/contents: read/);
   });
@@ -88,7 +84,11 @@ describe('checkJobWriteScopeAllowlist', () => {
 
   it('passes for the job-level scalar "read-all"', () => {
     const failures: WorkflowPolicyFailure[] = [];
-    checkJobWriteScopeAllowlist('ci.yml', doc('jobs:\n  build:\n    permissions: read-all\n'), failures);
+    checkJobWriteScopeAllowlist(
+      'ci.yml',
+      doc('jobs:\n  build:\n    permissions: read-all\n'),
+      failures,
+    );
     expect(failures).toEqual([]);
   });
 
@@ -106,9 +106,14 @@ describe('checkJobWriteScopeAllowlist', () => {
   // QNBS-v3: a per-key alias (contents: *grant) must resolve to "write", not the literal "*grant".
   it('resolves a per-key alias inside a job permissions map', () => {
     const failures: WorkflowPolicyFailure[] = [];
-    const content = ['x: &grant write', 'jobs:', '  build:', '    permissions:', '      contents: *grant', ''].join(
-      '\n',
-    );
+    const content = [
+      'x: &grant write',
+      'jobs:',
+      '  build:',
+      '    permissions:',
+      '      contents: *grant',
+      '',
+    ].join('\n');
     checkJobWriteScopeAllowlist('ci.yml', doc(content), failures);
     expect(failures).toHaveLength(1);
     expect(failures[0]?.message).toMatch(/contents/);
@@ -147,11 +152,7 @@ describe('checkNeedsGraph', () => {
 
   it('detects a two-job needs cycle', () => {
     const failures: WorkflowPolicyFailure[] = [];
-    checkNeedsGraph(
-      'x.yml',
-      doc('jobs:\n  a:\n    needs: [b]\n  b:\n    needs: [a]\n'),
-      failures,
-    );
+    checkNeedsGraph('x.yml', doc('jobs:\n  a:\n    needs: [b]\n  b:\n    needs: [a]\n'), failures);
     expect(failures.some((f) => f.message.includes('cycle detected'))).toBe(true);
   });
 
@@ -272,9 +273,14 @@ describe('checkActionPins', () => {
   // QNBS-v3: a Docker action has no steps: at all — its own runs.image needs the same pin check.
   it('fails for a mutable docker image on a Docker action (runs.using: docker)', () => {
     const failures: WorkflowPolicyFailure[] = [];
-    checkActionPins('action.yml', doc('runs:\n  using: docker\n  image: docker://alpine:latest\n'), failures, {
-      fileKind: 'action',
-    });
+    checkActionPins(
+      'action.yml',
+      doc('runs:\n  using: docker\n  image: docker://alpine:latest\n'),
+      failures,
+      {
+        fileKind: 'action',
+      },
+    );
     expect(failures).toHaveLength(1);
     expect(failures[0]?.message).toMatch(/@sha256/);
   });
@@ -339,9 +345,14 @@ describe('checkActionPins', () => {
   // QNBS-v3: GitHub resolves *action_ref before running the step — the checker must do the same.
   it('fails for an unpinned action reference hidden behind an alias', () => {
     const failures: WorkflowPolicyFailure[] = [];
-    const content = ['x: &action_ref actions/checkout@v4', 'jobs:', '  a:', '    steps:', '      - uses: *action_ref', ''].join(
-      '\n',
-    );
+    const content = [
+      'x: &action_ref actions/checkout@v4',
+      'jobs:',
+      '  a:',
+      '    steps:',
+      '      - uses: *action_ref',
+      '',
+    ].join('\n');
     checkActionPins('x.yml', doc(content), failures);
     expect(failures).toHaveLength(1);
     expect(failures[0]?.message).toMatch(/40-hex-char SHA/);
@@ -428,7 +439,7 @@ describe('checkAggregatorNeeds', () => {
     expect(failures).toEqual([]);
   });
 
-  it('fails when if: always() is set but the run script never checks a gating job\'s result', () => {
+  it("fails when if: always() is set but the run script never checks a gating job's result", () => {
     const failures: WorkflowPolicyFailure[] = [];
     checkAggregatorNeeds(
       'ci.yml',
@@ -441,12 +452,14 @@ describe('checkAggregatorNeeds', () => {
     expect(failures[0]?.message).toMatch(/never check needs\.a\.result/);
   });
 
-  it('passes when if: always() is set and the run script checks every gating job\'s result', () => {
+  it("passes when if: always() is set and the run script checks every gating job's result", () => {
     const failures: WorkflowPolicyFailure[] = [];
     const runLine = `[ \\"${githubExpression('needs.a.result')}\\" = success ] || exit 1`;
     checkAggregatorNeeds(
       'ci.yml',
-      doc(`jobs:\n  a: {}\n  ci-success:\n    if: always()\n    needs: [a]\n    steps:\n      - run: "${runLine}"\n`),
+      doc(
+        `jobs:\n  a: {}\n  ci-success:\n    if: always()\n    needs: [a]\n    steps:\n      - run: "${runLine}"\n`,
+      ),
       failures,
     );
     expect(failures).toEqual([]);
@@ -497,7 +510,9 @@ describe('checkAggregatorNeeds', () => {
     const runLine = `echo ${githubExpression('needs.a.result')}\\n# exit 1`;
     checkAggregatorNeeds(
       'ci.yml',
-      doc(`jobs:\n  a: {}\n  ci-success:\n    if: always()\n    needs: [a]\n    steps:\n      - run: "${runLine}"\n`),
+      doc(
+        `jobs:\n  a: {}\n  ci-success:\n    if: always()\n    needs: [a]\n    steps:\n      - run: "${runLine}"\n`,
+      ),
       failures,
     );
     expect(failures).toHaveLength(1);
@@ -508,28 +523,34 @@ describe('checkAggregatorNeeds', () => {
     const failures: WorkflowPolicyFailure[] = [];
     checkAggregatorNeeds(
       'ci.yml',
-      doc('jobs:\n  a: {}\n  ci-success:\n    needs: [a]\n  deploy:\n    needs: [ci-success]\n  smoke:\n    needs: [deploy]\n'),
+      doc(
+        'jobs:\n  a: {}\n  ci-success:\n    needs: [a]\n  deploy:\n    needs: [ci-success]\n  smoke:\n    needs: [deploy]\n',
+      ),
       failures,
     );
     expect(failures).toEqual([]);
   });
 
   // QNBS-v3: failure()/cancelled() bypass default gating exactly like always() — must be caught too.
-  it('fails when if: failure() is set but the run script never checks a gating job\'s result', () => {
+  it("fails when if: failure() is set but the run script never checks a gating job's result", () => {
     const failures: WorkflowPolicyFailure[] = [];
     checkAggregatorNeeds(
       'ci.yml',
-      doc('jobs:\n  a: {}\n  ci-success:\n    if: failure()\n    needs: [a]\n    steps:\n      - run: echo ok\n'),
+      doc(
+        'jobs:\n  a: {}\n  ci-success:\n    if: failure()\n    needs: [a]\n    steps:\n      - run: echo ok\n',
+      ),
       failures,
     );
     expect(failures).toHaveLength(1);
   });
 
-  it('fails when if: !cancelled() is set but the run script never checks a gating job\'s result', () => {
+  it("fails when if: !cancelled() is set but the run script never checks a gating job's result", () => {
     const failures: WorkflowPolicyFailure[] = [];
     checkAggregatorNeeds(
       'ci.yml',
-      doc('jobs:\n  a: {}\n  ci-success:\n    if: "!cancelled()"\n    needs: [a]\n    steps:\n      - run: echo ok\n'),
+      doc(
+        'jobs:\n  a: {}\n  ci-success:\n    if: "!cancelled()"\n    needs: [a]\n    steps:\n      - run: echo ok\n',
+      ),
       failures,
     );
     expect(failures).toHaveLength(1);
@@ -593,14 +614,22 @@ describe('checkPublishingBoundary', () => {
 
   it('fails for the job-level scalar "write-all" on a job not on the publishing allowlist', () => {
     const failures: WorkflowPolicyFailure[] = [];
-    checkPublishingBoundary('ci.yml', doc('jobs:\n  build:\n    permissions: write-all\n'), failures);
+    checkPublishingBoundary(
+      'ci.yml',
+      doc('jobs:\n  build:\n    permissions: write-all\n'),
+      failures,
+    );
     expect(failures).toHaveLength(1);
     expect(failures[0]?.message).toMatch(/not on the publishing allowlist/);
   });
 
   it('passes for the job-level scalar "read-all" (no implied contents:write)', () => {
     const failures: WorkflowPolicyFailure[] = [];
-    checkPublishingBoundary('ci.yml', doc('jobs:\n  build:\n    permissions: read-all\n'), failures);
+    checkPublishingBoundary(
+      'ci.yml',
+      doc('jobs:\n  build:\n    permissions: read-all\n'),
+      failures,
+    );
     expect(failures).toEqual([]);
   });
 });
@@ -688,11 +717,13 @@ describe('checkActionFile', () => {
 });
 
 describe('listActionFiles', () => {
-  it('discovers the repository\'s real .github/actions/setup/action.yml', () => {
+  it("discovers the repository's real .github/actions/setup/action.yml", () => {
     // QNBS-v3: existsSync isn't DI'd (matches listWorkflowFiles), so this hits the real fs.
     const files = listActionFiles();
     expect(
-      files.some((filePath) => filePath.endsWith(join('.github', 'actions', 'setup', 'action.yml'))),
+      files.some((filePath) =>
+        filePath.endsWith(join('.github', 'actions', 'setup', 'action.yml')),
+      ),
     ).toBe(true);
   });
 


### PR DESCRIPTION
## **User description**
## Summary

Fixes #591 and #593 — two real, independent bugs in `ensureWelcomePortalEntry()`'s Factory-Reset recovery flow, both root-caused via the actual Playwright trace/accessibility-snapshot/console-log artifacts from CI runs during this PR's own convergence.

## Bug 1 — #591: stale view-carrying URL survives the reset reload

`ensureWelcomePortalEntry()`'s Factory-Reset recovery flow necessarily navigates to Settings before triggering the reset. Ordinary in-app navigation writes `#/settings` into the URL hash via `pushHash()`. `wipeAllAppData()`'s final `window.location.reload()` preserves that same URL, and `useApp.ts`'s `readInitialView()` reads the hash (then the `view` query param) with **higher priority** than checking whether a project even exists — so a genuinely successful wipe could still reboot straight back into Settings.

**Fix:** `sanitizeViewCarryingUrlState()` strips the hash and the `view` query param via `history.replaceState` immediately before the real reload. (A follow-up Cubic finding on this fix was also addressed — see below.)

## Bug 2 — #593: visibilitychange flush races the reset's own reload

After #591's fix, a *different* symptom appeared at the same final assertion: the app landed on the **Dashboard with a synthetically-seeded placeholder project** instead of the WelcomePortal. Traced via console-log timeline evidence (no project-rehydration message after the reset+reload, ruling out an IDB-deletion race) plus source tracing of `index.tsx`'s boot sequence:

- `index.tsx`'s `visibilitychange` handler (and the desktop quit-flush, and `register-sw.ts`'s update flush — all three funnel through `flushPersistedState()`) fires on `window.location.reload()` itself, since a reload triggers `visibilitychange` before the page actually unloads.
- `wipeAllAppData()` doesn't stop the running app or its listeners during the 300ms settle window before that reload, so this flush can reopen and repopulate the IndexedDB database it just deleted with the stale, pre-reset in-memory Redux state.
- Settings appears to survive (a write far enough along to commit before the unload) while the project usually doesn't (interrupted first, later in the same `Promise.allSettled`) — producing exactly the "settings-only persisted state" shape that makes `index.tsx`'s `isNewUser = !preloadedState` evaluate `false` and skip the WelcomePortal, landing on the Dashboard instead, where `useProjectBootstrapEffect` then seeds a placeholder project title into the always-non-null default Redux project shell.

**Confirmed independent of PR #583's IDB reset-gate architecture in mechanism** (this closes one specific persistence-during-reset race with a minimal flag; #583 builds a general-purpose admission/generation/fail-closed gate for every long-lived connection) but the same *class* of problem — when #583 rebases, this invariant needs to be preserved inside its hardened reset implementation, not reintroduced separately.

**Fix:** `isFactoryResetInProgress()` is set before any wipe work starts and guards `flushPersistedState()` itself, so all three call sites are protected by one change. Resets back to `false` if the reset itself fails and never reloads, so a failed attempt doesn't silently block every future save for the rest of the session.

## Bug 3 (review finding) — reserialization of unrelated query state

A Cubic P3 finding on the original #591 fix was valid: `url.searchParams.delete('view')` followed by reading `url.search` back reserializes *every* retained query parameter via `URLSearchParams.toString()`, not just the one being removed — e.g. turning a raw `%20` into `+`, or a bare flag `?foo` into `?foo=`. Replaced with a string-level `stripViewQueryParam()` that removes only the `view` key, leaving every other parameter's raw encoding untouched. Verified against `URL`/`URLSearchParams` semantics directly (not assumed) before implementing.

## Non-goals

- Does not touch `hooks/useApp.ts`'s deep-link priority order or `services/deepLinkService.ts`.
- Does not import or reimplement any part of PR #583's reset-gate architecture.
- Does not increase any E2E timeout or Playwright retry count.

## Test plan

- [x] `pnpm run lint` — pass
- [x] `pnpm run typecheck` — pass (exact CI command)
- [x] `pnpm exec vitest run tests/unit/factoryResetService.test.ts tests/unit/persistedStateFlush.test.ts tests/unit/registerSwUpdateFlush.test.ts` — 27/27 pass, including new regression tests for both bugs and the query-encoding fix
- [x] `pnpm run ci:prepush` — pass
- [ ] Full GitHub CI, including a genuine first-attempt, zero-Playwright-retry Chromium + Mobile Chrome pass on `onboarding-entry-precondition.spec.ts` (no rerun-only acceptance, per this repo's standing bar for E2E-nondeterminism fixes)

## Summary by Sourcery

Make factory-reset recovery deterministic by clearing stale navigation state and preventing background persistence from recreating data during the reset.

Bug Fixes:
- Make factory reset reliably reopen the app on a clean Welcome screen instead of restoring stale view state or repopulated data.
- Prevent persistence and indexing writes from racing factory reset and recreating deleted state.
- Restore normal persistence after a failed reset without leaving writes permanently blocked.

Enhancements:
- Preserve unrelated URL query parameters exactly while removing only the view state used for navigation recovery.
- Ensure post-save indexing and analytics writes are tracked and completed before reset cleanup.

Tests:
- Add regression coverage for reset write races, URL sanitization and encoding preservation, failed-reset recovery, and awaited index writes.

Chores:
- Update documented test counts to reflect the expanded test suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Factory reset now completes pending saves and background writes before deleting data.
  * Persistence and debounced auto-save are paused while a factory reset is in progress.
  * Factory reset clears view-specific URL state while preserving unrelated URL parameters.
  * Failed reset operations no longer reload the application and correctly report the failure.

* **Documentation**
  * Updated README test metrics to reflect 7,368+ tests across 595 files.

* **Tests**
  * Expanded coverage for reset progress, failed resets, URL sanitization, pending writes, race conditions, and paused persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Make factory reset finish cleanly and reopen as a fresh install

### What Changed
- Factory reset now waits for pending saves and search or analytics updates before deleting app data.
- Saves triggered during reset, including reload-related flushes and delayed autosaves, are skipped so deleted data is not recreated.
- Reset removes the previous view from the URL before reloading, including encoded `view` parameters, while preserving unrelated URL parameters.
- Failed desktop resets clear the reset state so normal saving can resume without reloading.
- Added coverage for reset races, URL cleanup, pending writes, and post-reset save behavior.

### Impact
`✅ Factory reset opens the Welcome screen`
`✅ Deleted data is not recreated during reset`
`✅ Failed resets leave saving available`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
