### PR TITLE
build(deps): bump actions/setup-node to v6.5.0, fix composite-action sibling gap

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -23,8 +23,8 @@ runs:
 
     # QNBS-v3: When node-version is set (matrix), use it; otherwise read .nvmrc so
     # non-matrix jobs stay pinned to the project's declared Node version.
-    # Node 24 compatibility: actions/setup-node v6.4.0 handles both LTS versions correctly.
-    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+    # Node 24 compatibility: actions/setup-node v6.5.0 handles both LTS versions correctly.
+    - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
       with:
         node-version: ${{ inputs.node-version }}
         node-version-file: ${{ inputs.node-version == '' && inputs.node-version-file || '' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 11.22.0
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version-file: .nvmrc
           cache: pnpm

--- a/.github/workflows/deploy-cloudflare-pages.yml.disabled
+++ b/.github/workflows/deploy-cloudflare-pages.yml.disabled
@@ -49,7 +49,7 @@ jobs:
         with:
           version: 11.22.0
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 22
           cache: pnpm


### PR DESCRIPTION
## **User description**
## Summary

Supersedes #563. Dependabot proposed a major bump to `actions/setup-node` v7.0.0, but its github-actions ecosystem scanner only covers `.github/workflows/*.yml` — it cannot see `uses:` references inside composite action definitions under `.github/actions/`. As a result, PR #563 only updated `ci.yml`'s one direct reference (the small `workflow-policy` job's bootstrap step), leaving two more references at v6.4.0:

- `.github/actions/setup/action.yml` — the shared composite action actually used by the `security` and `quality` jobs (the substantive CI work: lint, typecheck, tests, coverage).
- `.github/workflows/deploy-cloudflare-pages.yml.disabled` — kept consistent for whenever it's re-enabled.

Merging #563 as-is would have left the bootstrap job on v7 while every job that matters stayed on v6.4.0 — the same sibling-reference-drift failure mode `docs/DEPENDABOT-TRIAGE.md` already documents an incident for with `codeql-action`, just caused by a different root cause (a Dependabot scanner blind spot rather than a missing `groups:` entry).

## Why v6.5.0, not v7.0.0

Compared both (published five minutes apart, per the GitHub Releases API) before choosing:

| | v7.0.0 | v6.5.0 |
|---|---|---|
| Payload | ESM migration, new unused cache-key outputs, `mirrorToken` fix (unused input here), dummy `NODE_AUTH_TOKEN` removal (unused var here) | `@actions/cache` → 5.1.0 + security overrides for `undici` and `fast-xml-parser` — the same fix, backported |
| Benefit to this repo | None of the above changes anything this repo actually uses | The real security-relevant payload |
| Risk | Major version — full manual review per `DEPENDABOT-TRIAGE.md`'s triage matrix | Same v6.x major, no behavior change beyond the dependency bump |

v6.5.0 delivers the one change that matters with none of the major-bump review burden.

## Test plan

- [x] `pnpm run lint` — clean
- [x] `pnpm exec vitest run tests/unit/tooling/workflowPolicyCheck.test.ts` — 71/71 pass (action-pin structural validation)
- [x] `pnpm run ci:prepush` — full local admission PASS
- [x] Verified `249970729cb0ef3589644e2896645e5dc5ba9c38` against the GitHub API resolves to the `v6.5.0` / `v6` tags in `actions/setup-node`
- [ ] CI green on this PR, then main green post-merge

## Summary by Sourcery

Standardize actions/setup-node on v6.5.0 across active and disabled CI configuration.

Bug Fixes:
- Update all repository references to actions/setup-node from v6.4.0 to v6.5.0, including the shared composite action and disabled deployment workflow, preventing version drift across CI jobs.

CI:
- Align CI bootstrap and shared setup steps on the v6.5.0 action revision, including its security-related dependency updates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates all `actions/setup-node` references from v6.4.0 to v6.5.0 instead of taking the proposed v7 major bump. This provides the relevant dependency security fixes without the v7 migration or behavior changes, while keeping every invocation on the same release.

**Dependencies**

- v6.5.0 updates `@actions/cache` to 5.1.0 and adds security overrides for `undici` and `fast-xml-parser`.
- The shared composite action is updated explicitly because Dependabot does not scan references under `.github/actions/`.

<sup>Written for commit ec2dc5f34e84655b8b5028919f51f74d34d4dc4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/qnbs/WorldScript-Studio/pull/594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Align all CI workflows on actions/setup-node v6.5.0

### What Changed
- Updated every active and disabled workflow reference to the same pinned setup-node v6.5.0 release
- Keeps the workflow policy, security, quality, and future Cloudflare deployment jobs consistent
- Includes the v6.5.0 security updates without introducing the unrelated major-version changes from v7

### Impact
`✅ Consistent Node.js setup across CI jobs`
`✅ Security fixes for dependency caching and parsing`
`✅ Fewer workflow failures from mismatched action versions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Node.js setup used by automated build, validation, and deployment workflows to version 6.5.0.
  - Refreshed pinned action references to maintain consistent workflow execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->