### PR TITLE
fix(deps): override fflate to 0.8.3, fixing a ZIP64-parsing DoS

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1852,6 +1852,7 @@ transitive deps and are never shipped to users.
 | ip-address | >=10.1.1 | preventive pin — no direct advisory | Dev/test transitive hardening; no advisory matches this floor. |
 | uuid | >=11.1.1 | preventive pin — no direct advisory | Conservative version floor; no security advisory applies (the prior "collision" note was inaccurate). |
 | joi (transitive via `wait-on` ← `@storybook/test-runner` → `jest-process-manager`) | ^18.2.1 | transitive hardening (dev-only) | `wait-on@7.2.0` originally pulled an older `joi`; lockfile pins `joi@18.2.1` for both `wait-on@7.2.0` and `wait-on@9.0.10`. Dev/test toolchain only, never shipped. |
+| fflate | >=0.8.3 | GHSA-px8p-9vwx-vf98 / CVE-2026-45820 | `unzipSync()` infinite loop on a crafted ZIP64 archive missing its required extra field (≤0.8.2; fixed 0.8.3). Transitive via `jspdf@4.2.1` (PDF export), whose own `^0.8.1` range already permits the patched version. Advisory elevated to GitHub-reviewed status 2026-09-03, discovered via a routine Security Audit CI failure the same day. |
 
 **Dependency hygiene status (2026-06-13):**
 - `pnpm audit --audit-level=high` → 0 vulnerabilities.

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1831,9 +1831,10 @@ Source of truth for the override floors is `pnpm-workspace.yaml` (`overrides:`).
 IDs below were re-verified against the GitHub Advisory Database on 2026-06-13, except the
 `@xmldom/xmldom`, `fast-uri`, and `qs` rows, re-verified 2026-09-02 (Dependabot alert #79
 and two `pnpm audit` sweeps) after all three floors were found to no longer exclude the
-then-currently-resolved vulnerable version. Floors are intentionally conservative (set at or
-above the patched version) as preventive supply-chain pins; several apply only to dev/test
-transitive deps and are never shipped to users.
+then-currently-resolved vulnerable version, and the `fflate` row, added 2026-09-03 the same
+day its advisory was elevated to GitHub-reviewed status. Floors are intentionally conservative
+(set at or above the patched version) as preventive supply-chain pins; several apply only to
+dev/test transitive deps and are never shipped to users.
 
 | Package | Override | Advisory | Justification |
 |---------|----------|----------|---------------|
@@ -1852,7 +1853,7 @@ transitive deps and are never shipped to users.
 | ip-address | >=10.1.1 | preventive pin — no direct advisory | Dev/test transitive hardening; no advisory matches this floor. |
 | uuid | >=11.1.1 | preventive pin — no direct advisory | Conservative version floor; no security advisory applies (the prior "collision" note was inaccurate). |
 | joi (transitive via `wait-on` ← `@storybook/test-runner` → `jest-process-manager`) | ^18.2.1 | transitive hardening (dev-only) | `wait-on@7.2.0` originally pulled an older `joi`; lockfile pins `joi@18.2.1` for both `wait-on@7.2.0` and `wait-on@9.0.10`. Dev/test toolchain only, never shipped. |
-| fflate | >=0.8.3 | GHSA-px8p-9vwx-vf98 / CVE-2026-45820 | `unzipSync()` infinite loop on a crafted ZIP64 archive missing its required extra field (≤0.8.2; fixed 0.8.3). Transitive via `jspdf@4.2.1` (PDF export), whose own `^0.8.1` range already permits the patched version. Advisory elevated to GitHub-reviewed status 2026-09-03, discovered via a routine Security Audit CI failure the same day. |
+| fflate | >=0.8.3 | GHSA-px8p-9vwx-vf98 / CVE-2026-45820 | `unzipSync()` infinite loop on a crafted ZIP64 archive missing its required extra field (≤0.8.2; fixed at or above 0.8.3). Transitive via `jspdf@4.2.1` (PDF export), whose own `^0.8.1` range already permits the patched version. Advisory elevated to GitHub-reviewed status 2026-09-03, discovered via a routine Security Audit CI failure the same day. |
 
 **Dependency hygiene status (2026-06-13):**
 - `pnpm audit --audit-level=high` → 0 vulnerabilities.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,7 @@ overrides:
   brace-expansion: '>=5.0.9'
   uuid: '>=11.1.1 <12.0.0 || >=12.0.1 <13.0.0 || >=13.0.1'
   qs: '>=6.16.0'
+  fflate: '>=0.8.3'
   dompurify: '>=3.4.13'
   '@babel/core': '>=7.29.6 <8'
   undici: '>=7.29.0 <8'
@@ -4658,8 +4659,8 @@ packages:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
 
-  fflate@0.8.2:
-    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   figures@2.0.0:
     resolution: {integrity: sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==}
@@ -12066,7 +12067,7 @@ snapshots:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
 
-  fflate@0.8.2: {}
+  fflate@0.8.3: {}
 
   figures@2.0.0:
     dependencies:
@@ -13267,7 +13268,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.29.2
       fast-png: 6.4.0
-      fflate: 0.8.2
+      fflate: 0.8.3
     optionalDependencies:
       canvg: 3.0.11
       core-js: 3.49.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -39,6 +39,7 @@ minimumReleaseAgeExclude:
 #     allows silent partial writes with an insufficient output buffer or wrong offset (fixed 11.1.1 /
 #     12.0.1 / 13.0.1 per major line; lockfile converges on 14.0.1, which the override floor now pins)
 # - qs: GHSA-hrpp-h998-j3pp / CVE-2022-24999 - prototype pollution fix; superseded by GHSA-4mjr-xmp4-gh2g / GHSA-x5fp-wj9c-mxmx - array-limit bypass / isBuffer DoS (fixed 6.16.0; see minimumReleaseAgeExclude above for the release-age exception this specific version needed)
+# - fflate: GHSA-px8p-9vwx-vf98 / CVE-2026-45820 - unzipSync() infinite loop on a malformed ZIP64 archive missing its extra-field tag (fixed 0.8.3); transitive via jspdf, whose own ^0.8.1 range already permits it
 # - esbuild: GHSA-67mh-4wv8-2f99 - dev-server CORS allowed any origin to read responses;
 #     GHSA-gv7w-rqvm-qjhr - missing binary integrity verification (Deno module);
 #     GHSA-g7r4-m6w7-qqqr - Windows path traversal in the dev-server file handler (all fixed 0.28.1)
@@ -82,6 +83,7 @@ overrides:
   # QNBS-v3: excludes the two exact unpatched releases (12.0.0, 13.0.0) a bare ">=11.1.1" floor would still permit; the resolved 14.0.1 already satisfies this.
   uuid: ">=11.1.1 <12.0.0 || >=12.0.1 <13.0.0 || >=13.0.1"
   qs: ">=6.16.0"
+  fflate: ">=0.8.3"
   dompurify: ">=3.4.13"
   "@babel/core": ">=7.29.6 <8"
   undici: ">=7.29.0 <8"


### PR DESCRIPTION
## Summary

`fflate` through 0.8.2 hangs in an infinite loop inside `unzipSync()` when parsing a crafted ZIP archive whose central directory declares the ZIP64 `compressed_size` sentinel (`0xFFFFFFFF`) but omits the required ZIP64 extra field — `z64e()` reads out of bounds, the result coerces to `0`, and the loop condition never becomes false. CVSS 6.6 (GitHub Reviewed, CVSS v4; the same advisory's older CVSS v3.1 vector scores 7.5 — GitHub's live "Moderate" severity classification uses the v4 score as canonical), [GHSA-px8p-9vwx-vf98](https://github.com/advisories/GHSA-px8p-9vwx-vf98) / CVE-2026-45820.

Transitive via `jspdf` (already pinned to the latest `4.2.1`, which already declares `"fflate": "^0.8.1"` — a range `0.8.3` already satisfies, so no `jspdf` bump was needed, just forcing pnpm's resolution to the patched version already within range via `pnpm.overrides`).

**Not caused by any recent change here** — the advisory was only elevated to GitHub-reviewed status today (`2026-09-03T14:58:12Z`, confirmed via the GitHub Advisories API). Main's own Security Audit job passed clean two hours before this run first caught it; it started blocking every PR (including an unrelated governance-config PR, #586) the moment the advisory went live.

## Test plan

- [x] `pnpm why fflate` → resolves to `0.8.3`
- [x] `pnpm audit --audit-level=high` → the fflate finding is gone; only the pre-existing, already-documented `extract-zip` advisory (no fix available, transitive Playwright browser download, no runtime footprint) remains
- [x] `pnpm run lint` / `pnpm run ci:prepush` — clean
- [x] CI green (Security Audit specifically)

## Summary by Sourcery

Pin the transitive fflate dependency to a patched version to prevent denial-of-service attacks from malformed ZIP64 archives.

Bug Fixes:
- Force fflate to version 0.8.3 or later to address the ZIP64 parsing infinite-loop denial-of-service vulnerability.

Enhancements:
- Document the fflate security override and its transitive relationship to jspdf.

Documentation:
- Update the dependency audit records with the fflate advisory, affected versions, and patched version.

Chores:
- Refresh the pnpm lockfile to resolve fflate at the patched version.