### PR TITLE
fix(ci): raise security/quality job timeouts for observed setup variance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
   security:
     name: 🔒 Security Audit
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     needs: [workflow-policy]
     # QNBS-v3: dependency-review-action needs readable PR metadata — otherwise the job fails unnecessarily on external PRs/scopes.
     permissions:
@@ -259,7 +259,7 @@ jobs:
   quality:
     name: 🔍 Quality Gate (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 22
     needs: [security]
     strategy:
       fail-fast: false


### PR DESCRIPTION
## **User description**
## Summary

Four independent timeout-cancellations occurred within ~2 hours of CI activity across two different jobs, all traced to the same root cause: the shared `./.github/actions/setup` composite (`pnpm install --frozen-lockfile`, with pnpm-store caching already configured via `cache: pnpm` on `actions/setup-node`) took 7+ minutes on affected runs instead of its typical ~1-2 minutes -- consistent with this repo's already-documented npm-registry/CDN edge-node variance (the same class of issue noted in this repo for `pnpm audit`'s decode failures), not a caching misconfiguration or a code regression.

**Direct evidence** (job step timestamps, independently confirmed on two different jobs):
- **Security Audit** (main, commit `c0f372b3`, first attempt): setup ran `00:24:06`-`00:31:28` (**7m22s**), leaving `pnpm audit` running until the 10-minute job timeout cancelled it -- OSV scan / gitleaks / dependency-review never got to run at all.
- **Quality Gate (Node 22)** (PR #596, second consecutive attempt): setup ran `00:47:10`-`00:54:37` (**7m27s**), leaving Vitest cut off by the 15-minute job timeout mid-run, even though lint/typecheck/every other gate had already passed in the remaining ~11 seconds.
- Separately, **Quality Gate (Node 24)** succeeded at both **9m17s** and **14m7s** on different runs of otherwise-identical content -- a 50%+ swing from runner/network variance alone.

## Fix

- `security` job: `timeout-minutes: 10` -> `15`
- `quality` job: `timeout-minutes: 15` -> `22`

Both sized to comfortably absorb a slow (~7-8 min) setup stacked with a normal-length run of the job's own real work, without weakening or skipping any test, lint, or security gate -- this only changes how long CI is willing to wait, not what it checks.

## Test plan

- [x] `pnpm run workflow-policy:check` -- clean (permissions, needs graph, action pins all structurally sound)
- [x] `pnpm run lint` -- clean
- [x] `pnpm run ci:prepush` -- all local checks PASS
- [ ] Fresh CI on this PR itself

## Summary by Sourcery

Increase security and quality CI job timeouts to accommodate transient dependency setup delays.

Bug Fixes:
- Increase the Security Audit job timeout to prevent cancellation during unusually slow dependency setup.
- Increase the Quality Gate job timeout to prevent cancellation during CI runtime variance.

CI:
- Raise CI time limits for security and quality jobs while preserving all existing validation checks.


___

## **CodeAnt-AI Description**
Prevent CI security and quality checks from being cancelled during slow setup

### What Changed
- Security audits can now run for up to 15 minutes instead of 10
- Quality checks can now run for up to 22 minutes instead of 15
- Existing security, lint, typecheck, and test checks remain unchanged

### Impact
`✅ Fewer security scan cancellations`
`✅ Fewer interrupted test runs`
`✅ CI tolerates slower dependency installation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the `security` and `quality` job timeouts so CI stops cancelling runs when the shared setup step is slow. Setup occasionally takes 7+ minutes instead of the usual 1–2 minutes due to registry/CDN variance, which caused four timeout-cancellations in two hours. `security` goes from 10 to 15 minutes and `quality` from 15 to 22 minutes; both still run the same checks.

<sup>Written for commit 7b0d14cce29b062875b6d1d40c1cc2ce7d3aa4f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/qnbs/WorldScript-Studio/pull/601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended the time limits for security and quality checks to allow longer-running validation tasks to complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->