### PR TITLE
fix(sw): scope every fetch-handler caches.match() to its owned cache (#514)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2940_keys-0EA5E9" alt="i18n 19 locales — 2940 keys">
-  <img src="https://img.shields.io/badge/Tests-7436%2B_%2F_598_files-22C55E" alt="7436+ tests / 598 files">
+  <img src="https://img.shields.io/badge/Tests-7437%2B_%2F_598_files-22C55E" alt="7437+ tests / 598 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2940 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7436+ tests / 598 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7437+ tests / 598 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7436+ tests, 598 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7437+ tests, 598 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -711,7 +711,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-09-04, source-synchronized; CI remains authoritative for pass/fail):**
-- **7436+ unit tests** across **598 test files** — CI is authoritative for pass/fail
+- **7437+ unit tests** across **598 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2940 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2940_keys-0EA5E9" alt="i18n 19 locales — 2940 keys">
-  <img src="https://img.shields.io/badge/Tests-7433%2B_%2F_597_files-22C55E" alt="7433+ tests / 597 files">
+  <img src="https://img.shields.io/badge/Tests-7436%2B_%2F_598_files-22C55E" alt="7436+ tests / 598 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2940 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7433+ tests / 597 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7436+ tests / 598 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7433+ tests, 597 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7436+ tests, 598 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -711,7 +711,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-09-04, source-synchronized; CI remains authoritative for pass/fail):**
-- **7433+ unit tests** across **597 test files** — CI is authoritative for pass/fail
+- **7436+ unit tests** across **598 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2940 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -88,7 +88,8 @@ async function trimCache(cacheName, maxEntries) {
 // ── Offline fallback per resource type ───────────────────────
 async function offlineFallback(request) {
   if (request.destination === 'document') {
-    const cached = await caches.match(`${BASE}offline.html`);
+    // QNBS-v3: scoped to CACHE_STATIC (where offline.html is precached) — an unscoped caches.match() searches every cache on the shared qnbs.github.io origin, not just this app's own.
+    const cached = await caches.match(`${BASE}offline.html`, { cacheName: CACHE_STATIC });
     return cached || new Response('<!doctype html><title>Offline</title><p>WorldScript Studio ist offline.</p>', {
       headers: { 'Content-Type': 'text/html' },
       status: 503,
@@ -241,7 +242,8 @@ self.addEventListener('fetch', (event) => {
     (request.destination === 'script' || request.destination === 'style')
   ) {
     event.respondWith(
-      caches.match(request).then((cached) => {
+      // QNBS-v3: scoped to CACHE_STATIC (where the network path below stores it) — same shared-origin rationale as offlineFallback's fix above.
+      caches.match(request, { cacheName: CACHE_STATIC }).then((cached) => {
         const networkFetch = fetch(request).then((response) => {
           if (response.ok) {
             caches.open(CACHE_STATIC).then((c) => c.put(request, response.clone()));
@@ -290,8 +292,9 @@ self.addEventListener('fetch', (event) => {
           return response;
         })
         .catch(async () =>
-          (await caches.match(request)) ||
-          (await caches.match(`${BASE}index.html`)) ||
+          // QNBS-v3: each lookup scoped to the cache it's actually written to (CACHE_DYNAMIC for the navigated URL, CACHE_STATIC for the precached SPA shell) — same shared-origin rationale as above.
+          (await caches.match(request, { cacheName: CACHE_DYNAMIC })) ||
+          (await caches.match(`${BASE}index.html`, { cacheName: CACHE_STATIC })) ||
           offlineFallback(request)
         )
     );

--- a/tests/unit/swCacheMatchScoping.test.ts
+++ b/tests/unit/swCacheMatchScoping.test.ts
@@ -30,7 +30,7 @@ function offlineFallbackBlock(src: string): string {
   return src.slice(start, end);
 }
 
-/** Every top-level `caches.match(...)` call found in a source block (not `cache.match(...)` on an already-opened, already-scoped handle). Strips `//` comments first so prose mentioning `caches.match()` can't masquerade as a real call site. */
+/** Every top-level `caches.match(...)` call found in a source block (not `cache.match(...)` on an already-opened, already-scoped handle). Strips `//` comments first so prose mentioning `caches.match()` can't masquerade as a real call site, and normalizes the `${BASE}` interpolation to a plain placeholder so expected-value strings in this file never need to embed a real template-literal placeholder themselves. */
 function cachesDotMatchCalls(block: string): string[] {
   const codeOnly = block
     .split('\n')
@@ -40,30 +40,42 @@ function cachesDotMatchCalls(block: string): string[] {
   const re = /\bcaches\.match\([^;]*?\)/g;
   let m: RegExpExecArray | null = re.exec(codeOnly);
   while (m !== null) {
-    calls.push(m[0]);
+    calls.push(m[0].replace(/\$\{BASE\}/, '<BASE>'));
     m = re.exec(codeOnly);
   }
   return calls;
 }
 
 describe('service worker — caches.match() is always scoped to an owned cache (#514)', () => {
-  it('the fetch handler contains at least the known caches.match() call sites', () => {
+  it('the fetch handler contains exactly the 3 known caches.match() call sites', () => {
+    // QNBS-v3: exact count, not a lower bound — a lower bound would let a call site silently disappear (e.g. an accidental merge/refactor) without this regression test failing.
     const calls = cachesDotMatchCalls(fetchHandlerBlock(swSource));
-    expect(calls.length).toBeGreaterThanOrEqual(2);
+    expect(calls.length).toBe(3);
   });
 
-  it('every caches.match() call in the fetch handler passes an explicit cacheName', () => {
-    const calls = cachesDotMatchCalls(fetchHandlerBlock(swSource));
-    for (const call of calls) {
-      expect(call).toMatch(/cacheName:\s*CACHE_(STATIC|DYNAMIC|IMAGES)/);
-    }
+  it('the JS/CSS Cache-First lookup reads from CACHE_STATIC, where the network path writes it', () => {
+    const start = swSource.indexOf('JS / CSS bundles');
+    expect(start).toBeGreaterThan(-1);
+    const end = swSource.indexOf('Locale JSON', start);
+    expect(end).toBeGreaterThan(start);
+    const calls = cachesDotMatchCalls(swSource.slice(start, end));
+    expect(calls).toEqual(['caches.match(request, { cacheName: CACHE_STATIC })']);
   });
 
-  it('offlineFallback (reachable from every fetch-handler catch path) also scopes its caches.match()', () => {
+  it("the navigation fallback reads the navigated URL from CACHE_DYNAMIC and the SPA shell from CACHE_STATIC — not each other's cache", () => {
+    const start = swSource.indexOf('Navigation — Network First');
+    expect(start).toBeGreaterThan(-1);
+    const end = swSource.indexOf('Everything else', start);
+    expect(end).toBeGreaterThan(start);
+    const calls = cachesDotMatchCalls(swSource.slice(start, end));
+    expect(calls).toEqual([
+      'caches.match(request, { cacheName: CACHE_DYNAMIC })',
+      'caches.match(`<BASE>index.html`, { cacheName: CACHE_STATIC })',
+    ]);
+  });
+
+  it('offlineFallback (reachable from every fetch-handler catch path) reads offline.html from CACHE_STATIC, where it is precached', () => {
     const calls = cachesDotMatchCalls(offlineFallbackBlock(swSource));
-    expect(calls.length).toBeGreaterThanOrEqual(1);
-    for (const call of calls) {
-      expect(call).toMatch(/cacheName:\s*CACHE_(STATIC|DYNAMIC|IMAGES)/);
-    }
+    expect(calls).toEqual(['caches.match(`<BASE>offline.html`, { cacheName: CACHE_STATIC })']);
   });
 });

--- a/tests/unit/swCacheMatchScoping.test.ts
+++ b/tests/unit/swCacheMatchScoping.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment node
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// QNBS-v3: regression guard for #514 — CacheStorage is origin-scoped, not path-scoped, so a bare
+// caches.match(request) on a shared origin like qnbs.github.io searches every cache on the origin,
+// not just this app's own. sw.js is a classic service worker (uses `self`, not importable), so we
+// assert its source contract instead of executing it, mirroring swLocaleStrategy.test.ts's pattern.
+const swSource = readFileSync(
+  fileURLToPath(new URL('../../public/sw.js', import.meta.url)),
+  'utf8',
+);
+
+/** Extract the body of the `self.addEventListener('fetch', ...)` handler. */
+function fetchHandlerBlock(src: string): string {
+  const start = src.indexOf("self.addEventListener('fetch'");
+  expect(start).toBeGreaterThan(-1);
+  const end = src.indexOf("self.addEventListener('message'", start);
+  expect(end).toBeGreaterThan(start);
+  return src.slice(start, end);
+}
+
+/** Extract the body of the `offlineFallback` helper, called from every fetch-handler catch path. */
+function offlineFallbackBlock(src: string): string {
+  const start = src.indexOf('async function offlineFallback');
+  expect(start).toBeGreaterThan(-1);
+  const end = src.indexOf('\n}', start);
+  expect(end).toBeGreaterThan(start);
+  return src.slice(start, end);
+}
+
+/** Every top-level `caches.match(...)` call found in a source block (not `cache.match(...)` on an already-opened, already-scoped handle). Strips `//` comments first so prose mentioning `caches.match()` can't masquerade as a real call site. */
+function cachesDotMatchCalls(block: string): string[] {
+  const codeOnly = block
+    .split('\n')
+    .map((line) => line.replace(/\/\/.*$/, ''))
+    .join('\n');
+  const calls: string[] = [];
+  const re = /\bcaches\.match\([^;]*?\)/g;
+  let m: RegExpExecArray | null = re.exec(codeOnly);
+  while (m !== null) {
+    calls.push(m[0]);
+    m = re.exec(codeOnly);
+  }
+  return calls;
+}
+
+describe('service worker — caches.match() is always scoped to an owned cache (#514)', () => {
+  it('the fetch handler contains at least the known caches.match() call sites', () => {
+    const calls = cachesDotMatchCalls(fetchHandlerBlock(swSource));
+    expect(calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('every caches.match() call in the fetch handler passes an explicit cacheName', () => {
+    const calls = cachesDotMatchCalls(fetchHandlerBlock(swSource));
+    for (const call of calls) {
+      expect(call).toMatch(/cacheName:\s*CACHE_(STATIC|DYNAMIC|IMAGES)/);
+    }
+  });
+
+  it('offlineFallback (reachable from every fetch-handler catch path) also scopes its caches.match()', () => {
+    const calls = cachesDotMatchCalls(offlineFallbackBlock(swSource));
+    expect(calls.length).toBeGreaterThanOrEqual(1);
+    for (const call of calls) {
+      expect(call).toMatch(/cacheName:\s*CACHE_(STATIC|DYNAMIC|IMAGES)/);
+    }
+  });
+});


### PR DESCRIPTION
## **User description**
Fixes #514.

## Problem

`CacheStorage` is origin-scoped, not path-scoped. `qnbs.github.io` hosts multiple independent GitHub Pages projects on different paths, so a bare `caches.match(request)` in `public/sw.js`'s fetch handler searches **every cache on the origin**, not just this app's own `CACHE_STATIC`/`CACHE_DYNAMIC`/`CACHE_IMAGES`. In principle a different project's cached `Response` for a request whose full URL happens to coincide with one WorldScript Studio fetches could be served here.

## Root cause

Four `caches.match()` call sites never passed an explicit `cacheName`:
1. JS/CSS Cache-First strategy — `caches.match(request)`
2. Navigation fallback — `caches.match(request)` and `caches.match(`${BASE}index.html`)`
3. `offlineFallback()`'s document branch — `caches.match(`${BASE}offline.html`)` (reachable from every fetch-handler catch path; not explicitly named in #514 but the identical gap, so fixed alongside it)

This is the read-path counterpart to DA-03 (#513), which fixed the same shared-origin invariant for cache *deletion*. Practical exploitability is low (per #514's own analysis — collision requires another origin-sibling app fetching/caching the exact same full URL), which is why this was correctly deferred rather than treated as a release blocker.

## Scope

`public/sw.js` fetch handler and the `offlineFallback` helper it calls, only. No behavior change for any request whose URL doesn't collide with a foreign cache entry — every scoped lookup targets exactly the cache each value is actually written to.

## Non-goals

- Not touching the deletion-scoping logic DA-03 already fixed.
- Not addressing #525/#526 (separate, unrelated SW/cache-lifecycle gaps that their own issues explicitly flag as needing dedicated multi-wave design work).

## Fix

Scoped all 4 call sites to the cache each one's value is actually written to, via the standard `{ cacheName }` match option — the same pattern already used elsewhere in this file for reads via an opened cache handle (e.g. the image Cache-First branch).

## Regression coverage

`tests/unit/swCacheMatchScoping.test.ts` — mirrors the existing source-contract test style for this classic (non-importable, `self`-using) worker script (see `swLocaleStrategy.test.ts`). Asserts every `caches.match()` call in the fetch handler and in `offlineFallback` carries an explicit `cacheName`. Verified via a manual negative-control: stashed the fix, confirmed 2 of 3 assertions fail against the original unscoped code, restored the fix, confirmed all 3 pass.

## Validation

- `pnpm exec vitest run tests/unit/swCacheMatchScoping.test.ts` — 3/3 pass.
- `pnpm exec biome check --error-on-warnings public/sw.js tests/unit/swCacheMatchScoping.test.ts` — clean.
- `node scripts/check-doc-metrics.mjs` — clean after syncing README's test-count metrics (598 files/7436 tests) for the new test file.
- Full CI is the authoritative gate for typecheck/build/E2E; not rerun locally per this repo's low-end-hardware guidance.

## Summary by Sourcery

Restrict service-worker cache reads to their owning caches and add regression coverage for shared-origin isolation.

Bug Fixes:
- Scope service-worker cache lookups to this application’s owned caches, preventing cached responses from other projects on the shared origin from being served.

Documentation:
- Update documented test metrics to include the new regression test file and test cases.

Tests:
- Add regression coverage verifying all fetch-handler and offline-fallback `caches.match()` calls specify an owned cache.


___

## **CodeAnt-AI Description**
Prevent offline pages and cached assets from being served from other apps on the same domain

### What Changed
- Service worker cache lookups now only use this app’s own caches for scripts, styles, navigation requests, the offline page, and the SPA fallback
- Added regression tests covering all service-worker cache lookups to prevent unscoped matches from returning another app’s cached response
- Updated documented test totals to include the new coverage

### Impact
`✅ Prevents cross-app cached content`
`✅ Keeps offline navigation within this app`
`✅ Protects service-worker cache behavior from regressions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes service worker cache reads to their owning caches so a request on the shared `qnbs.github.io` origin can't be served a response from another project's cache.

- Four `caches.match()` calls in the fetch handler and `offlineFallback` now pass an explicit `cacheName`.
- Adds a regression test that pins each call site to its exact expected cache and the total call count.
- No behavior change for requests that don't collide with a foreign cache entry.
- Updates README test metrics for the new test file.

<sup>Written for commit 1db048dea8ab6329474420a30b80d61a7bb324a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/qnbs/WorldScript-Studio/pull/612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved offline and navigation fallback behavior by limiting service-worker cache lookups to the app’s designated static and dynamic caches.
  - Helps prevent unrelated cached content from being returned during offline use.

- **Documentation**
  - Updated documented test metrics to reflect the latest test count and file count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->