### PR TITLE
fix(pwa): skip the controllerchange reload on a first-ever install (#585)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2940_keys-0EA5E9" alt="i18n 19 locales — 2940 keys">
-  <img src="https://img.shields.io/badge/Tests-7437%2B_%2F_598_files-22C55E" alt="7437+ tests / 598 files">
+  <img src="https://img.shields.io/badge/Tests-7456%2B_%2F_598_files-22C55E" alt="7456+ tests / 598 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2940 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7437+ tests / 598 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7456+ tests / 598 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7437+ tests, 598 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7456+ tests, 598 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -711,7 +711,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-09-04, source-synchronized; CI remains authoritative for pass/fail):**
-- **7437+ unit tests** across **598 test files** — CI is authoritative for pass/fail
+- **7456+ unit tests** across **598 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2940 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/register-sw.ts
+++ b/register-sw.ts
@@ -1,6 +1,6 @@
+import { flushPersistedState } from './app/persistedStateFlush';
 import type { RootState } from './app/store';
 import { appStoreRef } from './app/storeRef';
-import { flushPersistedState } from './app/persistedStateFlush';
 import { logger as appLogger } from './services/logger';
 
 // ============================================================
@@ -106,32 +106,184 @@ const isTauriEnvironment = (): boolean => {
 };
 
 // QNBS-v3: mirrors public/sw.js's isWorldScriptOwnedCache — duplicated since sw.js is a classic (non-module) script.
-const OWNED_CACHE_NAME_RE = /^worldscript-(?:static|dynamic|images)-v\d+\.\d+\.\d+(?:[-+][\w.-]+)?$/;
+const OWNED_CACHE_NAME_RE =
+  /^worldscript-(?:static|dynamic|images)-v\d+\.\d+\.\d+(?:[-+][\w.-]+)?$/;
 
-export const isWorldScriptOwnedCacheName = (name: string): boolean => OWNED_CACHE_NAME_RE.test(name);
+export const isWorldScriptOwnedCacheName = (name: string): boolean =>
+  OWNED_CACHE_NAME_RE.test(name);
+
+// QNBS-v3: a live Service Worker API snapshot cannot always tell "a registration exists because THIS is a concurrent first-ever install in progress" apart from "a registration exists because an ALREADY-ACTIVATED worker is transitioning to a newer version" — both read identically (no controller, active.state 'activating'). Only history (has a worker for this exact scope EVER reached 'activated' before) resolves that ambiguity, which a live check alone cannot see.
+function priorInstallFlagKey(swUrl: string): string {
+  // QNBS-v3: keyed by the exact sw.js URL, not just an origin-wide key — a shared origin (e.g. GitHub Pages) can host an unrelated app's own service worker at a different scope, and its history must never count as evidence for this app's own prior install.
+  return `worldscript-sw-installed:${swUrl}`;
+}
+
+function readPriorInstallFlag(swUrl: string): boolean {
+  try {
+    return localStorage.getItem(priorInstallFlagKey(swUrl)) === '1';
+  } catch {
+    return false; // storage inaccessible (private mode etc.) — fall back to the live-API heuristic below
+  }
+}
+
+function writePriorInstallFlag(swUrl: string): void {
+  try {
+    localStorage.setItem(priorInstallFlagKey(swUrl), '1');
+  } catch {
+    // non-critical — worst case, a future load falls back to the live-API heuristic again
+  }
+}
+
+// QNBS-v3: extracted to keep registerServiceWorker's own cyclomatic complexity bounded — encapsulates the first-install-vs-update classification and its one-shot consumption/guard state.
+function setupControllerChangeReloadHandler(swUrl: string): {
+  refineFirstInstallClassification: (
+    priorRegistration: ServiceWorkerRegistration | undefined,
+  ) => void;
+} {
+  // QNBS-v3: scoped to this app's own script URL — an unrelated worker at a broader scope on a shared origin (e.g. GitHub Pages) must never be mistaken for a prior WorldScript install. Residual gap tracked separately: a second tab still loading during another tab's shared first-ever install can see this already true before this load-handler runs at all — narrow, self-healing (the persistent flag below closes it permanently after that one occurrence), not release-blocking.
+  const hadOwnControllerAtLoad = navigator.serviceWorker.controller?.scriptURL === swUrl;
+  const hasPersistentInstallRecord = readPriorInstallFlag(swUrl);
+  // QNBS-v3: this positive live evidence must be backfilled to the persistent record now, not only once a future controllerchange happens to fire in some later session — otherwise a returning visitor who never sees an update in this session stays unrecorded, and a later force-refresh landing mid-transition (controller null, active only 'activating') would wrongly read as a first install with no history to override it.
+  if (hadOwnControllerAtLoad) writePriorInstallFlag(swUrl);
+  // QNBS-v3: the persistent flag alone already proves a prior install beyond any live-API ambiguity — classification is final immediately, no need to wait for (or be misled by) getRegistration()'s momentary snapshot.
+  let isClassificationReady = hadOwnControllerAtLoad || hasPersistentInstallRecord;
+  let isUnconsumedFirstInstallClaim = !isClassificationReady;
+  // QNBS-v3: only the visible tab flushes — a hidden tab's stale write could race a fresher one (residual multi-window gap: #518).
+  let refreshing = false;
+  let reloadPendingWhileHidden = false;
+  // QNBS-v3: a controllerchange firing before classification is ready (e.g. another tab's genuine update completing while this tab's getRegistration() is still pending) must be queued, not guessed at — guessing is exactly what produced several of the narrower races this mechanism went through.
+  let pendingControllerChangeCount = 0;
+
+  const handleControllerChange = () => {
+    if (refreshing) return;
+    writePriorInstallFlag(swUrl);
+    // QNBS-v3: a first-ever install's activate→clients.claim() also fires controllerchange on the page that just loaded, but there is no prior version's stale bundle to reload away from — reloading here was an undocumented side effect of a check meant only for genuine updates. One-shot: a second controllerchange on this same page load is by definition a later real update superseding an already-claimed controller, so it must still reload.
+    if (isUnconsumedFirstInstallClaim) {
+      isUnconsumedFirstInstallClaim = false;
+      appLogger.info('[SW] First-ever activation claimed this page — no reload needed.');
+      return;
+    }
+    if (document.visibilityState !== 'visible') {
+      reloadPendingWhileHidden = true;
+      return;
+    }
+    refreshing = true;
+    void flushLatestStateThenReload();
+  };
+
+  navigator.serviceWorker.addEventListener('controllerchange', () => {
+    // QNBS-v3: navigator.serviceWorker's controllerchange fires for ANY controller change on this page, including a foreign, broader-scoped worker's own claim on a shared origin — verifying the resulting controller is actually this app's own worker before queuing or handling it prevents a foreign claim from consuming the one-shot exemption or writing this app's persistent install record.
+    if (navigator.serviceWorker.controller?.scriptURL !== swUrl) return;
+    if (!isClassificationReady) {
+      pendingControllerChangeCount++;
+      return;
+    }
+    handleControllerChange();
+  });
+  document.addEventListener('visibilitychange', () => {
+    if (reloadPendingWhileHidden && document.visibilityState === 'visible' && !refreshing) {
+      refreshing = true;
+      // QNBS-v3: no flush here — index.tsx's best-effort hide-time flush may have failed, but re-flushing risks clobbering a fresher write from another tab, the worse failure mode of the two (#518).
+      window.location.reload();
+    }
+  });
+
+  return {
+    refineFirstInstallClassification: (priorRegistration) => {
+      if (isClassificationReady) return;
+      // QNBS-v3: scoped to this app's own script URL — see hadOwnControllerAtLoad's identical rationale above.
+      const isOwnActivatedRegistration =
+        priorRegistration?.active?.scriptURL === swUrl &&
+        priorRegistration.active.state === 'activated';
+      // QNBS-v3: same backfill rationale as hadOwnControllerAtLoad above — a force-refreshed returning visitor with no controllerchange due this session must not lose this positive evidence for future sessions.
+      if (isOwnActivatedRegistration) writePriorInstallFlag(swUrl);
+      isUnconsumedFirstInstallClaim = !isOwnActivatedRegistration;
+      isClassificationReady = true;
+      while (pendingControllerChangeCount > 0 && !refreshing) {
+        pendingControllerChangeCount--;
+        handleControllerChange();
+      }
+    },
+  };
+}
+
+// QNBS-v3: extracted from registerServiceWorker to keep that function's own nesting flat — self-contained teardown, only ever called from the isTauriEnvironment() branch.
+async function teardownServiceWorkerInTauri(): Promise<void> {
+  if (!('serviceWorker' in navigator)) return;
+  try {
+    const registrations = await navigator.serviceWorker.getRegistrations();
+    await Promise.all(registrations.map((reg) => reg.unregister()));
+    if (typeof caches !== 'undefined') {
+      const keys = await caches.keys();
+      await Promise.all(keys.filter(isWorldScriptOwnedCacheName).map((k) => caches.delete(k)));
+    }
+    appLogger.info('[SW] Tauri runtime — service worker disabled; any prior registration removed.');
+  } catch (error) {
+    appLogger.warn('[SW] Tauri service-worker teardown failed (non-fatal):', error);
+  }
+}
+
+// QNBS-v3: extracted from registerServiceWorker to keep that function's own nesting flat — userInitiatedUpdate removed since skipWaiting is now automatic (install event), so controllerchange always reloads; the banner's applyUpdate still works for explicit UX.
+function setupUpdateAvailableNotifications(registration: ServiceWorkerRegistration): void {
+  const announceUpdateAvailable = (worker: ServiceWorker) => {
+    window.dispatchEvent(
+      new CustomEvent('sw-update-available', {
+        detail: {
+          applyUpdate: () => {
+            worker.postMessage({ type: 'SKIP_WAITING' });
+          },
+        },
+      }),
+    );
+  };
+
+  const onNewWorkerReady = (worker: ServiceWorker) => {
+    worker.addEventListener('statechange', () => {
+      if (worker.state === 'installed' && navigator.serviceWorker.controller) {
+        announceUpdateAvailable(worker);
+      }
+    });
+  };
+
+  registration.addEventListener('updatefound', () => {
+    const newWorker = registration.installing;
+    if (newWorker) onNewWorkerReady(newWorker);
+  });
+
+  // If a worker is already waiting (e.g. user clicked "Later" earlier),
+  // surface the same toast again on next app start.
+  if (registration.waiting && navigator.serviceWorker.controller) {
+    announceUpdateAvailable(registration.waiting);
+  }
+}
+
+// QNBS-v3: extracted from registerServiceWorker to keep that function's own nesting flat — self-contained, best-effort, non-critical on any failure.
+async function registerPeriodicBackgroundSync(
+  registration: ServiceWorkerRegistration,
+): Promise<void> {
+  if (!('periodicSync' in registration)) return;
+  try {
+    const status = await navigator.permissions.query({
+      // @ts-expect-error — periodicSync not in TS lib yet
+      name: 'periodic-background-sync',
+    });
+    if (status.state === 'granted') {
+      // @ts-expect-error — periodicSync not in TS lib yet
+      await registration.periodicSync.register('worldscript-refresh', {
+        minInterval: 24 * 60 * 60 * 1000, // once per day
+      });
+    }
+  } catch {
+    // Periodic sync not available; non-critical
+  }
+}
 
 // ── Core registration ─────────────────────────────────────────
 const registerServiceWorker = async (): Promise<void> => {
   // QNBS-v3: In Tauri, never register — and proactively tear down any SW + caches a prior build
   // installed, so already-broken desktop installs self-heal on the first launch that boots the app.
   if (isTauriEnvironment()) {
-    if ('serviceWorker' in navigator) {
-      try {
-        const registrations = await navigator.serviceWorker.getRegistrations();
-        await Promise.all(registrations.map((reg) => reg.unregister()));
-        if (typeof caches !== 'undefined') {
-          const keys = await caches.keys();
-          await Promise.all(
-            keys.filter(isWorldScriptOwnedCacheName).map((k) => caches.delete(k)),
-          );
-        }
-        appLogger.info(
-          '[SW] Tauri runtime — service worker disabled; any prior registration removed.',
-        );
-      } catch (error) {
-        appLogger.warn('[SW] Tauri service-worker teardown failed (non-fatal):', error);
-      }
-    }
+    await teardownServiceWorkerInTauri();
     return;
   }
 
@@ -140,89 +292,44 @@ const registerServiceWorker = async (): Promise<void> => {
     return;
   }
 
+  // QNBS-v3: hoisted above the try so the outer catch can still finalize classification if register() itself also fails — otherwise a compound getRegistration()+register() failure would leave it stuck pending forever, queuing every future controllerchange with nothing left to ever drain the queue.
+  let refineFirstInstallClassification:
+    | ((priorRegistration: ServiceWorkerRegistration | undefined) => void)
+    | undefined;
   try {
     const basePath = import.meta.env.BASE_URL || '/';
-    const swUrl = `${basePath}sw.js`;
+    // QNBS-v3: ServiceWorker.scriptURL is always a fully resolved absolute URL per spec (e.g. https://host/path/sw.js), never a relative path — comparing it against an unresolved relative swUrl would never match in a real browser, silently breaking every returning visitor's classification. register() itself resolves a relative scriptURL internally, so passing the already-absolute form here works identically for it too.
+    const swUrl = new URL(`${basePath}sw.js`, window.location.href).href;
+
+    ({ refineFirstInstallClassification } = setupControllerChangeReloadHandler(swUrl));
+    // QNBS-v3: scoped to basePath, not the document-URL default — on a shared origin, the no-arg lookup can match a broader, unrelated worker's registration instead of this app's own.
+    let priorRegistration: ServiceWorkerRegistration | undefined;
+    let didGetRegistrationFail = false;
+    try {
+      priorRegistration = await navigator.serviceWorker.getRegistration(basePath);
+    } catch {
+      // QNBS-v3: a lookup failure must not abort registration entirely, but finalizing classification on zero evidence here would be worse than deferring it — register() below is idempotent and returns the definitive current registration regardless, so classification is recovered from that instead once it resolves.
+      didGetRegistrationFail = true;
+    }
+    if (!didGetRegistrationFail) {
+      refineFirstInstallClassification(priorRegistration);
+    }
 
     const registration = await navigator.serviceWorker.register(swUrl, {
       scope: basePath,
       updateViaCache: 'none', // always fetch new SW from network
     });
 
+    if (didGetRegistrationFail) {
+      // QNBS-v3: recovers classification from register()'s own result when the earlier lookup failed — an already-'activated' own worker here proves a genuine prior install exactly like a successful getRegistration() would have shown; a no-op if classification is somehow already finalized.
+      refineFirstInstallClassification(registration);
+    }
+
     window.worldScriptPWA.swRegistration = registration;
     appLogger.info('[SW] Registered, scope:', registration.scope);
 
-    // ── Detect and announce SW updates ───────────────────────
-    // QNBS-v3: userInitiatedUpdate removed — skipWaiting is now automatic (install event),
-    // so controllerchange always reloads. The banner's applyUpdate still works for explicit UX.
-    const announceUpdateAvailable = (worker: ServiceWorker) => {
-      window.dispatchEvent(
-        new CustomEvent('sw-update-available', {
-          detail: {
-            applyUpdate: () => {
-              worker.postMessage({ type: 'SKIP_WAITING' });
-            },
-          },
-        }),
-      );
-    };
-
-    const onNewWorkerReady = (worker: ServiceWorker) => {
-      worker.addEventListener('statechange', () => {
-        if (worker.state === 'installed' && navigator.serviceWorker.controller) {
-          announceUpdateAvailable(worker);
-        }
-      });
-    };
-
-    registration.addEventListener('updatefound', () => {
-      const newWorker = registration.installing;
-      if (newWorker) onNewWorkerReady(newWorker);
-    });
-
-    // If a worker is already waiting (e.g. user clicked "Later" earlier),
-    // surface the same toast again on next app start.
-    if (registration.waiting && navigator.serviceWorker.controller) {
-      announceUpdateAvailable(registration.waiting);
-    }
-
-    // QNBS-v3: only the visible tab flushes — a hidden tab's stale write could race a fresher one (residual multi-window gap: #518).
-    let refreshing = false;
-    let reloadPendingWhileHidden = false;
-    navigator.serviceWorker.addEventListener('controllerchange', () => {
-      if (refreshing) return;
-      if (document.visibilityState !== 'visible') {
-        reloadPendingWhileHidden = true;
-        return;
-      }
-      refreshing = true;
-      void flushLatestStateThenReload();
-    });
-    document.addEventListener('visibilitychange', () => {
-      if (reloadPendingWhileHidden && document.visibilityState === 'visible' && !refreshing) {
-        refreshing = true;
-        // QNBS-v3: no flush here — index.tsx's best-effort hide-time flush may have failed, but re-flushing risks clobbering a fresher write from another tab, the worse failure mode of the two (#518).
-        window.location.reload();
-      }
-    });
-
-    // ── Periodic background sync ──────────────────────────────
-    if ('periodicSync' in registration) {
-      try {
-        const status = await navigator.permissions.query({
-          // @ts-expect-error — periodicSync not in TS lib yet
-          name: 'periodic-background-sync',
-        });
-        if (status.state === 'granted') {
-          // @ts-expect-error — periodicSync not in TS lib yet
-          await registration.periodicSync.register('worldscript-refresh', {
-            minInterval: 24 * 60 * 60 * 1000, // once per day
-          });
-        }
-      } catch {
-        // Periodic sync not available; non-critical
-      }
-    }
+    setupUpdateAvailableNotifications(registration);
+    await registerPeriodicBackgroundSync(registration);
 
     // ── Detect standalone / installed mode ────────────────────
     if (
@@ -234,6 +341,8 @@ const registerServiceWorker = async (): Promise<void> => {
     }
   } catch (error) {
     appLogger.error('[SW] Registration failed:', error);
+    // QNBS-v3: safe terminal fallback for the one path above that never finalizes classification on its own — getRegistration() rejecting AND register() rejecting. No-op (via the internal isClassificationReady guard) if classification already finalized normally before this ran.
+    refineFirstInstallClassification?.(undefined);
   }
 };
 
@@ -290,7 +399,10 @@ async function flushLatestStateThenReload(): Promise<void> {
     await Promise.race([
       flushLatestState(),
       new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error(`Pre-reload flush timed out after ${FLUSH_TIMEOUT_MS}ms`)), FLUSH_TIMEOUT_MS),
+        setTimeout(
+          () => reject(new Error(`Pre-reload flush timed out after ${FLUSH_TIMEOUT_MS}ms`)),
+          FLUSH_TIMEOUT_MS,
+        ),
       ),
     ]);
   } catch (error) {

--- a/tests/unit/registerSwUpdateFlush.test.ts
+++ b/tests/unit/registerSwUpdateFlush.test.ts
@@ -20,12 +20,34 @@ function setVisibility(value: 'visible' | 'hidden'): void {
   Object.defineProperty(document, 'visibilityState', { value, configurable: true });
 }
 
+// QNBS-v3: ServiceWorker.scriptURL is always a fully resolved absolute URL per spec — a relative-path mock here would silently hide the exact absolute-vs-relative bug this regression suite exists to catch. import.meta.env.BASE_URL is '/' and window.location.href is 'http://localhost:3000/' in this test environment (both verified empirically), matching what registerServiceWorker itself resolves.
+const OWN_SW_URL = 'http://localhost:3000/sw.js';
+const FOREIGN_SW_URL = 'http://localhost:3000/unrelated-app/sw.js';
+
+// QNBS-v3: real browsers update navigator.serviceWorker.controller to the new controller BEFORE dispatching controllerchange — a static mock controller that never changes would hide the exact "listener must re-check the post-change controller" gap this helper exists to exercise.
+function setMockController(scriptURL: string | null): void {
+  Object.defineProperty(navigator.serviceWorker, 'controller', {
+    value: scriptURL ? { scriptURL } : null,
+    writable: true,
+    configurable: true,
+  });
+}
+
 describe('register-sw — controllerchange flush-then-reload (DA-02)', () => {
   let controllerChangeHandler: (() => void) | undefined;
   let reloadSpy: ReturnType<typeof vi.fn>;
 
+  // QNBS-v3: defined inside describe() to close over controllerChangeHandler, which each test's mock setup reassigns.
+  function fireControllerChange(scriptURL: string | null = OWN_SW_URL): void {
+    setMockController(scriptURL);
+    // QNBS-v3: registerServiceWorker() swallows setup errors, so an undefined handler here would make a test with only negative assertions pass without the classification path ever running — asserting this centrally protects every caller.
+    expect(controllerChangeHandler).toBeTypeOf('function');
+    controllerChangeHandler?.();
+  }
+
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
     controllerChangeHandler = undefined;
     setVisibility('visible');
 
@@ -44,13 +66,16 @@ describe('register-sw — controllerchange flush-then-reload (DA-02)', () => {
       scope: '/',
       installing: null,
       waiting: null,
+      // QNBS-v3: an 'activated' (not merely 'activating') worker at this app's own script URL represents a returning visitor whose prior install already completed — the update path this default mock exercises.
+      active: { state: 'activated', scriptURL: OWN_SW_URL },
       addEventListener: vi.fn(),
     };
 
     Object.defineProperty(navigator, 'serviceWorker', {
       value: {
         register: vi.fn().mockResolvedValue(fakeRegistration),
-        controller: {},
+        getRegistration: vi.fn().mockResolvedValue(fakeRegistration),
+        controller: { scriptURL: OWN_SW_URL },
         addEventListener: vi.fn((type: string, handler: () => void) => {
           if (type === 'controllerchange') controllerChangeHandler = handler;
         }),
@@ -60,7 +85,11 @@ describe('register-sw — controllerchange flush-then-reload (DA-02)', () => {
     });
 
     // QNBS-v3: a stable reference with real RootState shape — persistedSlices() reads project.present, matching production where project is never undefined.
-    const stableState = { project: { present: { fake: 'state' } }, versionControl: {}, settings: {} };
+    const stableState = {
+      project: { present: { fake: 'state' } },
+      versionControl: {},
+      settings: {},
+    };
     appStoreRef.current = {
       getState: () => stableState as never,
       dispatch: vi.fn() as never,
@@ -77,9 +106,8 @@ describe('register-sw — controllerchange flush-then-reload (DA-02)', () => {
   it('flushes pending state and reloads, in that order, when the visible tab takes control', async () => {
     mockFlushPersistedState.mockResolvedValue(undefined);
     await registerServiceWorker();
-    expect(controllerChangeHandler).toBeTypeOf('function');
 
-    controllerChangeHandler?.();
+    fireControllerChange();
     await flushMicrotasks();
 
     expect(mockFlushPersistedState).toHaveBeenCalledTimes(1);
@@ -93,7 +121,7 @@ describe('register-sw — controllerchange flush-then-reload (DA-02)', () => {
     mockFlushPersistedState.mockRejectedValue(new Error('IDB write failed'));
     await registerServiceWorker();
 
-    controllerChangeHandler?.();
+    fireControllerChange();
     await flushMicrotasks();
 
     expect(mockFlushPersistedState).toHaveBeenCalledTimes(1);
@@ -104,8 +132,8 @@ describe('register-sw — controllerchange flush-then-reload (DA-02)', () => {
     mockFlushPersistedState.mockResolvedValue(undefined);
     await registerServiceWorker();
 
-    controllerChangeHandler?.();
-    controllerChangeHandler?.();
+    fireControllerChange();
+    fireControllerChange();
     await flushMicrotasks();
 
     expect(mockFlushPersistedState).toHaveBeenCalledTimes(1);
@@ -116,7 +144,7 @@ describe('register-sw — controllerchange flush-then-reload (DA-02)', () => {
     appStoreRef.current = null;
     await registerServiceWorker();
 
-    controllerChangeHandler?.();
+    fireControllerChange();
     await flushMicrotasks();
 
     expect(mockFlushPersistedState).not.toHaveBeenCalled();
@@ -129,7 +157,7 @@ describe('register-sw — controllerchange flush-then-reload (DA-02)', () => {
     await registerServiceWorker();
     setVisibility('hidden');
 
-    controllerChangeHandler?.();
+    fireControllerChange();
     await flushMicrotasks();
 
     expect(mockFlushPersistedState).not.toHaveBeenCalled();
@@ -149,12 +177,16 @@ describe('register-sw — controllerchange flush-then-reload (DA-02)', () => {
     const stateA = { project: { present: { v: 'a' } }, versionControl: {}, settings: {} };
     const stateB = { project: { present: { v: 'b' } }, versionControl: {}, settings: {} };
     // 1st getState(): stateA. 2nd (after flush #1): stateB (changed — retry). 3rd (after flush #2): stateB (stable — stop).
-    const getStateMock = vi.fn().mockReturnValueOnce(stateA).mockReturnValueOnce(stateB).mockReturnValue(stateB);
+    const getStateMock = vi
+      .fn()
+      .mockReturnValueOnce(stateA)
+      .mockReturnValueOnce(stateB)
+      .mockReturnValue(stateB);
     appStoreRef.current = { getState: getStateMock, dispatch: vi.fn() as never };
     mockFlushPersistedState.mockResolvedValue(undefined);
 
     await registerServiceWorker();
-    controllerChangeHandler?.();
+    fireControllerChange();
     await flushMicrotasks();
 
     expect(mockFlushPersistedState).toHaveBeenCalledTimes(2);
@@ -179,7 +211,7 @@ describe('register-sw — controllerchange flush-then-reload (DA-02)', () => {
     mockFlushPersistedState.mockResolvedValue(undefined);
 
     await registerServiceWorker();
-    controllerChangeHandler?.();
+    fireControllerChange();
     await flushMicrotasks();
 
     // 5 in-loop attempts (states[0..4]) + 1 guaranteed final flush of the freshest state (states[6]).
@@ -202,7 +234,7 @@ describe('register-sw — controllerchange flush-then-reload (DA-02)', () => {
     mockFlushPersistedState.mockResolvedValue(undefined);
 
     await registerServiceWorker();
-    controllerChangeHandler?.();
+    fireControllerChange();
     await flushMicrotasks();
 
     expect(mockFlushPersistedState).toHaveBeenCalledTimes(1);
@@ -232,11 +264,679 @@ describe('register-sw — controllerchange flush-then-reload (DA-02)', () => {
     mockFlushPersistedState.mockResolvedValue(undefined);
 
     await registerServiceWorker();
-    controllerChangeHandler?.();
+    fireControllerChange();
     await flushMicrotasks();
 
     expect(mockFlushPersistedState).toHaveBeenCalledTimes(1);
     expect(reloadSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // QNBS-v3: regression guard — a fresh browser context's activate→clients.claim() also fires controllerchange on the page that just loaded, but there is no prior version to reload away from.
+  it('does not flush or reload on a first-ever install (no registration existed before registering)', async () => {
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: {
+        register: vi.fn().mockResolvedValue({
+          scope: '/',
+          installing: null,
+          waiting: null,
+          addEventListener: vi.fn(),
+        }),
+        getRegistration: vi.fn().mockResolvedValue(undefined),
+        controller: null,
+        addEventListener: vi.fn((type: string, handler: () => void) => {
+          if (type === 'controllerchange') controllerChangeHandler = handler;
+        }),
+      },
+      writable: true,
+      configurable: true,
+    });
+    mockFlushPersistedState.mockResolvedValue(undefined);
+
+    await registerServiceWorker();
+    fireControllerChange();
+    await flushMicrotasks();
+
+    expect(mockFlushPersistedState).not.toHaveBeenCalled();
+    expect(reloadSpy).not.toHaveBeenCalled();
+  });
+
+  // QNBS-v3: regression guard — classification must finalize even when getRegistration() rejects, or every controllerchange for the rest of the page's lifetime stays queued forever and a genuine later update never reloads.
+  it('finalizes classification even when getRegistration() rejects, so a later genuine update still reloads', async () => {
+    const registerMock = vi.fn().mockResolvedValue({
+      scope: '/',
+      installing: null,
+      waiting: null,
+      addEventListener: vi.fn(),
+    });
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: {
+        register: registerMock,
+        getRegistration: vi.fn().mockRejectedValue(new Error('getRegistration failed')),
+        controller: null,
+        addEventListener: vi.fn((type: string, handler: () => void) => {
+          if (type === 'controllerchange') controllerChangeHandler = handler;
+        }),
+      },
+      writable: true,
+      configurable: true,
+    });
+    mockFlushPersistedState.mockResolvedValue(undefined);
+
+    await registerServiceWorker();
+    // QNBS-v3: a getRegistration() lookup failure must not abort registration itself — a fresh client would otherwise get no worker at all (no offline support), and a returning client would never receive swRegistration or its update-notification hooks.
+    expect(registerMock).toHaveBeenCalledTimes(1);
+    expect(window.worldScriptPWA.swRegistration).not.toBeNull();
+
+    // First claim with no positive evidence and a failed getRegistration() defaults to first-install — no reload.
+    fireControllerChange();
+    await flushMicrotasks();
+    expect(mockFlushPersistedState).not.toHaveBeenCalled();
+    expect(reloadSpy).not.toHaveBeenCalled();
+
+    // A later genuine update on the same tab must still reload — proving classification finalized instead of leaving events queued forever.
+    fireControllerChange();
+    await flushMicrotasks();
+    expect(mockFlushPersistedState).toHaveBeenCalledTimes(1);
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // QNBS-v3: regression guard — a getRegistration() rejection must not finalize classification on zero evidence when register()'s own idempotent result immediately afterward proves this is actually a returning visitor, or a genuine update would be wrongly treated as first-install and skip its needed reload after caches were already pruned.
+  it("recovers classification from register()'s own result when getRegistration() rejected but the worker was already activated", async () => {
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: {
+        register: vi.fn().mockResolvedValue({
+          scope: '/',
+          installing: null,
+          waiting: null,
+          active: { state: 'activated', scriptURL: OWN_SW_URL },
+          addEventListener: vi.fn(),
+        }),
+        getRegistration: vi.fn().mockRejectedValue(new Error('getRegistration failed')),
+        // Force-refresh: no controller for this navigation despite a fully-activated own worker.
+        controller: null,
+        addEventListener: vi.fn((type: string, handler: () => void) => {
+          if (type === 'controllerchange') controllerChangeHandler = handler;
+        }),
+      },
+      writable: true,
+      configurable: true,
+    });
+    mockFlushPersistedState.mockResolvedValue(undefined);
+
+    await registerServiceWorker();
+    fireControllerChange();
+    await flushMicrotasks();
+
+    // Correctly reloads — recovered as a returning visitor via register()'s result, not misclassified as first-install.
+    expect(mockFlushPersistedState).toHaveBeenCalledTimes(1);
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+    // The recovery path backfills the persistent record exactly like a successful getRegistration() would have.
+    expect(localStorage.getItem(`worldscript-sw-installed:${OWN_SW_URL}`)).toBe('1');
+  });
+
+  // QNBS-v3: regression guard — a controllerchange firing while register() itself is still pending, during the getRegistration()-failure recovery window, must be queued (classification isn't finalized yet) and correctly replayed as a genuine update once register()'s result recovers classification — not lost, and not guessed at prematurely.
+  it("queues a controllerchange firing during register()'s own await in the getRegistration()-failure recovery window, and replays it correctly", async () => {
+    let capturedHandler: (() => void) | undefined;
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: {
+        register: vi.fn().mockImplementation(async () => {
+          // Simulates another tab's genuine update completing its claim while register() is still pending.
+          setMockController(OWN_SW_URL);
+          capturedHandler?.();
+          return {
+            scope: '/',
+            installing: null,
+            waiting: null,
+            active: { state: 'activated', scriptURL: OWN_SW_URL },
+            addEventListener: vi.fn(),
+          };
+        }),
+        getRegistration: vi.fn().mockRejectedValue(new Error('getRegistration failed')),
+        controller: null,
+        addEventListener: vi.fn((type: string, handler: () => void) => {
+          if (type === 'controllerchange') {
+            controllerChangeHandler = handler;
+            capturedHandler = handler;
+          }
+        }),
+      },
+      writable: true,
+      configurable: true,
+    });
+    mockFlushPersistedState.mockResolvedValue(undefined);
+
+    await registerServiceWorker();
+    await flushMicrotasks();
+
+    expect(mockFlushPersistedState).toHaveBeenCalledTimes(1);
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // QNBS-v3: regression guard — if BOTH getRegistration() and register() fail, classification must still resolve to a safe default instead of leaving every future controllerchange queued forever with nothing left in the call stack to ever drain it.
+  it('finalizes to a safe first-install default when both getRegistration() and register() reject, so a later controllerchange still resolves instead of queuing forever', async () => {
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: {
+        register: vi.fn().mockRejectedValue(new Error('register failed')),
+        getRegistration: vi.fn().mockRejectedValue(new Error('getRegistration failed')),
+        controller: null,
+        addEventListener: vi.fn((type: string, handler: () => void) => {
+          if (type === 'controllerchange') controllerChangeHandler = handler;
+        }),
+      },
+      writable: true,
+      configurable: true,
+    });
+    mockFlushPersistedState.mockResolvedValue(undefined);
+
+    await registerServiceWorker();
+
+    // Safe default (no evidence either way): treated as first-install — no reload.
+    fireControllerChange();
+    await flushMicrotasks();
+    expect(mockFlushPersistedState).not.toHaveBeenCalled();
+    expect(reloadSpy).not.toHaveBeenCalled();
+
+    // A later event on the same tab must still resolve deterministically — proving the queue actually drained instead of accepting events forever.
+    fireControllerChange();
+    await flushMicrotasks();
+    expect(mockFlushPersistedState).toHaveBeenCalledTimes(1);
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // QNBS-v3: regression guard — a second tab opened during the very same first-ever install observes the first tab's already-created but not-yet-active registration; that must still count as "no prior install" for both tabs, not as a genuine update.
+  it("does not flush or reload when getRegistration() finds another tab's in-progress (not yet active) first install", async () => {
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: {
+        register: vi.fn().mockResolvedValue({
+          scope: '/',
+          installing: null,
+          waiting: null,
+          addEventListener: vi.fn(),
+        }),
+        getRegistration: vi.fn().mockResolvedValue({ scope: '/', active: null }),
+        controller: null,
+        addEventListener: vi.fn((type: string, handler: () => void) => {
+          if (type === 'controllerchange') controllerChangeHandler = handler;
+        }),
+      },
+      writable: true,
+      configurable: true,
+    });
+    mockFlushPersistedState.mockResolvedValue(undefined);
+
+    await registerServiceWorker();
+    fireControllerChange();
+    await flushMicrotasks();
+
+    expect(mockFlushPersistedState).not.toHaveBeenCalled();
+    expect(reloadSpy).not.toHaveBeenCalled();
+  });
+
+  // QNBS-v3: regression guard — the spec populates .active as soon as a worker enters 'activating', before it actually finishes activating, so a second tab observing that in-between state must still treat it as the same still-in-progress first install, not a completed prior one.
+  it("does not flush or reload when getRegistration().active exists but is only 'activating', not yet 'activated'", async () => {
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: {
+        register: vi.fn().mockResolvedValue({
+          scope: '/',
+          installing: null,
+          waiting: null,
+          addEventListener: vi.fn(),
+        }),
+        getRegistration: vi.fn().mockResolvedValue({
+          scope: '/',
+          active: { state: 'activating', scriptURL: OWN_SW_URL },
+        }),
+        controller: null,
+        addEventListener: vi.fn((type: string, handler: () => void) => {
+          if (type === 'controllerchange') controllerChangeHandler = handler;
+        }),
+      },
+      writable: true,
+      configurable: true,
+    });
+    mockFlushPersistedState.mockResolvedValue(undefined);
+
+    await registerServiceWorker();
+    fireControllerChange();
+    await flushMicrotasks();
+
+    expect(mockFlushPersistedState).not.toHaveBeenCalled();
+    expect(reloadSpy).not.toHaveBeenCalled();
+  });
+
+  // QNBS-v3: regression guard — a force-refreshed returning visitor also has a null controller for that navigation (the browser bypasses SW control for it), but an existing registration proves this is not a first-ever install, so the genuine update must still reload.
+  it('reloads on the first controllerchange when a registration already existed, even though this navigation has no controller', async () => {
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: {
+        register: vi.fn().mockResolvedValue({
+          scope: '/',
+          installing: null,
+          waiting: null,
+          addEventListener: vi.fn(),
+        }),
+        // QNBS-v3: an 'activated' worker at this app's own script URL represents a returning visitor's already-completed prior install, surviving even though this force-refreshed navigation itself has no controller.
+        getRegistration: vi
+          .fn()
+          .mockResolvedValue({ scope: '/', active: { state: 'activated', scriptURL: OWN_SW_URL } }),
+        controller: null,
+        addEventListener: vi.fn((type: string, handler: () => void) => {
+          if (type === 'controllerchange') controllerChangeHandler = handler;
+        }),
+      },
+      writable: true,
+      configurable: true,
+    });
+    mockFlushPersistedState.mockResolvedValue(undefined);
+
+    await registerServiceWorker();
+    // QNBS-v3: this positive evidence must be backfilled to the persistent record immediately, not only once a controllerchange happens to fire in this session — a later force-refresh landing mid-transition would otherwise find no history to override live-API ambiguity.
+    expect(localStorage.getItem(`worldscript-sw-installed:${OWN_SW_URL}`)).toBe('1');
+    fireControllerChange();
+    await flushMicrotasks();
+
+    expect(mockFlushPersistedState).toHaveBeenCalledTimes(1);
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // QNBS-v3: regression guard — a genuine update's replacement worker briefly reads .active.state === 'activating' before finishing activation; the already-existing controller (an ordinary, non-force-refreshed returning visitor) is what must decide this is not a first install, independent of that transient registration state.
+  it("reloads on the first controllerchange when a controller already existed, even though the replacement worker is only 'activating'", async () => {
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: {
+        register: vi.fn().mockResolvedValue({
+          scope: '/',
+          installing: null,
+          waiting: null,
+          addEventListener: vi.fn(),
+        }),
+        getRegistration: vi.fn().mockResolvedValue({
+          scope: '/',
+          active: { state: 'activating', scriptURL: OWN_SW_URL },
+        }),
+        controller: { scriptURL: OWN_SW_URL },
+        addEventListener: vi.fn((type: string, handler: () => void) => {
+          if (type === 'controllerchange') controllerChangeHandler = handler;
+        }),
+      },
+      writable: true,
+      configurable: true,
+    });
+    mockFlushPersistedState.mockResolvedValue(undefined);
+
+    await registerServiceWorker();
+    // QNBS-v3: an own controller at load is positive evidence too — it must be backfilled to the persistent record immediately, the same as an own-activated registration.
+    expect(localStorage.getItem(`worldscript-sw-installed:${OWN_SW_URL}`)).toBe('1');
+    fireControllerChange();
+    await flushMicrotasks();
+
+    expect(mockFlushPersistedState).toHaveBeenCalledTimes(1);
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // QNBS-v3: regression guard — the controllerchange listener must be attached before any await (getRegistration()/register()), so a claim event racing ahead of that async setup (e.g. a concurrent tab's install completing in between) is never silently missed by a not-yet-attached listener.
+  it('does not miss a controllerchange that fires while getRegistration() is still pending', async () => {
+    let capturedHandler: (() => void) | undefined;
+    // QNBS-v3: a plain boolean, not an in-mock expect() — an assertion thrown inside this async mock would reject getRegistration()'s own promise, which registerServiceWorker()'s outer try/catch silently swallows, making the test pass vacuously either way instead of failing when the listener was attached too late.
+    let wasHandlerAttachedWhenGetRegistrationRan = false;
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: {
+        register: vi.fn().mockResolvedValue({
+          scope: '/',
+          installing: null,
+          waiting: null,
+          addEventListener: vi.fn(),
+        }),
+        // QNBS-v3: simulates the claim firing mid-await — if the listener were attached after this call (as in the original ordering), capturedHandler would still be undefined here and this invocation would be silently lost.
+        getRegistration: vi.fn().mockImplementation(async () => {
+          wasHandlerAttachedWhenGetRegistrationRan = typeof capturedHandler === 'function';
+          setMockController(OWN_SW_URL);
+          capturedHandler?.();
+          return undefined;
+        }),
+        controller: null,
+        addEventListener: vi.fn((type: string, handler: () => void) => {
+          if (type === 'controllerchange') {
+            controllerChangeHandler = handler;
+            capturedHandler = handler;
+          }
+        }),
+      },
+      writable: true,
+      configurable: true,
+    });
+    mockFlushPersistedState.mockResolvedValue(undefined);
+
+    await registerServiceWorker();
+    await flushMicrotasks();
+
+    expect(wasHandlerAttachedWhenGetRegistrationRan).toBe(true);
+    // The mid-await claim was this tab's genuine first-ever install claim — no flush/reload for it.
+    expect(mockFlushPersistedState).not.toHaveBeenCalled();
+    expect(reloadSpy).not.toHaveBeenCalled();
+  });
+
+  // QNBS-v3: regression guard — a tab that already had a controller at load is a known returning visitor; a controllerchange firing before getRegistration() resolves must still reload for it, not be misread as this tab's own first-install claim just because the async classification hasn't narrowed the (otherwise still-provisional) flag yet.
+  it('reloads on a controllerchange that fires while getRegistration() is pending, for a tab that already had a controller', async () => {
+    let capturedHandler: (() => void) | undefined;
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: {
+        register: vi.fn().mockResolvedValue({
+          scope: '/',
+          installing: null,
+          waiting: null,
+          addEventListener: vi.fn(),
+        }),
+        getRegistration: vi.fn().mockImplementation(async () => {
+          setMockController(OWN_SW_URL);
+          capturedHandler?.();
+          return { scope: '/', active: { state: 'activated', scriptURL: OWN_SW_URL } };
+        }),
+        controller: { scriptURL: OWN_SW_URL },
+        addEventListener: vi.fn((type: string, handler: () => void) => {
+          if (type === 'controllerchange') {
+            controllerChangeHandler = handler;
+            capturedHandler = handler;
+          }
+        }),
+      },
+      writable: true,
+      configurable: true,
+    });
+    mockFlushPersistedState.mockResolvedValue(undefined);
+
+    await registerServiceWorker();
+    await flushMicrotasks();
+
+    expect(mockFlushPersistedState).toHaveBeenCalledTimes(1);
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // QNBS-v3: regression guard — once a real controllerchange has consumed the provisional first-install exemption, the later async classification (from getRegistration()) must not unconditionally recompute and overwrite it back to true, or a subsequent genuine update's reload would be wrongly skipped a second time.
+  it('still reloads on a later genuine update after a mid-await first-install claim was already consumed', async () => {
+    let capturedHandler: (() => void) | undefined;
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: {
+        register: vi.fn().mockResolvedValue({
+          scope: '/',
+          installing: null,
+          waiting: null,
+          addEventListener: vi.fn(),
+        }),
+        getRegistration: vi.fn().mockImplementation(async () => {
+          setMockController(OWN_SW_URL); // simulates this tab's own first-ever install claim, mid-await
+          capturedHandler?.();
+          return undefined; // consistent with a genuine first install: no prior registration existed
+        }),
+        controller: null,
+        addEventListener: vi.fn((type: string, handler: () => void) => {
+          if (type === 'controllerchange') {
+            controllerChangeHandler = handler;
+            capturedHandler = handler;
+          }
+        }),
+      },
+      writable: true,
+      configurable: true,
+    });
+    mockFlushPersistedState.mockResolvedValue(undefined);
+
+    await registerServiceWorker();
+    await flushMicrotasks();
+    expect(mockFlushPersistedState).not.toHaveBeenCalled();
+    expect(reloadSpy).not.toHaveBeenCalled();
+
+    // A later, separate controllerchange on this same long-lived tab is a genuine update.
+    fireControllerChange();
+    await flushMicrotasks();
+    expect(mockFlushPersistedState).toHaveBeenCalledTimes(1);
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // QNBS-v3: regression guard — the first-install exemption must be one-shot. A tab that stayed open since a fresh install and outlives its own claim must still reload when a later, genuine update takes over.
+  it('reloads on a second controllerchange even though the first one was the no-reload first-install claim', async () => {
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: {
+        register: vi.fn().mockResolvedValue({
+          scope: '/',
+          installing: null,
+          waiting: null,
+          addEventListener: vi.fn(),
+        }),
+        getRegistration: vi.fn().mockResolvedValue(undefined),
+        controller: null,
+        addEventListener: vi.fn((type: string, handler: () => void) => {
+          if (type === 'controllerchange') controllerChangeHandler = handler;
+        }),
+      },
+      writable: true,
+      configurable: true,
+    });
+    mockFlushPersistedState.mockResolvedValue(undefined);
+
+    await registerServiceWorker();
+
+    // First claim: the tab's own first-ever install — no reload.
+    fireControllerChange();
+    await flushMicrotasks();
+    expect(mockFlushPersistedState).not.toHaveBeenCalled();
+    expect(reloadSpy).not.toHaveBeenCalled();
+
+    // Second claim on the same long-lived tab: a later real update — must reload.
+    fireControllerChange();
+    await flushMicrotasks();
+    expect(mockFlushPersistedState).toHaveBeenCalledTimes(1);
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // QNBS-v3: regression guard — a controller (or an active worker) belonging to an unrelated app on a shared origin (e.g. GitHub Pages) must never count as evidence of this app's own prior install.
+  it("treats a controller as first-install evidence only if its scriptURL is this app's own", async () => {
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: {
+        register: vi.fn().mockResolvedValue({
+          scope: '/',
+          installing: null,
+          waiting: null,
+          addEventListener: vi.fn(),
+        }),
+        getRegistration: vi.fn().mockResolvedValue(undefined),
+        // A foreign app's worker already controls this shared origin — must not be mistaken for our own.
+        controller: { scriptURL: FOREIGN_SW_URL },
+        addEventListener: vi.fn((type: string, handler: () => void) => {
+          if (type === 'controllerchange') controllerChangeHandler = handler;
+        }),
+      },
+      writable: true,
+      configurable: true,
+    });
+    mockFlushPersistedState.mockResolvedValue(undefined);
+
+    await registerServiceWorker();
+    fireControllerChange();
+    await flushMicrotasks();
+
+    // Correctly classified as this app's own first-ever install, ignoring the foreign controller.
+    expect(mockFlushPersistedState).not.toHaveBeenCalled();
+    expect(reloadSpy).not.toHaveBeenCalled();
+  });
+
+  it("treats a prior registration as first-install evidence only if its active worker's scriptURL is this app's own", async () => {
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: {
+        register: vi.fn().mockResolvedValue({
+          scope: '/',
+          installing: null,
+          waiting: null,
+          addEventListener: vi.fn(),
+        }),
+        // An unrelated, broader-scoped app's registration is already fully activated on this shared origin.
+        getRegistration: vi.fn().mockResolvedValue({
+          scope: '/',
+          active: { state: 'activated', scriptURL: FOREIGN_SW_URL },
+        }),
+        controller: null,
+        addEventListener: vi.fn((type: string, handler: () => void) => {
+          if (type === 'controllerchange') controllerChangeHandler = handler;
+        }),
+      },
+      writable: true,
+      configurable: true,
+    });
+    mockFlushPersistedState.mockResolvedValue(undefined);
+
+    await registerServiceWorker();
+    fireControllerChange();
+    await flushMicrotasks();
+
+    // Correctly classified as this app's own first-ever install, ignoring the foreign registration.
+    expect(mockFlushPersistedState).not.toHaveBeenCalled();
+    expect(reloadSpy).not.toHaveBeenCalled();
+  });
+
+  // QNBS-v3: regression guard — the controllerchange LISTENER fires for any controller change on the shared origin's navigator.serviceWorker, including a foreign, broader-scoped worker's own claim — that must be ignored outright, not just excluded from classification evidence, or it could consume the one-shot exemption and persist this app's own install record on a claim that was never actually this app's worker.
+  it('ignores a controllerchange whose resulting controller belongs to a foreign worker, without consuming the first-install exemption or persisting a record', async () => {
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: {
+        register: vi.fn().mockResolvedValue({
+          scope: '/',
+          installing: null,
+          waiting: null,
+          addEventListener: vi.fn(),
+        }),
+        getRegistration: vi.fn().mockResolvedValue(undefined),
+        controller: null,
+        addEventListener: vi.fn((type: string, handler: () => void) => {
+          if (type === 'controllerchange') controllerChangeHandler = handler;
+        }),
+      },
+      writable: true,
+      configurable: true,
+    });
+    mockFlushPersistedState.mockResolvedValue(undefined);
+
+    await registerServiceWorker();
+
+    // A foreign, broader-scoped worker on this shared origin claims the page — must be ignored entirely.
+    fireControllerChange(FOREIGN_SW_URL);
+    await flushMicrotasks();
+    expect(mockFlushPersistedState).not.toHaveBeenCalled();
+    expect(reloadSpy).not.toHaveBeenCalled();
+    expect(localStorage.getItem(`worldscript-sw-installed:${OWN_SW_URL}`)).toBeNull();
+
+    // This app's own first-ever claim follows — still correctly treated as first-install, proving the
+    // foreign event above did not consume the one-shot exemption.
+    fireControllerChange(OWN_SW_URL);
+    await flushMicrotasks();
+    expect(mockFlushPersistedState).not.toHaveBeenCalled();
+    expect(reloadSpy).not.toHaveBeenCalled();
+    expect(localStorage.getItem(`worldscript-sw-installed:${OWN_SW_URL}`)).toBe('1');
+
+    // A later genuine update on this same tab must still reload normally.
+    fireControllerChange(OWN_SW_URL);
+    await flushMicrotasks();
+    expect(mockFlushPersistedState).toHaveBeenCalledTimes(1);
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // QNBS-v3: regression guard — a force-refreshed returning visitor (no controller for this navigation) whose genuine update races ahead during getRegistration() must have that event queued, not guessed at, and correctly reloaded once classification confirms it was a real update.
+  it('reloads a controllerchange that fires mid-getRegistration() for a force-refreshed returning visitor, once classification confirms a genuine update', async () => {
+    let capturedHandler: (() => void) | undefined;
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: {
+        register: vi.fn().mockResolvedValue({
+          scope: '/',
+          installing: null,
+          waiting: null,
+          addEventListener: vi.fn(),
+        }),
+        // QNBS-v3: simulates another tab's genuine update completing its claim while this force-refreshed tab's own getRegistration() is still pending.
+        getRegistration: vi.fn().mockImplementation(async () => {
+          setMockController(OWN_SW_URL);
+          capturedHandler?.();
+          return { scope: '/', active: { state: 'activated', scriptURL: OWN_SW_URL } };
+        }),
+        controller: null, // force-refresh: no controller for this navigation despite a fully-activated own worker
+        addEventListener: vi.fn((type: string, handler: () => void) => {
+          if (type === 'controllerchange') {
+            controllerChangeHandler = handler;
+            capturedHandler = handler;
+          }
+        }),
+      },
+      writable: true,
+      configurable: true,
+    });
+    mockFlushPersistedState.mockResolvedValue(undefined);
+
+    await registerServiceWorker();
+    await flushMicrotasks();
+
+    expect(mockFlushPersistedState).toHaveBeenCalledTimes(1);
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // QNBS-v3: regression guard — a persistent record from an earlier successful classification must make classification immediate and correct, bypassing every live-API ambiguity (force-refresh, mid-activation timing) entirely.
+  it('reloads immediately on a force-refreshed visitor when a persistent prior-install record already exists, even with an activating replacement worker', async () => {
+    localStorage.setItem(`worldscript-sw-installed:${OWN_SW_URL}`, '1');
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: {
+        register: vi.fn().mockResolvedValue({
+          scope: '/',
+          installing: null,
+          waiting: null,
+          addEventListener: vi.fn(),
+        }),
+        // Ambiguous live state on its own (no controller, worker still activating) — the persistent record must override it.
+        getRegistration: vi.fn().mockResolvedValue({
+          scope: '/',
+          active: { state: 'activating', scriptURL: OWN_SW_URL },
+        }),
+        controller: null,
+        addEventListener: vi.fn((type: string, handler: () => void) => {
+          if (type === 'controllerchange') controllerChangeHandler = handler;
+        }),
+      },
+      writable: true,
+      configurable: true,
+    });
+    mockFlushPersistedState.mockResolvedValue(undefined);
+
+    await registerServiceWorker();
+    fireControllerChange();
+    await flushMicrotasks();
+
+    expect(mockFlushPersistedState).toHaveBeenCalledTimes(1);
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // QNBS-v3: regression guard — the very first genuine claim (whichever classification) must persist a record so every future load for this app's scope can classify instantly and correctly, without depending on live-API timing at all.
+  it("persists a prior-install record on the first genuine claim, scoped to this app's own script URL", async () => {
+    // QNBS-v3: starts with no controller and no registration — the default fixture's own controller would satisfy this test via the hadOwnControllerAtLoad backfill instead of the claim path this test exists to cover.
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: {
+        register: vi.fn().mockResolvedValue({
+          scope: '/',
+          installing: null,
+          waiting: null,
+          addEventListener: vi.fn(),
+        }),
+        getRegistration: vi.fn().mockResolvedValue(undefined),
+        controller: null,
+        addEventListener: vi.fn((type: string, handler: () => void) => {
+          if (type === 'controllerchange') controllerChangeHandler = handler;
+        }),
+      },
+      writable: true,
+      configurable: true,
+    });
+    mockFlushPersistedState.mockResolvedValue(undefined);
+
+    await registerServiceWorker();
+    // No positive evidence exists yet, so no backfill has happened.
+    expect(localStorage.getItem(`worldscript-sw-installed:${OWN_SW_URL}`)).toBeNull();
+
+    fireControllerChange();
+    await flushMicrotasks();
+
+    expect(localStorage.getItem(`worldscript-sw-installed:${OWN_SW_URL}`)).toBe('1');
   });
 
   // QNBS-v3: an unbounded wait (e.g. queued behind another tab's exclusive Web Lock) must not hang the reload forever on an already-cache-pruned bundle.
@@ -245,7 +945,7 @@ describe('register-sw — controllerchange flush-then-reload (DA-02)', () => {
     try {
       mockFlushPersistedState.mockImplementation(() => new Promise(() => {}));
       await registerServiceWorker();
-      controllerChangeHandler?.();
+      fireControllerChange();
 
       await vi.advanceTimersByTimeAsync(0);
       expect(reloadSpy).not.toHaveBeenCalled();


### PR DESCRIPTION
## **User description**
Fixes #585 (production-behavior direction only — see Non-goals).

## Problem

`public/sw.js` calls `self.clients.claim()` on `activate`, and `register-sw.ts`'s `controllerchange` handler unconditionally calls `flushLatestStateThenReload()` whenever the controller changes while the page is visible. `clients.claim()` claims already-open clients immediately, not just future navigations — so a completely fresh browser context's very first page load fires `controllerchange` on that same first-ever page, not only on a version update for a returning visitor. Every first-time visitor, and every fresh E2E browser context, underwent one automatic, unprompted reload shortly after the initial page load.

## Root cause

The reload's documented purpose is avoiding a missing-chunk failure, because `activate` already pruned the *old* version's cache by the time `controllerchange` fires — a risk specific to genuine updates. A first-ever install has no prior version to be stale relative to.

## Fix (converged through many rounds of review — each closing a narrower race or correctness gap than the last)

The final architecture, after the classification logic went through several rejected intermediate designs (each broken by a real, reproduced counter-example, each superseded fix verified with a negative control — revert → confirm the new test fails → restore → confirm it passes):

- **Absolute-URL identity.** `ServiceWorker.scriptURL` is always a fully resolved absolute URL per spec; `swUrl` is resolved to an absolute URL once (`new URL(...).href`) before every comparison, so this app's own worker is identified correctly instead of never matching (an earlier relative-path comparison would have silently misclassified every returning visitor).
- **Foreign-worker filtering.** On a shared origin (e.g. GitHub Pages), a broader-scoped worker's own `controllerchange` is ignored outright — verified by `scriptURL` before any queuing or classification — so it can never consume the one-shot exemption or write this app's own install record.
- **Persistent installation history.** A `localStorage` record keyed by this app's own absolute script URL is written from any positive evidence (an own controller already at page load, an own `'activated'` registration, or a first genuine claim), so future page loads classify instantly and correctly without depending on live Service Worker API timing at all.
- **Event queuing during classification.** A `controllerchange` arriving before classification is final — whether during `getRegistration()`, during its failure-recovery window, or during `register()` itself — is queued, not guessed at, and replayed once classification is final.
- **getRegistration()-failure recovery.** If `getRegistration()` rejects, classification is deferred rather than finalized on zero evidence, and recovered from `register()`'s own idempotent result once it resolves — so a force-refreshed returning visitor hitting a transient lookup failure is still classified correctly instead of misclassified as a first install. If `register()` *also* rejects, classification finalizes to a safe first-install default so no controllerchange is left queued forever.
- **One-shot exemption.** The first-install classification is consumed after its first use, so a long-lived tab that outlives its own first-install claim still reloads correctly when a later, genuine update takes over.

A full state-transition audit (persistent marker × controller-at-setup × `getRegistration()` outcome × prior-registration state × `register()` outcome × `controllerchange` timing) was performed before the architecture above was accepted as final — see the last two commits' messages for the two gaps it found and closed, and what it confirmed was already correct.

## Scope

`register-sw.ts`'s `controllerchange` handler and its pre-`register()` detection logic, only.

## Non-goals

Per #585's own "Scope for a fix" section, this closes only direction 1 (the production reload decision). Direction 2 (hardening `tests/e2e/helpers.ts`'s startup helpers against an unprompted navigation) is intentionally left to **#532**, which remains open and already names `controllerchange`-driven reload as one of several candidate mechanisms in its own still-unresolved startup/harness nondeterminism investigation — this PR does not attempt to close or reopen #532.

A pre-existing, unrelated finding (`flushLatestStateThenReload`'s timeout branch racing an in-flight flush) was verified byte-identical against base `main` and is out of scope here — dispositioned in review as a variant of the residual class already tracked in **#518**, not fixed in this PR.

A narrow, compound-timing residual — two tabs racing the *very first-ever* activation of this origin's service worker so closely that one tab's live (or, in a genuinely first-ever wave, not-yet-persisted) evidence reads as "already installed" — cannot be closed with a local, snapshot-based fix; it requires real cross-tab coordination (e.g. a `BroadcastChannel`-based install-wave announcement), which is new architectural surface, not a targeted bugfix. This is tracked in **#614**, not attempted here.

## Regression coverage

`tests/unit/registerSwUpdateFlush.test.ts` — grew from 10 tests to 29 across the review cycle, covering: first-ever install (no registration), one-shot consumption, force-refresh with an existing `'activated'` registration, concurrent tabs observing each other's in-progress (`installing`-only or `'activating'`-but-not-yet-`'activated'`) registration, absolute-vs-relative `scriptURL` scoping, foreign-worker exclusion, `controllerchange` events queued mid-`getRegistration()` and mid-`register()`, persistent-record backfill from positive live evidence (including the failure-recovery path), classification recovering from `register()`'s result when `getRegistration()` rejects, and the compound double-failure safe default. Every fix above was verified with its own negative control before being accepted.

## Validation

- `pnpm exec vitest run tests/unit/registerSwUpdateFlush.test.ts` — 29/29 pass on the final head.
- `pnpm run lint -- register-sw.ts tests/unit/registerSwUpdateFlush.test.ts` (exact CI command) — clean.
- `node scripts/check-doc-metrics.mjs` — clean after syncing README's test count (7456+ tests / 598 files).
- Full CI is the authoritative gate for typecheck/build/E2E; not rerun locally per this repo's low-end-hardware guidance.

## Summary by Sourcery## Summary by Sourcery

Skip the unnecessary first-load reload caused by service worker activation while retaining safe reload behavior for returning visitors after updates.

Bug Fixes:
- Prevent the service worker from triggering an automatic flush-and-reload during its first-ever activation while preserving reloads for genuine updates.
- Correct service worker ownership and installation classification across force refreshes, concurrent installs, shared origins, and asynchronous registration failures.

Enhancements:
- Persist app-specific service worker installation history and queue controller changes until classification is complete.
- Refactor service worker setup into focused helpers without changing update notifications, Tauri cleanup, or periodic sync behavior.

Documentation:
- Synchronize README test-count metrics with the expanded regression suite.

Tests:
- Expand registration and update regression coverage to 29 tests for first installs, update races, worker ownership, persistence, and failure recovery.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #585 by stopping the service worker's `controllerchange` reload from firing on a first-ever install, so first-time visitors no longer get an automatic reload. Genuine updates still flush state and reload for returning visitors.

**Bug Fixes**
- Classifies a first install only when no own controller, no own `'activated'` registration, and no persistent record existed at load; foreign workers on shared origins never count.
- Resolves `swUrl` to an absolute URL before comparing against `ServiceWorker.scriptURL` — the previous relative comparison silently misclassified every returning visitor.
- Queues `controllerchange` events arriving before classification completes and replays them once final, so claims racing the async setup aren't missed.
- Recovers classification from `register()`'s result when `getRegistration()` rejects; if both reject, defaults to first-install so no events stay queued forever.
- Persists a `localStorage` record keyed by this app's own script URL from positive evidence, so future loads classify without live-API timing.
- The exemption is one-shot, so a later genuine update on a long-lived tab still reloads.

**Refactors**
- Extracted classification, Tauri teardown, update-notification setup, and periodic sync into dedicated functions with no behavior change.
- Added regression tests covering installs, concurrent tabs, force-refreshed visitors, foreign workers, queued/rejected lookups, persistent records, and later updates.

<sup>Written for commit 0a0c71b62140962f7ed6ee0fcf8ab5625e67138e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/qnbs/WorldScript-Studio/pull/613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented unnecessary page reloads and persisted-state flushing during first-time service-worker installation, including installations racing asynchronous setup.
  - Preserved visibility-aware page reload behavior for subsequent service-worker updates.
  - Improved handling of service-worker updates during navigation and background synchronization.
  - Ignored unrelated service workers and improved reliability when detecting updates across refreshes and delayed registrations.

- **Documentation**
  - Updated README test metrics to reflect 7,452+ tests across project badges, technology details, structure, and CI metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Prevent first-install reloads while preserving service worker update refreshes

### What Changed
- First-time visitors no longer get an automatic page reload when the service worker takes control.
- Returning visitors still flush pending changes and reload after genuine service worker updates.
- Install history is tracked for this app, including cases where the page has no current controller or an update is still activating.
- Service worker changes from unrelated apps on shared origins are ignored.
- Added regression coverage for first installs, update races, hidden tabs, failed registration checks, foreign workers, and later updates in long-lived tabs.

### Impact
`✅ No unexpected reload on first visit`
`✅ Preserved update reloads for returning visitors`
`✅ Fewer lost or stale app-state risks during updates`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>