### PR TITLE
chore(release): bump version to v1.28.4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
 - **Primary deploy target:** Static SPA on GitHub Pages (`/WorldScript-Studio/` base path)
 - **Secondary targets:** Vercel (root base) and Cloudflare Pages via edge builds (`pnpm run build:edge`)
 - **Desktop:** Tauri 2 bundles for Linux (AppImage), macOS (DMG), and Windows (MSI); auto-updater enabled via `latest.json`
-- **Version:** `1.28.3`
+- **Version:** `1.28.4`
 - **License:** MIT
 
 The app supports a multi-provider AI stack (Gemini, OpenAI, Claude, Grok, OpenRouter, Ollama, WebLLM, ONNX Runtime Web, Transformers.js), four AI execution modes (Hybrid / Cloud / Local / Eco), real-time collaboration with E2E encryption, a Plot Board v2 with swimlane/canvas/timeline modes, character/world management, manuscript export, voice dictation, and a 19-locale i18n layer.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that's actually safe for it. PR #545.
 - **Intentionally cleared project metadata no longer reappears:** an empty title/logline set by the
   user could be silently repopulated during returning-user bootstrap. PR #546.
+- **Factory Reset could report success while user data remained:** `deleteDatabase()` treated a
+  genuine `onerror` or an `onblocked` event (another connection still open) as success, so
+  `wipeAllAppData()` could resolve without every database actually being deleted. `onerror` now
+  rejects, and `onblocked` waits for the connection to close before giving up. PR #596.
 
 ### Accessibility
 
@@ -62,9 +66,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   application — the gate was not protecting against real visual regressions. Now reaches actual app
   routes with real baselines and a proven negative control demonstrating a visible regression fails
   the gate. PR #610.
-- IDB reset-quiescence hardening across 9 service modules (PR #596; issue #532's own WelcomePortal
-  entry-nondeterminism root cause is a related but distinct class and remains open); WelcomePortal
-  E2E recovery navigation made locale-independent (PR #590).
+- **Async, generation/epoch-based IDB reset-quiescence contract** across 9 service modules, closing
+  every long-lived connection before a factory reset deletes anything (PR #596; issue #532's own
+  WelcomePortal entry-nondeterminism root cause is a related but distinct class and remains open).
+  WelcomePortal E2E recovery navigation made locale-independent (PR #590).
 
 ## [1.28.3] — 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+<!-- release-candidate: v1.28.4 -->
+## [1.28.4] — 2026-09-05
+
+### Fixed
+
+- **PWA first-install unprompted reload:** `clients.claim()` on activation fired `controllerchange`
+  on the very first-ever page load, not only on genuine updates, causing every first-time visitor
+  to undergo one automatic reload shortly after landing. Fixed via absolute-URL own-worker
+  identification, shared-origin foreign-worker exclusion, persistent installation history, event
+  queuing during classification, and recovery when `getRegistration()` fails. A narrow residual —
+  two tabs racing the very first-ever activation of this origin's service worker so closely that
+  one tab's evidence reads as "already installed" — requires real cross-tab coordination and
+  remains open as #614. Fixes #585, PR #613.
+- **Service-worker cache reads are now positively ownership-scoped:** every `caches.match()` call
+  in the fetch handler and offline fallback now specifies its owning cache by name, closing a
+  shared-origin (e.g. `qnbs.github.io` hosting multiple projects) cache-read isolation gap. Fixes
+  #514, PR #612.
+- **Factory Reset could reboot back into Settings instead of Welcome Portal:** a stale
+  view-carrying URL hash survived `wipeAllAppData()`'s reload, and `readInitialView()` read it with
+  higher priority than checking whether a project still existed. PR #592.
+- **Desktop project corruption is now preserve-first:** a corrupt desktop project is quarantined
+  (moved to `quarantined-projects` with a collision-safe name) rather than risking deletion; the
+  destructive IndexedDB-reset action is no longer offered for project-load failures. PR #542.
+- **Desktop filesystem I/O errors now get a distinct, truthful recovery action:** separated from
+  corruption-quarantine and generic-storage-reset, so each failure class only exposes the action
+  that's actually safe for it. PR #545.
+- **Intentionally cleared project metadata no longer reappears:** an empty title/logline set by the
+  user could be silently repopulated during returning-user bootstrap. PR #546.
+
+### Accessibility
+
+- **Welcome/Home dashboard WCAG AA contrast** and a repaired `prefers-reduced-motion` cascade (the
+  override now correctly wins over equal-specificity base rules); default appearance preset is now
+  `default` for new and invalid-legacy sessions. Fixes #565, PR #609.
+- **ManuscriptEditor deferred-mirror contrast** raised from 4.45:1 to ~5.10:1. PR #560.
+
+### Security
+
+- **`fflate` ZIP64-parsing DoS**, used by this app's export path: overridden to `0.8.3`. PR #595.
+- Routine dependency maintenance: `xmldom`/`fast-uri`/`qs` floor bumps (PR #587), `log` crate in
+  `src-tauri` (PR #561), `codeql-action` group (PR #562), `actions/setup-node` (PR #594).
+
 ### Documentation
 
-- **Post-release v1.28.3 truth sync:** removed the now-stale release-candidate markers from
-  README.md and CHANGELOG.md now that the `v1.28.3` tag and GitHub Release are published, and
-  recorded real release-gate evidence in AUDIT.md (main CI/CD run, CodeQL, GitHub Pages deploy,
-  tag-triggered Tauri/CI/Docker runs, published release assets).
+- **R-15 secure desktop storage — design contract admitted, implementation not started:** the full
+  storage/migration/recovery contract (S5-A, S5-B1, S5-B2, S5-B3) is now defined and its
+  cross-contract consistency audited. No code has shipped yet; desktop project files remain
+  documented as plaintext until this implementation lands. PRs #564, #580, #581, #582, #584.
+
+### Tests
+
+- **Visual regression testing repaired:** VRT baselines were directory listings, not the
+  application — the gate was not protecting against real visual regressions. Now reaches actual app
+  routes with real baselines and a proven negative control demonstrating a visible regression fails
+  the gate. PR #610.
+- IDB reset-quiescence hardening across 9 service modules (PR #596; issue #532's own WelcomePortal
+  entry-nondeterminism root cause is a related but distinct class and remains open); WelcomePortal
+  E2E recovery navigation made locale-independent (PR #590).
 
 ## [1.28.3] — 2026-08-27
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
   <img src="https://img.shields.io/badge/TypeScript-7.x_(tsgo)-3178C6?logo=typescript&logoColor=white" alt="TypeScript 7 (tsgo)">
   <img src="https://img.shields.io/badge/AI-Gemini_%7C_OpenAI_%7C_OpenRouter_%7C_Ollama_%7C_WebLLM-4285F4?logo=google" alt="Gemini · OpenAI · OpenRouter · Ollama · WebLLM">
   <img src="https://img.shields.io/badge/Local_AI-WebGPU_%7C_ONNX_%7C_Transformers.js-8B5CF6" alt="WebGPU · ONNX · Transformers.js">
-  <img src="https://img.shields.io/badge/Release-v1.28.3-6366F1" alt="Release v1.28.3">
+  <!-- release-candidate: v1.28.4 -->
+  <img src="https://img.shields.io/badge/Release-v1.28.4-6366F1" alt="Release v1.28.4">
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2940_keys-0EA5E9" alt="i18n 19 locales — 2940 keys">

--- a/TODO.md
+++ b/TODO.md
@@ -8,12 +8,43 @@ Status: 🔄 in progress | ⬜ open | ✅ done
 
 ---
 
-## Current Sprint — Post-#477 reconstruction reconciliation, Dependabot, and documentation truth (2026-08-26)
+## Current Sprint — Release truth reconciliation and R-15 desktop at-rest encryption priority (2026-09-05)
 
 > **Status: 🔄 in progress.** The authoritative native sequence remains
 > [`docs/native/ROADMAP-QT-GPUI-DESKTOP.md`](docs/native/ROADMAP-QT-GPUI-DESKTOP.md), with the
-> next Rust-Core capability choice recorded in [`docs/native/CORE-MIGRATION-LEDGER.md`](docs/native/CORE-MIGRATION-LEDGER.md);
-> no Qt or GPUI implementation work is part of this sprint.
+> next Rust-Core capability choice recorded in [`docs/native/CORE-MIGRATION-LEDGER.md`](docs/native/CORE-MIGRATION-LEDGER.md).
+> R-15 (desktop at-rest encryption) is now prioritized ahead of ordinary roadmap frontier work —
+> its design contract (S5-A/B1/B2/B3) is already admitted; this sprint moves it into
+> implementation. No Qt or GPUI implementation work is part of this sprint.
+
+- ✅ `v1.28.2` (2026-08-27) and `v1.28.3` (2026-08-27) released, closing out the prior sprint's
+  accumulated reconstruction-reconciliation and documentation-truth work.
+- ✅ PWA first-install unprompted-reload fix (#585, PR #613) and shared-origin service-worker
+  cache-read isolation fix (#514, PR #612) merged.
+- ✅ WCAG AA contrast + `prefers-reduced-motion` cascade fix and default-appearance-preset change
+  (#565, PR #609); ManuscriptEditor contrast fix (#341, PR #560).
+- ✅ Preserve-first desktop corruption recovery (PR #542) and a distinct filesystem-I/O recovery
+  action (PR #545) landed.
+- ✅ Visual regression testing repaired — baselines previously pointed at directory listings, not
+  the application (PR #610).
+- ✅ `v1.28.4` release cut, reconciling `CHANGELOG.md`/`TODO.md`/`AUDIT.md` truth with everything
+  merged since `v1.28.3`.
+- ⬜ R-15 desktop at-rest encryption implementation: select the smallest already-authorized
+  Wave 3/4 slice from `docs/native/R15-SECURE-STORAGE-CONTRACT.md` and
+  `docs/native/CORE-MIGRATION-LEDGER.md`, execute through the preserve-first migration gates.
+- ⬜ #614 (narrow concurrent-first-install multi-tab race, requires cross-tab coordination) and
+  #532 (WelcomePortal E2E entry nondeterminism root cause) remain open, tracked separately —
+  not part of this sprint unless they directly block release or R-15 work.
+
+## Archived sprint history
+
+The completed release and infrastructure sections below are retained for provenance. They are not
+the current sprint plan; long-term native sequencing belongs in the linked roadmap and ledger.
+
+## Archived — Post-#477 reconstruction reconciliation, Dependabot, and documentation truth (2026-08-26)
+
+> **Status: ✅ Superseded by the current sprint above.** The release this section's final bullet
+> anticipated shipped as `v1.28.2` and `v1.28.3` (2026-08-27).
 
 - ✅ PR #477 (Qt/PWA architecture-governance roadmap) merged; `v1.28.1` released 2026-08-23.
 - ✅ Reconstruction reconciliation: the frozen PR #491 bundle's three genuinely-still-required
@@ -27,14 +58,6 @@ Status: 🔄 in progress | ⬜ open | ✅ done
   test-oracle fix for the hardcoded SHA it changed) and #496 (`docker/setup-buildx-action`
   4.2.0→4.3.0) merged.
 - ✅ Documentation truth pass (`AUDIT.md`/`TODO.md`, this update).
-- 🔄 A new release cut for this sprint's accumulated work (reconstruction reconciliation,
-  Dependabot integration, this documentation pass) remains open — a new version, not a repeat of
-  the already-published `v1.28.1` above.
-
-## Archived sprint history
-
-The completed release and infrastructure sections below are retained for provenance. They are not
-the current sprint plan; long-term native sequencing belongs in the linked roadmap and ledger.
 
 ## Archived — Native desktop consolidation and Wave 2 G1 (2026-08-20)
 

--- a/TODO.md
+++ b/TODO.md
@@ -27,8 +27,10 @@ Status: 🔄 in progress | ⬜ open | ✅ done
   action (PR #545) landed.
 - ✅ Visual regression testing repaired — baselines previously pointed at directory listings, not
   the application (PR #610).
-- ✅ `v1.28.4` release cut, reconciling `CHANGELOG.md`/`TODO.md`/`AUDIT.md` truth with everything
-  merged since `v1.28.3`.
+- 🔄 `v1.28.4` release cut in progress: version/`CHANGELOG.md`/`TODO.md`/`README.md`
+  reconciliation for everything merged since `v1.28.3` is in PR #615. Tag, GitHub Release, release
+  artifacts, and the post-release `AUDIT.md` evidence entry all remain pending until after that PR
+  merges and post-merge main CI/CodeQL are green.
 - ⬜ R-15 desktop at-rest encryption implementation: select the smallest already-authorized
   Wave 3/4 slice from `docs/native/R15-SECURE-STORAGE-CONTRACT.md` and
   `docs/native/CORE-MIGRATION-LEDGER.md`, execute through the preserve-first migration gates.

--- a/TODO.md
+++ b/TODO.md
@@ -13,9 +13,13 @@ Status: 🔄 in progress | ⬜ open | ✅ done
 > **Status: 🔄 in progress.** The authoritative native sequence remains
 > [`docs/native/ROADMAP-QT-GPUI-DESKTOP.md`](docs/native/ROADMAP-QT-GPUI-DESKTOP.md), with the
 > next Rust-Core capability choice recorded in [`docs/native/CORE-MIGRATION-LEDGER.md`](docs/native/CORE-MIGRATION-LEDGER.md).
-> R-15 (desktop at-rest encryption) is now prioritized ahead of ordinary roadmap frontier work —
-> its design contract (S5-A/B1/B2/B3) is already admitted; this sprint moves it into
-> implementation. No Qt or GPUI implementation work is part of this sprint.
+> R-15 (desktop at-rest encryption) design work is complete — S5-A/B1/B2/B3 are all admitted — but
+> [`docs/native/DESKTOP-MIGRATION-ROADMAP-REV3.md`](docs/native/DESKTOP-MIGRATION-ROADMAP-REV3.md)
+> explicitly forbids pulling Wave 3/4 R-15 **implementation** ahead of unresolved Wave 2 authority
+> prerequisites, and the ledger's row 10 records `S5_IMPLEMENTATION_READY=NO`. This sprint's
+> desktop-storage work is therefore the still-open Wave 2 prerequisite (ledger row 9: the
+> project state-shape compatibility adapter), not R-15 implementation itself. No Qt or GPUI
+> implementation work is part of this sprint.
 
 - ✅ `v1.28.2` (2026-08-27) and `v1.28.3` (2026-08-27) released, closing out the prior sprint's
   accumulated reconstruction-reconciliation and documentation-truth work.
@@ -31,9 +35,9 @@ Status: 🔄 in progress | ⬜ open | ✅ done
   reconciliation for everything merged since `v1.28.3` is in PR #615. Tag, GitHub Release, release
   artifacts, and the post-release `AUDIT.md` evidence entry all remain pending until after that PR
   merges and post-merge main CI/CodeQL are green.
-- ⬜ R-15 desktop at-rest encryption implementation: select the smallest already-authorized
-  Wave 3/4 slice from `docs/native/R15-SECURE-STORAGE-CONTRACT.md` and
-  `docs/native/CORE-MIGRATION-LEDGER.md`, execute through the preserve-first migration gates.
+- ⬜ Close the outstanding Wave 2 prerequisite (ledger row 9: project state-shape compatibility
+  adapter) — currently in progress, not complete. Wave 3/4 R-15 implementation stays blocked
+  (`S5_IMPLEMENTATION_READY=NO`) until this and `S5_TERMINAL=YES` are both true.
 - ⬜ #614 (narrow concurrent-first-install multi-tab race, requires cross-tab coordination) and
   #532 (WelcomePortal E2E entry nondeterminism root cause) remain open, tracked separately —
   not part of this sprint unless they directly block release or R-15 work.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "worldscript-studio",
   "private": true,
-  "version": "1.28.3",
+  "version": "1.28.4",
   "description": "WorldScript Studio — offline-first, AI-powered creative writing application.",
   "author": "QNBS",
   "keywords": [

--- a/public/sw.js
+++ b/public/sw.js
@@ -6,7 +6,7 @@
 // ============================================================
 
 // QNBS-v3 (CodeRabbit): version bump auto-synced from package.json by scripts/sync-sw-version.mjs — every CACHE_STATIC/CACHE_DYNAMIC name changes too, so this alone invalidates all prior caches on next activate.
-const APP_VERSION   = '1.28.3';
+const APP_VERSION   = '1.28.4';
 const CACHE_STATIC  = `worldscript-static-v${APP_VERSION}`;
 const CACHE_DYNAMIC = `worldscript-dynamic-v${APP_VERSION}`;
 const CACHE_IMAGES  = `worldscript-images-v${APP_VERSION}`;

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6685,7 +6685,7 @@ dependencies = [
 
 [[package]]
 name = "worldscript-studio"
-version = "1.28.3"
+version = "1.28.4"
 dependencies = [
  "base64 0.23.1",
  "candle-core",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "worldscript-studio"
-version = "1.28.3"
+version = "1.28.4"
 description = "AI-powered creative writing and world-building application"
 authors = ["QNBS"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "WorldScript Studio",
-  "version": "1.28.3",
+  "version": "1.28.4",
   "identifier": "com.worldscript.studio",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

Release-prep for v1.28.4 — reconciles CHANGELOG.md/TODO.md/README.md/version manifests with everything merged to `main` since `v1.28.3` (62 commits / ~40 PRs, audited against live GitHub state).

## What shipped since v1.28.3

- **fix:** PWA first-install unprompted reload (#585, PR #613)
- **fix:** shared-origin service-worker cache-read isolation (#514, PR #612)
- **fix:** Factory Reset could reboot into Settings instead of Welcome Portal (PR #592)
- **fix:** preserve-first desktop corruption recovery (PR #542) and a distinct filesystem-I/O recovery action (PR #545)
- **fix:** intentionally cleared project metadata no longer reappears (PR #546)
- **a11y:** Welcome/Home dashboard WCAG AA contrast + reduced-motion cascade fix + default appearance preset change (#565, PR #609); ManuscriptEditor contrast (PR #560)
- **security:** `fflate` ZIP64-parsing DoS override (PR #595); routine dependency floor bumps (PR #587, #561, #562, #594)
- **docs:** R-15 secure desktop storage design contract admitted (PRs #564, #580, #581, #582, #584) — design only, no implementation yet
- **tests:** visual regression testing repaired — baselines were directory listings, not the application (PR #610); IDB reset-quiescence hardening (PR #596); WelcomePortal E2E navigation made locale-independent (PR #590)

Pure internal/CI-governance churn (PR-size exception plumbing, dual-graph tooling, toolchain pins) is intentionally omitted from CHANGELOG.md as non-user-facing.

## Version: v1.28.4 (patch), not v1.29.0

Precedent from CHANGELOG.md's own history: v1.28.0 (minor) shipped genuine new capability + a deprecation + a contract-level change. Everything since v1.28.3 is bug fixes, accessibility, security/dependency maintenance, CI/test integrity, and design-only documentation (R-15 contract, zero implementation) — no new capability, no deprecation, no breaking contract change. Matches the patch precedent.

## Changes

- Version bumped via the existing sync scripts (`sync-tauri-version.mjs`, `sync-sw-version.mjs`) across `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.lock`, `AGENTS.md`, and `public/sw.js`'s `APP_VERSION`.
- `CHANGELOG.md`/`README.md` use the established `<!-- release-candidate: v1.28.4 -->` marker convention (matches the v1.28.2/v1.28.3 precedent — `check-doc-metrics.mjs` explicitly permits a dated, untagged CHANGELOG entry and README badge only when this marker is present) so the entry is truthful before the tag exists. Both markers get removed in a follow-up post-release truth-sync once the tag + GitHub Release are published.
- `TODO.md`'s Current Sprint section archived (its final "release cut remains open" bullet is now resolved — v1.28.2 and v1.28.3 both already shipped) and replaced with the actual current sprint: this release cut, followed by the R-15 desktop at-rest encryption priority program.

## Non-goals

- `AUDIT.md` is intentionally **not** touched here — its release-gate entry needs real post-merge CI/CodeQL run evidence that doesn't exist until after this PR merges and the tag is cut, matching how every prior release's AUDIT.md entry was written (a follow-up commit, not part of release-prep).
- No R-15 implementation, no unrelated P2/P3 cleanup — scope is release truth only.

## Validation

- `node scripts/check-doc-metrics.mjs` — OK (release-candidate marker convention satisfied).
- `pnpm run lint` — clean (1831 files).
- `pnpm run i18n:check` — OK (19 locales, 2940 keys).
- `pnpm run guardrail:desktop-imports` — OK.
- `pnpm run native-readiness:check` — OK.
- `pnpm run csp:check` — OK.
- Pre-push local-admission checks — all PASS (dependency state, toolchain, docs/release truth, CSP, desktop import boundary, native readiness, i18n translation quality, content guard, workflow policy, TypeScript single-checker).
- Full CI is authoritative for the exact-head gate.

## Summary by Sourcery

Prepare the v1.28.4 patch release and synchronize version metadata and release documentation.

Enhancements:
- Reconcile release documentation with the changes shipped since v1.28.3, including fixes, accessibility improvements, security maintenance, and testing updates.
- Refresh the current sprint documentation and archive the completed sprint history.

Build:
- Bump the application version to v1.28.4 across package, service-worker, and Tauri release manifests.

Documentation:
- Add the v1.28.4 changelog entry and update the README release badge using the release-candidate convention.

Chores:
- Prepare the v1.28.4 patch release while deferring post-release audit evidence until after merge and publication.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares the v1.28.4 patch release: bumps the version to 1.28.4 across `package.json`, `public/sw.js`, the Tauri manifests, `Cargo.lock`, and `AGENTS.md`, and reconciles `CHANGELOG.md`, `README.md`, and `TODO.md` with the ~40 PRs merged to `main` since v1.28.3.

- `CHANGELOG.md` gains the v1.28.4 entry covering the fixes, accessibility, security, and test changes shipped in this window; PR #596's `deleteDatabase()` fix is recorded as a data-integrity fix in Fixed, not test hardening.
- `CHANGELOG.md` and `README.md` use the release-candidate marker so the dated entry is truthful before the tag is cut; a follow-up removes the markers after the release publishes.
- `TODO.md` archives the previous sprint and opens the current one with the v1.28.4 release cut still in progress, corrected to state R-15 implementation stays gated behind the still-open Wave 2 state-shape adapter prerequisite.
- `AUDIT.md` is intentionally left for a follow-up since its release-gate entry needs post-merge CI and CodeQL evidence.

<sup>Written for commit 09cf650061dc227e6eb0274b5cf38972dc73d148. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/qnbs/WorldScript-Studio/pull/615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the Progressive Web App cache version so existing caches are refreshed during activation.

- **Documentation**
  - Added the v1.28.4 release entry with recent fixes and improvements.
  - Updated the README and contributor documentation to reference v1.28.4.
  - Refreshed the project roadmap with completed work and current priorities.

- **Release**
  - Synchronized the application version across supported desktop and web builds to v1.28.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->