### PR TITLE
feat(project): observe schema-version classification on IDB project load (#553 Slice B, 1/N)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2940_keys-0EA5E9" alt="i18n 19 locales — 2940 keys">
-  <img src="https://img.shields.io/badge/Tests-7494%2B_%2F_601_files-22C55E" alt="7494+ tests / 601 files">
+  <img src="https://img.shields.io/badge/Tests-7495%2B_%2F_601_files-22C55E" alt="7495+ tests / 601 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2940 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7494+ tests / 601 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7495+ tests / 601 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7494+ tests, 601 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7495+ tests, 601 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -711,7 +711,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-09-04, source-synchronized; CI remains authoritative for pass/fail):**
-- **7494+ unit tests** across **601 test files** — CI is authoritative for pass/fail
+- **7495+ unit tests** across **601 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2940 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2940_keys-0EA5E9" alt="i18n 19 locales — 2940 keys">
-  <img src="https://img.shields.io/badge/Tests-7477%2B_%2F_599_files-22C55E" alt="7477+ tests / 599 files">
+  <img src="https://img.shields.io/badge/Tests-7494%2B_%2F_601_files-22C55E" alt="7494+ tests / 601 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2940 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7477+ tests / 599 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7494+ tests / 601 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7477+ tests, 599 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7494+ tests, 601 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -711,7 +711,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-09-04, source-synchronized; CI remains authoritative for pass/fail):**
-- **7477+ unit tests** across **599 test files** — CI is authoritative for pass/fail
+- **7494+ unit tests** across **601 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2940 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2940_keys-0EA5E9" alt="i18n 19 locales — 2940 keys">
-  <img src="https://img.shields.io/badge/Tests-7494%2B_%2F_601_files-22C55E" alt="7494+ tests / 601 files">
+  <img src="https://img.shields.io/badge/Tests-7489%2B_%2F_601_files-22C55E" alt="7489+ tests / 601 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2940 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7494+ tests / 601 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7489+ tests / 601 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7494+ tests, 601 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7489+ tests, 601 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -711,7 +711,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-09-04, source-synchronized; CI remains authoritative for pass/fail):**
-- **7494+ unit tests** across **601 test files** — CI is authoritative for pass/fail
+- **7489+ unit tests** across **601 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2940 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2940_keys-0EA5E9" alt="i18n 19 locales — 2940 keys">
-  <img src="https://img.shields.io/badge/Tests-7489%2B_%2F_601_files-22C55E" alt="7489+ tests / 601 files">
+  <img src="https://img.shields.io/badge/Tests-7492%2B_%2F_601_files-22C55E" alt="7492+ tests / 601 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2940 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7489+ tests / 601 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7492+ tests / 601 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7489+ tests, 601 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7492+ tests, 601 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -711,7 +711,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-09-04, source-synchronized; CI remains authoritative for pass/fail):**
-- **7489+ unit tests** across **601 test files** — CI is authoritative for pass/fail
+- **7492+ unit tests** across **601 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2940 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2940_keys-0EA5E9" alt="i18n 19 locales — 2940 keys">
-  <img src="https://img.shields.io/badge/Tests-7493%2B_%2F_601_files-22C55E" alt="7493+ tests / 601 files">
+  <img src="https://img.shields.io/badge/Tests-7494%2B_%2F_601_files-22C55E" alt="7494+ tests / 601 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2940 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7493+ tests / 601 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7494+ tests / 601 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7493+ tests, 601 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7494+ tests, 601 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -711,7 +711,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-09-04, source-synchronized; CI remains authoritative for pass/fail):**
-- **7493+ unit tests** across **601 test files** — CI is authoritative for pass/fail
+- **7494+ unit tests** across **601 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2940 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2940_keys-0EA5E9" alt="i18n 19 locales — 2940 keys">
-  <img src="https://img.shields.io/badge/Tests-7492%2B_%2F_601_files-22C55E" alt="7492+ tests / 601 files">
+  <img src="https://img.shields.io/badge/Tests-7493%2B_%2F_601_files-22C55E" alt="7493+ tests / 601 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2940 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7492+ tests / 601 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7493+ tests / 601 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7492+ tests, 601 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7493+ tests, 601 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -711,7 +711,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 | `scorecard`  | weekly + `main` push | OpenSSF Scorecard — SARIF uploaded to GitHub Code Scanning |
 
 **Current test metrics (2026-09-04, source-synchronized; CI remains authoritative for pass/fail):**
-- **7492+ unit tests** across **601 test files** — CI is authoritative for pass/fail
+- **7493+ unit tests** across **601 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2940 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/features/project/projectSchemaVersion.ts
+++ b/features/project/projectSchemaVersion.ts
@@ -198,6 +198,7 @@ export function classifyRawProjectVersion(rawText: string): ProjectVersionClassi
  * function ever sees the value — so this only needs the same value-grammar and
  * version-comparison rules, not a raw-text scan.
  */
+// QNBS-v3: a second classifier variant is required because IDB ingress has no raw JSON text at all - reusing classifyRawProjectVersion here would need a wasteful re-serialize just to re-parse.
 export function classifyProjectVersionFromObject(value: unknown): ProjectVersionClassification {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) {
     return 'MALFORMED';

--- a/features/project/projectSchemaVersion.ts
+++ b/features/project/projectSchemaVersion.ts
@@ -186,4 +186,29 @@ export function classifyRawProjectVersion(rawText: string): ProjectVersionClassi
   return classifyVersionNumber(value);
 }
 
+/**
+ * Classifies an already-deserialized persisted-project object by its `schemaVersion`, for
+ * ingress paths that never have a raw JSON text representation to classify in the first place —
+ * contract section 2.8's universal ingress admission names IndexedDB explicitly, and IndexedDB
+ * stores/retrieves structured-clone JS objects directly (`IDBObjectStore.put`/`.get`), with no
+ * JSON serialization step anywhere in that path (verified against
+ * `services/storage/idbProjectStore.ts`). Unlike `classifyRawProjectVersion`, there is no
+ * duplicate-key or JSON-escape concern here: a JS object literal cannot carry two properties with
+ * the same key — structured clone, like `JSON.parse`, has already resolved that before this
+ * function ever sees the value — so this only needs the same value-grammar and
+ * version-comparison rules, not a raw-text scan.
+ */
+export function classifyProjectVersionFromObject(value: unknown): ProjectVersionClassification {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return 'MALFORMED';
+  }
+  const record = value as Record<string, unknown>;
+  if (!Object.hasOwn(record, 'schemaVersion')) return 'LEGACY_UNVERSIONED';
+
+  const versionValue = record['schemaVersion'];
+  if (!isValidSchemaVersionValue(versionValue)) return 'MALFORMED';
+
+  return classifyVersionNumber(versionValue);
+}
+
 // QNBS-v3: LEGACY_TO_V1 stamping (contract section 2.4's "verify" action) is deliberately not implemented here - a correct verify step needs the canonical MODEL_AND_VALIDATE projection (title/logline/author/characters/worlds/manuscript per section 2.1.1), which does not exist yet; a partial heuristic risked being relied on as if it proved V1 conformance. Deferred to the #553 slice that builds that projection.

--- a/features/project/projectSchemaVersion.ts
+++ b/features/project/projectSchemaVersion.ts
@@ -203,6 +203,11 @@ export function classifyProjectVersionFromObject(value: unknown): ProjectVersion
   if (typeof value !== 'object' || value === null || Array.isArray(value)) {
     return 'MALFORMED';
   }
+  // QNBS-v3: IDB can store non-record structured-clone values (Date, Map, typed arrays); only a plain object literal (or Object.create(null)) is a valid project-envelope shape.
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== null && prototype !== Object.prototype) {
+    return 'MALFORMED';
+  }
   const record = value as Record<string, unknown>;
   if (!Object.hasOwn(record, 'schemaVersion')) return 'LEGACY_UNVERSIONED';
 

--- a/features/project/projectSchemaVersionShadow.ts
+++ b/features/project/projectSchemaVersionShadow.ts
@@ -1,0 +1,66 @@
+import { logger } from '../../services/logger';
+import {
+  classifyProjectVersionFromObject,
+  classifyRawProjectVersion,
+  type ProjectVersionClassification,
+} from './projectSchemaVersion';
+
+/**
+ * Universal ingress admission (contract section 2.8), staged as observation-only — the first
+ * ingress caller wired to the classifiers built in Slice A. Matches this codebase's established
+ * shadow-validation pattern (`coreValidationShadow.ts`): classify and log, never alter load
+ * behavior, never throw. Actual admission gating (refusing `FUTURE`/`MALFORMED`, migrating
+ * `LEGACY_UNVERSIONED`) is deferred to the #553 slice that implements section 2.4's fail-closed
+ * mechanism and the `LEGACY_TO_V1` migration — this only proves the classifiers against real,
+ * live ingress data first.
+ */
+function logClassification(
+  classification: ProjectVersionClassification,
+  ingressPath: string,
+): void {
+  const level = classification === 'MALFORMED' || classification === 'FUTURE' ? 'warn' : 'debug';
+  logger[level]('project schema-version classification (observation-only)', {
+    classification,
+    ingressPath,
+  });
+}
+
+/**
+ * Observes an already-deserialized persisted-project object's schema-version classification
+ * (e.g. from IndexedDB, which has no raw JSON text to classify — see
+ * `classifyProjectVersionFromObject`'s own doc comment). Never throws; a classification failure
+ * is itself logged, not propagated, so this can never delay or alter the caller's load result.
+ */
+export function observeProjectVersionClassificationFromObject(
+  rawProjectData: unknown,
+  ingressPath: string,
+): void {
+  try {
+    logClassification(classifyProjectVersionFromObject(rawProjectData), ingressPath);
+  } catch (error) {
+    logger.warn('project schema-version classification observation failed', {
+      ingressPath,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/**
+ * Observes raw persisted-project JSON text's schema-version classification (e.g. from the
+ * filesystem/desktop backend, or a file/backup import, which do have raw text to classify — see
+ * `classifyRawProjectVersion`). Never throws; a classification failure is itself logged, not
+ * propagated.
+ */
+export function observeProjectVersionClassificationFromText(
+  rawText: string,
+  ingressPath: string,
+): void {
+  try {
+    logClassification(classifyRawProjectVersion(rawText), ingressPath);
+  } catch (error) {
+    logger.warn('project schema-version classification observation failed', {
+      ingressPath,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/features/project/projectSchemaVersionShadow.ts
+++ b/features/project/projectSchemaVersionShadow.ts
@@ -14,6 +14,7 @@ import {
  * mechanism and the `LEGACY_TO_V1` migration — this only proves the classifiers against real,
  * live ingress data first.
  */
+// QNBS-v3: MALFORMED/FUTURE log at warn since they represent a genuine data-integrity or newer-build signal worth surfacing, while every other classification is routine debug noise.
 function logClassification(
   classification: ProjectVersionClassification,
   ingressPath: string,

--- a/features/project/projectSchemaVersionShadow.ts
+++ b/features/project/projectSchemaVersionShadow.ts
@@ -5,6 +5,7 @@ import {
   type ProjectVersionClassification,
 } from './projectSchemaVersion';
 
+// QNBS-v3: new observer module for #553 Slice B - proves Slice A's classifiers against real ingress data before any admission gating exists.
 /**
  * Universal ingress admission (contract section 2.8), staged as observation-only — the first
  * ingress caller wired to the classifiers built in Slice A. Matches this codebase's established
@@ -14,12 +15,17 @@ import {
  * mechanism and the `LEGACY_TO_V1` migration — this only proves the classifiers against real,
  * live ingress data first.
  */
-// QNBS-v3: MALFORMED/FUTURE log at warn since they represent a genuine data-integrity or newer-build signal worth surfacing, while every other classification is routine debug noise.
+// QNBS-v3: MALFORMED/FUTURE/UNSUPPORTED_OLDER all grant no write authority per contract section 2.5 - each is worth surfacing at warn, unlike the routine debug-level classifications.
 function logClassification(
   classification: ProjectVersionClassification,
   ingressPath: string,
 ): void {
-  const level = classification === 'MALFORMED' || classification === 'FUTURE' ? 'warn' : 'debug';
+  const level =
+    classification === 'MALFORMED' ||
+    classification === 'FUTURE' ||
+    classification === 'UNSUPPORTED_OLDER'
+      ? 'warn'
+      : 'debug';
   logger[level]('project schema-version classification (observation-only)', {
     classification,
     ingressPath,

--- a/services/storage/idbProjectStore.ts
+++ b/services/storage/idbProjectStore.ts
@@ -5,6 +5,7 @@
  *          Phase 2 B-1: encrypt/decrypt on every saveSlice / loadState call when key is active.
  */
 
+import { observeProjectVersionClassificationFromObject } from '../../features/project/projectSchemaVersionShadow';
 import type { ProjectData } from '../../features/project/projectSlice';
 import { normalizeAccessibilitySettings } from '../../features/settings/accessibilitySchema';
 import { getDefaultKeyboardShortcuts } from '../../features/settings/keyboardShortcutsDefaults';
@@ -224,6 +225,8 @@ export class IdbProjectStore extends IdbAssetStore {
     if (validProject) {
       const rawData = validProject.present ? validProject.present.data : validProject.data;
       if (rawData) {
+        // QNBS-v3: observes the as-persisted shape before any default-backfilling below, per contract section 2.8's universal ingress admission (observation-only, Slice B).
+        observeProjectVersionClassificationFromObject(rawData, 'idb-project-load');
         // Ensure projectGoals exists
         if (!rawData.projectGoals) {
           rawData.projectGoals = { totalWordCount: 50000, targetDate: null };

--- a/services/storage/idbProjectStore.ts
+++ b/services/storage/idbProjectStore.ts
@@ -216,6 +216,23 @@ interface PersistedState {
 export class IdbProjectStore extends IdbAssetStore {
   // Helper to validate state structure and fix common issues
   private validateAndFixState(project: unknown, settings: unknown): PersistedState | undefined {
+    // QNBS-v3: project !== undefined (not truthiness) distinguishes an absent IDB record from a present-but-falsy one, so a corrupted top-level project record is observed instead of silently treated as absent.
+    if (project !== undefined) {
+      const projectRecord =
+        typeof project === 'object' && project !== null
+          ? (project as PersistedProjectState)
+          : undefined;
+      const observedRawData = projectRecord
+        ? projectRecord.present
+          ? projectRecord.present.data
+          : projectRecord.data
+        : undefined;
+      observeProjectVersionClassificationFromObject(
+        observedRawData === undefined ? project : observedRawData,
+        'idb-project-load',
+      );
+    }
+
     // If project is missing but we have settings, return partial to allow new user flow
     if (!project && !settings) return undefined;
 
@@ -224,11 +241,6 @@ export class IdbProjectStore extends IdbAssetStore {
     // Ensure Project Structure consistency
     if (validProject) {
       const rawData = validProject.present ? validProject.present.data : validProject.data;
-      // QNBS-v3: undefined (not merely falsy) means neither .present.data nor .data resolved at all, so only then fall back to the envelope - a persisted null/false payload must be observed as itself, per contract section 2.8's universal ingress admission (observation-only, Slice B).
-      observeProjectVersionClassificationFromObject(
-        rawData === undefined ? validProject : rawData,
-        'idb-project-load',
-      );
       if (rawData) {
         // Ensure projectGoals exists
         if (!rawData.projectGoals) {

--- a/services/storage/idbProjectStore.ts
+++ b/services/storage/idbProjectStore.ts
@@ -213,22 +213,27 @@ interface PersistedState {
   settings?: Settings;
 }
 
+// QNBS-v3: extracted so validateAndFixState's own branching stays low - this owns only the "what should be observed" selection for an already-known-present raw IDB project value.
+function selectIdbProjectObservationTarget(project: unknown): unknown {
+  const projectRecord =
+    typeof project === 'object' && project !== null
+      ? (project as PersistedProjectState)
+      : undefined;
+  const rawData = projectRecord
+    ? projectRecord.present
+      ? projectRecord.present.data
+      : projectRecord.data
+    : undefined;
+  return rawData === undefined ? project : rawData;
+}
+
 export class IdbProjectStore extends IdbAssetStore {
   // Helper to validate state structure and fix common issues
   private validateAndFixState(project: unknown, settings: unknown): PersistedState | undefined {
     // QNBS-v3: project !== undefined (not truthiness) distinguishes an absent IDB record from a present-but-falsy one, so a corrupted top-level project record is observed instead of silently treated as absent.
     if (project !== undefined) {
-      const projectRecord =
-        typeof project === 'object' && project !== null
-          ? (project as PersistedProjectState)
-          : undefined;
-      const observedRawData = projectRecord
-        ? projectRecord.present
-          ? projectRecord.present.data
-          : projectRecord.data
-        : undefined;
       observeProjectVersionClassificationFromObject(
-        observedRawData === undefined ? project : observedRawData,
+        selectIdbProjectObservationTarget(project),
         'idb-project-load',
       );
     }

--- a/services/storage/idbProjectStore.ts
+++ b/services/storage/idbProjectStore.ts
@@ -224,8 +224,11 @@ export class IdbProjectStore extends IdbAssetStore {
     // Ensure Project Structure consistency
     if (validProject) {
       const rawData = validProject.present ? validProject.present.data : validProject.data;
-      // QNBS-v3: falls back to the envelope itself so a flat/malformed present record (neither .present.data nor .data resolving) is still observed, not silently skipped, per contract section 2.8's universal ingress admission (observation-only, Slice B).
-      observeProjectVersionClassificationFromObject(rawData ?? validProject, 'idb-project-load');
+      // QNBS-v3: undefined (not merely falsy) means neither .present.data nor .data resolved at all, so only then fall back to the envelope - a persisted null/false payload must be observed as itself, per contract section 2.8's universal ingress admission (observation-only, Slice B).
+      observeProjectVersionClassificationFromObject(
+        rawData === undefined ? validProject : rawData,
+        'idb-project-load',
+      );
       if (rawData) {
         // Ensure projectGoals exists
         if (!rawData.projectGoals) {

--- a/services/storage/idbProjectStore.ts
+++ b/services/storage/idbProjectStore.ts
@@ -219,6 +219,10 @@ function selectIdbProjectObservationTarget(project: unknown): unknown {
     typeof project === 'object' && project !== null
       ? (project as PersistedProjectState)
       : undefined;
+  // QNBS-v3: a record with its own schemaVersion is self-describing - classify it directly, before guessing it's a Redux envelope, so a flat FUTURE/CURRENT document that also happens to carry a data/present field is never misread via that field instead of its own header.
+  if (projectRecord && Object.hasOwn(projectRecord, 'schemaVersion')) {
+    return projectRecord;
+  }
   const rawData = projectRecord
     ? projectRecord.present
       ? projectRecord.present.data

--- a/services/storage/idbProjectStore.ts
+++ b/services/storage/idbProjectStore.ts
@@ -224,9 +224,9 @@ export class IdbProjectStore extends IdbAssetStore {
     // Ensure Project Structure consistency
     if (validProject) {
       const rawData = validProject.present ? validProject.present.data : validProject.data;
+      // QNBS-v3: falls back to the envelope itself so a flat/malformed present record (neither .present.data nor .data resolving) is still observed, not silently skipped, per contract section 2.8's universal ingress admission (observation-only, Slice B).
+      observeProjectVersionClassificationFromObject(rawData ?? validProject, 'idb-project-load');
       if (rawData) {
-        // QNBS-v3: observes the as-persisted shape before any default-backfilling below, per contract section 2.8's universal ingress admission (observation-only, Slice B).
-        observeProjectVersionClassificationFromObject(rawData, 'idb-project-load');
         // Ensure projectGoals exists
         if (!rawData.projectGoals) {
           rawData.projectGoals = { totalWordCount: 50000, targetDate: null };

--- a/tests/unit/features/project/projectSchemaVersion.test.ts
+++ b/tests/unit/features/project/projectSchemaVersion.test.ts
@@ -222,6 +222,19 @@ describe('classifyProjectVersionFromObject', () => {
     expect(classifyProjectVersionFromObject(undefined)).toBe('MALFORMED');
   });
 
+  it('classifies non-record structured-clone values (Date, Map, typed array) as MALFORMED', () => {
+    // QNBS-v3: IDB can store these directly; none is a valid project-envelope shape even though typeof is 'object'.
+    expect(classifyProjectVersionFromObject(new Date())).toBe('MALFORMED');
+    expect(classifyProjectVersionFromObject(new Map())).toBe('MALFORMED');
+    expect(classifyProjectVersionFromObject(new Uint8Array(4))).toBe('MALFORMED');
+  });
+
+  it('accepts a null-prototype plain object', () => {
+    const record = Object.create(null) as Record<string, unknown>;
+    record['schemaVersion'] = CURRENT_PROJECT_SCHEMA_VERSION;
+    expect(classifyProjectVersionFromObject(record)).toBe('CURRENT');
+  });
+
   it('does not misclassify a nested field also named schemaVersion', () => {
     expect(
       classifyProjectVersionFromObject({

--- a/tests/unit/features/project/projectSchemaVersion.test.ts
+++ b/tests/unit/features/project/projectSchemaVersion.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   CURRENT_PROJECT_SCHEMA_VERSION,
+  classifyProjectVersionFromObject,
   classifyRawProjectVersion,
 } from '../../../../features/project/projectSchemaVersion';
 
@@ -158,5 +159,74 @@ describe('classifyRawProjectVersion', () => {
     const depth = 256;
     const raw = `{"schemaVersion": ${CURRENT_PROJECT_SCHEMA_VERSION + 1}, "unrelated": ${'['.repeat(depth)}01${']'.repeat(depth)}}`;
     expect(classifyRawProjectVersion(raw)).toBe('MALFORMED');
+  });
+});
+
+describe('classifyProjectVersionFromObject', () => {
+  it('classifies an absent schemaVersion as LEGACY_UNVERSIONED', () => {
+    expect(classifyProjectVersionFromObject({ title: 'Old Project' })).toBe('LEGACY_UNVERSIONED');
+  });
+
+  it('classifies the current version as CURRENT', () => {
+    expect(
+      classifyProjectVersionFromObject({ schemaVersion: CURRENT_PROJECT_SCHEMA_VERSION }),
+    ).toBe('CURRENT');
+  });
+
+  it('classifies a higher version as FUTURE', () => {
+    expect(
+      classifyProjectVersionFromObject({ schemaVersion: CURRENT_PROJECT_SCHEMA_VERSION + 1 }),
+    ).toBe('FUTURE');
+  });
+
+  it('classifies an unregistered lower version as UNSUPPORTED_OLDER', () => {
+    expect(classifyProjectVersionFromObject({ schemaVersion: 0 })).toBe('UNSUPPORTED_OLDER');
+  });
+
+  it.each([
+    ['a string', '1'],
+    ['null', null],
+    ['a fractional number', 1.5],
+    ['a negative number', -1],
+    ['a boolean', true],
+  ])('classifies a present but invalid schemaVersion (%s) as MALFORMED', (_label, value) => {
+    expect(classifyProjectVersionFromObject({ schemaVersion: value })).toBe('MALFORMED');
+  });
+
+  it('treats a schemaVersion inherited only via a polluted Object.prototype as genuinely absent', () => {
+    Object.defineProperty(Object.prototype, 'schemaVersion', {
+      value: CURRENT_PROJECT_SCHEMA_VERSION,
+      configurable: true,
+      enumerable: false,
+      writable: true,
+    });
+    try {
+      expect(classifyProjectVersionFromObject({ title: 'Old Project' })).toBe('LEGACY_UNVERSIONED');
+    } finally {
+      delete (Object.prototype as Record<string, unknown>)['schemaVersion'];
+    }
+  });
+
+  it('classifies null as MALFORMED', () => {
+    expect(classifyProjectVersionFromObject(null)).toBe('MALFORMED');
+  });
+
+  it('classifies an array as MALFORMED', () => {
+    expect(classifyProjectVersionFromObject([1, 2, 3])).toBe('MALFORMED');
+  });
+
+  it('classifies a primitive as MALFORMED', () => {
+    expect(classifyProjectVersionFromObject('just a string')).toBe('MALFORMED');
+    expect(classifyProjectVersionFromObject(42)).toBe('MALFORMED');
+    expect(classifyProjectVersionFromObject(undefined)).toBe('MALFORMED');
+  });
+
+  it('does not misclassify a nested field also named schemaVersion', () => {
+    expect(
+      classifyProjectVersionFromObject({
+        schemaVersion: CURRENT_PROJECT_SCHEMA_VERSION,
+        nested: { schemaVersion: 999 },
+      }),
+    ).toBe('CURRENT');
   });
 });

--- a/tests/unit/features/project/projectSchemaVersion.test.ts
+++ b/tests/unit/features/project/projectSchemaVersion.test.ts
@@ -162,6 +162,7 @@ describe('classifyRawProjectVersion', () => {
   });
 });
 
+// QNBS-v3: covers the object-ingress classifier's own contract (no duplicate-key/escape concerns, same value-grammar/version rules) - distinct from classifyRawProjectVersion's text-based suite above.
 describe('classifyProjectVersionFromObject', () => {
   it('classifies an absent schemaVersion as LEGACY_UNVERSIONED', () => {
     expect(classifyProjectVersionFromObject({ title: 'Old Project' })).toBe('LEGACY_UNVERSIONED');

--- a/tests/unit/features/project/projectSchemaVersionShadow.test.ts
+++ b/tests/unit/features/project/projectSchemaVersionShadow.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CURRENT_PROJECT_SCHEMA_VERSION } from '../../../../features/project/projectSchemaVersion';
 
 const h = vi.hoisted(() => ({
   debug: vi.fn(),
@@ -31,6 +32,7 @@ describe('observeProjectVersionClassificationFromObject', () => {
     ['LEGACY_UNVERSIONED', { title: 'Old Project' }, 'debug'],
     ['MALFORMED', { schemaVersion: 'not-a-number' }, 'warn'],
     ['FUTURE', { schemaVersion: 999 }, 'warn'],
+    ['UNSUPPORTED_OLDER', { schemaVersion: 0 }, 'warn'],
   ] as const)('logs %s at %s level', (classification, input, level) => {
     observeProjectVersionClassificationFromObject(input, 'idb-load');
 
@@ -62,7 +64,7 @@ describe('observeProjectVersionClassificationFromObject', () => {
 
 describe('observeProjectVersionClassificationFromText', () => {
   it.each([
-    ['CURRENT', '{"schemaVersion": 1}', 'debug'],
+    ['CURRENT', `{"schemaVersion": ${CURRENT_PROJECT_SCHEMA_VERSION}}`, 'debug'],
     ['MALFORMED', '{not valid json', 'warn'],
   ] as const)('logs %s at %s level', (classification, rawText, level) => {
     observeProjectVersionClassificationFromText(rawText, 'filesystem-load');

--- a/tests/unit/features/project/projectSchemaVersionShadow.test.ts
+++ b/tests/unit/features/project/projectSchemaVersionShadow.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment node
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  debug: vi.fn(),
+  warn: vi.fn(),
+}));
+
+vi.mock('../../../../services/logger', () => ({
+  logger: { debug: h.debug, warn: h.warn },
+}));
+
+import {
+  observeProjectVersionClassificationFromObject,
+  observeProjectVersionClassificationFromText,
+} from '../../../../features/project/projectSchemaVersionShadow';
+
+beforeEach(() => {
+  h.debug.mockReset();
+  h.warn.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('observeProjectVersionClassificationFromObject', () => {
+  it('logs LEGACY_UNVERSIONED at debug level', () => {
+    observeProjectVersionClassificationFromObject({ title: 'Old Project' }, 'idb-load');
+
+    expect(h.debug).toHaveBeenCalledWith(
+      'project schema-version classification (observation-only)',
+      {
+        classification: 'LEGACY_UNVERSIONED',
+        ingressPath: 'idb-load',
+      },
+    );
+    expect(h.warn).not.toHaveBeenCalled();
+  });
+
+  it('logs MALFORMED at warn level', () => {
+    observeProjectVersionClassificationFromObject({ schemaVersion: 'not-a-number' }, 'idb-load');
+
+    expect(h.warn).toHaveBeenCalledWith(
+      'project schema-version classification (observation-only)',
+      {
+        classification: 'MALFORMED',
+        ingressPath: 'idb-load',
+      },
+    );
+    expect(h.debug).not.toHaveBeenCalled();
+  });
+
+  it('logs FUTURE at warn level', () => {
+    observeProjectVersionClassificationFromObject({ schemaVersion: 999 }, 'idb-load');
+
+    expect(h.warn).toHaveBeenCalledWith(
+      'project schema-version classification (observation-only)',
+      {
+        classification: 'FUTURE',
+        ingressPath: 'idb-load',
+      },
+    );
+  });
+
+  it('never throws, logging the observation failure instead', () => {
+    // QNBS-v3: proves a classifier exception can never propagate into the caller's load path.
+    const poisoned = {
+      get schemaVersion(): never {
+        throw new Error('boom');
+      },
+    };
+    expect(() => observeProjectVersionClassificationFromObject(poisoned, 'idb-load')).not.toThrow();
+    expect(h.warn).toHaveBeenCalledWith(
+      'project schema-version classification observation failed',
+      {
+        ingressPath: 'idb-load',
+        error: 'boom',
+      },
+    );
+  });
+});
+
+describe('observeProjectVersionClassificationFromText', () => {
+  it('logs CURRENT at debug level', () => {
+    observeProjectVersionClassificationFromText('{"schemaVersion": 1}', 'filesystem-load');
+
+    expect(h.debug).toHaveBeenCalledWith(
+      'project schema-version classification (observation-only)',
+      {
+        classification: 'CURRENT',
+        ingressPath: 'filesystem-load',
+      },
+    );
+  });
+
+  it('logs MALFORMED at warn level for unparseable text', () => {
+    observeProjectVersionClassificationFromText('{not valid json', 'filesystem-load');
+
+    expect(h.warn).toHaveBeenCalledWith(
+      'project schema-version classification (observation-only)',
+      {
+        classification: 'MALFORMED',
+        ingressPath: 'filesystem-load',
+      },
+    );
+  });
+});

--- a/tests/unit/features/project/projectSchemaVersionShadow.test.ts
+++ b/tests/unit/features/project/projectSchemaVersionShadow.test.ts
@@ -25,6 +25,7 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+// QNBS-v3: proves the observer never alters caller-visible behavior (log level per classification, exceptions contained) - the actual admission-gating contract is deferred, so only logging is under test here.
 describe('observeProjectVersionClassificationFromObject', () => {
   it.each([
     ['LEGACY_UNVERSIONED', { title: 'Old Project' }, 'debug'],

--- a/tests/unit/features/project/projectSchemaVersionShadow.test.ts
+++ b/tests/unit/features/project/projectSchemaVersionShadow.test.ts
@@ -26,42 +26,19 @@ afterEach(() => {
 });
 
 describe('observeProjectVersionClassificationFromObject', () => {
-  it('logs LEGACY_UNVERSIONED at debug level', () => {
-    observeProjectVersionClassificationFromObject({ title: 'Old Project' }, 'idb-load');
+  it.each([
+    ['LEGACY_UNVERSIONED', { title: 'Old Project' }, 'debug'],
+    ['MALFORMED', { schemaVersion: 'not-a-number' }, 'warn'],
+    ['FUTURE', { schemaVersion: 999 }, 'warn'],
+  ] as const)('logs %s at %s level', (classification, input, level) => {
+    observeProjectVersionClassificationFromObject(input, 'idb-load');
 
-    expect(h.debug).toHaveBeenCalledWith(
+    expect(h[level]).toHaveBeenCalledWith(
       'project schema-version classification (observation-only)',
-      {
-        classification: 'LEGACY_UNVERSIONED',
-        ingressPath: 'idb-load',
-      },
+      { classification, ingressPath: 'idb-load' },
     );
-    expect(h.warn).not.toHaveBeenCalled();
-  });
-
-  it('logs MALFORMED at warn level', () => {
-    observeProjectVersionClassificationFromObject({ schemaVersion: 'not-a-number' }, 'idb-load');
-
-    expect(h.warn).toHaveBeenCalledWith(
-      'project schema-version classification (observation-only)',
-      {
-        classification: 'MALFORMED',
-        ingressPath: 'idb-load',
-      },
-    );
-    expect(h.debug).not.toHaveBeenCalled();
-  });
-
-  it('logs FUTURE at warn level', () => {
-    observeProjectVersionClassificationFromObject({ schemaVersion: 999 }, 'idb-load');
-
-    expect(h.warn).toHaveBeenCalledWith(
-      'project schema-version classification (observation-only)',
-      {
-        classification: 'FUTURE',
-        ingressPath: 'idb-load',
-      },
-    );
+    const otherLevel = level === 'debug' ? 'warn' : 'debug';
+    expect(h[otherLevel]).not.toHaveBeenCalled();
   });
 
   it('never throws, logging the observation failure instead', () => {
@@ -83,27 +60,15 @@ describe('observeProjectVersionClassificationFromObject', () => {
 });
 
 describe('observeProjectVersionClassificationFromText', () => {
-  it('logs CURRENT at debug level', () => {
-    observeProjectVersionClassificationFromText('{"schemaVersion": 1}', 'filesystem-load');
+  it.each([
+    ['CURRENT', '{"schemaVersion": 1}', 'debug'],
+    ['MALFORMED', '{not valid json', 'warn'],
+  ] as const)('logs %s at %s level', (classification, rawText, level) => {
+    observeProjectVersionClassificationFromText(rawText, 'filesystem-load');
 
-    expect(h.debug).toHaveBeenCalledWith(
+    expect(h[level]).toHaveBeenCalledWith(
       'project schema-version classification (observation-only)',
-      {
-        classification: 'CURRENT',
-        ingressPath: 'filesystem-load',
-      },
-    );
-  });
-
-  it('logs MALFORMED at warn level for unparseable text', () => {
-    observeProjectVersionClassificationFromText('{not valid json', 'filesystem-load');
-
-    expect(h.warn).toHaveBeenCalledWith(
-      'project schema-version classification (observation-only)',
-      {
-        classification: 'MALFORMED',
-        ingressPath: 'filesystem-load',
-      },
+      { classification, ingressPath: 'filesystem-load' },
     );
   });
 });

--- a/tests/unit/services/storage/idbProjectStoreLoadStateObservation.test.ts
+++ b/tests/unit/services/storage/idbProjectStoreLoadStateObservation.test.ts
@@ -118,6 +118,26 @@ describe('IdbProjectStore#loadState — universal ingress admission observation'
     expect(h.observe).toHaveBeenCalledWith(null, 'idb-project-load');
   });
 
+  it('observes a top-level falsy-but-present project record as itself', async () => {
+    // QNBS-v3: project !== undefined (not truthiness) gates this - a corrupted top-level null/false record is a real classification target, distinct from an absent IDB record (undefined), even though both trigger the same "no project to load" early return below.
+    const projectStore = new IdbProjectStore();
+    const { store, projectRequest, settingsRequest } = makeFakeStore(null, undefined);
+    vi.spyOn(
+      projectStore as unknown as { getObjectStore: () => Promise<unknown> },
+      'getObjectStore',
+    ).mockResolvedValue(store as never);
+
+    const loadPromise = projectStore.loadState();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    projectRequest.onsuccess?.();
+    settingsRequest.onsuccess?.();
+    const result = await loadPromise;
+
+    expect(h.observe).toHaveBeenCalledTimes(1);
+    expect(h.observe).toHaveBeenCalledWith(null, 'idb-project-load');
+    expect(result).toBeUndefined();
+  });
+
   it('does not observe when no project is persisted', async () => {
     const projectStore = new IdbProjectStore();
     const { store, projectRequest, settingsRequest } = makeFakeStore(undefined, { theme: 'dark' });

--- a/tests/unit/services/storage/idbProjectStoreLoadStateObservation.test.ts
+++ b/tests/unit/services/storage/idbProjectStoreLoadStateObservation.test.ts
@@ -98,6 +98,26 @@ describe('IdbProjectStore#loadState — universal ingress admission observation'
     expect(h.observe).toHaveBeenCalledWith(flatPayload, 'idb-project-load');
   });
 
+  it('observes an explicit null payload as itself, not the outer envelope', async () => {
+    // QNBS-v3: a persisted null/false payload is a real (malformed) classification target - falling back to the envelope on any falsy value would misreport it as the envelope's own LEGACY_UNVERSIONED shape instead of MALFORMED.
+    const projectStore = new IdbProjectStore();
+    const envelope = { data: null };
+    const { store, projectRequest, settingsRequest } = makeFakeStore(envelope, undefined);
+    vi.spyOn(
+      projectStore as unknown as { getObjectStore: () => Promise<unknown> },
+      'getObjectStore',
+    ).mockResolvedValue(store as never);
+
+    const loadPromise = projectStore.loadState();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    projectRequest.onsuccess?.();
+    settingsRequest.onsuccess?.();
+    await loadPromise;
+
+    expect(h.observe).toHaveBeenCalledTimes(1);
+    expect(h.observe).toHaveBeenCalledWith(null, 'idb-project-load');
+  });
+
   it('does not observe when no project is persisted', async () => {
     const projectStore = new IdbProjectStore();
     const { store, projectRequest, settingsRequest } = makeFakeStore(undefined, { theme: 'dark' });

--- a/tests/unit/services/storage/idbProjectStoreLoadStateObservation.test.ts
+++ b/tests/unit/services/storage/idbProjectStoreLoadStateObservation.test.ts
@@ -138,6 +138,26 @@ describe('IdbProjectStore#loadState — universal ingress admission observation'
     expect(result).toBeUndefined();
   });
 
+  it('classifies a flat record with its own schemaVersion directly, not via a coincidental data field', async () => {
+    // QNBS-v3: a top-level schemaVersion is self-describing and must win over the envelope-unwrap heuristic - otherwise a FUTURE document with an unrelated truthy data/present field gets misread as LEGACY_UNVERSIONED via that field instead of its own header.
+    const projectStore = new IdbProjectStore();
+    const futureFlatRecord = { schemaVersion: 999, data: {} };
+    const { store, projectRequest, settingsRequest } = makeFakeStore(futureFlatRecord, undefined);
+    vi.spyOn(
+      projectStore as unknown as { getObjectStore: () => Promise<unknown> },
+      'getObjectStore',
+    ).mockResolvedValue(store as never);
+
+    const loadPromise = projectStore.loadState();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    projectRequest.onsuccess?.();
+    settingsRequest.onsuccess?.();
+    await loadPromise;
+
+    expect(h.observe).toHaveBeenCalledTimes(1);
+    expect(h.observe).toHaveBeenCalledWith(futureFlatRecord, 'idb-project-load');
+  });
+
   it('does not observe when no project is persisted', async () => {
     const projectStore = new IdbProjectStore();
     const { store, projectRequest, settingsRequest } = makeFakeStore(undefined, { theme: 'dark' });

--- a/tests/unit/services/storage/idbProjectStoreLoadStateObservation.test.ts
+++ b/tests/unit/services/storage/idbProjectStoreLoadStateObservation.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests IdbProjectStore#loadState wires the as-persisted project object through
+ * observeProjectVersionClassificationFromObject (contract section 2.8's universal ingress
+ * admission, Slice B) before any default-backfilling in validateAndFixState runs.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  observe: vi.fn(),
+}));
+
+vi.mock('../../../../features/project/projectSchemaVersionShadow', () => ({
+  observeProjectVersionClassificationFromObject: h.observe,
+}));
+
+vi.mock('../../../../services/storage/storageEncryptionService', () => ({
+  resolveProtectedWriteKey: vi.fn().mockResolvedValue(null),
+  assertNoActiveEncryptionMigration: vi.fn().mockResolvedValue(undefined),
+  idbEncryptWithKey: vi.fn(),
+  idbReadSecure: vi.fn(async (raw: unknown) => raw),
+  assertIdbProtectedWriteAllowed: vi.fn().mockResolvedValue(undefined),
+  assertSecureStorageReadable: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { IdbProjectStore } from '../../../../services/storage/idbProjectStore';
+
+interface FakeIdbRequest {
+  result: unknown;
+  onsuccess: (() => void) | null;
+  onerror: (() => void) | null;
+  error: unknown;
+}
+
+function makeFakeRequest(result: unknown): FakeIdbRequest {
+  return { result, onsuccess: null, onerror: null, error: null };
+}
+
+function makeFakeStore(projectResult: unknown, settingsResult: unknown) {
+  const projectRequest = makeFakeRequest(projectResult);
+  const settingsRequest = makeFakeRequest(settingsResult);
+  const store = {
+    get: (key: string) => (key === 'project' ? projectRequest : settingsRequest),
+  };
+  return { store, projectRequest, settingsRequest };
+}
+
+beforeEach(() => {
+  h.observe.mockReset();
+});
+
+describe('IdbProjectStore#loadState — universal ingress admission observation', () => {
+  it('observes the as-persisted project data before default-backfilling', async () => {
+    const projectStore = new IdbProjectStore();
+    const persistedData = { title: 'Old Project', manuscript: [] };
+    // QNBS-v3: captures a snapshot at call time - persistedData is mutated in-place by the backfill logic afterward, so asserting against the live reference later would see the post-backfill state instead.
+    let observedSnapshot: unknown;
+    h.observe.mockImplementation((data: unknown) => {
+      observedSnapshot = JSON.parse(JSON.stringify(data));
+    });
+    const { store, projectRequest, settingsRequest } = makeFakeStore(
+      { data: persistedData },
+      undefined,
+    );
+    vi.spyOn(
+      projectStore as unknown as { getObjectStore: () => Promise<unknown> },
+      'getObjectStore',
+    ).mockResolvedValue(store as never);
+
+    const loadPromise = projectStore.loadState();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    projectRequest.onsuccess?.();
+    settingsRequest.onsuccess?.();
+    const result = await loadPromise;
+
+    expect(h.observe).toHaveBeenCalledTimes(1);
+    expect(h.observe).toHaveBeenCalledWith(persistedData, 'idb-project-load');
+    expect(observedSnapshot).not.toHaveProperty('projectGoals');
+    expect(result?.project?.data).toHaveProperty('projectGoals');
+  });
+
+  it('does not observe when no project is persisted', async () => {
+    const projectStore = new IdbProjectStore();
+    const { store, projectRequest, settingsRequest } = makeFakeStore(undefined, { theme: 'dark' });
+    vi.spyOn(
+      projectStore as unknown as { getObjectStore: () => Promise<unknown> },
+      'getObjectStore',
+    ).mockResolvedValue(store as never);
+
+    const loadPromise = projectStore.loadState();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    projectRequest.onsuccess?.();
+    settingsRequest.onsuccess?.();
+    await loadPromise;
+
+    expect(h.observe).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/services/storage/idbProjectStoreLoadStateObservation.test.ts
+++ b/tests/unit/services/storage/idbProjectStoreLoadStateObservation.test.ts
@@ -78,6 +78,26 @@ describe('IdbProjectStore#loadState — universal ingress admission observation'
     expect(result?.project?.data).toHaveProperty('projectGoals');
   });
 
+  it('observes a flat/malformed present record by falling back to the envelope itself', async () => {
+    // QNBS-v3: neither .present.data nor .data resolves here (a flat/corrupt payload) - the observation must not be silently skipped for a present-but-unusual record.
+    const projectStore = new IdbProjectStore();
+    const flatPayload = { title: 'Flat legacy shape', manuscript: [] };
+    const { store, projectRequest, settingsRequest } = makeFakeStore(flatPayload, undefined);
+    vi.spyOn(
+      projectStore as unknown as { getObjectStore: () => Promise<unknown> },
+      'getObjectStore',
+    ).mockResolvedValue(store as never);
+
+    const loadPromise = projectStore.loadState();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    projectRequest.onsuccess?.();
+    settingsRequest.onsuccess?.();
+    await loadPromise;
+
+    expect(h.observe).toHaveBeenCalledTimes(1);
+    expect(h.observe).toHaveBeenCalledWith(flatPayload, 'idb-project-load');
+  });
+
   it('does not observe when no project is persisted', async () => {
     const projectStore = new IdbProjectStore();
     const { store, projectRequest, settingsRequest } = makeFakeStore(undefined, { theme: 'dark' });


### PR DESCRIPTION
## **User description**
## Summary

First ingress path of Slice B, wired to the classifiers built in Slice A (#618), per the admitted contract's §2.8 universal ingress admission requirement.

- **`classifyProjectVersionFromObject`** (new, `features/project/projectSchemaVersion.ts`) — a second classifier variant for ingress paths with no raw JSON text to begin with. Verified against live source: IndexedDB stores/retrieves structured-clone JS objects directly (`IDBObjectStore.put`/`.get`), never a JSON string — `classifyRawProjectVersion`'s raw-text scanning (duplicate-key detection, escape validation) doesn't apply here, and a JS object literal cannot carry duplicate keys in the first place.
- **`projectSchemaVersionShadow.ts`** (new) — the observation wrapper, matching this codebase's established Core shadow-validation pattern (`coreValidationShadow.ts`): classify and log via `services/logger.ts`, never alter load behavior, never throw. Covers both the new object-based classifier and Slice A's text-based one (for the remaining ingress paths in this slice).
- Wired into `IdbProjectStore#loadState` (via `validateAndFixState`), observing the as-persisted project data before any default-backfilling runs.

**Deliberately observation-only, not enforcing:** actual admission gating (refusing `FUTURE`/`MALFORMED`, migrating `LEGACY_UNVERSIONED`) is deferred to the slice that implements §2.4's fail-closed mechanism and the `LEGACY_TO_V1` migration. Every real, existing project has no `schemaVersion` field today — enforcing that migration now, before it exists, would immediately reclassify every user's every project on next load. This PR only proves the classifier against real, live ingress data first.

**Remaining ingress paths** (filesystem load, IDB snapshot restore, backup import, recovery restore) are separate, subsequent Slice B commits/PRs — one causal path at a time.

## Test plan
- [x] `pnpm exec vitest run tests/unit/features/project/projectSchemaVersion.test.ts` — 40/40 passing
- [x] `pnpm exec vitest run tests/unit/features/project/projectSchemaVersionShadow.test.ts` — 6/6 passing
- [x] `pnpm exec vitest run tests/unit/services/storage/idbProjectStoreLoadStateObservation.test.ts` — 2/2 passing (verifies observation fires before default-backfilling, and does not fire when no project is persisted)
- [x] `pnpm run ci:prepush` — local admission gate PASS
- [ ] CI: exact-head required + advisory checks green
- [ ] CI: CodeQL SUCCESS

## Summary by Sourcery

Observe project schema compatibility during IndexedDB loads without changing existing project loading behavior.

New Features:
- Add object-based project schema-version classification for structured-clone persistence data.
- Add observation-only schema-version logging for project ingress paths, including IndexedDB loads.

Bug Fixes:
- Ensure malformed, falsy, and unusual persisted project records are observed without interrupting loading, while absent records remain ignored.

Enhancements:
- Classify persisted IndexedDB project data before default backfilling and surface incompatible versions at warning level without changing admission or load behavior.

Documentation:
- Update documented test counts to reflect the added coverage.

Tests:
- Add coverage for object-based classification, observation behavior, error containment, and IndexedDB load ordering and edge cases.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds observation-only schema-version classification to IndexedDB project loads, so schema compatibility issues are logged before any default-backfilling runs. Previously no classification happened on load; load behavior is unchanged and observation never throws.

- New `classifyProjectVersionFromObject` classifies structured-clone objects (IndexedDB has no raw JSON text), rejecting non-record clones like `Date` and typed arrays.
- Observation is gated on the record being present (`project !== undefined`), not truthy, so corrupted falsy records are still observed; `MALFORMED`, `FUTURE`, and `UNSUPPORTED_OLDER` log at warn, the rest at debug.
- A record carrying its own top-level `schemaVersion` is classified directly, before the envelope-unwrap heuristic, so a flat `FUTURE` record with an unrelated `data` field isn't misread as `LEGACY_UNVERSIONED`.
- Enforcing admission (refusing `FUTURE`/`MALFORMED`, migrating `LEGACY_UNVERSIONED`) is deferred; every existing project lacks `schemaVersion` today.
- Remaining ingress paths (filesystem load, backup import, snapshot restore) are separate follow-up PRs.

<sup>Written for commit 5871fdd3905c11e68f9a272faf6ddd11d12e394c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/qnbs/WorldScript-Studio/pull/619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved project schema-version detection during project loading, including malformed, unsupported, future, legacy, and missing-version data.
  * Added diagnostic logging for compatibility issues without interrupting normal loading or default handling.
  * Extended detection to cover persisted project records in varied or malformed states.

* **Documentation**
  * Updated README test metrics to reflect 7,494+ tests across 601 files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Observe project schema versions during IndexedDB loads without changing load behavior

### What Changed
- IndexedDB project loads now classify the persisted project data before default fields are added.
- Invalid, future, or unsupported schema versions are logged as warnings; normal and legacy projects are logged for observation.
- Corrupt, null, falsy, and unusual persisted records are still observed, while missing project records are ignored.
- Schema classification failures are contained and cannot interrupt project loading.
- Added coverage for object-based schema classification and IndexedDB observation behavior.

### Impact
`✅ Earlier visibility into incompatible project data`
`✅ Project loads continue when observation encounters malformed data`
`✅ Clearer warnings for unsupported schema versions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>