### PR TITLE
fix(i18n): add unsupported-project startup copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <img src="https://img.shields.io/badge/Release-v1.28.4-6366F1" alt="Release v1.28.4">
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
-  <img src="https://img.shields.io/badge/i18n-19_locales-2940_keys-0EA5E9" alt="i18n 19 locales — 2940 keys">
+  <img src="https://img.shields.io/badge/i18n-19_locales-2941_keys-0EA5E9" alt="i18n 19 locales — 2941 keys">
   <img src="https://img.shields.io/badge/Tests-7512%2B_%2F_602_files-22C55E" alt="7512+ tests / 602 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
@@ -401,7 +401,7 @@ Infrastructure-level features that keep the app fast and extensible as projects 
 
 ### 🌐 Full Multi-Language Support
 
-Shipped UI locales with **2940 i18n keys** across all 19 languages — zero hardcoded user-facing strings:
+Shipped UI locales with **2941 i18n keys** across all 19 languages — zero hardcoded user-facing strings:
 
 - 🇩🇪 **German** (Deutsch)
 - 🇬🇧 **English**
@@ -510,7 +510,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **PDF Export**       | jsPDF                                                     | Client-side, configurable PDF document generation                    |
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
-| **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2940 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
+| **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2941 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
 | **Testing**          | Vitest 4.x (7512+ tests / 602 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
@@ -716,7 +716,7 @@ Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendo
 **Current test metrics (2026-09-06, source-synchronized; CI remains authoritative for pass/fail):**
 - **7512+ unit tests** across **602 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
-- i18n: **2940 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
+- i18n: **2941 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 
 **CI-cloud-first workflow (recommended):** On constrained hardware run **`pnpm run lint && pnpm run i18n:check && pnpm run typecheck`** locally, then push and let CI handle coverage, E2E, Lighthouse, and Stryker. Authoritative numbers come from CI artifacts (Codecov, JUnit). After CI goes green, update the README badges and `AUDIT.md` quality-gate line from the reported metrics. See **[`docs/CI.md`](docs/CI.md) § Cloud CI-first vs local development** for the full post-merge doc-update checklist.
 

--- a/locales/ar/common.json
+++ b/locales/ar/common.json
@@ -700,6 +700,7 @@
   "error.startup.storageUnavailable": "Local storage could not be opened. Reload and try again.",
   "error.startup.projectUnavailable": "A local project could not be opened. Reload and try again.",
   "error.startup.projectIoUnavailable": "The project could not currently be read because of a storage or file-access problem. It has not been classified as corrupt or changed. Check the storage device and file permissions, then retry.",
+  "error.startup.projectUnsupported": "This project uses a schema version this build cannot edit. The original file has not been changed. Upgrade WorldScript Studio or open it with a compatible build.",
   "error.startup.reload": "Reload",
   "error.startup.retry": "Retry",
   "error.startup.recover": "Quarantine project and reload",

--- a/locales/de/common.json
+++ b/locales/de/common.json
@@ -700,6 +700,7 @@
   "error.startup.storageUnavailable": "Der lokale Speicher konnte nicht geöffnet werden. Laden Sie die Anwendung neu und versuchen Sie es erneut.",
   "error.startup.projectUnavailable": "Ein lokales Projekt konnte nicht geöffnet werden. Laden Sie die Anwendung neu und versuchen Sie es erneut.",
   "error.startup.projectIoUnavailable": "Das Projekt konnte derzeit aufgrund eines Speicher- oder Dateizugriffsproblems nicht gelesen werden. Es wurde nicht als beschädigt oder verändert eingestuft. Prüfen Sie die Verfügbarkeit des Speichers und die Dateiberechtigungen und versuchen Sie es erneut.",
+  "error.startup.projectUnsupported": "Dieses Projekt verwendet eine Schema-Version, die dieser Build nicht bearbeiten kann. Die Originaldatei wurde nicht verändert. Aktualisieren Sie WorldScript Studio oder öffnen Sie das Projekt mit einem kompatiblen Build.",
   "error.startup.reload": "Neu laden",
   "error.startup.retry": "Erneut versuchen",
   "error.startup.recover": "Projekt unter Quarantäne stellen und neu laden",

--- a/locales/el/common.json
+++ b/locales/el/common.json
@@ -700,6 +700,7 @@
   "error.startup.storageUnavailable": "Local storage could not be opened. Reload and try again.",
   "error.startup.projectUnavailable": "A local project could not be opened. Reload and try again.",
   "error.startup.projectIoUnavailable": "The project could not currently be read because of a storage or file-access problem. It has not been classified as corrupt or changed. Check the storage device and file permissions, then retry.",
+  "error.startup.projectUnsupported": "This project uses a schema version this build cannot edit. The original file has not been changed. Upgrade WorldScript Studio or open it with a compatible build.",
   "error.startup.reload": "Reload",
   "error.startup.retry": "Retry",
   "error.startup.recover": "Quarantine project and reload",

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -700,6 +700,7 @@
   "error.startup.storageUnavailable": "Local storage could not be opened. Reload and try again.",
   "error.startup.projectUnavailable": "A local project could not be opened. Reload and try again.",
   "error.startup.projectIoUnavailable": "The project could not currently be read because of a storage or file-access problem. It has not been classified as corrupt or changed. Check the storage device and file permissions, then retry.",
+  "error.startup.projectUnsupported": "This project uses a schema version this build cannot edit. The original file has not been changed. Upgrade WorldScript Studio or open it with a compatible build.",
   "error.startup.reload": "Reload",
   "error.startup.retry": "Retry",
   "error.startup.recover": "Quarantine project and reload",

--- a/locales/es/common.json
+++ b/locales/es/common.json
@@ -700,6 +700,7 @@
   "error.startup.storageUnavailable": "No se pudo abrir el almacenamiento local. Recarga la aplicación e inténtalo de nuevo.",
   "error.startup.projectUnavailable": "No se pudo abrir un proyecto local. Recarga la aplicación e inténtalo de nuevo.",
   "error.startup.projectIoUnavailable": "No se pudo leer el proyecto en este momento debido a un problema de almacenamiento o acceso a los archivos. El proyecto no se ha clasificado como dañado ni como modificado. Comprueba la disponibilidad del dispositivo de almacenamiento y los permisos de los archivos, y vuelve a intentarlo.",
+  "error.startup.projectUnsupported": "Este proyecto utiliza una versión de esquema que esta compilación no puede editar. El archivo original no se ha modificado. Actualiza WorldScript Studio o abre el proyecto con una compilación compatible.",
   "error.startup.reload": "Recargar",
   "error.startup.retry": "Reintentar",
   "error.startup.recover": "Poner el proyecto en cuarentena y recargar",

--- a/locales/eu/common.json
+++ b/locales/eu/common.json
@@ -700,6 +700,7 @@
   "error.startup.storageUnavailable": "Local storage could not be opened. Reload and try again.",
   "error.startup.projectUnavailable": "A local project could not be opened. Reload and try again.",
   "error.startup.projectIoUnavailable": "The project could not currently be read because of a storage or file-access problem. It has not been classified as corrupt or changed. Check the storage device and file permissions, then retry.",
+  "error.startup.projectUnsupported": "This project uses a schema version this build cannot edit. The original file has not been changed. Upgrade WorldScript Studio or open it with a compatible build.",
   "error.startup.reload": "Reload",
   "error.startup.retry": "Retry",
   "error.startup.recover": "Quarantine project and reload",

--- a/locales/fa/common.json
+++ b/locales/fa/common.json
@@ -700,6 +700,7 @@
   "error.startup.storageUnavailable": "Local storage could not be opened. Reload and try again.",
   "error.startup.projectUnavailable": "A local project could not be opened. Reload and try again.",
   "error.startup.projectIoUnavailable": "The project could not currently be read because of a storage or file-access problem. It has not been classified as corrupt or changed. Check the storage device and file permissions, then retry.",
+  "error.startup.projectUnsupported": "This project uses a schema version this build cannot edit. The original file has not been changed. Upgrade WorldScript Studio or open it with a compatible build.",
   "error.startup.reload": "Reload",
   "error.startup.retry": "Retry",
   "error.startup.recover": "Quarantine project and reload",

--- a/locales/fi/common.json
+++ b/locales/fi/common.json
@@ -700,6 +700,7 @@
   "error.startup.storageUnavailable": "Local storage could not be opened. Reload and try again.",
   "error.startup.projectUnavailable": "A local project could not be opened. Reload and try again.",
   "error.startup.projectIoUnavailable": "The project could not currently be read because of a storage or file-access problem. It has not been classified as corrupt or changed. Check the storage device and file permissions, then retry.",
+  "error.startup.projectUnsupported": "This project uses a schema version this build cannot edit. The original file has not been changed. Upgrade WorldScript Studio or open it with a compatible build.",
   "error.startup.reload": "Reload",
   "error.startup.retry": "Retry",
   "error.startup.recover": "Quarantine project and reload",

--- a/locales/fr/common.json
+++ b/locales/fr/common.json
@@ -700,6 +700,7 @@
   "error.startup.storageUnavailable": "Le stockage local n’a pas pu être ouvert. Rechargez l’application et réessayez.",
   "error.startup.projectUnavailable": "Un projet local n’a pas pu être ouvert. Rechargez l’application et réessayez.",
   "error.startup.projectIoUnavailable": "Le projet n’a pas pu être lu pour le moment en raison d’un problème de stockage ou d’accès aux fichiers. Il n’a pas été considéré comme corrompu ni modifié. Vérifiez la disponibilité du support de stockage et les autorisations des fichiers, puis réessayez.",
+  "error.startup.projectUnsupported": "Ce projet utilise une version de schéma que cette version ne peut pas modifier. Le fichier d’origine n’a pas été modifié. Mettez à jour WorldScript Studio ou ouvrez le projet avec une version compatible.",
   "error.startup.reload": "Recharger",
   "error.startup.retry": "Réessayer",
   "error.startup.recover": "Mettre le projet en quarantaine et recharger",

--- a/locales/he/common.json
+++ b/locales/he/common.json
@@ -700,6 +700,7 @@
   "error.startup.storageUnavailable": "Local storage could not be opened. Reload and try again.",
   "error.startup.projectUnavailable": "A local project could not be opened. Reload and try again.",
   "error.startup.projectIoUnavailable": "The project could not currently be read because of a storage or file-access problem. It has not been classified as corrupt or changed. Check the storage device and file permissions, then retry.",
+  "error.startup.projectUnsupported": "This project uses a schema version this build cannot edit. The original file has not been changed. Upgrade WorldScript Studio or open it with a compatible build.",
   "error.startup.reload": "Reload",
   "error.startup.retry": "Retry",
   "error.startup.recover": "Quarantine project and reload",

--- a/locales/hu/common.json
+++ b/locales/hu/common.json
@@ -700,6 +700,7 @@
   "error.startup.storageUnavailable": "Local storage could not be opened. Reload and try again.",
   "error.startup.projectUnavailable": "A local project could not be opened. Reload and try again.",
   "error.startup.projectIoUnavailable": "The project could not currently be read because of a storage or file-access problem. It has not been classified as corrupt or changed. Check the storage device and file permissions, then retry.",
+  "error.startup.projectUnsupported": "This project uses a schema version this build cannot edit. The original file has not been changed. Upgrade WorldScript Studio or open it with a compatible build.",
   "error.startup.reload": "Reload",
   "error.startup.retry": "Retry",
   "error.startup.recover": "Quarantine project and reload",

--- a/locales/is/common.json
+++ b/locales/is/common.json
@@ -700,6 +700,7 @@
   "error.startup.storageUnavailable": "Local storage could not be opened. Reload and try again.",
   "error.startup.projectUnavailable": "A local project could not be opened. Reload and try again.",
   "error.startup.projectIoUnavailable": "The project could not currently be read because of a storage or file-access problem. It has not been classified as corrupt or changed. Check the storage device and file permissions, then retry.",
+  "error.startup.projectUnsupported": "This project uses a schema version this build cannot edit. The original file has not been changed. Upgrade WorldScript Studio or open it with a compatible build.",
   "error.startup.reload": "Reload",
   "error.startup.retry": "Retry",
   "error.startup.recover": "Quarantine project and reload",

--- a/locales/it/common.json
+++ b/locales/it/common.json
@@ -700,6 +700,7 @@
   "error.startup.storageUnavailable": "Non è stato possibile aprire l’archiviazione locale. Ricarica l’applicazione e riprova.",
   "error.startup.projectUnavailable": "Non è stato possibile aprire un progetto locale. Ricarica l’applicazione e riprova.",
   "error.startup.projectIoUnavailable": "Non è stato possibile leggere il progetto in questo momento a causa di un problema di archiviazione o di accesso ai file. Il progetto non è stato classificato come danneggiato né modificato. Verifica la disponibilità del dispositivo di archiviazione e i permessi dei file, quindi riprova.",
+  "error.startup.projectUnsupported": "Questo progetto usa una versione dello schema che questa build non può modificare. Il file originale non è stato cambiato. Aggiorna WorldScript Studio o apri il progetto con una build compatibile.",
   "error.startup.reload": "Ricarica",
   "error.startup.retry": "Riprova",
   "error.startup.recover": "Metti il progetto in quarantena e ricarica",

--- a/locales/ja/common.json
+++ b/locales/ja/common.json
@@ -700,6 +700,7 @@
   "error.startup.storageUnavailable": "Local storage could not be opened. Reload and try again.",
   "error.startup.projectUnavailable": "A local project could not be opened. Reload and try again.",
   "error.startup.projectIoUnavailable": "The project could not currently be read because of a storage or file-access problem. It has not been classified as corrupt or changed. Check the storage device and file permissions, then retry.",
+  "error.startup.projectUnsupported": "This project uses a schema version this build cannot edit. The original file has not been changed. Upgrade WorldScript Studio or open it with a compatible build.",
   "error.startup.reload": "Reload",
   "error.startup.retry": "Retry",
   "error.startup.recover": "Quarantine project and reload",

--- a/locales/ko/common.json
+++ b/locales/ko/common.json
@@ -700,6 +700,7 @@
   "error.startup.storageUnavailable": "Local storage could not be opened. Reload and try again.",
   "error.startup.projectUnavailable": "A local project could not be opened. Reload and try again.",
   "error.startup.projectIoUnavailable": "The project could not currently be read because of a storage or file-access problem. It has not been classified as corrupt or changed. Check the storage device and file permissions, then retry.",
+  "error.startup.projectUnsupported": "This project uses a schema version this build cannot edit. The original file has not been changed. Upgrade WorldScript Studio or open it with a compatible build.",
   "error.startup.reload": "Reload",
   "error.startup.retry": "Retry",
   "error.startup.recover": "Quarantine project and reload",

--- a/locales/pt/common.json
+++ b/locales/pt/common.json
@@ -700,6 +700,7 @@
   "error.startup.storageUnavailable": "Local storage could not be opened. Reload and try again.",
   "error.startup.projectUnavailable": "A local project could not be opened. Reload and try again.",
   "error.startup.projectIoUnavailable": "The project could not currently be read because of a storage or file-access problem. It has not been classified as corrupt or changed. Check the storage device and file permissions, then retry.",
+  "error.startup.projectUnsupported": "This project uses a schema version this build cannot edit. The original file has not been changed. Upgrade WorldScript Studio or open the project with a compatible build.",
   "error.startup.reload": "Reload",
   "error.startup.retry": "Retry",
   "error.startup.recover": "Quarantine project and reload",

--- a/locales/ru/common.json
+++ b/locales/ru/common.json
@@ -700,6 +700,7 @@
   "error.startup.storageUnavailable": "Local storage could not be opened. Reload and try again.",
   "error.startup.projectUnavailable": "A local project could not be opened. Reload and try again.",
   "error.startup.projectIoUnavailable": "The project could not currently be read because of a storage or file-access problem. It has not been classified as corrupt or changed. Check the storage device and file permissions, then retry.",
+  "error.startup.projectUnsupported": "This project uses a schema version this build cannot edit. The original file has not been changed. Upgrade WorldScript Studio or open it with a compatible build.",
   "error.startup.reload": "Reload",
   "error.startup.retry": "Retry",
   "error.startup.recover": "Quarantine project and reload",

--- a/locales/sv/common.json
+++ b/locales/sv/common.json
@@ -700,6 +700,7 @@
   "error.startup.storageUnavailable": "Local storage could not be opened. Reload and try again.",
   "error.startup.projectUnavailable": "A local project could not be opened. Reload and try again.",
   "error.startup.projectIoUnavailable": "The project could not currently be read because of a storage or file-access problem. It has not been classified as corrupt or changed. Check the storage device and file permissions, then retry.",
+  "error.startup.projectUnsupported": "This project uses a schema version this build cannot edit. The original file has not been changed. Upgrade WorldScript Studio or open it with a compatible build.",
   "error.startup.reload": "Reload",
   "error.startup.retry": "Retry",
   "error.startup.recover": "Quarantine project and reload",

--- a/locales/zh/common.json
+++ b/locales/zh/common.json
@@ -700,6 +700,7 @@
   "error.startup.storageUnavailable": "Local storage could not be opened. Reload and try again.",
   "error.startup.projectUnavailable": "A local project could not be opened. Reload and try again.",
   "error.startup.projectIoUnavailable": "The project could not currently be read because of a storage or file-access problem. It has not been classified as corrupt or changed. Check the storage device and file permissions, then retry.",
+  "error.startup.projectUnsupported": "This project uses a schema version this build cannot edit. The original file has not been changed. Upgrade WorldScript Studio or open it with a compatible build.",
   "error.startup.reload": "Reload",
   "error.startup.retry": "Retry",
   "error.startup.recover": "Quarantine project and reload",

--- a/public/locales/ar/bundle.json
+++ b/public/locales/ar/bundle.json
@@ -816,6 +816,7 @@
   "error.startup.storageUnavailable": "Local storage could not be opened. Reload and try again.",
   "error.startup.projectUnavailable": "A local project could not be opened. Reload and try again.",
   "error.startup.projectIoUnavailable": "The project could not currently be read because of a storage or file-access problem. It has not been classified as corrupt or changed. Check the storage device and file permissions, then retry.",
+  "error.startup.projectUnsupported": "This project uses a schema version this build cannot edit. The original file has not been changed. Upgrade WorldScript Studio or open it with a compatible build.",
   "error.startup.reload": "Reload",
   "error.startup.retry": "Retry",
   "error.startup.recover": "Quarantine project and reload",

--- a/public/locales/de/bundle.json
+++ b/public/locales/de/bundle.json
@@ -816,6 +816,7 @@
   "error.startup.storageUnavailable": "Der lokale Speicher konnte nicht geöffnet werden. Laden Sie die Anwendung neu und versuchen Sie es erneut.",
   "error.startup.projectUnavailable": "Ein lokales Projekt konnte nicht geöffnet werden. Laden Sie die Anwendung neu und versuchen Sie es erneut.",
   "error.startup.projectIoUnavailable": "Das Projekt konnte derzeit aufgrund eines Speicher- oder Dateizugriffsproblems nicht gelesen werden. Es wurde nicht als beschädigt oder verändert eingestuft. Prüfen Sie die Verfügbarkeit des Speichers und die Dateiberechtigungen und versuchen Sie es erneut.",
+  "error.startup.projectUnsupported": "Dieses Projekt verwendet eine Schema-Version, die dieser Build nicht bearbeiten kann. Die Originaldatei wurde nicht verändert. Aktualisieren Sie WorldScript Studio oder öffnen Sie das Projekt mit einem kompatiblen Build.",
   "error.startup.reload": "Neu laden",
   "error.startup.retry": "Erneut versuchen",
   "error.startup.recover": "Projekt unter Quarantäne stellen und neu laden",

--- a/public/locales/el/bundle.json
+++ b/public/locales/el/bundle.json
@@ -816,6 +816,7 @@
   "error.startup.storageUnavailable": "Local storage could not be opened. Reload and try again.",
   "error.startup.projectUnavailable": "A local project could not be opened. Reload and try again.",
   "error.startup.projectIoUnavailable": "The project could not currently be read because of a storage or file-access problem. It has not been classified as corrupt or changed. Check the storage device and file permissions, then retry.",
+  "error.startup.projectUnsupported": "This project uses a schema version this build cannot edit. The original file has not been changed. Upgrade WorldScript Studio or open it with a compatible build.",
   "error.startup.reload": "Reload",
   "error.startup.retry": "Retry",
   "error.startup.recover": "Quarantine project and reload",

--- a/public/locales/en/bundle.json
+++ b/public/locales/en/bundle.json
@@ -816,6 +816,7 @@
   "error.startup.storageUnavailable": "Local storage could not be opened. Reload and try again.",
   "error.startup.projectUnavailable": "A local project could not be opened. Reload and try again.",
   "error.startup.projectIoUnavailable": "The project could not currently be read because of a storage or file-access problem. It has not been classified as corrupt or changed. Check the storage device and file permissions, then retry.",
+  "error.startup.projectUnsupported": "This project uses a schema version this build cannot edit. The original file has not been changed. Upgrade WorldScript Studio or open it with a compatible build.",
   "error.startup.reload": "Reload",
   "error.startup.retry": "Retry",
   "error.startup.recover": "Quarantine project and reload",

--- a/public/locales/es/bundle.json
+++ b/public/locales/es/bundle.json
@@ -816,6 +816,7 @@
   "error.startup.storageUnavailable": "No se pudo abrir el almacenamiento local. Recarga la aplicación e inténtalo de nuevo.",
   "error.startup.projectUnavailable": "No se pudo abrir un proyecto local. Recarga la aplicación e inténtalo de nuevo.",
   "error.startup.projectIoUnavailable": "No se pudo leer el proyecto en este momento debido a un problema de almacenamiento o acceso a los archivos. El proyecto no se ha clasificado como dañado ni como modificado. Comprueba la disponibilidad del dispositivo de almacenamiento y los permisos de los archivos, y vuelve a intentarlo.",
+  "error.startup.projectUnsupported": "Este proyecto utiliza una versión de esquema que esta compilación no puede editar. El archivo original no se ha modificado. Actualiza WorldScript Studio o abre el proyecto con una compilación compatible.",
   "error.startup.reload": "Recargar",
   "error.startup.retry": "Reintentar",
   "error.startup.recover": "Poner el proyecto en cuarentena y recargar",

--- a/public/locales/eu/bundle.json
+++ b/public/locales/eu/bundle.json
@@ -816,6 +816,7 @@
   "error.startup.storageUnavailable": "Local storage could not be opened. Reload and try again.",
   "error.startup.projectUnavailable": "A local project could not be opened. Reload and try again.",
   "error.startup.projectIoUnavailable": "The project could not currently be read because of a storage or file-access problem. It has not been classified as corrupt or changed. Check the storage device and file permissions, then retry.",
+  "error.startup.projectUnsupported": "This project uses a schema version this build cannot edit. The original file has not been changed. Upgrade WorldScript Studio or open it with a compatible build.",
   "error.startup.reload": "Reload",
   "error.startup.retry": "Retry",
   "error.startup.recover": "Quarantine project and reload",

--- a/public/locales/fa/bundle.json
+++ b/public/locales/fa/bundle.json
@@ -816,6 +816,7 @@
   "error.startup.storageUnavailable": "Local storage could not be opened. Reload and try again.",
   "error.startup.projectUnavailable": "A local project could not be opened. Reload and try again.",
   "error.startup.projectIoUnavailable": "The project could not currently be read because of a storage or file-access problem. It has not been classified as corrupt or changed. Check the storage device and file permissions, then retry.",
+  "error.startup.projectUnsupported": "This project uses a schema version this build cannot edit. The original file has not been changed. Upgrade WorldScript Studio or open it with a compatible build.",
   "error.startup.reload": "Reload",
   "error.startup.retry": "Retry",
   "error.startup.recover": "Quarantine project and reload",

--- a/public/locales/fi/bundle.json
+++ b/public/locales/fi/bundle.json
@@ -816,6 +816,7 @@
   "error.startup.storageUnavailable": "Local storage could not be opened. Reload and try again.",
   "error.startup.projectUnavailable": "A local project could not be opened. Reload and try again.",
   "error.startup.projectIoUnavailable": "The project could not currently be read because of a storage or file-access problem. It has not been classified as corrupt or changed. Check the storage device and file permissions, then retry.",
+  "error.startup.projectUnsupported": "This project uses a schema version this build cannot edit. The original file has not been changed. Upgrade WorldScript Studio or open it with a compatible build.",
   "error.startup.reload": "Reload",
   "error.startup.retry": "Retry",
   "error.startup.recover": "Quarantine project and reload",

--- a/public/locales/fr/bundle.json
+++ b/public/locales/fr/bundle.json
@@ -816,6 +816,7 @@
   "error.startup.storageUnavailable": "Le stockage local n’a pas pu être ouvert. Rechargez l’application et réessayez.",
   "error.startup.projectUnavailable": "Un projet local n’a pas pu être ouvert. Rechargez l’application et réessayez.",
   "error.startup.projectIoUnavailable": "Le projet n’a pas pu être lu pour le moment en raison d’un problème de stockage ou d’accès aux fichiers. Il n’a pas été considéré comme corrompu ni modifié. Vérifiez la disponibilité du support de stockage et les autorisations des fichiers, puis réessayez.",
+  "error.startup.projectUnsupported": "Ce projet utilise une version de schéma que cette version ne peut pas modifier. Le fichier d’origine n’a pas été modifié. Mettez à jour WorldScript Studio ou ouvrez le projet avec une version compatible.",
   "error.startup.reload": "Recharger",
   "error.startup.retry": "Réessayer",
   "error.startup.recover": "Mettre le projet en quarantaine et recharger",

--- a/public/locales/he/bundle.json
+++ b/public/locales/he/bundle.json
@@ -816,6 +816,7 @@
   "error.startup.storageUnavailable": "Local storage could not be opened. Reload and try again.",
   "error.startup.projectUnavailable": "A local project could not be opened. Reload and try again.",
   "error.startup.projectIoUnavailable": "The project could not currently be read because of a storage or file-access problem. It has not been classified as corrupt or changed. Check the storage device and file permissions, then retry.",
+  "error.startup.projectUnsupported": "This project uses a schema version this build cannot edit. The original file has not been changed. Upgrade WorldScript Studio or open it with a compatible build.",
   "error.startup.reload": "Reload",
   "error.startup.retry": "Retry",
   "error.startup.recover": "Quarantine project and reload",

--- a/public/locales/hu/bundle.json
+++ b/public/locales/hu/bundle.json
@@ -816,6 +816,7 @@
   "error.startup.storageUnavailable": "Local storage could not be opened. Reload and try again.",
   "error.startup.projectUnavailable": "A local project could not be opened. Reload and try again.",
   "error.startup.projectIoUnavailable": "The project could not currently be read because of a storage or file-access problem. It has not been classified as corrupt or changed. Check the storage device and file permissions, then retry.",
+  "error.startup.projectUnsupported": "This project uses a schema version this build cannot edit. The original file has not been changed. Upgrade WorldScript Studio or open it with a compatible build.",
   "error.startup.reload": "Reload",
   "error.startup.retry": "Retry",
   "error.startup.recover": "Quarantine project and reload",

--- a/public/locales/is/bundle.json
+++ b/public/locales/is/bundle.json
@@ -816,6 +816,7 @@
   "error.startup.storageUnavailable": "Local storage could not be opened. Reload and try again.",
   "error.startup.projectUnavailable": "A local project could not be opened. Reload and try again.",
   "error.startup.projectIoUnavailable": "The project could not currently be read because of a storage or file-access problem. It has not been classified as corrupt or changed. Check the storage device and file permissions, then retry.",
+  "error.startup.projectUnsupported": "This project uses a schema version this build cannot edit. The original file has not been changed. Upgrade WorldScript Studio or open it with a compatible build.",
   "error.startup.reload": "Reload",
   "error.startup.retry": "Retry",
   "error.startup.recover": "Quarantine project and reload",

--- a/public/locales/it/bundle.json
+++ b/public/locales/it/bundle.json
@@ -816,6 +816,7 @@
   "error.startup.storageUnavailable": "Non è stato possibile aprire l’archiviazione locale. Ricarica l’applicazione e riprova.",
   "error.startup.projectUnavailable": "Non è stato possibile aprire un progetto locale. Ricarica l’applicazione e riprova.",
   "error.startup.projectIoUnavailable": "Non è stato possibile leggere il progetto in questo momento a causa di un problema di archiviazione o di accesso ai file. Il progetto non è stato classificato come danneggiato né modificato. Verifica la disponibilità del dispositivo di archiviazione e i permessi dei file, quindi riprova.",
+  "error.startup.projectUnsupported": "Questo progetto usa una versione dello schema che questa build non può modificare. Il file originale non è stato cambiato. Aggiorna WorldScript Studio o apri il progetto con una build compatibile.",
   "error.startup.reload": "Ricarica",
   "error.startup.retry": "Riprova",
   "error.startup.recover": "Metti il progetto in quarantena e ricarica",

--- a/public/locales/ja/bundle.json
+++ b/public/locales/ja/bundle.json
@@ -816,6 +816,7 @@
   "error.startup.storageUnavailable": "Local storage could not be opened. Reload and try again.",
   "error.startup.projectUnavailable": "A local project could not be opened. Reload and try again.",
   "error.startup.projectIoUnavailable": "The project could not currently be read because of a storage or file-access problem. It has not been classified as corrupt or changed. Check the storage device and file permissions, then retry.",
+  "error.startup.projectUnsupported": "This project uses a schema version this build cannot edit. The original file has not been changed. Upgrade WorldScript Studio or open it with a compatible build.",
   "error.startup.reload": "Reload",
   "error.startup.retry": "Retry",
   "error.startup.recover": "Quarantine project and reload",

--- a/public/locales/ko/bundle.json
+++ b/public/locales/ko/bundle.json
@@ -816,6 +816,7 @@
   "error.startup.storageUnavailable": "Local storage could not be opened. Reload and try again.",
   "error.startup.projectUnavailable": "A local project could not be opened. Reload and try again.",
   "error.startup.projectIoUnavailable": "The project could not currently be read because of a storage or file-access problem. It has not been classified as corrupt or changed. Check the storage device and file permissions, then retry.",
+  "error.startup.projectUnsupported": "This project uses a schema version this build cannot edit. The original file has not been changed. Upgrade WorldScript Studio or open it with a compatible build.",
   "error.startup.reload": "Reload",
   "error.startup.retry": "Retry",
   "error.startup.recover": "Quarantine project and reload",

--- a/public/locales/pt/bundle.json
+++ b/public/locales/pt/bundle.json
@@ -816,6 +816,7 @@
   "error.startup.storageUnavailable": "Local storage could not be opened. Reload and try again.",
   "error.startup.projectUnavailable": "A local project could not be opened. Reload and try again.",
   "error.startup.projectIoUnavailable": "The project could not currently be read because of a storage or file-access problem. It has not been classified as corrupt or changed. Check the storage device and file permissions, then retry.",
+  "error.startup.projectUnsupported": "This project uses a schema version this build cannot edit. The original file has not been changed. Upgrade WorldScript Studio or open the project with a compatible build.",
   "error.startup.reload": "Reload",
   "error.startup.retry": "Retry",
   "error.startup.recover": "Quarantine project and reload",

--- a/public/locales/ru/bundle.json
+++ b/public/locales/ru/bundle.json
@@ -816,6 +816,7 @@
   "error.startup.storageUnavailable": "Local storage could not be opened. Reload and try again.",
   "error.startup.projectUnavailable": "A local project could not be opened. Reload and try again.",
   "error.startup.projectIoUnavailable": "The project could not currently be read because of a storage or file-access problem. It has not been classified as corrupt or changed. Check the storage device and file permissions, then retry.",
+  "error.startup.projectUnsupported": "This project uses a schema version this build cannot edit. The original file has not been changed. Upgrade WorldScript Studio or open it with a compatible build.",
   "error.startup.reload": "Reload",
   "error.startup.retry": "Retry",
   "error.startup.recover": "Quarantine project and reload",

--- a/public/locales/sv/bundle.json
+++ b/public/locales/sv/bundle.json
@@ -816,6 +816,7 @@
   "error.startup.storageUnavailable": "Local storage could not be opened. Reload and try again.",
   "error.startup.projectUnavailable": "A local project could not be opened. Reload and try again.",
   "error.startup.projectIoUnavailable": "The project could not currently be read because of a storage or file-access problem. It has not been classified as corrupt or changed. Check the storage device and file permissions, then retry.",
+  "error.startup.projectUnsupported": "This project uses a schema version this build cannot edit. The original file has not been changed. Upgrade WorldScript Studio or open it with a compatible build.",
   "error.startup.reload": "Reload",
   "error.startup.retry": "Retry",
   "error.startup.recover": "Quarantine project and reload",

--- a/public/locales/zh/bundle.json
+++ b/public/locales/zh/bundle.json
@@ -816,6 +816,7 @@
   "error.startup.storageUnavailable": "Local storage could not be opened. Reload and try again.",
   "error.startup.projectUnavailable": "A local project could not be opened. Reload and try again.",
   "error.startup.projectIoUnavailable": "The project could not currently be read because of a storage or file-access problem. It has not been classified as corrupt or changed. Check the storage device and file permissions, then retry.",
+  "error.startup.projectUnsupported": "This project uses a schema version this build cannot edit. The original file has not been changed. Upgrade WorldScript Studio or open it with a compatible build.",
   "error.startup.reload": "Reload",
   "error.startup.retry": "Retry",
   "error.startup.recover": "Quarantine project and reload",


### PR DESCRIPTION
## **User description**
## Scope

This is the locale-synchronization predecessor split from #654 because the normal PR-size ceiling counts 33 meaningful files on #654.

This PR owns only:
- `error.startup.projectUnsupported` across all 19 locale source trees;
- canonical generated runtime bundles;
- the directly required README i18n metric update.

The filesystem admission implementation, recovery behavior, backup/writeback fencing, and tests remain owned by #654. Merging this independently reviewable translation slice lets #654 inherit the synchronized locale key from `main` and return below the 30 meaningful-file ceiling without weakening governance.

Validation: `pnpm run i18n:check`, `pnpm run docs:check`, `git diff --check`, and the normal signed pre-push hook passed.


___

## **CodeAnt-AI Description**
Add startup guidance for projects this build cannot edit

### What Changed
- Adds a localized startup message across all 19 supported languages explaining that projects using an unsupported schema version cannot be edited
- Tells users the original project file was not changed and directs them to upgrade WorldScript Studio or use a compatible build
- Updates the documented localization count from 2940 to 2941 keys

### Impact
`✅ Clearer unsupported-project errors`
`✅ Safer project handling`
`✅ Consistent startup guidance across 19 languages`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added startup messaging for projects using unsupported schema versions.
  - Messages explain that the original project remains unchanged and recommend upgrading or using a compatible build.
  - Added translations across all supported locales.

- **Documentation**
  - Updated README metrics to reflect 2,941 localized keys across 19 locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->