### PR TITLE
fix(agent): reject AI/session attribution in commits and PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,8 +263,8 @@ jobs:
           fi
           HEAD="${{ github.sha }}"
           if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ] || ! git cat-file -e "$BASE" 2>/dev/null; then
-            echo "::notice::No usable base SHA to diff against — skipping (nothing to compare)"
-            exit 0
+            echo "::error::No usable base SHA to diff against — cannot verify introduced commits for AI/session attribution. This is expected only on the repository's first-ever commit; review manually before merging."
+            exit 1
           fi
           node scripts/check-commit-attribution.mjs "$BASE" "$HEAD"
       - name: Reject AI/session attribution in PR title/body

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,6 +256,7 @@ jobs:
         run: node scripts/signing/verify-github-signatures.mjs
       - name: Reject AI/session attribution in introduced commits
         run: |
+          set -euo pipefail
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             BASE="${{ github.event.pull_request.base.sha }}"
           else
@@ -266,12 +267,18 @@ jobs:
             echo "::error::No usable base SHA to diff against — cannot verify introduced commits for AI/session attribution. This is expected only on the repository's first-ever commit; review manually before merging."
             exit 1
           fi
-          node scripts/check-commit-attribution.mjs "$BASE" "$HEAD"
-      - name: Reject AI/session attribution in PR title/body
-        if: github.event_name == 'pull_request'
-        env:
-          GITHUB_EVENT_PATH: ${{ github.event_path }}
-        run: node scripts/check-pr-text-attribution.mjs
+          # QNBS-v3: run the base-ref copy on PRs so this PR can't weaken the checker that grades it.
+          CHECKER=scripts/check-commit-attribution.mjs
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            mkdir -p /tmp/base-scripts
+            if git show "$BASE:scripts/check-commit-attribution.mjs" > /tmp/base-scripts/check-commit-attribution.mjs 2>/dev/null; then
+              CHECKER=/tmp/base-scripts/check-commit-attribution.mjs
+            else
+              echo "::notice::check-commit-attribution.mjs not found on base ref (bootstrap PR) — using this PR's own copy this one time."
+            fi
+          fi
+          node "$CHECKER" "$BASE" "$HEAD"
+          # QNBS-v3: PR title/body attribution is checked by the separate, cheap pr-text-attribution.yml (also runs on `edited`, which this workflow's trigger deliberately excludes).
 
   # ----------------------------------------------------------
   # 1. QUALITY GATE: Lint + Typecheck + Tests (parallel matrix)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,6 +254,24 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node scripts/signing/verify-github-signatures.mjs
+      - name: Reject AI/session attribution in introduced commits
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE="${{ github.event.before }}"
+          fi
+          HEAD="${{ github.sha }}"
+          if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ] || ! git cat-file -e "$BASE" 2>/dev/null; then
+            echo "::notice::No usable base SHA to diff against — skipping (nothing to compare)"
+            exit 0
+          fi
+          node scripts/check-commit-attribution.mjs "$BASE" "$HEAD"
+      - name: Reject AI/session attribution in PR title/body
+        if: github.event_name == 'pull_request'
+        env:
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+        run: node scripts/check-pr-text-attribution.mjs
 
   # ----------------------------------------------------------
   # 1. QUALITY GATE: Lint + Typecheck + Tests (parallel matrix)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,9 +269,10 @@ jobs:
               echo "::notice::check-commit-attribution.mjs not found on base ref (bootstrap PR) — using this PR's own copy this one time."
             fi
             node "$CHECKER" "$BASE" "$HEAD"
-          elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
-            # QNBS-v3: a new tag's push `before` is always all-zero — check the tag object and its target commit instead of diffing a range.
-            node "$CHECKER" --tag "$HEAD"
+          elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            # QNBS-v3: github.sha is the dereferenced commit for a tag push; rev-parse the ref for the actual tag object so the annotation itself gets checked.
+            TAG_SHA=$(git rev-parse "$GITHUB_REF")
+            node "$CHECKER" --tag "$TAG_SHA"
           else
             BASE="${{ github.event.before }}"
             if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ] || ! git cat-file -e "$BASE" 2>/dev/null; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,27 +257,29 @@ jobs:
       - name: Reject AI/session attribution in introduced commits
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE="${{ github.event.pull_request.base.sha }}"
-          else
-            BASE="${{ github.event.before }}"
-          fi
           HEAD="${{ github.sha }}"
-          if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ] || ! git cat-file -e "$BASE" 2>/dev/null; then
-            echo "::error::No usable base SHA to diff against — cannot verify introduced commits for AI/session attribution. This is expected only on the repository's first-ever commit; review manually before merging."
-            exit 1
-          fi
           # QNBS-v3: run the base-ref copy on PRs so this PR can't weaken the checker that grades it.
           CHECKER=scripts/check-commit-attribution.mjs
           if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
             mkdir -p /tmp/base-scripts
             if git show "$BASE:scripts/check-commit-attribution.mjs" > /tmp/base-scripts/check-commit-attribution.mjs 2>/dev/null; then
               CHECKER=/tmp/base-scripts/check-commit-attribution.mjs
             else
               echo "::notice::check-commit-attribution.mjs not found on base ref (bootstrap PR) — using this PR's own copy this one time."
             fi
+            node "$CHECKER" "$BASE" "$HEAD"
+          elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            # QNBS-v3: a new tag's push `before` is always all-zero — check the tag object and its target commit instead of diffing a range.
+            node "$CHECKER" --tag "$HEAD"
+          else
+            BASE="${{ github.event.before }}"
+            if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ] || ! git cat-file -e "$BASE" 2>/dev/null; then
+              echo "::error::No usable base SHA to diff against — cannot verify introduced commits for AI/session attribution. This is expected only on the repository's first-ever commit; review manually before merging."
+              exit 1
+            fi
+            node "$CHECKER" "$BASE" "$HEAD"
           fi
-          node "$CHECKER" "$BASE" "$HEAD"
           # QNBS-v3: PR title/body attribution is checked by the separate, cheap pr-text-attribution.yml (also runs on `edited`, which this workflow's trigger deliberately excludes).
 
   # ----------------------------------------------------------

--- a/.github/workflows/pr-text-attribution.yml
+++ b/.github/workflows/pr-text-attribution.yml
@@ -1,0 +1,37 @@
+name: PR Text Attribution Guard
+
+# QNBS-v3: separate + cheap so `edited` (title/body-only changes) never re-triggers the full ci.yml pipeline.
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Reject AI/session attribution in PR title/body
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Reject AI/session attribution in PR title/body
+        env:
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+        run: |
+          set -euo pipefail
+          BASE="${{ github.event.pull_request.base.sha }}"
+          mkdir -p /tmp/base-scripts
+          # QNBS-v3: run the base-ref copy so this PR can't weaken the checker that grades it.
+          CHECKER=scripts/check-pr-text-attribution.mjs
+          if git show "$BASE:scripts/check-commit-attribution.mjs" > /tmp/base-scripts/check-commit-attribution.mjs 2>/dev/null \
+             && git show "$BASE:scripts/check-pr-text-attribution.mjs" > /tmp/base-scripts/check-pr-text-attribution.mjs 2>/dev/null; then
+            CHECKER=/tmp/base-scripts/check-pr-text-attribution.mjs
+          else
+            echo "::notice::check-pr-text-attribution.mjs not found on base ref (bootstrap PR) — using this PR's own copy this one time."
+          fi
+          node "$CHECKER"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,12 +82,13 @@ When a task enters commit/push/PR/CI/review/merge work, read and follow
 `docs/PR-CI-MERGE-WORKFLOW.md`; do not load that procedure for an unrelated tiny edit.
 
 - Use a feature branch and conventional commits. Never commit directly to `main`.
-- Do not add AI/model/tool attribution, generated-by footers, or Claude/session URLs to commit
+- Do not add Claude/Anthropic attribution, generated-by footers, or session URLs to commit
   messages, tags, PR titles/bodies, or maintainer-authored review comments. Repository history
-  records the code change, not the agent session. Never add `Co-Authored-By` for an AI agent or
-  a `Claude-Session` trailer. `scripts/check-commit-attribution.mjs` mechanically enforces this
-  for commit messages and PR titles/bodies (commit-msg hook, pre-push, and CI); review comments
-  and replies have no automated check and stay a manual policy — never append these footers there.
+  records the code change, not the agent session. Never add `Co-Authored-By` for Claude or a
+  `Claude-Session` trailer, including the `GitHub Copilot (Claude ...)` co-author form.
+  `scripts/check-commit-attribution.mjs` mechanically enforces this for commit messages, tags,
+  and PR titles/bodies (commit-msg hook, pre-push, and CI); review comments and replies have no
+  automated check and stay a manual policy — never append these footers there.
 - Before new history, run `pnpm run signing:doctor` and install hooks with
   `pnpm run hooks:install`. Commits and tags must be normally signed and Git-verified; never
   use `--no-gpg-sign`, `--no-verify`, unsigned temporary history, or force-push ordinary PR

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,11 @@ When a task enters commit/push/PR/CI/review/merge work, read and follow
 `docs/PR-CI-MERGE-WORKFLOW.md`; do not load that procedure for an unrelated tiny edit.
 
 - Use a feature branch and conventional commits. Never commit directly to `main`.
+- Do not add AI/model/tool attribution, generated-by footers, or Claude/session URLs to commit
+  messages, tags, PR titles/bodies, or maintainer-authored review comments. Repository history
+  records the code change, not the agent session. Never add `Co-Authored-By` for an AI agent or
+  a `Claude-Session` trailer. Enforced by `scripts/check-commit-attribution.mjs` (commit-msg hook,
+  pre-push, and CI).
 - Before new history, run `pnpm run signing:doctor` and install hooks with
   `pnpm run hooks:install`. Commits and tags must be normally signed and Git-verified; never
   use `--no-gpg-sign`, `--no-verify`, unsigned temporary history, or force-push ordinary PR

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,8 +85,9 @@ When a task enters commit/push/PR/CI/review/merge work, read and follow
 - Do not add AI/model/tool attribution, generated-by footers, or Claude/session URLs to commit
   messages, tags, PR titles/bodies, or maintainer-authored review comments. Repository history
   records the code change, not the agent session. Never add `Co-Authored-By` for an AI agent or
-  a `Claude-Session` trailer. Enforced by `scripts/check-commit-attribution.mjs` (commit-msg hook,
-  pre-push, and CI).
+  a `Claude-Session` trailer. `scripts/check-commit-attribution.mjs` mechanically enforces this
+  for commit messages and PR titles/bodies (commit-msg hook, pre-push, and CI); review comments
+  and replies have no automated check and stay a manual policy — never append these footers there.
 - Before new history, run `pnpm run signing:doctor` and install hooks with
   `pnpm run hooks:install`. Commits and tags must be normally signed and Git-verified; never
   use `--no-gpg-sign`, `--no-verify`, unsigned temporary history, or force-push ordinary PR

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="i18n 19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7565%2B_%2F_603_files-22C55E" alt="7565+ tests / 603 files">
+  <img src="https://img.shields.io/badge/Tests-7567%2B_%2F_603_files-22C55E" alt="7567+ tests / 603 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2942 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7565+ tests / 603 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7567+ tests / 603 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7565+ tests, 603 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7567+ tests, 603 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -714,7 +714,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendor **6200 KB**, other JavaScript **2500 KB**, and WASM **30000 KB**.
 
 **Current test metrics (2026-09-07, source-synchronized; CI remains authoritative for pass/fail):**
-- **7565+ unit tests** across **603 test files** — CI is authoritative for pass/fail
+- **7567+ unit tests** across **603 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2942 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="i18n 19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7561%2B_%2F_603_files-22C55E" alt="7561+ tests / 603 files">
+  <img src="https://img.shields.io/badge/Tests-7563%2B_%2F_603_files-22C55E" alt="7563+ tests / 603 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2942 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7561+ tests / 603 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7563+ tests / 603 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7561+ tests, 603 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7563+ tests, 603 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -714,7 +714,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendor **6200 KB**, other JavaScript **2500 KB**, and WASM **30000 KB**.
 
 **Current test metrics (2026-09-07, source-synchronized; CI remains authoritative for pass/fail):**
-- **7561+ unit tests** across **603 test files** — CI is authoritative for pass/fail
+- **7563+ unit tests** across **603 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2942 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="i18n 19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7563%2B_%2F_603_files-22C55E" alt="7563+ tests / 603 files">
+  <img src="https://img.shields.io/badge/Tests-7565%2B_%2F_603_files-22C55E" alt="7565+ tests / 603 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2942 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7563+ tests / 603 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7565+ tests / 603 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7563+ tests, 603 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7565+ tests, 603 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -714,7 +714,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendor **6200 KB**, other JavaScript **2500 KB**, and WASM **30000 KB**.
 
 **Current test metrics (2026-09-07, source-synchronized; CI remains authoritative for pass/fail):**
-- **7563+ unit tests** across **603 test files** — CI is authoritative for pass/fail
+- **7565+ unit tests** across **603 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2942 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="i18n 19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7547%2B_%2F_603_files-22C55E" alt="7547+ tests / 603 files">
+  <img src="https://img.shields.io/badge/Tests-7555%2B_%2F_603_files-22C55E" alt="7555+ tests / 603 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2942 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7547+ tests / 603 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7555+ tests / 603 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7547+ tests, 603 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7555+ tests, 603 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -714,7 +714,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendor **6200 KB**, other JavaScript **2500 KB**, and WASM **30000 KB**.
 
 **Current test metrics (2026-09-07, source-synchronized; CI remains authoritative for pass/fail):**
-- **7547+ unit tests** across **603 test files** — CI is authoritative for pass/fail
+- **7555+ unit tests** across **603 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2942 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="i18n 19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7555%2B_%2F_603_files-22C55E" alt="7555+ tests / 603 files">
+  <img src="https://img.shields.io/badge/Tests-7556%2B_%2F_603_files-22C55E" alt="7556+ tests / 603 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2942 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7555+ tests / 603 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7556+ tests / 603 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7555+ tests, 603 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7556+ tests, 603 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -714,7 +714,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendor **6200 KB**, other JavaScript **2500 KB**, and WASM **30000 KB**.
 
 **Current test metrics (2026-09-07, source-synchronized; CI remains authoritative for pass/fail):**
-- **7555+ unit tests** across **603 test files** — CI is authoritative for pass/fail
+- **7556+ unit tests** across **603 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2942 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="i18n 19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7556%2B_%2F_603_files-22C55E" alt="7556+ tests / 603 files">
+  <img src="https://img.shields.io/badge/Tests-7561%2B_%2F_603_files-22C55E" alt="7561+ tests / 603 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2942 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7556+ tests / 603 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7561+ tests / 603 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7556+ tests, 603 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7561+ tests, 603 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -714,7 +714,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendor **6200 KB**, other JavaScript **2500 KB**, and WASM **30000 KB**.
 
 **Current test metrics (2026-09-07, source-synchronized; CI remains authoritative for pass/fail):**
-- **7556+ unit tests** across **603 test files** — CI is authoritative for pass/fail
+- **7561+ unit tests** across **603 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2942 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="i18n 19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7538%2B_%2F_602_files-22C55E" alt="7538+ tests / 602 files">
+  <img src="https://img.shields.io/badge/Tests-7547%2B_%2F_603_files-22C55E" alt="7547+ tests / 603 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2942 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7538+ tests / 602 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7547+ tests / 603 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7538+ tests, 602 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7547+ tests, 603 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -714,7 +714,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendor **6200 KB**, other JavaScript **2500 KB**, and WASM **30000 KB**.
 
 **Current test metrics (2026-09-07, source-synchronized; CI remains authoritative for pass/fail):**
-- **7538+ unit tests** across **602 test files** — CI is authoritative for pass/fail
+- **7547+ unit tests** across **603 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2942 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/docs/CODEANT-REVIEW-LOOP.md
+++ b/docs/CODEANT-REVIEW-LOOP.md
@@ -210,11 +210,9 @@ git commit -m "refactor(scope): address CodeAnt wave N review feedback"
 git push origin <feature-branch>
 ```
 
-End commit messages with the attribution matching whichever agent/model actually made the change, e.g.:
-
-```text
-Co-Authored-By: GitHub Copilot (Claude Sonnet 5) <noreply@github.com>
-```
+Do not add an agent/model co-author trailer, generated-by footer, or session URL — see AGENTS.md's
+commit/PR attribution rule; `scripts/check-commit-attribution.mjs` rejects one at commit-msg,
+pre-push, and CI.
 
 ## 6. Reply to every thread, then resolve it → 0 unresolved
 

--- a/docs/DEEPSOURCE-REVIEW-LOOP.md
+++ b/docs/DEEPSOURCE-REVIEW-LOOP.md
@@ -229,8 +229,9 @@ git commit -m "refactor(scope): address DeepSource wave N (<issue codes>)"
 git push origin <feature-branch>
 ```
 
-End commit messages with the attribution matching whichever agent/model actually made the change, e.g.
-`Co-Authored-By: GitHub Copilot (Claude Sonnet 5) <noreply@github.com>`.
+Do not add an agent/model co-author trailer, generated-by footer, or session URL — see AGENTS.md's
+commit/PR attribution rule; `scripts/check-commit-attribution.mjs` rejects one at commit-msg,
+pre-push, and CI.
 **No manual re-trigger** — DeepSource analyses the new head SHA on its own. Wait for the fresh run,
 then go back to §3.
 

--- a/docs/SESSION-HANDOFF-MAIN-CI-COVERAGE.md
+++ b/docs/SESSION-HANDOFF-MAIN-CI-COVERAGE.md
@@ -163,6 +163,7 @@ Flow-Mode fullscreen + docs). Each = one PR off main, CodeAnt deferred.
 ## Environment reminders
 - **ONE Bash call per turn** (low-end hardware ~3.7 GB RAM); no concurrent heavy shells. A full local
   coverage run ≈ 1 hour — prefer single-file runs for diagnosis.
-- Co-Author commits with the attribution matching whichever agent/model actually made the change, e.g.
-  `Co-Authored-By: GitHub Copilot (Claude Sonnet 5) <noreply@github.com>`.
+- Do not add an agent/model co-author trailer, generated-by footer, or session URL — see AGENTS.md's
+  commit/PR attribution rule; `scripts/check-commit-attribution.mjs` rejects one at commit-msg,
+  pre-push, and CI.
 - Never lower coverage thresholds or `it.skip` to go green — fix the root cause.

--- a/docs/history/KIMI-INSTRUCT.md
+++ b/docs/history/KIMI-INSTRUCT.md
@@ -108,7 +108,7 @@ pnpm exec vitest run <betroffene-testdateien>
 - Lint/Format-Fehler vor dem Commit beheben (`biome check --write ...`).
 - TypeScript-Fehler sofort beheben.
 - i18n-Keys bei neuem UI-Text zu **allen 19 Locales** hinzufügen (`node scripts/check-i18n-keys.mjs --fix`) und Bundles neu bauen (`pnpm run i18n:bundle`).
-- Commit-Nachrichten mit der Zuordnung des tatsächlich arbeitenden Agenten/Modells abschließen, z. B. `Co-Authored-By: Kimi K2 <noreply@moonshot.ai>` — niemals eine generische oder falsche Modellangabe übernehmen.
+- Keine Agent-/Modell-Attribution (Co-Author-Trailer, Generated-by-Footer, Session-URL) an Commit-Nachrichten anhängen — siehe AGENTS.md.
 
 ### 3.4 Commit & Push
 

--- a/package.json
+++ b/package.json
@@ -217,6 +217,7 @@
   },
   "simple-git-hooks": {
     "pre-commit": "node scripts/hooks/pre-commit.mjs",
+    "commit-msg": "node scripts/hooks/commit-msg.mjs \"$1\"",
     "pre-push": "node scripts/hooks/pre-push.mjs \"$@\""
   },
   "lint-staged": {

--- a/scripts/check-commit-attribution.d.mts
+++ b/scripts/check-commit-attribution.d.mts
@@ -1,0 +1,15 @@
+export interface AttributionPattern {
+  name: string;
+  regex: RegExp;
+}
+
+export const FORBIDDEN_ATTRIBUTION_PATTERNS: AttributionPattern[];
+
+export interface AttributionCheckResult {
+  ok: boolean;
+  matches: string[];
+}
+
+export function checkAttributionText(text: string | undefined | null): AttributionCheckResult;
+
+export function main(): void;

--- a/scripts/check-commit-attribution.mjs
+++ b/scripts/check-commit-attribution.mjs
@@ -17,7 +17,9 @@ export const FORBIDDEN_ATTRIBUTION_PATTERNS = [
   { name: 'claude-session-trailer', regex: /^Claude-Session:/im },
   { name: 'claude-session-url', regex: /claude\.ai\/code\/session_/i },
   { name: 'claude-com-session-url', regex: /claude\.com\/[^\s]*session_/i },
+  // QNBS-v3: covers Anthropic too, not just Claude, matching AGENTS.md's Claude/Anthropic wording.
   { name: 'co-authored-by-claude', regex: /^Co-Authored-By:\s*(?:Claude|Anthropic)\b/im },
+  // QNBS-v3: trailer-scoped so prose merely discussing the address (e.g. documenting this guard) isn't rejected.
   {
     name: 'anthropic-noreply-email',
     regex: /^(?:Co-Authored-By|Signed-off-by):.*noreply@anthropic\.com/im,

--- a/scripts/check-commit-attribution.mjs
+++ b/scripts/check-commit-attribution.mjs
@@ -16,7 +16,7 @@ import { pathToFileURL } from 'node:url';
 export const FORBIDDEN_ATTRIBUTION_PATTERNS = [
   { name: 'claude-session-trailer', regex: /^Claude-Session:/im },
   { name: 'claude-session-url', regex: /claude\.ai\/code\/session_/i },
-  { name: 'claude-com-session-url', regex: /claude\.com\/[^\s]*\/session_/i },
+  { name: 'claude-com-session-url', regex: /claude\.com\/[^\s]*session_/i },
   { name: 'co-authored-by-claude', regex: /^Co-Authored-By:\s*Claude\b/im },
   { name: 'anthropic-noreply-email', regex: /noreply@anthropic\.com/i },
   { name: 'generated-by-claude-footer', regex: /^🤖\s*(Generated|Addressed)\s+.*Claude/im },
@@ -30,6 +30,8 @@ export function checkAttributionText(text) {
   return { ok: matches.length === 0, matches };
 }
 
+const SHA_LINE = /^[0-9a-f]{40}$/i;
+
 function runGit(args) {
   const result = spawnSync('git', args, { encoding: 'utf8' });
   if (result.error || result.status !== 0) throw new Error(`git ${args.join(' ')} failed`);
@@ -42,11 +44,72 @@ function checkRange(base, head) {
     .filter(Boolean);
   const failures = [];
   for (const sha of shas) {
+    // QNBS-v3: fail closed on any unexpected rev-list output shape before it reaches a git arg.
+    if (!SHA_LINE.test(sha)) throw new Error(`unexpected non-SHA line from git rev-list: ${sha}`);
     const message = runGit(['show', '-s', '--format=%B', sha]);
     const result = checkAttributionText(message);
     if (!result.ok) failures.push({ sha, matches: result.matches });
   }
   return failures;
+}
+
+function usageError(message) {
+  console.error(`[check-commit-attribution] ${message}`);
+  console.error(
+    'usage: node scripts/check-commit-attribution.mjs --file <path> | --message <text> | <base-sha> <head-sha>',
+  );
+  process.exitCode = 2;
+}
+
+function reportResult(result, label) {
+  if (result.ok) {
+    console.log('[check-commit-attribution] OK');
+    return;
+  }
+  console.error(
+    `[check-commit-attribution] ${label}forbidden pattern(s) ${result.matches.join(', ')} — remove AI/session attribution (see AGENTS.md).`,
+  );
+  process.exitCode = 1;
+}
+
+function runFileMode(filePath) {
+  let text;
+  try {
+    text = readFileSync(filePath, 'utf8');
+  } catch (error) {
+    console.error(
+      `[check-commit-attribution] cannot read ${filePath}: ${error instanceof Error ? error.message : 'unknown error'}`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+  reportResult(checkAttributionText(text), `${filePath}: `);
+}
+
+function runRangeMode(base, head) {
+  let failures;
+  try {
+    failures = checkRange(base, head);
+  } catch (error) {
+    console.error(
+      `[check-commit-attribution] ${error instanceof Error ? error.message : 'range check failed'}`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+  if (failures.length === 0) {
+    console.log(`[check-commit-attribution] OK — 0 forbidden patterns in ${base}..${head}`);
+    return;
+  }
+  for (const f of failures) {
+    console.error(
+      `[check-commit-attribution] ${f.sha.slice(0, 12)}: forbidden pattern(s) ${f.matches.join(', ')}`,
+    );
+  }
+  console.error(
+    '[check-commit-attribution] FAIL — remove AI/model/session attribution from the listed commits (see AGENTS.md).',
+  );
+  process.exitCode = 1;
 }
 
 export function main() {
@@ -56,53 +119,17 @@ export function main() {
 
   if (fileIndex >= 0) {
     const filePath = args[fileIndex + 1];
-    const result = checkAttributionText(readFileSync(filePath, 'utf8'));
-    if (!result.ok) {
-      console.error(
-        `[check-commit-attribution] ${filePath}: forbidden pattern(s) ${result.matches.join(', ')} — remove AI/session attribution (see AGENTS.md).`,
-      );
-      process.exitCode = 1;
-      return;
-    }
-    console.log('[check-commit-attribution] OK');
-    return;
+    if (!filePath) return usageError('--file requires a path argument');
+    return runFileMode(filePath);
   }
-
   if (messageIndex >= 0) {
-    const result = checkAttributionText(args[messageIndex + 1]);
-    if (!result.ok) {
-      console.error(
-        `[check-commit-attribution] forbidden pattern(s) ${result.matches.join(', ')} — remove AI/session attribution (see AGENTS.md).`,
-      );
-      process.exitCode = 1;
-      return;
-    }
-    console.log('[check-commit-attribution] OK');
-    return;
+    const text = args[messageIndex + 1];
+    if (text === undefined) return usageError('--message requires a text argument');
+    return reportResult(checkAttributionText(text), '');
   }
-
   const [base, head] = args;
-  if (!base || !head) {
-    console.error(
-      'usage: node scripts/check-commit-attribution.mjs --file <path> | --message <text> | <base-sha> <head-sha>',
-    );
-    process.exitCode = 2;
-    return;
-  }
-  const failures = checkRange(base, head);
-  if (failures.length > 0) {
-    for (const f of failures) {
-      console.error(
-        `[check-commit-attribution] ${f.sha.slice(0, 12)}: forbidden pattern(s) ${f.matches.join(', ')}`,
-      );
-    }
-    console.error(
-      '[check-commit-attribution] FAIL — remove AI/model/session attribution from the listed commits (see AGENTS.md).',
-    );
-    process.exitCode = 1;
-    return;
-  }
-  console.log(`[check-commit-attribution] OK — 0 forbidden patterns in ${base}..${head}`);
+  if (!base || !head) return usageError('requires --file, --message, or <base-sha> <head-sha>');
+  return runRangeMode(base, head);
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) main();

--- a/scripts/check-commit-attribution.mjs
+++ b/scripts/check-commit-attribution.mjs
@@ -19,7 +19,10 @@ export const FORBIDDEN_ATTRIBUTION_PATTERNS = [
   { name: 'claude-com-session-url', regex: /claude\.com\/[^\s]*session_/i },
   { name: 'co-authored-by-claude', regex: /^Co-Authored-By:\s*Claude\b/im },
   { name: 'anthropic-noreply-email', regex: /noreply@anthropic\.com/i },
-  { name: 'generated-by-claude-footer', regex: /^🤖\s*(Generated|Addressed)\s+.*Claude/im },
+  {
+    name: 'generated-by-claude-footer',
+    regex: /^(?:🤖\s*)?(Generated|Addressed)\s+(with|by)\s+.*Claude/im,
+  },
   { name: 'copilot-claude-co-author', regex: /^Co-Authored-By:\s*GitHub Copilot \(Claude/im },
 ];
 
@@ -112,24 +115,31 @@ function runRangeMode(base, head) {
   process.exitCode = 1;
 }
 
+function dispatchFileMode(args, fileIndex) {
+  const filePath = args[fileIndex + 1];
+  if (!filePath) return usageError('--file requires a path argument');
+  return runFileMode(filePath);
+}
+
+function dispatchMessageMode(args, messageIndex) {
+  const text = args[messageIndex + 1];
+  if (text === undefined) return usageError('--message requires a text argument');
+  return reportResult(checkAttributionText(text), '');
+}
+
+function dispatchRangeMode(args) {
+  const [base, head] = args;
+  if (!base || !head) return usageError('requires --file, --message, or <base-sha> <head-sha>');
+  return runRangeMode(base, head);
+}
+
 export function main() {
   const args = process.argv.slice(2);
   const fileIndex = args.indexOf('--file');
   const messageIndex = args.indexOf('--message');
-
-  if (fileIndex >= 0) {
-    const filePath = args[fileIndex + 1];
-    if (!filePath) return usageError('--file requires a path argument');
-    return runFileMode(filePath);
-  }
-  if (messageIndex >= 0) {
-    const text = args[messageIndex + 1];
-    if (text === undefined) return usageError('--message requires a text argument');
-    return reportResult(checkAttributionText(text), '');
-  }
-  const [base, head] = args;
-  if (!base || !head) return usageError('requires --file, --message, or <base-sha> <head-sha>');
-  return runRangeMode(base, head);
+  if (fileIndex >= 0) return dispatchFileMode(args, fileIndex);
+  if (messageIndex >= 0) return dispatchMessageMode(args, messageIndex);
+  return dispatchRangeMode(args);
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) main();

--- a/scripts/check-commit-attribution.mjs
+++ b/scripts/check-commit-attribution.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+/**
+ * Rejects AI/model/session attribution in commit messages and PR text (maintainer policy: repo
+ * history records the code change, not the agent session — see AGENTS.md).
+ *
+ * Run: node scripts/check-commit-attribution.mjs --file <commit-msg-file>
+ *      node scripts/check-commit-attribution.mjs --message "<text>"
+ *      node scripts/check-commit-attribution.mjs <base-sha> <head-sha>   # scans every commit in range
+ */
+import { readFileSync } from 'node:fs';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+// QNBS-v3: anchored so legitimate prose ("Claude provider", "Anthropic API docs") never matches.
+export const FORBIDDEN_ATTRIBUTION_PATTERNS = [
+  { name: 'claude-session-trailer', regex: /^Claude-Session:/im },
+  { name: 'claude-session-url', regex: /claude\.ai\/code\/session_/i },
+  { name: 'claude-com-session-url', regex: /claude\.com\/[^\s]*\/session_/i },
+  { name: 'co-authored-by-claude', regex: /^Co-Authored-By:\s*Claude\b/im },
+  { name: 'anthropic-noreply-email', regex: /noreply@anthropic\.com/i },
+  { name: 'generated-by-claude-footer', regex: /^🤖\s*(Generated|Addressed)\s+.*Claude/im },
+  { name: 'copilot-claude-co-author', regex: /^Co-Authored-By:\s*GitHub Copilot \(Claude/im },
+];
+
+export function checkAttributionText(text) {
+  const matches = FORBIDDEN_ATTRIBUTION_PATTERNS.filter((p) => p.regex.test(text ?? '')).map(
+    (p) => p.name,
+  );
+  return { ok: matches.length === 0, matches };
+}
+
+function runGit(args) {
+  const result = spawnSync('git', args, { encoding: 'utf8' });
+  if (result.error || result.status !== 0) throw new Error(`git ${args.join(' ')} failed`);
+  return result.stdout;
+}
+
+function checkRange(base, head) {
+  const shas = runGit(['rev-list', '--reverse', `${base}..${head}`])
+    .split(/\r?\n/)
+    .filter(Boolean);
+  const failures = [];
+  for (const sha of shas) {
+    const message = runGit(['show', '-s', '--format=%B', sha]);
+    const result = checkAttributionText(message);
+    if (!result.ok) failures.push({ sha, matches: result.matches });
+  }
+  return failures;
+}
+
+export function main() {
+  const args = process.argv.slice(2);
+  const fileIndex = args.indexOf('--file');
+  const messageIndex = args.indexOf('--message');
+
+  if (fileIndex >= 0) {
+    const filePath = args[fileIndex + 1];
+    const result = checkAttributionText(readFileSync(filePath, 'utf8'));
+    if (!result.ok) {
+      console.error(
+        `[check-commit-attribution] ${filePath}: forbidden pattern(s) ${result.matches.join(', ')} — remove AI/session attribution (see AGENTS.md).`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+    console.log('[check-commit-attribution] OK');
+    return;
+  }
+
+  if (messageIndex >= 0) {
+    const result = checkAttributionText(args[messageIndex + 1]);
+    if (!result.ok) {
+      console.error(
+        `[check-commit-attribution] forbidden pattern(s) ${result.matches.join(', ')} — remove AI/session attribution (see AGENTS.md).`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+    console.log('[check-commit-attribution] OK');
+    return;
+  }
+
+  const [base, head] = args;
+  if (!base || !head) {
+    console.error(
+      'usage: node scripts/check-commit-attribution.mjs --file <path> | --message <text> | <base-sha> <head-sha>',
+    );
+    process.exitCode = 2;
+    return;
+  }
+  const failures = checkRange(base, head);
+  if (failures.length > 0) {
+    for (const f of failures) {
+      console.error(
+        `[check-commit-attribution] ${f.sha.slice(0, 12)}: forbidden pattern(s) ${f.matches.join(', ')}`,
+      );
+    }
+    console.error(
+      '[check-commit-attribution] FAIL — remove AI/model/session attribution from the listed commits (see AGENTS.md).',
+    );
+    process.exitCode = 1;
+    return;
+  }
+  console.log(`[check-commit-attribution] OK — 0 forbidden patterns in ${base}..${head}`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) main();

--- a/scripts/check-commit-attribution.mjs
+++ b/scripts/check-commit-attribution.mjs
@@ -41,6 +41,22 @@ function runGit(args) {
   return result.stdout;
 }
 
+// QNBS-v3: a clean tag annotation can still target an attributed commit — check both objects.
+function checkTagAndTarget(sha) {
+  if (!SHA_LINE.test(sha)) throw new Error(`--tag requires a full commit/tag SHA, got: ${sha}`);
+  const tagText = runGit(['cat-file', '-p', sha]);
+  const tagResult = checkAttributionText(tagText);
+  const type = runGit(['cat-file', '-t', sha]).trim();
+  if (type !== 'tag') return tagResult;
+  const targetSha = tagText.match(/^object ([0-9a-f]{40})$/m)?.[1];
+  if (!targetSha || runGit(['cat-file', '-t', targetSha]).trim() !== 'commit') return tagResult;
+  const commitResult = checkAttributionText(runGit(['show', '-s', '--format=%B', targetSha]));
+  return {
+    ok: tagResult.ok && commitResult.ok,
+    matches: [...new Set([...tagResult.matches, ...commitResult.matches])],
+  };
+}
+
 function checkRange(base, head) {
   const shas = runGit(['rev-list', '--reverse', `${base}..${head}`])
     .split(/\r?\n/)
@@ -129,16 +145,35 @@ function dispatchMessageMode(args, messageIndex) {
 
 function dispatchRangeMode(args) {
   const [base, head] = args;
-  if (!base || !head) return usageError('requires --file, --message, or <base-sha> <head-sha>');
+  if (!base || !head)
+    return usageError('requires --file, --message, --tag, or <base-sha> <head-sha>');
   return runRangeMode(base, head);
+}
+
+function dispatchTagMode(args, tagIndex) {
+  const sha = args[tagIndex + 1];
+  if (!sha) return usageError('--tag requires a SHA argument');
+  let result;
+  try {
+    result = checkTagAndTarget(sha);
+  } catch (error) {
+    console.error(
+      `[check-commit-attribution] ${error instanceof Error ? error.message : 'tag check failed'}`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+  return reportResult(result, `${sha.slice(0, 12)}: `);
 }
 
 export function main() {
   const args = process.argv.slice(2);
   const fileIndex = args.indexOf('--file');
   const messageIndex = args.indexOf('--message');
+  const tagIndex = args.indexOf('--tag');
   if (fileIndex >= 0) return dispatchFileMode(args, fileIndex);
   if (messageIndex >= 0) return dispatchMessageMode(args, messageIndex);
+  if (tagIndex >= 0) return dispatchTagMode(args, tagIndex);
   return dispatchRangeMode(args);
 }
 

--- a/scripts/check-commit-attribution.mjs
+++ b/scripts/check-commit-attribution.mjs
@@ -18,7 +18,10 @@ export const FORBIDDEN_ATTRIBUTION_PATTERNS = [
   { name: 'claude-session-url', regex: /claude\.ai\/code\/session_/i },
   { name: 'claude-com-session-url', regex: /claude\.com\/[^\s]*session_/i },
   { name: 'co-authored-by-claude', regex: /^Co-Authored-By:\s*(?:Claude|Anthropic)\b/im },
-  { name: 'anthropic-noreply-email', regex: /noreply@anthropic\.com/i },
+  {
+    name: 'anthropic-noreply-email',
+    regex: /^(?:Co-Authored-By|Signed-off-by):.*noreply@anthropic\.com/im,
+  },
   {
     name: 'generated-by-claude-footer',
     regex: /^(?:🤖\s*)?(Generated|Addressed)\s+(with|by)\s+.*(?:Claude|Anthropic)\b/im,

--- a/scripts/check-commit-attribution.mjs
+++ b/scripts/check-commit-attribution.mjs
@@ -24,9 +24,11 @@ export const FORBIDDEN_ATTRIBUTION_PATTERNS = [
     name: 'anthropic-noreply-email',
     regex: /^(?:Co-Authored-By|Signed-off-by):.*noreply@anthropic\.com/im,
   },
+  // QNBS-v3: end-anchored to the actual footer shape so prose discussing/quoting it isn't rejected.
   {
     name: 'generated-by-claude-footer',
-    regex: /^(?:🤖\s*)?(Generated|Addressed)\s+(with|by)\s+.*(?:Claude|Anthropic)\b/im,
+    regex:
+      /^(?:🤖\s*)?(?:Generated|Addressed)\s+(?:with|by)\s+(?:\[Claude Code\]\([^)]*\)|Claude Code|Anthropic)\s*$/im,
   },
   { name: 'copilot-claude-co-author', regex: /^Co-Authored-By:\s*GitHub Copilot \(Claude/im },
 ];

--- a/scripts/check-commit-attribution.mjs
+++ b/scripts/check-commit-attribution.mjs
@@ -17,11 +17,11 @@ export const FORBIDDEN_ATTRIBUTION_PATTERNS = [
   { name: 'claude-session-trailer', regex: /^Claude-Session:/im },
   { name: 'claude-session-url', regex: /claude\.ai\/code\/session_/i },
   { name: 'claude-com-session-url', regex: /claude\.com\/[^\s]*session_/i },
-  { name: 'co-authored-by-claude', regex: /^Co-Authored-By:\s*Claude\b/im },
+  { name: 'co-authored-by-claude', regex: /^Co-Authored-By:\s*(?:Claude|Anthropic)\b/im },
   { name: 'anthropic-noreply-email', regex: /noreply@anthropic\.com/i },
   {
     name: 'generated-by-claude-footer',
-    regex: /^(?:🤖\s*)?(Generated|Addressed)\s+(with|by)\s+.*Claude/im,
+    regex: /^(?:🤖\s*)?(Generated|Addressed)\s+(with|by)\s+.*(?:Claude|Anthropic)\b/im,
   },
   { name: 'copilot-claude-co-author', regex: /^Co-Authored-By:\s*GitHub Copilot \(Claude/im },
 ];

--- a/scripts/check-pr-text-attribution.mjs
+++ b/scripts/check-pr-text-attribution.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+/**
+ * CI-only companion to check-commit-attribution.mjs: checks PR title/body text, which local hooks
+ * never see. Parses GITHUB_EVENT_PATH in Node — never interpolate PR text into a shell command.
+ */
+import { readFileSync } from 'node:fs';
+import process from 'node:process';
+import { checkAttributionText } from './check-commit-attribution.mjs';
+
+const eventPath = process.env.GITHUB_EVENT_PATH;
+if (!eventPath) {
+  console.log('[check-pr-text-attribution] no GITHUB_EVENT_PATH — skipping');
+  process.exit(0);
+}
+
+let payload;
+try {
+  payload = JSON.parse(readFileSync(eventPath, 'utf8'));
+} catch (error) {
+  console.error(
+    `[check-pr-text-attribution] cannot read event payload: ${error instanceof Error ? error.message : 'invalid JSON'}`,
+  );
+  process.exit(1);
+}
+
+const pr = payload.pull_request;
+if (!pr) {
+  console.log('[check-pr-text-attribution] not a pull_request event — skipping');
+  process.exit(0);
+}
+
+const failures = [];
+for (const [field, text] of [
+  ['title', pr.title],
+  ['body', pr.body],
+]) {
+  const result = checkAttributionText(text ?? '');
+  if (!result.ok) failures.push({ field, matches: result.matches });
+}
+
+if (failures.length > 0) {
+  for (const f of failures) {
+    console.error(
+      `[check-pr-text-attribution] PR ${f.field}: forbidden pattern(s) ${f.matches.join(', ')}`,
+    );
+  }
+  console.error(
+    '[check-pr-text-attribution] FAIL — remove AI/model/session attribution from the PR title/body (see AGENTS.md).',
+  );
+  process.exit(1);
+}
+console.log('[check-pr-text-attribution] OK');

--- a/scripts/hooks/commit-msg.mjs
+++ b/scripts/hooks/commit-msg.mjs
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs';
+import process from 'node:process';
+import { checkAttributionText } from '../check-commit-attribution.mjs';
+
+const file = process.argv[2];
+if (!file) {
+  console.error('commit-msg hook requires the commit message file path.');
+  process.exit(1);
+}
+const result = checkAttributionText(readFileSync(file, 'utf8'));
+if (!result.ok) {
+  console.error(
+    `commit rejected: forbidden AI/session attribution pattern(s) ${result.matches.join(', ')} — see AGENTS.md.`,
+  );
+  process.exit(1);
+}
+process.exit(0);

--- a/scripts/hooks/commit-msg.mjs
+++ b/scripts/hooks/commit-msg.mjs
@@ -7,7 +7,16 @@ if (!file) {
   console.error('commit-msg hook requires the commit message file path.');
   process.exit(1);
 }
-const result = checkAttributionText(readFileSync(file, 'utf8'));
+let message;
+try {
+  message = readFileSync(file, 'utf8');
+} catch (error) {
+  console.error(
+    `commit-msg hook cannot read ${file}: ${error instanceof Error ? error.message : 'unknown error'}`,
+  );
+  process.exit(1);
+}
+const result = checkAttributionText(message);
 if (!result.ok) {
   console.error(
     `commit rejected: forbidden AI/session attribution pattern(s) ${result.matches.join(', ')} — see AGENTS.md.`,

--- a/scripts/hooks/pre-push.mjs
+++ b/scripts/hooks/pre-push.mjs
@@ -19,6 +19,8 @@ try {
   writePrePushEvidenceFile(evidenceFile, updates);
   const childArgs = [...process.argv.slice(2), '--prepush-evidence-file', evidenceFile];
   exitCode = await runNodeScript('scripts/signing/verify-outgoing.mjs', childArgs);
+  if (exitCode === 0)
+    exitCode = await runNodeScript('scripts/signing/verify-attribution.mjs', childArgs);
   if (exitCode === 0) exitCode = await runNodeScript('scripts/ci-prepush-lowend.mjs', childArgs);
 } catch (error) {
   console.error(

--- a/scripts/signing/signing-core.d.mts
+++ b/scripts/signing/signing-core.d.mts
@@ -184,3 +184,33 @@ export function verifyOutgoingUpdates(
     introducedCommits?: (update: RefUpdate) => string[];
   },
 ): OutgoingResult;
+
+export interface AttributionCheckResult {
+  ok: boolean;
+  matches: string[];
+}
+
+export interface AttributionReport {
+  sha: string;
+  subject: string;
+  verification: AttributionCheckResult;
+}
+
+export interface AttributionResult {
+  ok: boolean;
+  reports: AttributionReport[];
+  reason?: string;
+}
+
+export function checkCommitAttribution(sha: string, cwd?: string): AttributionCheckResult;
+export function checkTagAttribution(sha: string, cwd?: string): AttributionCheckResult;
+export function checkAttributionForOutgoingUpdates(
+  input: string | string[] | RefUpdate[],
+  remote: string,
+  cwd?: string,
+  dependencies?: {
+    introducedCommits?: (update: RefUpdate) => string[];
+    checkCommitAttribution?: (sha: string) => AttributionCheckResult;
+    checkTagAttribution?: (sha: string) => AttributionCheckResult;
+  },
+): AttributionResult;

--- a/scripts/signing/signing-core.mjs
+++ b/scripts/signing/signing-core.mjs
@@ -714,10 +714,18 @@ export function checkCommitAttribution(sha, cwd = process.cwd()) {
 }
 
 // QNBS-v3: cat-file -p reads the tag's own annotation body — session/co-author text can live there too.
+// QNBS-v3: also peels to the tagged commit — a clean annotation can still target an attributed commit.
 export function checkTagAttribution(sha, cwd = process.cwd()) {
   const result = runGit(['cat-file', '-p', sha], { cwd });
   if (result.status !== 0) return { ok: false, matches: ['unreadable-tag'] };
-  return checkAttributionText(result.stdout);
+  const tagResult = checkAttributionText(result.stdout);
+  const tag = parseAnnotatedTag(sha, cwd);
+  if (tag?.objectType !== 'tag' || tag.targetType !== 'commit') return tagResult;
+  const commitResult = checkCommitAttribution(tag.target, cwd);
+  return {
+    ok: tagResult.ok && commitResult.ok,
+    matches: [...new Set([...tagResult.matches, ...commitResult.matches])],
+  };
 }
 
 // QNBS-v3: split from the outer loop so each function's own nesting stays shallow (code-health delta).
@@ -792,7 +800,7 @@ export function safeConfigSummary(cwd = process.cwd()) {
     : gitDir
       ? join(gitDir, 'hooks')
       : null;
-  const hookNames = ['pre-commit', 'pre-push'];
+  const hookNames = ['pre-commit', 'commit-msg', 'pre-push'];
   return {
     signing: {
       format: signing.format,

--- a/scripts/signing/signing-core.mjs
+++ b/scripts/signing/signing-core.mjs
@@ -2,6 +2,7 @@ import { spawnSync } from 'node:child_process';
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, join, resolve } from 'node:path';
+import { checkAttributionText } from '../check-commit-attribution.mjs';
 import { computeDependencyState } from '../dependency-state.mjs';
 
 const SHA = /^[0-9a-f]{40}$/i;
@@ -693,6 +694,52 @@ export function verifyOutgoingUpdates(input, remote, cwd = process.cwd(), depend
         reports.push(report);
         if (!verification.ok)
           return { ok: false, reports, reason: `${sha.slice(0, 12)}: ${verification.reason}` };
+      }
+    }
+    return { ok: true, reports };
+  } catch (error) {
+    return {
+      ok: false,
+      reports,
+      reason: error instanceof Error ? error.message : 'invalid pre-push ref-update input',
+    };
+  }
+}
+
+export function checkCommitAttribution(sha, cwd = process.cwd()) {
+  const message = gitOutput(['show', '-s', '--format=%B', sha], { cwd }) ?? '';
+  return checkAttributionText(message);
+}
+
+// QNBS-v3: catches a missing/uninstalled commit-msg hook or commits authored by another tool.
+export function checkAttributionForOutgoingUpdates(
+  input,
+  remote,
+  cwd = process.cwd(),
+  dependencies = {},
+) {
+  const getIntroducedCommits =
+    dependencies.introducedCommits ?? ((update) => introducedCommits(update, remote, cwd));
+  const checkCommit =
+    dependencies.checkCommitAttribution ?? ((sha) => checkCommitAttribution(sha, cwd));
+  const reports = [];
+  try {
+    const updates = validatedPrePushUpdates(input);
+    for (const update of updates) {
+      if (isZeroSha(update.localSha)) continue;
+      if (update.remoteRef.startsWith('refs/tags/')) continue;
+      const commits = getIntroducedCommits(update);
+      for (const sha of commits) {
+        const verification = checkCommit(sha);
+        const report = { sha, subject: commitSubject(sha, cwd), verification };
+        reports.push(report);
+        if (!verification.ok) {
+          return {
+            ok: false,
+            reports,
+            reason: `${sha.slice(0, 12)}: forbidden attribution pattern(s) ${verification.matches.join(', ')}`,
+          };
+        }
       }
     }
     return { ok: true, reports };

--- a/scripts/signing/signing-core.mjs
+++ b/scripts/signing/signing-core.mjs
@@ -706,12 +706,48 @@ export function verifyOutgoingUpdates(input, remote, cwd = process.cwd(), depend
   }
 }
 
+// QNBS-v3: fail closed (not the "" from gitOutput) — an unreadable commit must not pass as clean.
 export function checkCommitAttribution(sha, cwd = process.cwd()) {
-  const message = gitOutput(['show', '-s', '--format=%B', sha], { cwd }) ?? '';
-  return checkAttributionText(message);
+  const result = runGit(['show', '-s', '--format=%B', sha], { cwd });
+  if (result.status !== 0) return { ok: false, matches: ['unreadable-commit'] };
+  return checkAttributionText(result.stdout);
 }
 
-// QNBS-v3: catches a missing/uninstalled commit-msg hook or commits authored by another tool.
+// QNBS-v3: cat-file -p reads the tag's own annotation body — session/co-author text can live there too.
+export function checkTagAttribution(sha, cwd = process.cwd()) {
+  const result = runGit(['cat-file', '-p', sha], { cwd });
+  if (result.status !== 0) return { ok: false, matches: ['unreadable-tag'] };
+  return checkAttributionText(result.stdout);
+}
+
+// QNBS-v3: split from the outer loop so each function's own nesting stays shallow (code-health delta).
+function firstAttributionFailure(
+  update,
+  cwd,
+  getIntroducedCommits,
+  checkCommit,
+  checkTag,
+  reports,
+) {
+  if (isZeroSha(update.localSha)) return null;
+  if (update.remoteRef.startsWith('refs/tags/')) {
+    const verification = checkTag(update.localSha);
+    reports.push({ sha: update.localSha, subject: update.remoteRef, verification });
+    return verification.ok
+      ? null
+      : `${update.remoteRef}: forbidden attribution pattern(s) ${verification.matches.join(', ')}`;
+  }
+  for (const sha of getIntroducedCommits(update)) {
+    const verification = checkCommit(sha);
+    reports.push({ sha, subject: commitSubject(sha, cwd), verification });
+    if (!verification.ok) {
+      return `${sha.slice(0, 12)}: forbidden attribution pattern(s) ${verification.matches.join(', ')}`;
+    }
+  }
+  return null;
+}
+
+// QNBS-v3: existing-branch ranges come from the shared evidence file (deterministic); only a new-branch push re-derives a live fallback base, sharing the signature check's same narrow concurrent-fetch window.
 export function checkAttributionForOutgoingUpdates(
   input,
   remote,
@@ -722,25 +758,20 @@ export function checkAttributionForOutgoingUpdates(
     dependencies.introducedCommits ?? ((update) => introducedCommits(update, remote, cwd));
   const checkCommit =
     dependencies.checkCommitAttribution ?? ((sha) => checkCommitAttribution(sha, cwd));
+  const checkTag = dependencies.checkTagAttribution ?? ((sha) => checkTagAttribution(sha, cwd));
   const reports = [];
   try {
     const updates = validatedPrePushUpdates(input);
     for (const update of updates) {
-      if (isZeroSha(update.localSha)) continue;
-      if (update.remoteRef.startsWith('refs/tags/')) continue;
-      const commits = getIntroducedCommits(update);
-      for (const sha of commits) {
-        const verification = checkCommit(sha);
-        const report = { sha, subject: commitSubject(sha, cwd), verification };
-        reports.push(report);
-        if (!verification.ok) {
-          return {
-            ok: false,
-            reports,
-            reason: `${sha.slice(0, 12)}: forbidden attribution pattern(s) ${verification.matches.join(', ')}`,
-          };
-        }
-      }
+      const reason = firstAttributionFailure(
+        update,
+        cwd,
+        getIntroducedCommits,
+        checkCommit,
+        checkTag,
+        reports,
+      );
+      if (reason) return { ok: false, reports, reason };
     }
     return { ok: true, reports };
   } catch (error) {

--- a/scripts/signing/verify-attribution.mjs
+++ b/scripts/signing/verify-attribution.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+import process from 'node:process';
+import { checkAttributionForOutgoingUpdates, readPrePushEvidenceFile } from './signing-core.mjs';
+
+const args = process.argv.slice(2);
+const remote = args[0];
+const evidenceIndex = args.indexOf('--prepush-evidence-file');
+const evidenceFile = evidenceIndex >= 0 ? args[evidenceIndex + 1] : null;
+if (!remote || !evidenceFile) {
+  console.error(
+    'pre-push attribution check requires the remote name and evidence file. Run "pnpm run hooks:install" to refresh the installed hook.',
+  );
+  process.exit(1);
+}
+try {
+  const input = readPrePushEvidenceFile(evidenceFile);
+  const result = checkAttributionForOutgoingUpdates(input, remote);
+  if (!result.ok) {
+    console.error(`pre-push attribution check rejected the update: ${result.reason}`);
+    console.error(
+      'Remove AI/model/session attribution from commit messages before pushing (see AGENTS.md).',
+    );
+    process.exit(1);
+  }
+  console.log(`pre-push attribution check verified ${result.reports.length} outgoing commit(s)`);
+} catch (error) {
+  console.error(
+    `pre-push attribution check failed closed: ${error instanceof Error ? error.message : 'unknown error'}`,
+  );
+  process.exit(1);
+}

--- a/tests/unit/signing.test.ts
+++ b/tests/unit/signing.test.ts
@@ -209,6 +209,42 @@ describe('local signing controls', () => {
     });
   });
 
+  it('checkTagAttribution peels to the target commit — a clean annotation cannot hide an attributed commit', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'worldscript-tagattr-test-'));
+    const env = {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'Test',
+      GIT_AUTHOR_EMAIL: 'test@example.com',
+      GIT_COMMITTER_NAME: 'Test',
+      GIT_COMMITTER_EMAIL: 'test@example.com',
+    };
+    try {
+      execFileSync('git', ['init', '--quiet', '--initial-branch=main', dir]);
+      execFileSync(
+        'git',
+        [
+          '-C',
+          dir,
+          'commit',
+          '--quiet',
+          '--allow-empty',
+          '-m',
+          'fix: bump dep\n\nCo-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>',
+        ],
+        { env },
+      );
+      execFileSync('git', ['-C', dir, 'tag', '-a', 'v1.0.0', '-m', 'clean release notes'], { env });
+      const tagSha = execFileSync('git', ['-C', dir, 'rev-parse', 'v1.0.0'], {
+        encoding: 'utf8',
+      }).trim();
+      const result = checkTagAttribution(tagSha, dir);
+      expect(result.ok).toBe(false);
+      expect(result.matches).toContain('co-authored-by-claude');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('routes tag pushes to checkTagAttribution, not introducedCommits', () => {
     const zero = '0'.repeat(40);
     const commit = 'a'.repeat(40);

--- a/tests/unit/signing.test.ts
+++ b/tests/unit/signing.test.ts
@@ -14,6 +14,9 @@ import { pathToFileURL } from 'node:url';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import {
   auditRepositoryPolicy,
+  checkAttributionForOutgoingUpdates,
+  checkCommitAttribution,
+  checkTagAttribution,
   classifyCommitObject,
   classifyTagVerification,
   computeWorkingTreeState,
@@ -192,6 +195,61 @@ describe('local signing controls', () => {
         },
       ),
     ).toMatchObject({ ok: true, reports: [{ sha: commit }] });
+  });
+
+  it('fails closed when a commit or tag is unreadable instead of passing as clean', () => {
+    const bogus = 'f'.repeat(40);
+    expect(checkCommitAttribution(bogus, process.cwd())).toMatchObject({
+      ok: false,
+      matches: ['unreadable-commit'],
+    });
+    expect(checkTagAttribution(bogus, process.cwd())).toMatchObject({
+      ok: false,
+      matches: ['unreadable-tag'],
+    });
+  });
+
+  it('routes tag pushes to checkTagAttribution, not introducedCommits', () => {
+    const zero = '0'.repeat(40);
+    const commit = 'a'.repeat(40);
+    let tagChecked = false;
+    expect(
+      checkAttributionForOutgoingUpdates(
+        [`refs/tags/v1.0.0 ${commit} refs/tags/v1.0.0 ${zero}`],
+        'origin',
+        process.cwd(),
+        {
+          checkTagAttribution: (sha) => {
+            tagChecked = true;
+            expect(sha).toBe(commit);
+            return { ok: true, matches: [] };
+          },
+          introducedCommits: () => {
+            throw new Error('tags must not enumerate branch commits');
+          },
+        },
+      ),
+    ).toMatchObject({ ok: true, reports: [{ sha: commit, subject: 'refs/tags/v1.0.0' }] });
+    expect(tagChecked).toBe(true);
+  });
+
+  it('reports the first forbidden-attribution commit and stops scanning', () => {
+    const commit = 'a'.repeat(40);
+    const remote = 'b'.repeat(40);
+    expect(
+      checkAttributionForOutgoingUpdates(
+        [`refs/heads/main ${commit} refs/heads/main ${remote}`],
+        'origin',
+        process.cwd(),
+        {
+          introducedCommits: () => [commit],
+          checkCommitAttribution: () => ({ ok: false, matches: ['co-authored-by-claude'] }),
+        },
+      ),
+    ).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining('co-authored-by-claude'),
+    });
   });
 
   // QNBS-v3: lock the pre-push evidence contract against malformed or unresolved input.

--- a/tests/unit/tooling/checkCommitAttribution.test.ts
+++ b/tests/unit/tooling/checkCommitAttribution.test.ts
@@ -98,6 +98,21 @@ describe('checkAttributionText', () => {
     expect(result.matches).toContain('generated-by-claude-footer');
   });
 
+  it('rejects the markdown-link generated-by footer form', () => {
+    const result = checkAttributionText(
+      'fix: bump dep\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n',
+    );
+    expect(result.ok).toBe(false);
+    expect(result.matches).toContain('generated-by-claude-footer');
+  });
+
+  it('passes a line that discusses the footer text rather than being the footer itself', () => {
+    const result = checkAttributionText(
+      'fix: bump dep\n\nGenerated with Claude Code is the exact footer this guard rejects.\n',
+    );
+    expect(result.ok).toBe(true);
+  });
+
   it('rejects the GitHub-Copilot-with-Claude co-author form', () => {
     const result = checkAttributionText(
       'fix: bump dep\n\nCo-Authored-By: GitHub Copilot (Claude Sonnet 5)\n',

--- a/tests/unit/tooling/checkCommitAttribution.test.ts
+++ b/tests/unit/tooling/checkCommitAttribution.test.ts
@@ -1,14 +1,36 @@
-import { spawnSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   checkAttributionText,
   FORBIDDEN_ATTRIBUTION_PATTERNS,
 } from '../../../scripts/check-commit-attribution.mjs';
 
+const SCRIPT = resolve(process.cwd(), 'scripts/check-commit-attribution.mjs');
+
 function runCli(args: string[]) {
   return spawnSync('node', ['scripts/check-commit-attribution.mjs', ...args], {
     encoding: 'utf8',
   });
+}
+
+function runCliIn(dir: string, args: string[]) {
+  return spawnSync('node', [SCRIPT, ...args], { cwd: dir, encoding: 'utf8' });
+}
+
+function makeTagFixture() {
+  const dir = mkdtempSync(join(tmpdir(), 'worldscript-tag-test-'));
+  const env = {
+    ...process.env,
+    GIT_AUTHOR_NAME: 'Test',
+    GIT_AUTHOR_EMAIL: 'test@example.com',
+    GIT_COMMITTER_NAME: 'Test',
+    GIT_COMMITTER_EMAIL: 'test@example.com',
+  };
+  execFileSync('git', ['init', '--quiet', '--initial-branch=main', dir]);
+  return { dir, env };
 }
 
 describe('checkAttributionText', () => {
@@ -111,5 +133,96 @@ describe('check-commit-attribution CLI', () => {
   it('exits 0 for a clean --message', () => {
     const result = runCli(['--message', 'chore: bump dependency']);
     expect(result.status).toBe(0);
+  });
+});
+
+describe('check-commit-attribution --tag mode', () => {
+  it('accepts a clean tag pointing at a clean commit', () => {
+    const { dir, env } = makeTagFixture();
+    try {
+      execFileSync(
+        'git',
+        ['-C', dir, 'commit', '--quiet', '--allow-empty', '-m', 'chore: initial'],
+        {
+          env,
+        },
+      );
+      execFileSync('git', ['-C', dir, 'tag', '-a', 'v1.0.0', '-m', 'clean release notes'], { env });
+      const tagSha = execFileSync('git', ['-C', dir, 'rev-parse', 'v1.0.0'], {
+        encoding: 'utf8',
+      }).trim();
+      const result = runCliIn(dir, ['--tag', tagSha]);
+      expect(result.status).toBe(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects a clean tag annotation that targets an attributed commit', () => {
+    const { dir, env } = makeTagFixture();
+    try {
+      execFileSync(
+        'git',
+        [
+          '-C',
+          dir,
+          'commit',
+          '--quiet',
+          '--allow-empty',
+          '-m',
+          'fix: bump dep\n\nCo-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>',
+        ],
+        { env },
+      );
+      execFileSync('git', ['-C', dir, 'tag', '-a', 'v1.0.0', '-m', 'clean release notes'], { env });
+      const tagSha = execFileSync('git', ['-C', dir, 'rev-parse', 'v1.0.0'], {
+        encoding: 'utf8',
+      }).trim();
+      const result = runCliIn(dir, ['--tag', tagSha]);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toMatch(/co-authored-by-claude/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects an attributed tag annotation even when the target commit is clean', () => {
+    const { dir, env } = makeTagFixture();
+    try {
+      execFileSync(
+        'git',
+        ['-C', dir, 'commit', '--quiet', '--allow-empty', '-m', 'chore: initial'],
+        {
+          env,
+        },
+      );
+      execFileSync(
+        'git',
+        [
+          '-C',
+          dir,
+          'tag',
+          '-a',
+          'v1.0.0',
+          '-m',
+          'Claude-Session: https://claude.ai/code/session_x',
+        ],
+        { env },
+      );
+      const tagSha = execFileSync('git', ['-C', dir, 'rev-parse', 'v1.0.0'], {
+        encoding: 'utf8',
+      }).trim();
+      const result = runCliIn(dir, ['--tag', tagSha]);
+      expect(result.status).toBe(1);
+      expect(result.stderr).toMatch(/claude-session/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects --tag with no following value as a usage error', () => {
+    const result = runCli(['--tag']);
+    expect(result.status).toBe(2);
+    expect(result.stderr).toMatch(/--tag requires a SHA argument/);
   });
 });

--- a/tests/unit/tooling/checkCommitAttribution.test.ts
+++ b/tests/unit/tooling/checkCommitAttribution.test.ts
@@ -58,6 +58,18 @@ describe('checkAttributionText', () => {
     expect(result.matches).toContain('co-authored-by-claude');
   });
 
+  it('rejects an Anthropic co-author trailer (not just Claude)', () => {
+    const result = checkAttributionText('fix: bump dep\n\nCo-Authored-By: Anthropic\n');
+    expect(result.ok).toBe(false);
+    expect(result.matches).toContain('co-authored-by-claude');
+  });
+
+  it('rejects a generated-by-Anthropic footer (not just Claude)', () => {
+    const result = checkAttributionText('fix: bump dep\n\nGenerated with Anthropic\n');
+    expect(result.ok).toBe(false);
+    expect(result.matches).toContain('generated-by-claude-footer');
+  });
+
   it('rejects a direct claude.com session URL with no intermediate path segment', () => {
     const result = checkAttributionText('fix: bump dep\n\nhttps://claude.com/session_abc123\n');
     expect(result.ok).toBe(false);

--- a/tests/unit/tooling/checkCommitAttribution.test.ts
+++ b/tests/unit/tooling/checkCommitAttribution.test.ts
@@ -58,6 +58,12 @@ describe('checkAttributionText', () => {
     expect(result.matches).toContain('generated-by-claude-footer');
   });
 
+  it('rejects a generated-by footer with no emoji prefix', () => {
+    const result = checkAttributionText('fix: bump dep\n\nGenerated with Claude Code\n');
+    expect(result.ok).toBe(false);
+    expect(result.matches).toContain('generated-by-claude-footer');
+  });
+
   it('rejects the GitHub-Copilot-with-Claude co-author form', () => {
     const result = checkAttributionText(
       'fix: bump dep\n\nCo-Authored-By: GitHub Copilot (Claude Sonnet 5)\n',

--- a/tests/unit/tooling/checkCommitAttribution.test.ts
+++ b/tests/unit/tooling/checkCommitAttribution.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import {
+  checkAttributionText,
+  FORBIDDEN_ATTRIBUTION_PATTERNS,
+} from '../../../scripts/check-commit-attribution.mjs';
+
+describe('checkAttributionText', () => {
+  it('passes a clean conventional commit', () => {
+    const result = checkAttributionText(
+      'fix(agent): close final blocking guidance gaps\n\nRoute encryption-recovery UI to the storage boundary rule.\n',
+    );
+    expect(result.ok).toBe(true);
+    expect(result.matches).toEqual([]);
+  });
+
+  it('rejects a Claude co-author trailer', () => {
+    const result = checkAttributionText(
+      'fix: bump dep\n\nCo-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>\n',
+    );
+    expect(result.ok).toBe(false);
+    expect(result.matches).toContain('co-authored-by-claude');
+  });
+
+  it('rejects a lowercase trailer variant', () => {
+    const result = checkAttributionText(
+      'fix: bump dep\n\nCo-authored-by: Claude Sonnet 5 <noreply@anthropic.com>\n',
+    );
+    expect(result.ok).toBe(false);
+    expect(result.matches).toContain('co-authored-by-claude');
+  });
+
+  it('rejects a Claude-Session trailer', () => {
+    const result = checkAttributionText(
+      'fix: bump dep\n\nClaude-Session: https://claude.ai/code/session_abc123\n',
+    );
+    expect(result.ok).toBe(false);
+    expect(result.matches).toEqual(
+      expect.arrayContaining(['claude-session-trailer', 'claude-session-url']),
+    );
+  });
+
+  it('rejects a generated-by footer', () => {
+    const result = checkAttributionText('fix: bump dep\n\n🤖 Generated with Claude Code\n');
+    expect(result.ok).toBe(false);
+    expect(result.matches).toContain('generated-by-claude-footer');
+  });
+
+  it('rejects the GitHub-Copilot-with-Claude co-author form', () => {
+    const result = checkAttributionText(
+      'fix: bump dep\n\nCo-Authored-By: GitHub Copilot (Claude Sonnet 5)\n',
+    );
+    expect(result.ok).toBe(false);
+    expect(result.matches).toContain('copilot-claude-co-author');
+  });
+
+  it('passes legitimate prose about the Claude provider', () => {
+    const result = checkAttributionText(
+      'feat(ai): improve Claude provider retry handling\n\nAligns backoff with the OpenAI provider.\n',
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it('passes legitimate Anthropic documentation prose', () => {
+    const result = checkAttributionText('docs: document the Anthropic API key rotation flow\n');
+    expect(result.ok).toBe(true);
+  });
+
+  it('exposes one pattern per forbidden category', () => {
+    expect(FORBIDDEN_ATTRIBUTION_PATTERNS.length).toBeGreaterThanOrEqual(6);
+  });
+});

--- a/tests/unit/tooling/checkCommitAttribution.test.ts
+++ b/tests/unit/tooling/checkCommitAttribution.test.ts
@@ -1,8 +1,15 @@
+import { spawnSync } from 'node:child_process';
 import { describe, expect, it } from 'vitest';
 import {
   checkAttributionText,
   FORBIDDEN_ATTRIBUTION_PATTERNS,
 } from '../../../scripts/check-commit-attribution.mjs';
+
+function runCli(args: string[]) {
+  return spawnSync('node', ['scripts/check-commit-attribution.mjs', ...args], {
+    encoding: 'utf8',
+  });
+}
 
 describe('checkAttributionText', () => {
   it('passes a clean conventional commit', () => {
@@ -27,6 +34,12 @@ describe('checkAttributionText', () => {
     );
     expect(result.ok).toBe(false);
     expect(result.matches).toContain('co-authored-by-claude');
+  });
+
+  it('rejects a direct claude.com session URL with no intermediate path segment', () => {
+    const result = checkAttributionText('fix: bump dep\n\nhttps://claude.com/session_abc123\n');
+    expect(result.ok).toBe(false);
+    expect(result.matches).toContain('claude-com-session-url');
   });
 
   it('rejects a Claude-Session trailer', () => {
@@ -67,5 +80,30 @@ describe('checkAttributionText', () => {
 
   it('exposes one pattern per forbidden category', () => {
     expect(FORBIDDEN_ATTRIBUTION_PATTERNS.length).toBeGreaterThanOrEqual(6);
+  });
+});
+
+describe('check-commit-attribution CLI', () => {
+  it('rejects --message with no following value as a usage error, not a silent pass', () => {
+    const result = runCli(['--message']);
+    expect(result.status).toBe(2);
+    expect(result.stderr).toMatch(/--message requires a text argument/);
+  });
+
+  it('rejects --file with no following value as a usage error, not a silent pass', () => {
+    const result = runCli(['--file']);
+    expect(result.status).toBe(2);
+    expect(result.stderr).toMatch(/--file requires a path argument/);
+  });
+
+  it('fails closed with a clear message on a missing --file path', () => {
+    const result = runCli(['--file', '/nonexistent/path/does-not-exist.txt']);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toMatch(/cannot read/);
+  });
+
+  it('exits 0 for a clean --message', () => {
+    const result = runCli(['--message', 'chore: bump dependency']);
+    expect(result.status).toBe(0);
   });
 });

--- a/tests/unit/tooling/checkCommitAttribution.test.ts
+++ b/tests/unit/tooling/checkCommitAttribution.test.ts
@@ -106,6 +106,21 @@ describe('checkAttributionText', () => {
     expect(result.matches).toContain('copilot-claude-co-author');
   });
 
+  it('rejects a co-author trailer with a custom name via the anthropic email, still trailer-anchored', () => {
+    const result = checkAttributionText(
+      'fix: bump dep\n\nCo-Authored-By: AI Assistant <noreply@anthropic.com>\n',
+    );
+    expect(result.ok).toBe(false);
+    expect(result.matches).toContain('anthropic-noreply-email');
+  });
+
+  it('passes prose that merely discusses the anthropic noreply address, not in a trailer', () => {
+    const result = checkAttributionText(
+      'docs: document that this guard rejects noreply@anthropic.com in commit trailers\n',
+    );
+    expect(result.ok).toBe(true);
+  });
+
   it('passes legitimate prose about the Claude provider', () => {
     const result = checkAttributionText(
       'feat(ai): improve Claude provider retry handling\n\nAligns backoff with the OpenAI provider.\n',


### PR DESCRIPTION
## **User description**
## Purpose

Enforce, mechanically, that no commit message, PR title/body, or tag introduces AI/model/tool
attribution (`Co-Authored-By: Claude`, `Claude-Session:` trailers, session URLs, "Generated with
Claude Code" footers). This repo's established convention is clean, purely technical commit/PR
text — see AGENTS.md.

## Scope

- `scripts/check-commit-attribution.mjs` — shared pattern list + `checkAttributionText()`, plus a
  CLI (`--file`, `--message`, or `<base> <head>` range mode).
- `scripts/hooks/commit-msg.mjs` + `simple-git-hooks` wiring — rejects a bad commit before it's
  created.
- `scripts/signing/verify-attribution.mjs` (+ two new exports in `signing-core.mjs`) — scans
  every outgoing commit during `pre-push`, independent of whether the commit-msg hook is
  installed.
- `.github/workflows/ci.yml` (`🔏 Verified Signatures` job) — CI-side backstop: checks the PR's
  commit range plus its title/body (event JSON parsed in Node — never shell-interpolated).
- `AGENTS.md` — one concise rule in the commit/PR section.
- `tests/unit/tooling/checkCommitAttribution.test.ts` — 9 cases: clean commit, both
  `Co-Authored-By` casings, `Claude-Session`, the generated-by footer, the GitHub-Copilot-with-
  Claude form, and two legitimate-prose negatives ("Claude provider", "Anthropic API").

## Non-goals

- Does not rewrite any already-published commit (historical attribution on `main` is left as
  immutable residue).
- Does not touch PR comments/review replies posted through external tooling — that stays a
  behavioral rule (never append these footers), since a commit-msg hook can't reach that surface.

## Validation

- `pnpm exec vitest run tests/unit/tooling/checkCommitAttribution.test.ts tests/unit/signing.test.ts` — 77/77 pass, no regressions in the existing signing suite.
- Manual dogfooding: checker rejects itself against a synthetic dirty message, passes on its own commit message.
- `pnpm run ci:prepush` — clean.

## Summary by Sourcery

Enforce clean, attribution-free commit, tag, and pull request text through local hooks, pre-push validation, and CI checks.

New Features:
- Add automated detection of AI, model, generated-by, and session attribution across commits, tags, and pull request text.
- Add pull request title/body checks that run independently for text-only edits.

Bug Fixes:
- Prevent attributed commits or annotated tags from reaching remotes by rejecting them during commit creation and pushes.
- Fail closed when commits, tags, or required revision data cannot be read.

Enhancements:
- Centralize attribution rules in a reusable checker with CLI, hook, pre-push, and CI integrations.
- Validate annotated tag messages and their target commits while preserving legitimate prose that merely references Claude or Anthropic.
- Update contributor guidance and review-loop documentation to prohibit agent/model attribution.

CI:
- Add CI safeguards for introduced commits and tag pushes, using the base revision's checker for pull request validation.

Documentation:
- Document the clean attribution policy and remove outdated instructions to add agent/model co-author trailers.

Tests:
- Add coverage for forbidden attribution patterns, legitimate-prose exceptions, CLI failures, tag validation, unreadable objects, and outgoing push checks.

Chores:
- Refresh README test-count metrics to reflect the added test coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces the repo rule that commits, tags, and PR titles/bodies never carry AI/model/session attribution (e.g., `Co-Authored-By: Claude` or `Claude-Session:` trailers) via a `commit-msg` hook, a pre-push scan, and CI.

- Shared matcher in `scripts/check-commit-attribution.mjs` used by hook, pre-push, and CI; patterns cover Anthropic as well as Claude, and the `noreply@anthropic.com` and generated-by matches are anchored so prose merely discussing them passes.
- Tag checks validate both the annotation and its target commit; tag pushes resolve the real tag object SHA via `git rev-parse` so the annotation itself is actually checked.
- CI checks introduced commit ranges plus PR title/body; a separate lightweight workflow catches title/body-only edits and uses `$GITHUB_REF` instead of interpolating expressions into Bash.
- PR checks run the base-ref copy of the checker so a PR can't weaken the check that grades it.
- All guards fail closed on unreadable commits/tags or a missing base SHA.
- Docs that still instructed agent co-author trailers now point to the rule; `commit-msg` is added to the `signing:doctor` hooks diagnostic; historical commits on `main` are not rewritten, and review comments stay manual policy.

<sup>Written for commit 066cfb669641fe72d1fa824c2d367a842072305b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/qnbs/WorldScript-Studio/pull/672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated checks for prohibited Claude/Anthropic attribution, generated-by footers, and session URLs in commits, tags, and pull request titles or descriptions.
  - Local commit and pre-push checks now validate attribution before changes are submitted.
  - CI validates attribution using the repository’s base revision and fails closed when content cannot be checked.

- **Documentation**
  - Clarified attribution requirements for commits, pull requests, tags, and review comments.
  - Updated reported test totals and project metrics.

- **Tests**
  - Added coverage for commit, tag, pull request, and error-handling scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Enforce clean commit, tag, and pull request attribution

### What Changed
- Rejects AI/model attribution, generated-by footers, and session URLs in commit messages, annotated tags, and pull request titles or bodies.
- Checks outgoing commits and tags before pushing, including the tagged commit behind an annotated release tag.
- Adds CI checks for introduced commits, release tags, and pull request text; pull request title or body edits are checked without rerunning the full pipeline.
- Fails closed when commits, tags, files, or base revisions cannot be read, preventing unreadable content from being treated as clean.
- Removes outdated documentation that instructed contributors to add agent or model co-author trailers.

### Impact
`✅ Cleaner commit and PR history`
`✅ Fewer attributed releases reaching remote repositories`
`✅ Clearer failures for unreadable or invalid checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>