### PR TITLE
chore(release): bump version to v1.28.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+<!-- release-candidate: v1.28.5 -->
+## [1.28.5] — 2026-09-09
+
 ### Added
 
 - **Project schema-version classification (Slice A, #553):** `PROJECT_SCHEMA_V1` as a fresh

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
   <img src="https://img.shields.io/badge/TypeScript-7.x_(tsgo)-3178C6?logo=typescript&logoColor=white" alt="TypeScript 7 (tsgo)">
   <img src="https://img.shields.io/badge/AI-Gemini_%7C_OpenAI_%7C_OpenRouter_%7C_Ollama_%7C_WebLLM-4285F4?logo=google" alt="Gemini · OpenAI · OpenRouter · Ollama · WebLLM">
   <img src="https://img.shields.io/badge/Local_AI-WebGPU_%7C_ONNX_%7C_Transformers.js-8B5CF6" alt="WebGPU · ONNX · Transformers.js">
-  <img src="https://img.shields.io/badge/Release-v1.28.4-6366F1" alt="Release v1.28.4">
+  <!-- release-candidate: v1.28.5 -->
+  <img src="https://img.shields.io/badge/Release-v1.28.5-6366F1" alt="Release v1.28.5">
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="i18n 19 locales — 2942 keys">

--- a/TODO.md
+++ b/TODO.md
@@ -8,18 +8,43 @@ Status: 🔄 in progress | ⬜ open | ✅ done
 
 ---
 
-## Current Sprint — Release truth reconciliation and R-15 desktop at-rest encryption priority (2026-09-05)
+## Current Sprint — v1.28.5 release cut and post-audit remediation continuation (2026-09-09)
 
 > **Status: 🔄 in progress.** The authoritative native sequence remains
 > [`docs/native/ROADMAP-QT-GPUI-DESKTOP.md`](docs/native/ROADMAP-QT-GPUI-DESKTOP.md), with the
 > next Rust-Core capability choice recorded in [`docs/native/CORE-MIGRATION-LEDGER.md`](docs/native/CORE-MIGRATION-LEDGER.md).
-> R-15 (desktop at-rest encryption) design work is complete — S5-A/B1/B2/B3 are all admitted — but
-> [`docs/native/DESKTOP-MIGRATION-ROADMAP-REV3.md`](docs/native/DESKTOP-MIGRATION-ROADMAP-REV3.md)
-> explicitly forbids pulling Wave 3/4 R-15 **implementation** ahead of unresolved Wave 2 authority
-> prerequisites, and the ledger's row 10 records `S5_IMPLEMENTATION_READY=NO`. This sprint's
-> desktop-storage work is therefore the still-open Wave 2 prerequisite (ledger row 9: the
-> project state-shape compatibility adapter), not R-15 implementation itself. No Qt or GPUI
-> implementation work is part of this sprint.
+> R-15 implementation stays blocked behind the still-open Wave 2 prerequisite (ledger row 9). No
+> Qt, GPUI, or R-15 implementation work is part of this sprint.
+
+- ✅ `v1.28.4` released (PR #615, tag+release published 2026-09-05); the prior sprint's release
+  and governance work (attribution-hygiene guard PR #672, security-docs truth fix PR #673) closed
+  out.
+- ✅ PR #674 merged (2026-09-09): the CHANGELOG completeness gate upgraded from accepting any
+  non-empty `[Unreleased]` section forever to requiring every governed commit to be individually
+  referenced by PR number or subject slug; backfilled 13 previously-undocumented entries. Four
+  correction waves addressed branch-local-vs-ancestry classification, negation/refusal polarity,
+  PR-number token boundaries, and multi-entry reservation gaps. The remaining structural
+  heuristic-matching limitation (a short token like a version number can still clear the
+  word-overlap ratio in an otherwise-matching sentence) is intentionally out of this gate's
+  deterministic, non-NLP scope and is tracked separately as #675.
+- 🔄 `v1.28.5` release cut in progress: version/`CHANGELOG.md`/`TODO.md`/`README.md`
+  reconciliation for everything merged since `v1.28.4` (headlined by PR #674) is in PR #676. Tag,
+  GitHub Release, release artifacts, and the post-release `AUDIT.md` evidence entry all remain
+  pending until after that PR merges and post-merge main CI/CodeQL are green.
+- ⬜ Ledger row 9 (project state-shape compatibility adapter) remains open: durable
+  source-generation fencing, writer integration, universal ingress/egress, and authority switch
+  per `docs/native/CORE-MIGRATION-LEDGER.md` row 9. Wave 3/4 R-15 implementation stays blocked
+  (`S5_IMPLEMENTATION_READY=NO`, recorded on row 10) until row 9 and `S5_TERMINAL=YES` are both
+  true — no target release is set for that yet (tracked, not invented).
+- ⬜ #614 (narrow concurrent-first-install multi-tab race), #532 (WelcomePortal E2E entry
+  nondeterminism root cause), and #675 (deterministic contract for the changelog gate's
+  unnumbered-commit heuristic) remain open, tracked separately — not part of this sprint unless
+  they directly block release or R-15 work.
+
+## Archived — Release truth reconciliation and R-15 desktop at-rest encryption priority (2026-09-05)
+
+> **Status: ✅ Superseded by the current sprint above.** `v1.28.4` shipped 2026-09-05; PR #674 and
+> the `v1.28.5` release cut are the current sprint's continuation of this same work.
 
 - ✅ `v1.28.2` (2026-08-27) and `v1.28.3` (2026-08-27) released, closing out the prior sprint's
   accumulated reconstruction-reconciliation and documentation-truth work.
@@ -41,18 +66,6 @@ Status: 🔄 in progress | ⬜ open | ✅ done
   citations in `docs/SECURITY-THREAT-MODEL.md`/`docs/IDB-ENCRYPTION.md` rewritten to anchor on the
   living ledger state, with a mechanical `check-doc-metrics.mjs` guard against recurrence (first
   slice of the 2026-09-08 external audit's S1–S10 remediation sequence; further slices in progress).
-- 🔄 Ledger row 9 (project state-shape compatibility adapter) — five `feat`/`fix` PRs landed
-  (#618 Slice A persisted schema-version classification, #619 Slice B IDB-load observation, #621
-  raw-integer-grammar hardening, #653 the non-destructive `LEGACY_TO_V1` admission primitive, #658
-  filesystem-admission convergence) but **still not complete**: durable source-generation fencing,
-  writer integration, universal ingress/egress, and authority switch remain open per
-  `docs/native/CORE-MIGRATION-LEDGER.md` row 9. Wave 3/4 R-15 implementation stays blocked
-  (`S5_IMPLEMENTATION_READY=NO`, recorded on row 10) until row 9 and `S5_TERMINAL=YES` are both
-  true — no target release is set for that yet (tracked, not invented; see the S1–S10 remediation
-  plan's exit-criterion work).
-- ⬜ #614 (narrow concurrent-first-install multi-tab race, requires cross-tab coordination) and
-  #532 (WelcomePortal E2E entry nondeterminism root cause) remain open, tracked separately —
-  not part of this sprint unless they directly block release or R-15 work.
 
 ## Archived sprint history
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "worldscript-studio",
   "private": true,
-  "version": "1.28.4",
+  "version": "1.28.5",
   "description": "WorldScript Studio — offline-first, AI-powered creative writing application.",
   "author": "QNBS",
   "keywords": [

--- a/public/sw.js
+++ b/public/sw.js
@@ -6,7 +6,7 @@
 // ============================================================
 
 // QNBS-v3 (CodeRabbit): version bump auto-synced from package.json by scripts/sync-sw-version.mjs — every CACHE_STATIC/CACHE_DYNAMIC name changes too, so this alone invalidates all prior caches on next activate.
-const APP_VERSION   = '1.28.4';
+const APP_VERSION   = '1.28.5';
 const CACHE_STATIC  = `worldscript-static-v${APP_VERSION}`;
 const CACHE_DYNAMIC = `worldscript-dynamic-v${APP_VERSION}`;
 const CACHE_IMAGES  = `worldscript-images-v${APP_VERSION}`;

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6685,7 +6685,7 @@ dependencies = [
 
 [[package]]
 name = "worldscript-studio"
-version = "1.28.4"
+version = "1.28.5"
 dependencies = [
  "base64 0.23.1",
  "candle-core",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "worldscript-studio"
-version = "1.28.4"
+version = "1.28.5"
 description = "AI-powered creative writing and world-building application"
 authors = ["QNBS"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "WorldScript Studio",
-  "version": "1.28.4",
+  "version": "1.28.5",
   "identifier": "com.worldscript.studio",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Purpose

Release-truth reconciliation for `v1.28.5`, covering everything merged to `main` since `v1.28.4` (headlined by PR #674, the CHANGELOG completeness-gate upgrade).

## Scope

- Version bump across `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.lock`, `public/sw.js` (via the existing sync scripts). `AGENTS.md` no longer carries a duplicated version marker (removed by #659's instruction-context slimming), so it is untouched.
- `CHANGELOG.md`: `[Unreleased]` content (already accumulated per-PR under this repo's own completeness gate) converted to the dated `[1.28.5]` entry with the established `<!-- release-candidate: v1.28.5 -->` marker.
- `README.md`: version badge bumped with the same marker.
- `TODO.md`: Current Sprint archived and replaced with the actual current state (this release cut, ledger-row-9 continuation, open #614/#532/#675).

## Non-goals

- No public tag or GitHub Release created here — that is a separate, explicitly-confirmed step after this PR merges and resulting-main CI/CodeQL are green.
- `AUDIT.md` is not touched — its release-gate entry needs real post-merge CI/CodeQL evidence that doesn't exist yet, matching every prior release's pattern.
- No R-15/Qt/GPUI implementation work; no unrelated dependency or refactor churn.

## Validation

- `node scripts/check-doc-metrics.mjs` — release-candidate marker accepted pre-tag, all 7 tracked files consistent.
- `pnpm run ci:prepush` — full local admission gate (dependency state, toolchain, docs/release truth, CSP, desktop-import boundary, native-readiness, i18n key parity + bundle rebuild + translation quality, content guard, workflow policy, single-checker TypeScript) — all pass.

## Summary by Sourcery

Prepare the repository for the v1.28.5 release by synchronizing version metadata and finalizing release documentation.

Enhancements:
- Reconcile the project’s release metadata and documentation for v1.28.5, including the changelog, README badge, service-worker cache version, and current sprint status.

Build:
- Bump the application version across the JavaScript and Tauri package manifests and lock/configuration files.

Documentation:
- Convert the accumulated unreleased changelog content into the dated v1.28.5 release entry and update the release-truth tracking documentation.

Chores:
- Prepare the v1.28.5 release candidate without creating the public tag or GitHub Release.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the project version to v1.28.5 and reconciles release documentation with everything merged to main since v1.28.4 (headlined by the CHANGELOG completeness-gate upgrade). No public tag or GitHub Release is created here — that is a separate step once this merges and post-merge CI/CodeQL are green.

- Version bumped across `package.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, `src-tauri/tauri.conf.json`, and `public/sw.js`.
- `CHANGELOG.md` `[Unreleased]` content converted to a dated `[1.28.5]` entry with the `<!-- release-candidate: v1.28.5 -->` marker.
- `README.md` version badge bumped to v1.28.5.
- `TODO.md` current sprint archived and replaced with the current release-cut state, continuing to track ledger-row-9 and open issues #614/#532/#675.
- `AUDIT.md` intentionally untouched — its release-gate entry requires post-merge CI/CodeQL evidence that doesn't exist yet.

<sup>Written for commit e0c33258f2ed068a9a7c4d9d7926c8574f5939eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/qnbs/WorldScript-Studio/pull/676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the application to version **1.28.5**.
  * Added the release-candidate marker and release date of **September 9, 2026**.
  * Updated displayed version information across the application and documentation.
  * Refreshed service-worker cache versioning so previously cached assets are invalidated during the update.
* **Documentation**
  * Updated release references and sprint tracking to reflect the 1.28.5 release cut and ongoing follow-up work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->