### PR TITLE
docs: reference PR #678 in the Tauri plugin-parity CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`@tauri-apps/plugin-http`, `@tauri-apps/plugin-notification`) after #661 bumped only the Rust
   side, failing every platform's Tauri release build. Bumped the npm packages to match; added
   `check-tauri-plugin-versions.mjs`, a cheap CI guard catching this class of mismatch before the
-  next release tag instead of at tag-triggered release time.
+  next release tag instead of at tag-triggered release time. PR #678.
 
 <!-- release-candidate: v1.28.5 -->
 ## [1.28.5] — 2026-09-09


### PR DESCRIPTION
## **User description**
## Purpose

Resulting-main CI/CD failed after #678 merged: the doc-metrics completeness gate (`scripts/check-doc-metrics.mjs`, the subject of #674) requires every post-tag `feat`/`fix`/`perf` commit to be referenced in `CHANGELOG.md`'s `[Unreleased]` section by PR number or subject. The Tauri plugin-parity fix's entry described the change but never cited its own PR number, unlike every other entry in the file.

## Fix

Append "PR #678." to the existing Unreleased entry, matching the established convention.

## Validation

- `node scripts/check-doc-metrics.mjs` — passes locally.
- `pnpm run ci:prepush` — full local admission gate passes.

## Summary by Sourcery

Add the missing PR reference to the Unreleased changelog entry to satisfy documentation completeness validation.

Bug Fixes:
- Reference PR #678 in the Unreleased changelog entry so the documentation metrics completeness check recognizes the change.

Documentation:
- Update the Unreleased changelog entry to include its associated pull request number.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the missing PR #678 reference to the Tauri plugin-parity CHANGELOG entry so the doc-metrics completeness gate passes.

<sup>Written for commit 8be1f7572e6afa8f0f6073b1cbdaadf047306fe4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/qnbs/WorldScript-Studio/pull/679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Reference PR #678 in the Tauri plugin version-parity changelog entry

### What Changed
- Added the missing PR #678 reference to the existing Unreleased changelog entry

### Impact
`✅ Changelog entry passes documentation completeness checks`
`✅ Easier traceability from the fix to its pull request`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
