### PR TITLE
chore(release): bump version to v1.28.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,19 +19,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `check-tauri-plugin-versions.mjs`, a cheap CI guard catching this class of mismatch before the
   next release tag instead of at tag-triggered release time. PR #678.
 - **CHANGELOG completeness-gate PR-number reference restored:** the Tauri plugin-parity entry
-  above passed PR-branch CI but failed on resulting-`main` immediately after squash-merge, since
-  the gate's PR-number match is only checkable against the final squashed commit subject, which
-  only exists post-merge. PR #679.
+  above passed PR-branch CI but failed on resulting-`main` right after squash-merge. PR #678's
+  number was already known before merge; only the final squash commit's SHA/subject did not
+  exist yet. The PR-branch check does not enforce the current PR's own already-known number
+  against `[Unreleased]`, only resulting-`main`'s commit history — so PR CI stayed green, and
+  only after the squash commit landed on `main` did `docs:check` correctly flag the missing
+  reference. PR #679.
 
 ## [1.28.5] — 2026-09-09
 
-> **This tagged release's desktop build never completed.** The tag-triggered Tauri release
-> workflow failed on every platform (Windows/Linux/macOS) with the Rust/npm plugin version
-> mismatch fixed in `[1.28.6]` above. No GitHub Release or installer/updater artifacts were ever
-> published for `v1.28.5` — the bundle jobs failed before producing assets, so nothing broken
-> reached users. The `v1.28.5` git tag itself is intentionally never deleted, moved, or
-> re-tagged; it remains permanently bound to its original commit as the historical
-> failed/incomplete desktop-release cut. `v1.28.6` is the corrected, complete release.
+> **This tagged release's desktop build never completed.** The tag-triggered Tauri desktop
+> release workflow failed on every platform (Windows/Linux/macOS) with the Rust/npm plugin
+> version mismatch fixed in `[1.28.6]` above, so no GitHub desktop Release or installer/updater
+> assets were ever published for `v1.28.5` — those bundle jobs failed before producing assets.
+> This was a desktop-build-specific failure: the separate Docker/GHCR publish workflow for this
+> tag succeeded, so a container image for `v1.28.5` does exist. The `v1.28.5` git tag itself is
+> intentionally never deleted, moved, or re-tagged; it remains permanently bound to its original
+> commit as the historical failed/incomplete desktop-release cut. `v1.28.6` is the corrected,
+> complete release.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+<!-- release-candidate: v1.28.6 -->
+## [1.28.6] — 2026-09-09
+
 ### Fixed
 
 - **Tauri plugin Rust/npm version parity restored:** `tauri-plugin-http` and
@@ -15,9 +18,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   side, failing every platform's Tauri release build. Bumped the npm packages to match; added
   `check-tauri-plugin-versions.mjs`, a cheap CI guard catching this class of mismatch before the
   next release tag instead of at tag-triggered release time. PR #678.
+- **CHANGELOG completeness-gate PR-number reference restored:** the Tauri plugin-parity entry
+  above passed PR-branch CI but failed on resulting-`main` immediately after squash-merge, since
+  the gate's PR-number match is only checkable against the final squashed commit subject, which
+  only exists post-merge. PR #679.
 
-<!-- release-candidate: v1.28.5 -->
 ## [1.28.5] — 2026-09-09
+
+> **This tagged release's desktop build never completed.** The tag-triggered Tauri release
+> workflow failed on every platform (Windows/Linux/macOS) with the Rust/npm plugin version
+> mismatch fixed in `[1.28.6]` above. No GitHub Release or installer/updater artifacts were ever
+> published for `v1.28.5` — the bundle jobs failed before producing assets, so nothing broken
+> reached users. The `v1.28.5` git tag itself is intentionally never deleted, moved, or
+> re-tagged; it remains permanently bound to its original commit as the historical
+> failed/incomplete desktop-release cut. `v1.28.6` is the corrected, complete release.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
   <img src="https://img.shields.io/badge/TypeScript-7.x_(tsgo)-3178C6?logo=typescript&logoColor=white" alt="TypeScript 7 (tsgo)">
   <img src="https://img.shields.io/badge/AI-Gemini_%7C_OpenAI_%7C_OpenRouter_%7C_Ollama_%7C_WebLLM-4285F4?logo=google" alt="Gemini · OpenAI · OpenRouter · Ollama · WebLLM">
   <img src="https://img.shields.io/badge/Local_AI-WebGPU_%7C_ONNX_%7C_Transformers.js-8B5CF6" alt="WebGPU · ONNX · Transformers.js">
-  <!-- release-candidate: v1.28.5 -->
-  <img src="https://img.shields.io/badge/Release-v1.28.5-6366F1" alt="Release v1.28.5">
+  <!-- release-candidate: v1.28.6 -->
+  <img src="https://img.shields.io/badge/Release-v1.28.6-6366F1" alt="Release v1.28.6">
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="i18n 19 locales — 2942 keys">

--- a/TODO.md
+++ b/TODO.md
@@ -19,19 +19,26 @@ Status: 🔄 in progress | ⬜ open | ✅ done
 - ✅ `v1.28.5` tagged (PR #676, 2026-09-09) — but its tag-triggered Tauri desktop release build
   failed on every platform with a Rust/npm plugin version mismatch (`tauri-plugin-http`,
   `tauri-plugin-notification` drifted ahead of their npm counterparts after #661's Rust-only
-  bump). No GitHub Release or installer artifacts were ever published for it. The `v1.28.5` tag
-  is permanently kept as-is (never deleted/moved/re-tagged) as the historical failed/incomplete
+  bump), so no GitHub desktop Release or installer/updater assets were ever published for it.
+  This was desktop-build-specific: the separate Docker/GHCR publish workflow for this tag
+  succeeded, so a container image for `v1.28.5` does exist. The `v1.28.5` tag is permanently
+  kept as-is (never deleted/moved/re-tagged) as the historical failed/incomplete desktop-release
   cut; the corrected release ships as `v1.28.6`.
 - ✅ PR #678 merged (2026-09-09): aligned the drifted npm plugin versions and added
   `check-tauri-plugin-versions.mjs`, a cheap CI guard mirroring Tauri's own build-time
   Rust/npm parity check for every workspace importer, so this class of mismatch is caught before
   the next release tag instead of at tag-triggered release time. Cross-platform
-  Windows/Ubuntu/macOS `tauri-build.yml` qualification passed on the exact merged SHA before
-  merge.
+  Windows/Ubuntu/macOS `tauri-build.yml` qualification succeeded on the exact final PR head /
+  merge-candidate SHA (`52f14d15aebede5a0482225ba6327221ef81d9c8`) before merge; the resulting
+  squash-merge commit on `main` was a different SHA, produced only after that qualification.
 - ✅ PR #679 merged (2026-09-09): resulting-`main` CI failed once post-#678 on the CHANGELOG
-  completeness gate's own PR-number-reference requirement (only checkable against the final
-  squashed commit subject, which doesn't exist until after merge — see the deferred governance
-  note this incident produced); a one-line CHANGELOG fix restored resulting-`main` to green.
+  completeness gate's PR-number-reference requirement. PR #678's number was already known
+  before merge; what didn't exist yet was the final squash commit. The PR-branch check doesn't
+  enforce a current PR's own already-known number against `[Unreleased]`, only resulting-`main`'s
+  commit history, so PR CI stayed green and only resulting-`main`'s `docs:check` caught the
+  missing reference; a one-line CHANGELOG fix restored it to green. (A possible future pre-merge
+  hardening of this check is recorded as deferred, memory-only follow-up — not part of this
+  release cut.)
 - 🔄 `v1.28.6` release cut in progress (this sprint's active PR): version/`CHANGELOG.md`/
   `TODO.md`/`README.md` reconciliation for the Tauri plugin-parity recovery. Tag, GitHub Release,
   release artifacts, and the post-release `AUDIT.md` evidence entry all remain pending until
@@ -53,7 +60,7 @@ Status: 🔄 in progress | ⬜ open | ✅ done
   unnumbered-commit heuristic) remain open, tracked separately — not part of this sprint unless
   they directly block release or R-15 work.
 
-## Archived — v1.28.5 release cut and post-audit remediation continuation (2026-09-09)
+## Archived — v1.28.5 release cut, superseded by the v1.28.6 corrected release (2026-09-09)
 
 - ✅ `v1.28.4` released (PR #615, tag+release published 2026-09-05); the prior sprint's release
   and governance work (attribution-hygiene guard PR #672, security-docs truth fix PR #673) closed

--- a/TODO.md
+++ b/TODO.md
@@ -72,8 +72,9 @@ Status: 🔄 in progress | ⬜ open | ✅ done
 
 ## Archived — Release truth reconciliation and R-15 desktop at-rest encryption priority (2026-09-05)
 
-> **Status: ✅ Superseded by the current sprint above.** `v1.28.4` shipped 2026-09-05; PR #674 and
-> the `v1.28.5` release cut are the current sprint's continuation of this same work.
+> **Status: ✅ Superseded by the current sprint above.** `v1.28.4` shipped 2026-09-05; PR #674, the
+> `v1.28.5` release cut, and its `v1.28.6` desktop-release-build recovery are the current sprint's
+> continuation of this same work.
 
 - ✅ `v1.28.2` (2026-08-27) and `v1.28.3` (2026-08-27) released, closing out the prior sprint's
   accumulated reconstruction-reconciliation and documentation-truth work.

--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,7 @@ Status: 🔄 in progress | ⬜ open | ✅ done
 
 ---
 
-## Current Sprint — v1.28.5 release cut and post-audit remediation continuation (2026-09-09)
+## Current Sprint — v1.28.6 corrected release cut: Tauri desktop release-build recovery (2026-09-09)
 
 > **Status: 🔄 in progress.** The authoritative native sequence remains
 > [`docs/native/ROADMAP-QT-GPUI-DESKTOP.md`](docs/native/ROADMAP-QT-GPUI-DESKTOP.md), with the
@@ -16,21 +16,33 @@ Status: 🔄 in progress | ⬜ open | ✅ done
 > R-15 implementation stays blocked behind the still-open Wave 2 prerequisite (ledger row 9). No
 > Qt, GPUI, or R-15 implementation work is part of this sprint.
 
-- ✅ `v1.28.4` released (PR #615, tag+release published 2026-09-05); the prior sprint's release
-  and governance work (attribution-hygiene guard PR #672, security-docs truth fix PR #673) closed
-  out.
+- ✅ `v1.28.5` tagged (PR #676, 2026-09-09) — but its tag-triggered Tauri desktop release build
+  failed on every platform with a Rust/npm plugin version mismatch (`tauri-plugin-http`,
+  `tauri-plugin-notification` drifted ahead of their npm counterparts after #661's Rust-only
+  bump). No GitHub Release or installer artifacts were ever published for it. The `v1.28.5` tag
+  is permanently kept as-is (never deleted/moved/re-tagged) as the historical failed/incomplete
+  cut; the corrected release ships as `v1.28.6`.
+- ✅ PR #678 merged (2026-09-09): aligned the drifted npm plugin versions and added
+  `check-tauri-plugin-versions.mjs`, a cheap CI guard mirroring Tauri's own build-time
+  Rust/npm parity check for every workspace importer, so this class of mismatch is caught before
+  the next release tag instead of at tag-triggered release time. Cross-platform
+  Windows/Ubuntu/macOS `tauri-build.yml` qualification passed on the exact merged SHA before
+  merge.
+- ✅ PR #679 merged (2026-09-09): resulting-`main` CI failed once post-#678 on the CHANGELOG
+  completeness gate's own PR-number-reference requirement (only checkable against the final
+  squashed commit subject, which doesn't exist until after merge — see the deferred governance
+  note this incident produced); a one-line CHANGELOG fix restored resulting-`main` to green.
+- 🔄 `v1.28.6` release cut in progress (this sprint's active PR): version/`CHANGELOG.md`/
+  `TODO.md`/`README.md` reconciliation for the Tauri plugin-parity recovery. Tag, GitHub Release,
+  release artifacts, and the post-release `AUDIT.md` evidence entry all remain pending until
+  after this PR merges, post-merge main CI/CodeQL are green, and an exact-SHA
+  Windows/Ubuntu/macOS `tauri-build.yml` qualification passes on the intended tag commit.
 - ✅ PR #674 merged (2026-09-09): the CHANGELOG completeness gate upgraded from accepting any
   non-empty `[Unreleased]` section forever to requiring every governed commit to be individually
-  referenced by PR number or subject slug; backfilled 13 previously-undocumented entries. Four
-  correction waves addressed branch-local-vs-ancestry classification, negation/refusal polarity,
-  PR-number token boundaries, and multi-entry reservation gaps. The remaining structural
-  heuristic-matching limitation (a short token like a version number can still clear the
-  word-overlap ratio in an otherwise-matching sentence) is intentionally out of this gate's
-  deterministic, non-NLP scope and is tracked separately as #675.
-- 🔄 `v1.28.5` release cut in progress: version/`CHANGELOG.md`/`TODO.md`/`README.md`
-  reconciliation for everything merged since `v1.28.4` (headlined by PR #674) is in PR #676. Tag,
-  GitHub Release, release artifacts, and the post-release `AUDIT.md` evidence entry all remain
-  pending until after that PR merges and post-merge main CI/CodeQL are green.
+  referenced by PR number or subject slug; backfilled 13 previously-undocumented entries. The
+  remaining structural heuristic-matching limitation (a short token like a version number can
+  still clear the word-overlap ratio in an otherwise-matching sentence) is intentionally out of
+  this gate's deterministic, non-NLP scope and is tracked separately as #675.
 - ⬜ Ledger row 9 (project state-shape compatibility adapter) remains open: durable
   source-generation fencing, writer integration, universal ingress/egress, and authority switch
   per `docs/native/CORE-MIGRATION-LEDGER.md` row 9. Wave 3/4 R-15 implementation stays blocked
@@ -40,6 +52,16 @@ Status: 🔄 in progress | ⬜ open | ✅ done
   nondeterminism root cause), and #675 (deterministic contract for the changelog gate's
   unnumbered-commit heuristic) remain open, tracked separately — not part of this sprint unless
   they directly block release or R-15 work.
+
+## Archived — v1.28.5 release cut and post-audit remediation continuation (2026-09-09)
+
+- ✅ `v1.28.4` released (PR #615, tag+release published 2026-09-05); the prior sprint's release
+  and governance work (attribution-hygiene guard PR #672, security-docs truth fix PR #673) closed
+  out.
+- ✅ PR #674 merged (2026-09-09): CHANGELOG completeness-gate upgrade (see current sprint entry
+  above for the full description, carried forward since it remains active work).
+- ✅ `v1.28.5` release-prep PR #676 merged and tagged (2026-09-09) — see current sprint above for
+  why this release cut is superseded by `v1.28.6`.
 
 ## Archived — Release truth reconciliation and R-15 desktop at-rest encryption priority (2026-09-05)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "worldscript-studio",
   "private": true,
-  "version": "1.28.5",
+  "version": "1.28.6",
   "description": "WorldScript Studio — offline-first, AI-powered creative writing application.",
   "author": "QNBS",
   "keywords": [

--- a/public/sw.js
+++ b/public/sw.js
@@ -6,7 +6,7 @@
 // ============================================================
 
 // QNBS-v3 (CodeRabbit): version bump auto-synced from package.json by scripts/sync-sw-version.mjs — every CACHE_STATIC/CACHE_DYNAMIC name changes too, so this alone invalidates all prior caches on next activate.
-const APP_VERSION   = '1.28.5';
+const APP_VERSION   = '1.28.6';
 const CACHE_STATIC  = `worldscript-static-v${APP_VERSION}`;
 const CACHE_DYNAMIC = `worldscript-dynamic-v${APP_VERSION}`;
 const CACHE_IMAGES  = `worldscript-images-v${APP_VERSION}`;

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6685,7 +6685,7 @@ dependencies = [
 
 [[package]]
 name = "worldscript-studio"
-version = "1.28.5"
+version = "1.28.6"
 dependencies = [
  "base64 0.23.1",
  "candle-core",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "worldscript-studio"
-version = "1.28.5"
+version = "1.28.6"
 description = "AI-powered creative writing and world-building application"
 authors = ["QNBS"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "WorldScript Studio",
-  "version": "1.28.5",
+  "version": "1.28.6",
   "identifier": "com.worldscript.studio",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Purpose

`v1.28.5` was tagged (#676) but its tag-triggered Tauri desktop release build failed on every platform with the Rust/npm plugin version mismatch fixed by #678, so no GitHub Release or installer artifacts were ever published for it. The `v1.28.5` tag stays permanently as-is (never deleted, moved, or re-tagged) as the historical failed/incomplete cut; `v1.28.6` is the corrected, complete release.

## Changes

- Version bumped 1.28.5 → 1.28.6 via the existing sync scripts (`sync-sw-version.mjs`, `sync-tauri-version.mjs`) across `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.lock`, and `public/sw.js`'s `APP_VERSION`.
- `CHANGELOG.md`: `[Unreleased]` content (the #678/#679 Tauri plugin-parity recovery) converted into the dated `[1.28.6]` entry with the release-candidate marker convention, plus a note under `[1.28.5]` recording why that release never completed.
- `README.md`: version badge + marker updated to v1.28.6.
- `TODO.md`: Current Sprint archived and replaced with the actual current sprint (this release cut plus still-open #614/#532/#675).
- `AUDIT.md` intentionally untouched — its release-gate entry needs real post-merge CI/CodeQL evidence that doesn't exist until after this PR merges, matching every prior release.

## Validation

- `node scripts/check-doc-metrics.mjs` — passes locally.
- `pnpm run ci:prepush` — full local admission gate passes.

## Summary by Sourcery

Prepare the corrected v1.28.6 release and reconcile its version, release notes, and project status documentation.

Bug Fixes:
- Document the incomplete v1.28.5 desktop release and prepare the corrected v1.28.6 release after resolving the Tauri plugin version-parity failure.

Enhancements:
- Update project, service-worker, desktop, and release documentation version metadata from 1.28.5 to 1.28.6.
- Record the Tauri plugin-parity recovery and changelog completeness fix in the v1.28.6 release notes.
- Refresh sprint tracking to archive the superseded v1.28.5 release cut and track the v1.28.6 recovery.

Documentation:
- Update the README release marker and document the failed v1.28.5 desktop release and corrected v1.28.6 release in the changelog.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares the v1.28.6 corrected release since the v1.28.5 tag's Tauri desktop build failed on every platform, leaving no installer or updater assets published.

- Bumps version to 1.28.6 across `package.json`, `Cargo.toml`, `tauri.conf.json`, `Cargo.lock`, and `sw.js`.
- Moves the Tauri plugin-parity fix into the dated `[1.28.6]` changelog entry and documents why the `[1.28.5]` desktop release never completed.
- Updates the README release badge and marker.
- Archives the old sprint in `TODO.md` and rolls in the current release-cut sprint, including accuracy corrections to the release-truth narrative.
- Leaves `AUDIT.md` untouched; its release-gate entry requires post-merge CI/CodeQL evidence.

<sup>Written for commit 30db952bb9007996cdaa08794136c64877c85f1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/qnbs/WorldScript-Studio/pull/680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the application to version 1.28.6.
  * Updated the desktop application and service worker versions for consistency.
  * Refreshed the release badge and current sprint information.

* **Documentation**
  * Documented the corrected 1.28.6 release and the failed, unpublished 1.28.5 desktop release.
  * Recorded related release recovery and audit information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->