### PR TITLE
docs: reference PR #684 in the Tauri parity-preflight CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   platform's `v1.28.5` release build. Added a `parity-preflight` job (checkout + one dependency-free
   Node script, no `pnpm install`) that runs `check-tauri-plugin-versions.mjs` before the bundle
   matrix starts, gated behind `verify-release-tag` so no repository code runs on an unverified
-  release tag. On both `workflow_dispatch` and tag pushes.
+  release tag. On both `workflow_dispatch` and tag pushes. PR #684.
+
 ### Documentation
 
 - **Post-release v1.28.6 truth sync:** removed the now-stale release-candidate markers from


### PR DESCRIPTION
## **User description**
## Purpose

Resulting-main CI/CD failed after #684 merged: the doc-metrics completeness gate (`scripts/check-doc-metrics.mjs`, the subject of #674, recurred around #678/#679) requires every post-tag `feat`/`fix`/`perf` commit to be referenced in `CHANGELOG.md`'s `[Unreleased]` section by PR number or subject. The parity-preflight entry existed and described the change accurately but had its PR-number reference dropped while reverting the unrelated Dependabot multi-ecosystem grouping attempt from the same PR.

## Fix

Append "PR #684." to the existing Unreleased entry, matching the established convention.

## Validation

- `node scripts/check-doc-metrics.mjs` — passes locally.
- `pnpm run ci:prepush` — full local admission gate passes.

## Summary by Sourcery

Documentation:
- Add the PR #684 reference to the Tauri parity-preflight entry in the unreleased changelog.


___

## **CodeAnt-AI Description**
Reference PR #684 in the unreleased parity-preflight changelog entry

### What Changed
- Adds the PR #684 reference to the existing Tauri parity-preflight entry in the `[Unreleased]` changelog

### Impact
`✅ Complete changelog attribution`
`✅ Successful documentation completeness checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the missing PR #684 reference to the Tauri parity-preflight CHANGELOG entry so the doc-metrics completeness gate passes on main. The reference was dropped when an unrelated Dependabot revert was applied.

<sup>Written for commit 893da903bdb1267737738483b8207b2639593b09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/qnbs/WorldScript-Studio/pull/685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

