### PR TITLE
fix(pwa): gate service-worker cache-generation activation on precache success

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="i18n 19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7650%2B_%2F_604_files-22C55E" alt="7650+ tests / 604 files">
+  <img src="https://img.shields.io/badge/Tests-7651%2B_%2F_604_files-22C55E" alt="7651+ tests / 604 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2942 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7650+ tests / 604 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7651+ tests / 604 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7650+ tests, 604 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7651+ tests, 604 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -714,7 +714,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendor **6200 KB**, other JavaScript **2500 KB**, and WASM **30000 KB**.
 
 **Current test metrics (2026-09-10, source-synchronized; CI remains authoritative for pass/fail):**
-- **7650+ unit tests** across **604 test files** — CI is authoritative for pass/fail
+- **7651+ unit tests** across **604 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2942 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="i18n 19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7649%2B_%2F_604_files-22C55E" alt="7649+ tests / 604 files">
+  <img src="https://img.shields.io/badge/Tests-7650%2B_%2F_604_files-22C55E" alt="7650+ tests / 604 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2942 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7649+ tests / 604 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7650+ tests / 604 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7649+ tests, 604 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7650+ tests, 604 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -714,7 +714,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendor **6200 KB**, other JavaScript **2500 KB**, and WASM **30000 KB**.
 
 **Current test metrics (2026-09-10, source-synchronized; CI remains authoritative for pass/fail):**
-- **7649+ unit tests** across **604 test files** — CI is authoritative for pass/fail
+- **7650+ unit tests** across **604 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2942 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="i18n 19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7644%2B_%2F_604_files-22C55E" alt="7644+ tests / 604 files">
+  <img src="https://img.shields.io/badge/Tests-7647%2B_%2F_604_files-22C55E" alt="7647+ tests / 604 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2942 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7644+ tests / 604 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7647+ tests / 604 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7644+ tests, 604 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7647+ tests, 604 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -713,8 +713,8 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 <!-- bundle-budget:source-of-truth -->
 Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendor **6200 KB**, other JavaScript **2500 KB**, and WASM **30000 KB**.
 
-**Current test metrics (2026-09-07, source-synchronized; CI remains authoritative for pass/fail):**
-- **7644+ unit tests** across **604 test files** — CI is authoritative for pass/fail
+**Current test metrics (2026-09-10, source-synchronized; CI remains authoritative for pass/fail):**
+- **7647+ unit tests** across **604 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2942 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="i18n 19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7647%2B_%2F_604_files-22C55E" alt="7647+ tests / 604 files">
+  <img src="https://img.shields.io/badge/Tests-7649%2B_%2F_604_files-22C55E" alt="7649+ tests / 604 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2942 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7647+ tests / 604 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7649+ tests / 604 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7647+ tests, 604 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7649+ tests, 604 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -714,7 +714,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendor **6200 KB**, other JavaScript **2500 KB**, and WASM **30000 KB**.
 
 **Current test metrics (2026-09-10, source-synchronized; CI remains authoritative for pass/fail):**
-- **7647+ unit tests** across **604 test files** — CI is authoritative for pass/fail
+- **7649+ unit tests** across **604 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2942 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -42,14 +42,15 @@ const swLogger = {
 // eslint-disable-next-line no-underscore-dangle
 const _WB_MANIFEST = self.__WB_MANIFEST || [];
 
-const PRECACHE_URLS = [
-  BASE,
-  `${BASE}index.html`,
-  `${BASE}manifest.json`,
-  `${BASE}favicon.svg`,
-  `${BASE}offline.html`,
-  ..._WB_MANIFEST.map((entry) => (typeof entry === 'string' ? entry : entry.url)),
-];
+const EXPLICIT_SHELL_URLS = [BASE, `${BASE}index.html`, `${BASE}manifest.json`, `${BASE}favicon.svg`, `${BASE}offline.html`];
+
+// QNBS-v3: keep these files in the injected manifest (their content hash still changes sw.js's own bytes, triggering an update with no version bump) but drop them here so cache.addAll() never sees the same resolved URL twice.
+const explicitResolvedUrls = new Set(EXPLICIT_SHELL_URLS.map((url) => new URL(url, self.location.href).href));
+const manifestUrls = _WB_MANIFEST
+  .map((entry) => (typeof entry === 'string' ? entry : entry.url))
+  .filter((url) => !explicitResolvedUrls.has(new URL(url, self.location.href).href));
+
+const PRECACHE_URLS = [...EXPLICIT_SHELL_URLS, ...manifestUrls];
 
 // QNBS-v3: marker written into CACHE_STATIC only once precache fully succeeds; activate checks it before pruning an older generation.
 const PRECACHE_ADMISSION_URL = `${BASE}__sw-precache-complete__`;

--- a/public/sw.js
+++ b/public/sw.js
@@ -164,23 +164,23 @@ self.addEventListener('activate', (event) => {
   }
   event.waitUntil(
     (async () => {
-      // QNBS-v3: admission gate — only prune older caches once this generation's own precache is proven complete; otherwise leave every cache untouched.
+      // QNBS-v3: admission gate — only an admitted generation may prune stale caches or claim clients.
       const staticCache = await caches.open(CACHE_STATIC);
       const precacheComplete = Boolean(await staticCache.match(PRECACHE_ADMISSION_URL));
-      if (precacheComplete) {
-        const cacheNames = await caches.keys();
-        await Promise.all(
-          cacheNames
-            // QNBS-v3: prune only owned-and-stale — never delete a cache we don't positively own.
-            .filter((name) => isWorldScriptOwnedCache(name) && !ALL_CACHES.includes(name))
-            .map((name) => {
-              swLogger.log('Pruning old cache:', name);
-              return caches.delete(name);
-            })
-        );
-      } else {
+      if (!precacheComplete) {
         swLogger.warn('Skipping cache-generation cutover: this generation\'s precache never completed');
+        return;
       }
+      const cacheNames = await caches.keys();
+      await Promise.all(
+        cacheNames
+          // QNBS-v3: prune only owned-and-stale — never delete a cache we don't positively own.
+          .filter((name) => isWorldScriptOwnedCache(name) && !ALL_CACHES.includes(name))
+          .map((name) => {
+            swLogger.log('Pruning old cache:', name);
+            return caches.delete(name);
+          })
+      );
       await self.clients.claim();
     })()
   );

--- a/public/sw.js
+++ b/public/sw.js
@@ -128,8 +128,9 @@ self.addEventListener('install', (event) => {
         self.skipWaiting();
       })
       .catch((err) => {
-        // QNBS-v3: no skipWaiting on failure — a working prior generation keeps serving clients until a later install succeeds.
-        swLogger.warn('Precache failed — this generation will not take over from a working prior worker:', err);
+        // QNBS-v3: rethrow so install() itself fails — a worker that never reaches "installed" can never be waited-on, activated, or SKIP_WAITING'd.
+        swLogger.warn('Precache failed — this installation will not complete:', err);
+        throw err;
       })
   );
 });

--- a/public/sw.js
+++ b/public/sw.js
@@ -44,11 +44,16 @@ const _WB_MANIFEST = self.__WB_MANIFEST || [];
 
 const EXPLICIT_SHELL_URLS = [BASE, `${BASE}index.html`, `${BASE}manifest.json`, `${BASE}favicon.svg`, `${BASE}offline.html`];
 
-// QNBS-v3: keep these files in the injected manifest (their content hash still changes sw.js's own bytes, triggering an update with no version bump) but drop them here so cache.addAll() never sees the same resolved URL twice.
-const explicitResolvedUrls = new Set(EXPLICIT_SHELL_URLS.map((url) => new URL(url, self.location.href).href));
+// QNBS-v3: keep these files in the injected manifest (their content hash still changes sw.js's own bytes, triggering an update with no version bump) but drop them here so cache.addAll() never sees the same resolved URL twice — tracked against every URL seen so far, not just the explicit list, since two manifest entries could otherwise collide with each other.
+const seenResolvedUrls = new Set(EXPLICIT_SHELL_URLS.map((url) => new URL(url, self.location.href).href));
 const manifestUrls = _WB_MANIFEST
   .map((entry) => (typeof entry === 'string' ? entry : entry.url))
-  .filter((url) => !explicitResolvedUrls.has(new URL(url, self.location.href).href));
+  .filter((url) => {
+    const resolved = new URL(url, self.location.href).href;
+    if (seenResolvedUrls.has(resolved)) return false;
+    seenResolvedUrls.add(resolved);
+    return true;
+  });
 
 const PRECACHE_URLS = [...EXPLICIT_SHELL_URLS, ...manifestUrls];
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -51,6 +51,9 @@ const PRECACHE_URLS = [
   ..._WB_MANIFEST.map((entry) => (typeof entry === 'string' ? entry : entry.url)),
 ];
 
+// QNBS-v3: marker written into CACHE_STATIC only once precache fully succeeds; activate checks it before pruning an older generation.
+const PRECACHE_ADMISSION_URL = `${BASE}__sw-precache-complete__`;
+
 // ── Max age / entry limits ───────────────────────────────────
 const MAX_AGE_DYNAMIC = 7  * 24 * 60 * 60 * 1000; // 7 days
 const MAX_AGE_IMAGES  = 30 * 24 * 60 * 60 * 1000; // 30 days
@@ -112,16 +115,21 @@ async function offlineFallback(request) {
 // INSTALL — Precache shell
 // ════════════════════════════════════════════════════════════
 self.addEventListener('install', (event) => {
-  // QNBS-v3: activates immediately, no waiting — register-sw.ts owns the bounded pre-reload flush mitigation, residual risk tracked in #518.
-  self.skipWaiting();
   // QNBS-v3: Never precache inside Tauri — the desktop app serves its shell from the bundle.
-  if (IS_TAURI) return;
+  if (IS_TAURI) {
+    self.skipWaiting();
+    return;
+  }
   event.waitUntil(
     caches.open(CACHE_STATIC)
-      .then((cache) => cache.addAll(PRECACHE_URLS))
+      .then((cache) => cache.addAll(PRECACHE_URLS).then(() => cache.put(PRECACHE_ADMISSION_URL, new Response('ok'))))
+      .then(() => {
+        // QNBS-v3: only claim the update once precache fully succeeded; register-sw.ts owns the pre-reload flush mitigation for the resulting reload.
+        self.skipWaiting();
+      })
       .catch((err) => {
-        // Some precache entries (e.g. offline.html) may not exist yet; continue anyway
-        swLogger.warn('Precache partial failure (non-fatal):', err);
+        // QNBS-v3: no skipWaiting on failure — a working prior generation keeps serving clients until a later install succeeds.
+        swLogger.warn('Precache failed — this generation will not take over from a working prior worker:', err);
       })
   );
 });
@@ -154,9 +162,13 @@ self.addEventListener('activate', (event) => {
     return;
   }
   event.waitUntil(
-    caches.keys()
-      .then((cacheNames) =>
-        Promise.all(
+    (async () => {
+      // QNBS-v3: admission gate — only prune older caches once this generation's own precache is proven complete; otherwise leave every cache untouched.
+      const staticCache = await caches.open(CACHE_STATIC);
+      const precacheComplete = Boolean(await staticCache.match(PRECACHE_ADMISSION_URL));
+      if (precacheComplete) {
+        const cacheNames = await caches.keys();
+        await Promise.all(
           cacheNames
             // QNBS-v3: prune only owned-and-stale — never delete a cache we don't positively own.
             .filter((name) => isWorldScriptOwnedCache(name) && !ALL_CACHES.includes(name))
@@ -164,9 +176,12 @@ self.addEventListener('activate', (event) => {
               swLogger.log('Pruning old cache:', name);
               return caches.delete(name);
             })
-        )
-      )
-      .then(() => self.clients.claim())
+        );
+      } else {
+        swLogger.warn('Skipping cache-generation cutover: this generation\'s precache never completed');
+      }
+      await self.clients.claim();
+    })()
   );
 });
 

--- a/tests/unit/serviceWorkerCacheOwnership.test.ts
+++ b/tests/unit/serviceWorkerCacheOwnership.test.ts
@@ -53,7 +53,8 @@ function createFakeCaches(
     rejectOnDelete?: string | undefined;
     failAddAllFor?: string | undefined;
     failAddAllTimes?: number | undefined;
-  } = {},
+    swHref: string;
+  },
 ): FakeCaches {
   const store = new Set(initialNames);
   const entries = new Map<string, Set<string>>();
@@ -75,7 +76,16 @@ function createFakeCaches(
             remainingAddAllFailures--;
             throw new Error(`simulated precache failure for ${name}`);
           }
-          for (const url of urls) bucket.add(url);
+          // QNBS-v3: mirrors real Cache.addAll() — rejects when two entries resolve to the same absolute URL, even if their literal strings differ.
+          const resolvedSeen = new Set<string>();
+          for (const url of urls) {
+            const resolved = new URL(url, opts.swHref).href;
+            if (resolvedSeen.has(resolved)) {
+              throw new Error(`simulated InvalidStateError: duplicate request for ${resolved}`);
+            }
+            resolvedSeen.add(resolved);
+            bucket.add(url);
+          }
         },
         match: async (key: string) => (bucket.has(key) ? { ok: true } : undefined),
         put: async (key: string) => {
@@ -107,12 +117,16 @@ function loadServiceWorker(opts: {
   rejectOnDelete?: string;
   failAddAllFor?: string;
   failAddAllTimes?: number;
+  manifest?: Array<string | { url: string; revision: string }>;
 }) {
   const handlers: Record<string, SwHandler> = {};
+  // QNBS-v3: real service-worker scripts resolve bare manifest URLs relative to their own script location — the fake needs the same href to detect duplicate-request rejections realistically.
+  const swHref = `${opts.protocol}//${opts.hostname}${TEST_BASE}sw.js`;
   const fakeCaches = createFakeCaches(opts.initialCacheNames, {
     rejectOnDelete: opts.rejectOnDelete,
     failAddAllFor: opts.failAddAllFor,
     failAddAllTimes: opts.failAddAllTimes,
+    swHref,
   });
   let skipWaitingCallCount = 0;
   let clientsClaimCallCount = 0;
@@ -121,6 +135,7 @@ function loadServiceWorker(opts: {
       protocol: opts.protocol,
       hostname: opts.hostname,
       pathname: `${TEST_BASE}sw.js`,
+      href: swHref,
     },
     console: { log: () => {}, warn: () => {}, error: () => {} },
     addEventListener: (type: string, handler: SwHandler) => {
@@ -135,12 +150,13 @@ function loadServiceWorker(opts: {
     skipWaiting: () => {
       skipWaitingCallCount++;
     },
-    __WB_MANIFEST: [],
+    __WB_MANIFEST: opts.manifest ?? [],
   };
   const context = vm.createContext({
     self: selfMock,
     caches: fakeCaches,
     console: selfMock.console,
+    URL,
     Response: class {
       constructor(public body?: unknown) {}
     },
@@ -387,5 +403,26 @@ describe('service worker — precache admission gate (#525)', () => {
     expect(clientsClaimCalls()).toBe(1);
     expect(fakeCaches.names()).not.toContain(STALE_STATIC);
     expect(fakeCaches.names()).toContain(CURRENT_STATIC);
+  });
+});
+
+// QNBS-v3: regression coverage for a review finding on the #525 fix itself — VitePWA's injected manifest independently discovers index.html/offline.html/favicon.svg, which must not collide with PRECACHE_URLS's own explicit entries for the same files.
+describe('service worker — precache manifest deduplication (#525 follow-up)', () => {
+  it('a manifest entry resolving to the same URL as an explicit shell asset does not trigger a duplicate-request rejection', async () => {
+    const { getHandler, fakeCaches, skipWaitingCalls } = loadServiceWorker({
+      protocol: 'https:',
+      hostname: 'qnbs.github.io',
+      initialCacheNames: [],
+      manifest: [
+        { url: 'index.html', revision: 'abc123' },
+        { url: 'offline.html', revision: 'def456' },
+        { url: 'favicon.svg', revision: 'ghi789' },
+        { url: 'assets/app-somehash.js', revision: '' },
+      ],
+    });
+    await runWaitUntil(getHandler('install'));
+    const staticCache = await fakeCaches.open(CURRENT_STATIC);
+    expect(await staticCache.match(ADMISSION_MARKER_URL)).toBeTruthy();
+    expect(skipWaitingCalls()).toBe(1);
   });
 });

--- a/tests/unit/serviceWorkerCacheOwnership.test.ts
+++ b/tests/unit/serviceWorkerCacheOwnership.test.ts
@@ -46,11 +46,17 @@ interface FakeCaches {
 
 function createFakeCaches(
   initialNames: string[],
-  opts: { rejectOnDelete?: string | undefined; failAddAllFor?: string | undefined } = {},
+  opts: {
+    rejectOnDelete?: string | undefined;
+    failAddAllFor?: string | undefined;
+    failAddAllTimes?: number | undefined;
+  } = {},
 ): FakeCaches {
   const store = new Set(initialNames);
   const entries = new Map<string, Set<string>>();
   const attemptedDeletes: string[] = [];
+  // QNBS-v3: a countdown (not a fixed boolean) so the SAME fake caches instance can simulate a real second install attempt succeeding after an earlier one failed.
+  let remainingAddAllFailures = opts.failAddAllTimes ?? (opts.failAddAllFor ? 1 : 0);
   return {
     async keys() {
       return [...store];
@@ -62,8 +68,10 @@ function createFakeCaches(
       if (!bucket) throw new Error('unreachable: bucket just inserted');
       return {
         addAll: async (urls: string[]) => {
-          if (opts.failAddAllFor === name)
+          if (opts.failAddAllFor === name && remainingAddAllFailures > 0) {
+            remainingAddAllFailures--;
             throw new Error(`simulated precache failure for ${name}`);
+          }
           for (const url of urls) bucket.add(url);
         },
         match: async (key: string) => (bucket.has(key) ? { ok: true } : undefined),
@@ -95,12 +103,15 @@ function loadServiceWorker(opts: {
   initialCacheNames: string[];
   rejectOnDelete?: string;
   failAddAllFor?: string;
+  failAddAllTimes?: number;
 }) {
   const handlers: Record<string, SwHandler> = {};
   const fakeCaches = createFakeCaches(opts.initialCacheNames, {
     rejectOnDelete: opts.rejectOnDelete,
     failAddAllFor: opts.failAddAllFor,
+    failAddAllTimes: opts.failAddAllTimes,
   });
+  let skipWaitingCallCount = 0;
   const selfMock = {
     location: {
       protocol: opts.protocol,
@@ -113,7 +124,9 @@ function loadServiceWorker(opts: {
     },
     clients: { claim: async () => {} },
     registration: { unregister: async () => {} },
-    skipWaiting: () => {},
+    skipWaiting: () => {
+      skipWaitingCallCount++;
+    },
     __WB_MANIFEST: [],
   };
   const context = vm.createContext({
@@ -131,7 +144,7 @@ function loadServiceWorker(opts: {
     if (!handler) throw new Error(`sw.js never registered a "${type}" listener`);
     return handler;
   };
-  return { getHandler, fakeCaches };
+  return { getHandler, fakeCaches, skipWaitingCalls: () => skipWaitingCallCount };
 }
 
 async function runWaitUntil(handler: SwHandler, event: Record<string, unknown> = {}) {
@@ -291,9 +304,44 @@ describe('service worker — cache ownership (activate / CLEAR_CACHE never delet
   });
 });
 
-// QNBS-v3: regression coverage for #525 — a partial precache must never displace a working prior generation.
+// QNBS-v3: a rejected install can never reach 'installed'/'waiting', so register-sw.ts's SKIP_WAITING message can't reach an incomplete generation either — no extra gating needed there.
 describe('service worker — precache admission gate (#525)', () => {
-  it('successful install admits the new generation: activate prunes the previous complete generation', async () => {
+  it('failed addAll() causes the install waitUntil() promise to reject', async () => {
+    const { getHandler } = loadServiceWorker({
+      protocol: 'https:',
+      hostname: 'qnbs.github.io',
+      initialCacheNames: [],
+      failAddAllFor: CURRENT_STATIC,
+      failAddAllTimes: 1,
+    });
+    await expect(runWaitUntil(getHandler('install'))).rejects.toThrow();
+  });
+
+  it('skipWaiting() is not called for a failed installation', async () => {
+    const { getHandler, skipWaitingCalls } = loadServiceWorker({
+      protocol: 'https:',
+      hostname: 'qnbs.github.io',
+      initialCacheNames: [],
+      failAddAllFor: CURRENT_STATIC,
+      failAddAllTimes: 1,
+    });
+    await expect(runWaitUntil(getHandler('install'))).rejects.toThrow();
+    expect(skipWaitingCalls()).toBe(0);
+  });
+
+  it('successful install completes, writes the admission marker and invokes skipWaiting()', async () => {
+    const { getHandler, fakeCaches, skipWaitingCalls } = loadServiceWorker({
+      protocol: 'https:',
+      hostname: 'qnbs.github.io',
+      initialCacheNames: [],
+    });
+    await runWaitUntil(getHandler('install'));
+    const staticCache = await fakeCaches.open(CURRENT_STATIC);
+    expect(await staticCache.match(ADMISSION_MARKER_URL)).toBeTruthy();
+    expect(skipWaitingCalls()).toBe(1);
+  });
+
+  it('successful activate after an admitted install prunes the previous owned generation', async () => {
     const { getHandler, fakeCaches } = loadServiceWorker({
       protocol: 'https:',
       hostname: 'qnbs.github.io',
@@ -305,33 +353,22 @@ describe('service worker — precache admission gate (#525)', () => {
     expect(fakeCaches.names()).toContain(CURRENT_STATIC);
   });
 
-  it('failed precache never admits the new generation: activate preserves every existing cache, including the previous complete generation', async () => {
+  it('a later real successful install attempt after a failed one succeeds normally (no permanent stuck state)', async () => {
     const { getHandler, fakeCaches } = loadServiceWorker({
       protocol: 'https:',
       hostname: 'qnbs.github.io',
       initialCacheNames: [STALE_STATIC],
       failAddAllFor: CURRENT_STATIC,
+      failAddAllTimes: 1,
     });
-    await runWaitUntil(getHandler('install'));
+    // QNBS-v3: the first attempt fails and must reject; activate must never run for a rejected install in real life, but even if reached the marker check still preserves the previous generation as defense in depth.
+    await expect(runWaitUntil(getHandler('install'))).rejects.toThrow();
     await runWaitUntil(getHandler('activate'));
-    // QNBS-v3: STALE_STATIC represents the previous, complete, last-known-good generation here.
     expect(fakeCaches.names()).toContain(STALE_STATIC);
     expect(fakeCaches.attemptedDeletes).not.toContain(STALE_STATIC);
-  });
 
-  it('a later successful install can still admit and prune after an earlier failed attempt (no permanent stuck state)', async () => {
-    const { getHandler, fakeCaches } = loadServiceWorker({
-      protocol: 'https:',
-      hostname: 'qnbs.github.io',
-      initialCacheNames: [STALE_STATIC],
-      failAddAllFor: CURRENT_STATIC,
-    });
+    // QNBS-v3: a real second install attempt (same worker source and fake caches, not a marker shortcut) now succeeds because the failure countdown is exhausted.
     await runWaitUntil(getHandler('install'));
-    await runWaitUntil(getHandler('activate'));
-    expect(fakeCaches.names()).toContain(STALE_STATIC);
-
-    // QNBS-v3: simulate a subsequent successful install for the same generation by admitting it directly.
-    await admitPrecache(fakeCaches);
     await runWaitUntil(getHandler('activate'));
     expect(fakeCaches.names()).not.toContain(STALE_STATIC);
     expect(fakeCaches.names()).toContain(CURRENT_STATIC);

--- a/tests/unit/serviceWorkerCacheOwnership.test.ts
+++ b/tests/unit/serviceWorkerCacheOwnership.test.ts
@@ -46,7 +46,7 @@ interface FakeCaches {
 
 function createFakeCaches(
   initialNames: string[],
-  opts: { rejectOnDelete?: string; failAddAllFor?: string } = {},
+  opts: { rejectOnDelete?: string | undefined; failAddAllFor?: string | undefined } = {},
 ): FakeCaches {
   const store = new Set(initialNames);
   const entries = new Map<string, Set<string>>();

--- a/tests/unit/serviceWorkerCacheOwnership.test.ts
+++ b/tests/unit/serviceWorkerCacheOwnership.test.ts
@@ -13,12 +13,15 @@ const extractedVersion = appVersionMatch?.[1];
 if (!extractedVersion) throw new Error('Could not extract APP_VERSION from public/sw.js');
 const APP_VERSION = extractedVersion;
 
-// QNBS-v3: extracted from source (not hardcoded) so this test tracks the real constant, not a guess.
+// QNBS-v3: the one BASE every loadServiceWorker() call below uses via selfMock.location.pathname — shared so ADMISSION_MARKER_URL can never silently diverge from it.
+const TEST_BASE = '/WorldScript-Studio/';
+
+// QNBS-v3: only the suffix is extracted from source; TEST_BASE above is the single hardcoded value both this constant and selfMock.location.pathname derive from.
 const admissionUrlMatch = swSource.match(/const PRECACHE_ADMISSION_URL\s*=\s*`\$\{BASE\}([^`]+)`/);
 const extractedAdmissionSuffix = admissionUrlMatch?.[1];
 if (!extractedAdmissionSuffix)
   throw new Error('Could not extract PRECACHE_ADMISSION_URL from public/sw.js');
-const ADMISSION_MARKER_URL = `/WorldScript-Studio/${extractedAdmissionSuffix}`;
+const ADMISSION_MARKER_URL = `${TEST_BASE}${extractedAdmissionSuffix}`;
 
 const CURRENT_STATIC = `worldscript-static-v${APP_VERSION}`;
 const CURRENT_DYNAMIC = `worldscript-dynamic-v${APP_VERSION}`;
@@ -117,7 +120,7 @@ function loadServiceWorker(opts: {
     location: {
       protocol: opts.protocol,
       hostname: opts.hostname,
-      pathname: '/WorldScript-Studio/sw.js',
+      pathname: `${TEST_BASE}sw.js`,
     },
     console: { log: () => {}, warn: () => {}, error: () => {} },
     addEventListener: (type: string, handler: SwHandler) => {

--- a/tests/unit/serviceWorkerCacheOwnership.test.ts
+++ b/tests/unit/serviceWorkerCacheOwnership.test.ts
@@ -112,6 +112,7 @@ function loadServiceWorker(opts: {
     failAddAllTimes: opts.failAddAllTimes,
   });
   let skipWaitingCallCount = 0;
+  let clientsClaimCallCount = 0;
   const selfMock = {
     location: {
       protocol: opts.protocol,
@@ -122,7 +123,11 @@ function loadServiceWorker(opts: {
     addEventListener: (type: string, handler: SwHandler) => {
       handlers[type] = handler;
     },
-    clients: { claim: async () => {} },
+    clients: {
+      claim: async () => {
+        clientsClaimCallCount++;
+      },
+    },
     registration: { unregister: async () => {} },
     skipWaiting: () => {
       skipWaitingCallCount++;
@@ -144,7 +149,12 @@ function loadServiceWorker(opts: {
     if (!handler) throw new Error(`sw.js never registered a "${type}" listener`);
     return handler;
   };
-  return { getHandler, fakeCaches, skipWaitingCalls: () => skipWaitingCallCount };
+  return {
+    getHandler,
+    fakeCaches,
+    skipWaitingCalls: () => skipWaitingCallCount,
+    clientsClaimCalls: () => clientsClaimCallCount,
+  };
 }
 
 async function runWaitUntil(handler: SwHandler, event: Record<string, unknown> = {}) {
@@ -354,22 +364,24 @@ describe('service worker — precache admission gate (#525)', () => {
   });
 
   it('a later real successful install attempt after a failed one succeeds normally (no permanent stuck state)', async () => {
-    const { getHandler, fakeCaches } = loadServiceWorker({
+    const { getHandler, fakeCaches, clientsClaimCalls } = loadServiceWorker({
       protocol: 'https:',
       hostname: 'qnbs.github.io',
       initialCacheNames: [STALE_STATIC],
       failAddAllFor: CURRENT_STATIC,
       failAddAllTimes: 1,
     });
-    // QNBS-v3: the first attempt fails and must reject; activate must never run for a rejected install in real life, but even if reached the marker check still preserves the previous generation as defense in depth.
+    // QNBS-v3: the first attempt fails and must reject; activate must never run for a rejected install in real life, but even if reached the marker check still preserves the previous generation and never claims clients, as defense in depth.
     await expect(runWaitUntil(getHandler('install'))).rejects.toThrow();
     await runWaitUntil(getHandler('activate'));
     expect(fakeCaches.names()).toContain(STALE_STATIC);
     expect(fakeCaches.attemptedDeletes).not.toContain(STALE_STATIC);
+    expect(clientsClaimCalls()).toBe(0);
 
     // QNBS-v3: a real second install attempt (same worker source and fake caches, not a marker shortcut) now succeeds because the failure countdown is exhausted.
     await runWaitUntil(getHandler('install'));
     await runWaitUntil(getHandler('activate'));
+    expect(clientsClaimCalls()).toBe(1);
     expect(fakeCaches.names()).not.toContain(STALE_STATIC);
     expect(fakeCaches.names()).toContain(CURRENT_STATIC);
   });

--- a/tests/unit/serviceWorkerCacheOwnership.test.ts
+++ b/tests/unit/serviceWorkerCacheOwnership.test.ts
@@ -13,6 +13,13 @@ const extractedVersion = appVersionMatch?.[1];
 if (!extractedVersion) throw new Error('Could not extract APP_VERSION from public/sw.js');
 const APP_VERSION = extractedVersion;
 
+// QNBS-v3: extracted from source (not hardcoded) so this test tracks the real constant, not a guess.
+const admissionUrlMatch = swSource.match(/const PRECACHE_ADMISSION_URL\s*=\s*`\$\{BASE\}([^`]+)`/);
+const extractedAdmissionSuffix = admissionUrlMatch?.[1];
+if (!extractedAdmissionSuffix)
+  throw new Error('Could not extract PRECACHE_ADMISSION_URL from public/sw.js');
+const ADMISSION_MARKER_URL = `/WorldScript-Studio/${extractedAdmissionSuffix}`;
+
 const CURRENT_STATIC = `worldscript-static-v${APP_VERSION}`;
 const CURRENT_DYNAMIC = `worldscript-dynamic-v${APP_VERSION}`;
 const CURRENT_IMAGES = `worldscript-images-v${APP_VERSION}`;
@@ -21,38 +28,55 @@ const FOREIGN_CACHE = 'some-other-github-pages-app-cache-v1';
 // QNBS-v3: a startsWith('worldscript-static-v') predicate would wrongly treat this as owned.
 const COLLIDING_FOREIGN_CACHE = 'worldscript-static-vendor-cache';
 
+interface FakeCache {
+  addAll: (urls: string[]) => Promise<void>;
+  match: (key: string) => Promise<{ ok: true } | undefined>;
+  put: (key: string, value: unknown) => Promise<void>;
+  keys: () => Promise<never[]>;
+}
+
 interface FakeCaches {
   keys(): Promise<string[]>;
-  open(name: string): Promise<{
-    addAll: () => Promise<void>;
-    match: () => Promise<undefined>;
-    put: () => Promise<void>;
-    keys: () => Promise<never[]>;
-  }>;
+  open(name: string): Promise<FakeCache>;
   delete(name: string): Promise<boolean>;
   match(): Promise<undefined>;
   attemptedDeletes: string[];
   names(): string[];
 }
 
-function createFakeCaches(initialNames: string[], rejectOnDelete?: string): FakeCaches {
+function createFakeCaches(
+  initialNames: string[],
+  opts: { rejectOnDelete?: string; failAddAllFor?: string } = {},
+): FakeCaches {
   const store = new Set(initialNames);
+  const entries = new Map<string, Set<string>>();
   const attemptedDeletes: string[] = [];
   return {
     async keys() {
       return [...store];
     },
-    async open() {
+    async open(name: string) {
+      store.add(name);
+      if (!entries.has(name)) entries.set(name, new Set());
+      const bucket = entries.get(name);
+      if (!bucket) throw new Error('unreachable: bucket just inserted');
       return {
-        addAll: async () => {},
-        match: async () => undefined,
-        put: async () => {},
+        addAll: async (urls: string[]) => {
+          if (opts.failAddAllFor === name)
+            throw new Error(`simulated precache failure for ${name}`);
+          for (const url of urls) bucket.add(url);
+        },
+        match: async (key: string) => (bucket.has(key) ? { ok: true } : undefined),
+        put: async (key: string) => {
+          bucket.add(key);
+        },
         keys: async () => [],
       };
     },
     async delete(name: string) {
       attemptedDeletes.push(name);
-      if (name === rejectOnDelete) throw new Error(`simulated delete failure for ${name}`);
+      if (name === opts.rejectOnDelete) throw new Error(`simulated delete failure for ${name}`);
+      entries.delete(name);
       return store.delete(name);
     },
     async match() {
@@ -70,11 +94,19 @@ function loadServiceWorker(opts: {
   hostname: string;
   initialCacheNames: string[];
   rejectOnDelete?: string;
+  failAddAllFor?: string;
 }) {
   const handlers: Record<string, SwHandler> = {};
-  const fakeCaches = createFakeCaches(opts.initialCacheNames, opts.rejectOnDelete);
+  const fakeCaches = createFakeCaches(opts.initialCacheNames, {
+    rejectOnDelete: opts.rejectOnDelete,
+    failAddAllFor: opts.failAddAllFor,
+  });
   const selfMock = {
-    location: { protocol: opts.protocol, hostname: opts.hostname, pathname: '/WorldScript-Studio/sw.js' },
+    location: {
+      protocol: opts.protocol,
+      hostname: opts.hostname,
+      pathname: '/WorldScript-Studio/sw.js',
+    },
     console: { log: () => {}, warn: () => {}, error: () => {} },
     addEventListener: (type: string, handler: SwHandler) => {
       handlers[type] = handler;
@@ -84,10 +116,17 @@ function loadServiceWorker(opts: {
     skipWaiting: () => {},
     __WB_MANIFEST: [],
   };
-  const context = vm.createContext({ self: selfMock, caches: fakeCaches, console: selfMock.console });
+  const context = vm.createContext({
+    self: selfMock,
+    caches: fakeCaches,
+    console: selfMock.console,
+    Response: class {
+      constructor(public body?: unknown) {}
+    },
+  });
   vm.runInContext(swSource, context);
   // QNBS-v3: bracket-index + explicit throw satisfies noUncheckedIndexedAccess and yields non-optional SwHandler.
-  const getHandler = (type: 'activate' | 'message'): SwHandler => {
+  const getHandler = (type: 'install' | 'activate' | 'message'): SwHandler => {
     const handler = handlers[type];
     if (!handler) throw new Error(`sw.js never registered a "${type}" listener`);
     return handler;
@@ -97,8 +136,19 @@ function loadServiceWorker(opts: {
 
 async function runWaitUntil(handler: SwHandler, event: Record<string, unknown> = {}) {
   let captured: unknown;
-  await handler({ ...event, waitUntil: (p: unknown) => { captured = p; } });
+  await handler({
+    ...event,
+    waitUntil: (p: unknown) => {
+      captured = p;
+    },
+  });
   await captured;
+}
+
+/** Seeds CACHE_STATIC with the admission marker directly, simulating "a prior install already completed successfully" without re-running install. */
+async function admitPrecache(fakeCaches: FakeCaches) {
+  const cache = await fakeCaches.open(CURRENT_STATIC);
+  await cache.put(ADMISSION_MARKER_URL, { ok: true });
 }
 
 describe('service worker — cache ownership (activate / CLEAR_CACHE never delete unowned caches)', () => {
@@ -110,8 +160,15 @@ describe('service worker — cache ownership (activate / CLEAR_CACHE never delet
     const { getHandler, fakeCaches } = loadServiceWorker({
       protocol: 'https:',
       hostname: 'qnbs.github.io',
-      initialCacheNames: [STALE_STATIC, CURRENT_STATIC, CURRENT_DYNAMIC, CURRENT_IMAGES, FOREIGN_CACHE],
+      initialCacheNames: [
+        STALE_STATIC,
+        CURRENT_STATIC,
+        CURRENT_DYNAMIC,
+        CURRENT_IMAGES,
+        FOREIGN_CACHE,
+      ],
     });
+    await admitPrecache(fakeCaches);
     await runWaitUntil(getHandler('activate'));
     const remaining = fakeCaches.names();
     expect(remaining).not.toContain(STALE_STATIC);
@@ -127,6 +184,7 @@ describe('service worker — cache ownership (activate / CLEAR_CACHE never delet
       hostname: 'qnbs.github.io',
       initialCacheNames: [STALE_STATIC, CURRENT_STATIC, FOREIGN_CACHE],
     });
+    await admitPrecache(fakeCaches);
     await runWaitUntil(getHandler('activate'));
     expect(fakeCaches.attemptedDeletes).not.toContain(FOREIGN_CACHE);
   });
@@ -152,7 +210,10 @@ describe('service worker — cache ownership (activate / CLEAR_CACHE never delet
       hostname: 'qnbs.github.io',
       initialCacheNames: [STALE_STATIC, CURRENT_STATIC, CURRENT_IMAGES, FOREIGN_CACHE],
     });
-    await getHandler('message')({ data: { type: 'CLEAR_CACHE' }, source: { postMessage: () => {} } });
+    await getHandler('message')({
+      data: { type: 'CLEAR_CACHE' },
+      source: { postMessage: () => {} },
+    });
     await new Promise((resolve) => setTimeout(resolve, 0));
     const remaining = fakeCaches.names();
     expect(remaining).not.toContain(STALE_STATIC);
@@ -167,7 +228,10 @@ describe('service worker — cache ownership (activate / CLEAR_CACHE never delet
       hostname: 'qnbs.github.io',
       initialCacheNames: [CURRENT_STATIC, FOREIGN_CACHE],
     });
-    await getHandler('message')({ data: { type: 'CLEAR_CACHE' }, source: { postMessage: () => {} } });
+    await getHandler('message')({
+      data: { type: 'CLEAR_CACHE' },
+      source: { postMessage: () => {} },
+    });
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(fakeCaches.attemptedDeletes).not.toContain(FOREIGN_CACHE);
   });
@@ -179,6 +243,7 @@ describe('service worker — cache ownership (activate / CLEAR_CACHE never delet
       initialCacheNames: [STALE_STATIC, CURRENT_STATIC, FOREIGN_CACHE],
       rejectOnDelete: STALE_STATIC,
     });
+    await admitPrecache(fakeCaches);
     // QNBS-v3: Promise.all rejects on the simulated failure — activate's own promise chain rejects too.
     await expect(runWaitUntil(getHandler('activate'))).rejects.toThrow();
     expect(fakeCaches.attemptedDeletes).not.toContain(FOREIGN_CACHE);
@@ -204,6 +269,7 @@ describe('service worker — cache ownership (activate / CLEAR_CACHE never delet
       hostname: 'qnbs.github.io',
       initialCacheNames: [CURRENT_STATIC, COLLIDING_FOREIGN_CACHE],
     });
+    await admitPrecache(fakeCaches);
     await runWaitUntil(getHandler('activate'));
     expect(fakeCaches.attemptedDeletes).not.toContain(COLLIDING_FOREIGN_CACHE);
     expect(fakeCaches.names()).toContain(COLLIDING_FOREIGN_CACHE);
@@ -215,9 +281,59 @@ describe('service worker — cache ownership (activate / CLEAR_CACHE never delet
       hostname: 'qnbs.github.io',
       initialCacheNames: [CURRENT_STATIC, COLLIDING_FOREIGN_CACHE],
     });
-    await getHandler('message')({ data: { type: 'CLEAR_CACHE' }, source: { postMessage: () => {} } });
+    await getHandler('message')({
+      data: { type: 'CLEAR_CACHE' },
+      source: { postMessage: () => {} },
+    });
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(fakeCaches.attemptedDeletes).not.toContain(COLLIDING_FOREIGN_CACHE);
     expect(fakeCaches.names()).toContain(COLLIDING_FOREIGN_CACHE);
+  });
+});
+
+// QNBS-v3: regression coverage for #525 — a partial precache must never displace a working prior generation.
+describe('service worker — precache admission gate (#525)', () => {
+  it('successful install admits the new generation: activate prunes the previous complete generation', async () => {
+    const { getHandler, fakeCaches } = loadServiceWorker({
+      protocol: 'https:',
+      hostname: 'qnbs.github.io',
+      initialCacheNames: [STALE_STATIC],
+    });
+    await runWaitUntil(getHandler('install'));
+    await runWaitUntil(getHandler('activate'));
+    expect(fakeCaches.names()).not.toContain(STALE_STATIC);
+    expect(fakeCaches.names()).toContain(CURRENT_STATIC);
+  });
+
+  it('failed precache never admits the new generation: activate preserves every existing cache, including the previous complete generation', async () => {
+    const { getHandler, fakeCaches } = loadServiceWorker({
+      protocol: 'https:',
+      hostname: 'qnbs.github.io',
+      initialCacheNames: [STALE_STATIC],
+      failAddAllFor: CURRENT_STATIC,
+    });
+    await runWaitUntil(getHandler('install'));
+    await runWaitUntil(getHandler('activate'));
+    // QNBS-v3: STALE_STATIC represents the previous, complete, last-known-good generation here.
+    expect(fakeCaches.names()).toContain(STALE_STATIC);
+    expect(fakeCaches.attemptedDeletes).not.toContain(STALE_STATIC);
+  });
+
+  it('a later successful install can still admit and prune after an earlier failed attempt (no permanent stuck state)', async () => {
+    const { getHandler, fakeCaches } = loadServiceWorker({
+      protocol: 'https:',
+      hostname: 'qnbs.github.io',
+      initialCacheNames: [STALE_STATIC],
+      failAddAllFor: CURRENT_STATIC,
+    });
+    await runWaitUntil(getHandler('install'));
+    await runWaitUntil(getHandler('activate'));
+    expect(fakeCaches.names()).toContain(STALE_STATIC);
+
+    // QNBS-v3: simulate a subsequent successful install for the same generation by admitting it directly.
+    await admitPrecache(fakeCaches);
+    await runWaitUntil(getHandler('activate'));
+    expect(fakeCaches.names()).not.toContain(STALE_STATIC);
+    expect(fakeCaches.names()).toContain(CURRENT_STATIC);
   });
 });

--- a/tests/unit/serviceWorkerCacheOwnership.test.ts
+++ b/tests/unit/serviceWorkerCacheOwnership.test.ts
@@ -425,4 +425,21 @@ describe('service worker — precache manifest deduplication (#525 follow-up)', 
     expect(await staticCache.match(ADMISSION_MARKER_URL)).toBeTruthy();
     expect(skipWaitingCalls()).toBe(1);
   });
+
+  it('two manifest entries that resolve to the same URL as each other (not the explicit list) do not trigger a duplicate-request rejection', async () => {
+    // QNBS-v3: exercises the fake's InvalidStateError branch through real production dedup logic, not just the explicit-list case above — proves the rejection path is actually reachable and correctly avoided.
+    const { getHandler, fakeCaches, skipWaitingCalls } = loadServiceWorker({
+      protocol: 'https:',
+      hostname: 'qnbs.github.io',
+      initialCacheNames: [],
+      manifest: [
+        { url: 'assets/app-somehash.js', revision: '' },
+        { url: 'assets/app-somehash.js', revision: '' },
+      ],
+    });
+    await runWaitUntil(getHandler('install'));
+    const staticCache = await fakeCaches.open(CURRENT_STATIC);
+    expect(await staticCache.match(ADMISSION_MARKER_URL)).toBeTruthy();
+    expect(skipWaitingCalls()).toBe(1);
+  });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -76,6 +76,10 @@ export default defineConfig({
           '**/*.wasm',
           // QNBS-v3 (F-09): self-hosted duckdb-wasm *.worker.js (scripts/copy-duckdb-assets.mjs) matches the **/*.js allowlist above unlike the already-excluded *.wasm — exclude explicitly, same feature-flag-gated reasoning as vendor-duckdb*.
           '**/duckdb/**',
+          // QNBS-v3: sw.js's own PRECACHE_URLS already lists these with the deployment BASE prefix — leaving them in the injected manifest too resolves to duplicate cache.addAll() requests, which throws.
+          'index.html',
+          'offline.html',
+          'favicon.svg',
         ],
       },
       // Manifest bereits in public/manifest.json eingebunden

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -76,10 +76,6 @@ export default defineConfig({
           '**/*.wasm',
           // QNBS-v3 (F-09): self-hosted duckdb-wasm *.worker.js (scripts/copy-duckdb-assets.mjs) matches the **/*.js allowlist above unlike the already-excluded *.wasm — exclude explicitly, same feature-flag-gated reasoning as vendor-duckdb*.
           '**/duckdb/**',
-          // QNBS-v3: sw.js's own PRECACHE_URLS already lists these with the deployment BASE prefix — leaving them in the injected manifest too resolves to duplicate cache.addAll() requests, which throws.
-          'index.html',
-          'offline.html',
-          'favicon.svg',
         ],
       },
       // Manifest bereits in public/manifest.json eingebunden


### PR DESCRIPTION
## Purpose

Fixes #525. The service worker's `install` handler treated a partial or fully
failed precache as non-fatal by catching the error without rethrowing —
`event.waitUntil()` therefore resolved successfully even when precache failed.
Not calling `skipWaiting()` on failure did **not** stop the worker from
installing: a worker that finishes `install` without rejecting still reaches
the "installed"/"waiting" state and can later activate naturally once the
previous worker has no controlled clients. Once active, that worker's own
fetch handlers read only its own (version-specific) `CACHE_STATIC`/
`CACHE_DYNAMIC` constants — so merely leaving the previous generation's cache
un-pruned in `CacheStorage` never meant it was still being served; an
incomplete generation could take over and serve broken/missing assets with no
working fallback.

## Fix

`install` now **rethrows** on precache/admission-marker failure, so the whole
installation itself rejects. A worker whose `install()` rejects never reaches
"installed" or "waiting" — these are browser-native Service Worker lifecycle
states — so it can never activate, call `clients.claim()`, or receive the
app's `SKIP_WAITING` update message (`register-sw.ts` only ever targets
`registration.waiting` / a worker whose `state` reached `'installed'`). That
closes the update-message path structurally, with no additional gating needed
in the message handler. The `activate`-side admission-marker check is
**retained as defense in depth** and now, if it is ever reached with no
marker present, returns immediately without pruning **or** claiming clients —
an unadmitted generation must not take control of any page either.

**Duplicate-precache-request risk found by review (chatgpt-codex-connector +
cubic-dev-ai independently) and corrected without losing update signal:**
VitePWA's `injectManifest` glob independently discovers `index.html`,
`offline.html` and `favicon.svg` — the same three files already listed
explicitly (with the deployment `BASE` prefix) in `PRECACHE_URLS`. Verified
empirically with a real production build: all three appear as duplicate
manifest entries resolving to the same absolute URLs, which `cache.addAll()`
rejects with `InvalidStateError`. Combined with the install-rejection fix
above, this would have made **every** production install fail permanently.
An initial fix excluded these files from the injected manifest via
`vite.config.ts`, but review correctly pointed out this throws away their
content-hash revision tracking — the exact signal that lets the browser
detect and install an update when only one of these files changes, without a
`package.json` version bump. The final fix keeps the manifest untouched (full
revision tracking preserved) and instead resolves + dedupes the URLs at
runtime in `sw.js` before they ever reach `cache.addAll()`, so the redundant
*request* is removed without losing the update-detection *signal*. Re-built
production output and confirmed both properties hold: the manifest still
carries revision hashes for all three files, and the final precache list has
zero duplicates.

## Non-goals

- Does not touch #480/#485/#518 (cross-tab writer coordination) — different
  subsystem, no code overlap.
- Does not change per-asset runtime-caching strategy — only install/activate
  generation admission.
- No user-facing "update failed" UI — that belongs with the broader update-UX
  work.
- No precache retry/backoff scheduler — a bounded, deterministic pass/fail
  gate is the intended scope.

## Validation

`tests/unit/serviceWorkerCacheOwnership.test.ts` — 15/15 passing, proving the
lifecycle directly against the real `install`/`activate` handlers running
against the actual `public/sw.js` source (Node `vm` sandbox):
1. a failed `addAll()` causes the install `waitUntil()` promise to reject;
2. `skipWaiting()` is not called for a failed installation;
3. a successful install writes the admission marker and calls `skipWaiting()`;
4. a successful activate after an admitted install prunes the previous owned
   generation;
5. a **real second install attempt** after an earlier failed one succeeds
   normally (no permanent stuck state), also asserting `clients.claim()`
   stays uncalled through the markerless activate and fires exactly once
   after the real successful recovery;
6. a manifest entry that resolves to the same URL as an explicit shell asset
   does not trigger a duplicate-request rejection — the fake cache's
   `addAll()` mirrors real `Cache.addAll()` semantics (rejects on resolved-URL
   collision) rather than silently deduping, and this test was
   mutation-tested by reverting the runtime dedup and confirming it fails
   with the expected simulated `InvalidStateError`.

All existing foreign-cache-ownership assertions are unchanged.

- Real production build (`pnpm run build`) confirms the manifest still tracks
  revisions for `index.html`/`offline.html`/`favicon.svg` and the final
  precache list contains zero duplicate entries.
- `node scripts/dependency-state.mjs verify` — fingerprint valid.
- `node scripts/check-doc-metrics.mjs` — passes (README test-count metric
  resynced via the authoritative `pnpm run sync:readme` script: 7644 -> 7650).
- Full local admission gate (`pnpm run ci:prepush`, run automatically by the
  pre-push hook) — passes.

## Summary by Sourcery

Gate service-worker cache-generation cutover on successful precaching and preserve reliable update detection without duplicate precache requests.

Bug Fixes:
- Make service-worker installation fail when precaching or writing the admission marker fails, preventing incomplete cache generations from activating.
- Prevent unadmitted service-worker generations from pruning older caches or claiming clients.
- Deduplicate resolved precache URLs while preserving injected-manifest revision tracking.

Documentation:
- Update README test-count metrics and synchronization date.

Tests:
- Expand service-worker lifecycle coverage for failed and recovered installs, admission-gated activation, client claiming, cache pruning, and duplicate precache URLs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved service worker installation by preventing duplicate asset requests during caching.
  - Failed asset caching now correctly stops installation instead of completing partially.
  - Improved activation handling to prevent stale cache cleanup or client updates when installation has not been successfully admitted.
  - Added more reliable retry behavior after a failed installation.

- **Documentation**
  - Updated README test metrics from 7,647+ to 7,650+ tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->