### PR TITLE
docs: reference PR #699 in the SW precache-admission CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Node script, no `pnpm install`) that runs `check-tauri-plugin-versions.mjs` before the bundle
   matrix starts, gated behind `verify-release-tag` so no repository code runs on an unverified
   release tag. On both `workflow_dispatch` and tag pushes. PR #684.
+- **PWA: a failed precache can no longer displace a working service-worker generation (#525):**
+  `install` previously caught a `cache.addAll()`/admission-marker failure without rethrowing, so
+  the browser still recorded the worker as successfully installed; it could later activate and
+  claim clients with an incomplete cache and no working fallback. `install` now rethrows on
+  failure so the whole installation rejects — a worker that never reaches `installed` can never
+  activate, claim clients, or receive an update message. The `activate`-side admission check is
+  kept as defense in depth, returning immediately (no pruning, no `clients.claim()`) if it is ever
+  reached without a completed marker. Also fixed a duplicate-precache-request risk the lifecycle
+  fix would otherwise have turned fatal: VitePWA's injected manifest independently discovers
+  `index.html`/`offline.html`/`favicon.svg`, colliding with the same files already listed
+  explicitly in `PRECACHE_URLS`; these are now resolved and deduplicated at runtime (against each
+  other too, not just the explicit list) before reaching `cache.addAll()`, while the manifest keeps
+  its content-hash revision tracking for update detection. PR #699.
 
 ### Documentation
 


### PR DESCRIPTION
## **User description**
## Purpose

Resulting-main's \`docs:check\` failed after #699 merged: the \`[Unreleased]\`
CHANGELOG section never referenced PR #699 (its squash-commit subject or
number), which \`scripts/check-doc-metrics.mjs\` requires for every merged
feat/fix/perf commit. Same completeness gate that previously caught #678
(fixed by #679) and #684 (fixed by #685).

## Fix

Added a \`### Fixed\` entry under \`[Unreleased]\` describing #699's actual
change (the SW precache-admission-gate lifecycle fix plus the
duplicate-manifest-request fix it required), referencing "PR #699."

## Validation

- \`node scripts/check-doc-metrics.mjs\` — passes.
- Full local admission gate (\`pnpm run ci:prepush\`, run automatically by the
  pre-push hook) — passes.

## Summary by Sourcery

Record the service-worker precache reliability fixes from PR #699 in the unreleased changelog.

Bug Fixes:
- Document the service-worker precache admission lifecycle fix so failed precaches cannot activate or claim clients with incomplete caches, and prevent duplicate precache requests from causing installation failures.

Documentation:
- Add the PR #699 service-worker precache fix to the unreleased changelog.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the missing PR #699 reference to the `[Unreleased]` CHANGELOG entry so `docs:check` passes again.

- The new `### Fixed` entry documents the service-worker precache-admission lifecycle fix and the duplicate-manifest-request deduplication.

<sup>Written for commit 9d52b672355020e11ebf4490437af50dcc8bdfa2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/qnbs/WorldScript-Studio/pull/700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Document the service-worker precache reliability fixes from PR #699

### What Changed
- Added an unreleased changelog entry explaining that failed precaches can no longer activate or take control of pages with incomplete caches
- Documented the safeguard that prevents cache cleanup and client claiming when precache admission is incomplete
- Documented deduplication of overlapping precache files to prevent installation failures while preserving update detection

### Impact
`✅ Fewer broken service-worker updates`
`✅ Reduced risk of pages losing offline fallbacks`
`✅ Clearer release notes for precache reliability changes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Progressive Web App update reliability by preventing incomplete service workers from activating or taking control.
  - Added safeguards during activation to ensure only fully prepared workers become active.
  - Prevented duplicate precache entries while preserving cache version information.

- **Documentation**
  - Added an unreleased changelog entry documenting the service-worker lifecycle improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->