### PR TITLE
fix(ci): require pre-merge CHANGELOG PR-reference for governed changes

### DIFF
--- a/.github/workflows/pr-changelog-reference.yml
+++ b/.github/workflows/pr-changelog-reference.yml
@@ -1,0 +1,31 @@
+name: PR CHANGELOG Reference Guard
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [main]
+permissions:
+  contents: read
+jobs:
+  check:
+    name: Require this PR's own number in CHANGELOG.md [Unreleased] before merge
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Require [Unreleased] to reference this PR before merge
+        env:
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+        run: |
+          set -euo pipefail
+          BASE="${{ github.event.pull_request.base.sha }}"
+          mkdir -p /tmp/base-scripts
+          CHECKER=scripts/check-pr-changelog-reference.mjs
+          if git show "$BASE:scripts/check-pr-changelog-reference.mjs" > /tmp/base-scripts/check-pr-changelog-reference.mjs 2>/dev/null; then
+            CHECKER=/tmp/base-scripts/check-pr-changelog-reference.mjs
+          else
+            echo "::notice::check-pr-changelog-reference.mjs not found on base ref (bootstrap PR) — using this PR's own copy this one time."
+          fi
+          node "$CHECKER"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   explicitly in `PRECACHE_URLS`; these are now resolved and deduplicated at runtime (against each
   other too, not just the explicit list) before reaching `cache.addAll()`, while the manifest keeps
   its content-hash revision tracking for update detection. PR #699.
+- **A governed PR can no longer merge without a CHANGELOG reference to itself:** the completeness
+  gate in `check-doc-metrics.mjs` only enforced a PR-number reference in `[Unreleased]` after
+  squash-merge, once the commit already carried `(#N)` — nothing stopped a governed PR from merging
+  without ever adding the entry, even though its real PR number is knowable before merge. Recurred
+  three times (#678→#679, #684→#685, #699→#700). A new pre-merge admission gate
+  (`.github/workflows/pr-changelog-reference.yml` + `check-pr-changelog-reference.mjs`, run from the
+  PR's base ref to prevent self-weakening) now fails a governed PR's CI unless `[Unreleased]` already
+  references it as `PR #<N>`. PR #705.
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="i18n 19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7651%2B_%2F_604_files-22C55E" alt="7651+ tests / 604 files">
+  <img src="https://img.shields.io/badge/Tests-7668%2B_%2F_605_files-22C55E" alt="7668+ tests / 605 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2942 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7651+ tests / 604 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7668+ tests / 605 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7651+ tests, 604 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7668+ tests, 605 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -714,7 +714,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendor **6200 KB**, other JavaScript **2500 KB**, and WASM **30000 KB**.
 
 **Current test metrics (2026-09-10, source-synchronized; CI remains authoritative for pass/fail):**
-- **7651+ unit tests** across **604 test files** — CI is authoritative for pass/fail
+- **7668+ unit tests** across **605 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2942 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="i18n 19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7656%2B_%2F_605_files-22C55E" alt="7656+ tests / 605 files">
+  <img src="https://img.shields.io/badge/Tests-7658%2B_%2F_605_files-22C55E" alt="7658+ tests / 605 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2942 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7656+ tests / 605 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7658+ tests / 605 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7656+ tests, 605 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7658+ tests, 605 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -714,7 +714,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendor **6200 KB**, other JavaScript **2500 KB**, and WASM **30000 KB**.
 
 **Current test metrics (2026-09-10, source-synchronized; CI remains authoritative for pass/fail):**
-- **7656+ unit tests** across **605 test files** — CI is authoritative for pass/fail
+- **7658+ unit tests** across **605 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2942 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="i18n 19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7658%2B_%2F_605_files-22C55E" alt="7658+ tests / 605 files">
+  <img src="https://img.shields.io/badge/Tests-7659%2B_%2F_605_files-22C55E" alt="7659+ tests / 605 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2942 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7658+ tests / 605 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7659+ tests / 605 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7658+ tests, 605 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7659+ tests, 605 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -714,7 +714,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendor **6200 KB**, other JavaScript **2500 KB**, and WASM **30000 KB**.
 
 **Current test metrics (2026-09-10, source-synchronized; CI remains authoritative for pass/fail):**
-- **7658+ unit tests** across **605 test files** — CI is authoritative for pass/fail
+- **7659+ unit tests** across **605 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2942 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="i18n 19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7659%2B_%2F_605_files-22C55E" alt="7659+ tests / 605 files">
+  <img src="https://img.shields.io/badge/Tests-7660%2B_%2F_605_files-22C55E" alt="7660+ tests / 605 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2942 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7659+ tests / 605 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7660+ tests / 605 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7659+ tests, 605 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7660+ tests, 605 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -714,7 +714,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendor **6200 KB**, other JavaScript **2500 KB**, and WASM **30000 KB**.
 
 **Current test metrics (2026-09-10, source-synchronized; CI remains authoritative for pass/fail):**
-- **7659+ unit tests** across **605 test files** — CI is authoritative for pass/fail
+- **7660+ unit tests** across **605 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2942 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="i18n 19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7660%2B_%2F_605_files-22C55E" alt="7660+ tests / 605 files">
+  <img src="https://img.shields.io/badge/Tests-7662%2B_%2F_605_files-22C55E" alt="7662+ tests / 605 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2942 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7660+ tests / 605 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7662+ tests / 605 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7660+ tests, 605 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7662+ tests, 605 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -714,7 +714,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendor **6200 KB**, other JavaScript **2500 KB**, and WASM **30000 KB**.
 
 **Current test metrics (2026-09-10, source-synchronized; CI remains authoritative for pass/fail):**
-- **7660+ unit tests** across **605 test files** — CI is authoritative for pass/fail
+- **7662+ unit tests** across **605 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2942 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="i18n 19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7668%2B_%2F_605_files-22C55E" alt="7668+ tests / 605 files">
+  <img src="https://img.shields.io/badge/Tests-7656%2B_%2F_605_files-22C55E" alt="7656+ tests / 605 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2942 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7668+ tests / 605 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7656+ tests / 605 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7668+ tests, 605 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7656+ tests, 605 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -714,7 +714,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendor **6200 KB**, other JavaScript **2500 KB**, and WASM **30000 KB**.
 
 **Current test metrics (2026-09-10, source-synchronized; CI remains authoritative for pass/fail):**
-- **7668+ unit tests** across **605 test files** — CI is authoritative for pass/fail
+- **7656+ unit tests** across **605 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2942 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/scripts/check-pr-changelog-reference.d.mts
+++ b/scripts/check-pr-changelog-reference.d.mts
@@ -1,5 +1,7 @@
 export function isReferencedByPrLabel(prNumber: number, text: string): boolean;
 
+export function isValidPrMetadata(pr: unknown): boolean;
+
 export interface CheckPrChangelogReferenceInput {
   prNumber: number;
   prTitle: string | undefined | null;

--- a/scripts/check-pr-changelog-reference.d.mts
+++ b/scripts/check-pr-changelog-reference.d.mts
@@ -1,0 +1,18 @@
+export function isReferencedByPrLabel(prNumber: number, unreleasedSection: string): boolean;
+
+export interface CheckPrChangelogReferenceInput {
+  prNumber: number;
+  prTitle: string | undefined | null;
+  changelog: string | undefined | null;
+}
+
+export type CheckPrChangelogReferenceReason = 'not-governed' | 'referenced' | 'missing-reference';
+
+export interface CheckPrChangelogReferenceResult {
+  ok: boolean;
+  reason: CheckPrChangelogReferenceReason;
+}
+
+export function checkPrChangelogReference(
+  input: CheckPrChangelogReferenceInput,
+): CheckPrChangelogReferenceResult;

--- a/scripts/check-pr-changelog-reference.d.mts
+++ b/scripts/check-pr-changelog-reference.d.mts
@@ -1,4 +1,4 @@
-export function isReferencedByPrLabel(prNumber: number, unreleasedSection: string): boolean;
+export function isReferencedByPrLabel(prNumber: number, text: string): boolean;
 
 export interface CheckPrChangelogReferenceInput {
   prNumber: number;

--- a/scripts/check-pr-changelog-reference.mjs
+++ b/scripts/check-pr-changelog-reference.mjs
@@ -42,6 +42,8 @@ function extractBulletEntries(unreleasedSection) {
     if (/^-\s/.test(line)) {
       flush();
       current.push(line);
+    } else if (/^#{1,6}\s/.test(line)) {
+      flush();
     } else if (current.length > 0 && line !== '') {
       current.push(line);
     } else if (line === '') {
@@ -52,9 +54,9 @@ function extractBulletEntries(unreleasedSection) {
   return entries;
 }
 
-// QNBS-v3: exact "PR #NNN" grammar, stricter than check-doc-metrics.mjs's post-merge bare "#NNN" matcher — pre-merge there is no squash-appended "(#NNN)" to anchor on, so a bare "#NNN" could belong to an unrelated issue/PR mention instead of a genuine self-reference.
+// QNBS-v3: exact "PR #NNN" grammar with a full trailing word boundary (rejects "PR #705alpha"/"PR #705_"), stricter than check-doc-metrics.mjs's post-merge bare "#NNN" matcher since pre-merge there is no squash-appended "(#NNN)" to anchor on.
 export function isReferencedByPrLabel(prNumber, text) {
-  return new RegExp(`\\bPR\\s*#${prNumber}(?!\\d)`, 'i').test(text);
+  return new RegExp(`\\bPR\\s*#${prNumber}(?!\\w)`, 'i').test(text);
 }
 
 /** Pure decision function — kept separate from I/O so it is directly unit-testable. */
@@ -88,9 +90,15 @@ function main() {
   }
 
   const pr = payload.pull_request;
-  if (!pr || typeof pr.number !== 'number') {
+  if (!pr) {
     console.log('[check-pr-changelog-reference] not a pull_request event — skipping');
     process.exit(0);
+  }
+  if (typeof pr.number !== 'number') {
+    console.error(
+      '[check-pr-changelog-reference] pull_request event payload is missing a numeric "number" field',
+    );
+    process.exit(1);
   }
 
   let changelog;

--- a/scripts/check-pr-changelog-reference.mjs
+++ b/scripts/check-pr-changelog-reference.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+/**
+ * CI-only pre-merge admission gate: before a governed (feat|fix|perf) PR can merge, its own
+ * CHANGELOG.md [Unreleased] section must already reference this PR's real GitHub-assigned number
+ * as "PR #<N>". This closes the blind spot where scripts/check-doc-metrics.mjs's completeness
+ * check only fires AFTER squash-merge, once the commit is on main and its subject already carries
+ * "(#N)" — a gap that has recurred three times (#678->#679, #684->#685, #699->#700), each requiring
+ * a same-pattern follow-up PR to add the missing reference after the fact.
+ *
+ * Deliberately self-contained (no local imports, mirrors check-commit-attribution.mjs) so the
+ * base-ref self-grading copy in .github/workflows/pr-changelog-reference.yml never breaks on a
+ * missing transitive dependency (check-doc-metrics.mjs itself imports two further local modules
+ * that would also need copying and keeping in sync).
+ */
+import { readFileSync } from 'node:fs';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+// QNBS-v3: duplicated from check-doc-metrics.mjs's GOVERNED_COMMIT_TYPE (kept in sync manually, not via import) so this file has zero local dependencies — see file header.
+const GOVERNED_COMMIT_TYPE = /^(?:feat|fix|perf)(?:\([^)]*\))?!?:\s*/i;
+
+// QNBS-v3: duplicated from check-doc-metrics.mjs's getUnreleasedSectionText for the same self-containment reason.
+function getUnreleasedSectionText(changelog) {
+  const heading = /^## \[Unreleased\]\s*$/m.exec(changelog);
+  if (!heading) return '';
+  const afterHeading = changelog.slice(heading.index + heading[0].length);
+  const nextHeading = afterHeading.search(/^##\s/m);
+  const section = nextHeading === -1 ? afterHeading : afterHeading.slice(0, nextHeading);
+  return section.replace(/<!--[\s\S]*?(?:-->|$)/g, '');
+}
+
+// QNBS-v3: exact "PR #NNN" grammar, stricter than check-doc-metrics.mjs's post-merge bare "#NNN" matcher — pre-merge there is no squash-appended "(#NNN)" to anchor on, so a bare "#NNN" could belong to an unrelated issue/PR mention instead of a genuine self-reference.
+export function isReferencedByPrLabel(prNumber, unreleasedSection) {
+  return new RegExp(`\\bPR\\s*#${prNumber}(?!\\d)`, 'i').test(unreleasedSection);
+}
+
+/** Pure decision function — kept separate from I/O so it is directly unit-testable. */
+export function checkPrChangelogReference({ prNumber, prTitle, changelog }) {
+  if (!GOVERNED_COMMIT_TYPE.test(prTitle ?? '')) {
+    return { ok: true, reason: 'not-governed' };
+  }
+  const unreleasedSection = getUnreleasedSectionText(changelog ?? '');
+  return isReferencedByPrLabel(prNumber, unreleasedSection)
+    ? { ok: true, reason: 'referenced' }
+    : { ok: false, reason: 'missing-reference' };
+}
+
+function main() {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath) {
+    console.log('[check-pr-changelog-reference] no GITHUB_EVENT_PATH — skipping');
+    process.exit(0);
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(readFileSync(eventPath, 'utf8'));
+  } catch (error) {
+    console.error(
+      `[check-pr-changelog-reference] cannot read event payload: ${error instanceof Error ? error.message : 'invalid JSON'}`,
+    );
+    process.exit(1);
+  }
+
+  const pr = payload.pull_request;
+  if (!pr || typeof pr.number !== 'number') {
+    console.log('[check-pr-changelog-reference] not a pull_request event — skipping');
+    process.exit(0);
+  }
+
+  let changelog;
+  try {
+    changelog = readFileSync('CHANGELOG.md', 'utf8');
+  } catch (error) {
+    console.error(
+      `[check-pr-changelog-reference] cannot read CHANGELOG.md: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exit(1);
+  }
+
+  const result = checkPrChangelogReference({ prNumber: pr.number, prTitle: pr.title, changelog });
+  if (result.reason === 'not-governed') {
+    console.log(
+      '[check-pr-changelog-reference] PR title is not a governed feat/fix/perf change — skipping',
+    );
+    process.exit(0);
+  }
+  if (!result.ok) {
+    console.error(
+      `[check-pr-changelog-reference] FAIL — CHANGELOG.md's [Unreleased] section does not yet reference "PR #${pr.number}". Add (or update) a bullet describing this change and reference it literally as "PR #${pr.number}" before merging.`,
+    );
+    process.exit(1);
+  }
+  console.log(`[check-pr-changelog-reference] OK — [Unreleased] references PR #${pr.number}`);
+}
+
+// QNBS-v3: only run the CLI side-effect when invoked directly — checkPrChangelogReference stays importable from a unit test.
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/scripts/check-pr-changelog-reference.mjs
+++ b/scripts/check-pr-changelog-reference.mjs
@@ -29,7 +29,7 @@ function getUnreleasedSectionText(changelog) {
   return nextHeading === -1 ? afterHeading : afterHeading.slice(0, nextHeading);
 }
 
-// QNBS-v3: duplicated from check-doc-metrics.mjs's splitUnreleasedEntries for the same self-containment reason — joins a bullet's own soft-wrapped continuation lines into one entry.
+// QNBS-v3: a continuation line must be INDENTED (this project's own convention for a soft-wrapped bullet, confirmed in every real multi-line CHANGELOG entry) — any flush-left line that isn't itself a new bullet (heading, blockquote, code fence, hr, stray prose) ends the current entry instead of being absorbed, without needing to enumerate every Markdown block type individually.
 function extractBulletEntries(unreleasedSection) {
   const entries = [];
   let current = [];
@@ -38,15 +38,13 @@ function extractBulletEntries(unreleasedSection) {
     current = [];
   };
   for (const rawLine of unreleasedSection.split('\n')) {
-    const line = rawLine.trim();
-    if (/^-\s/.test(line)) {
+    const trimmed = rawLine.trim();
+    if (/^-\s/.test(trimmed)) {
       flush();
-      current.push(line);
-    } else if (/^#{1,6}\s/.test(line)) {
-      flush();
-    } else if (current.length > 0 && line !== '') {
-      current.push(line);
-    } else if (line === '') {
+      current.push(trimmed);
+    } else if (current.length > 0 && trimmed !== '' && /^\s/.test(rawLine)) {
+      current.push(trimmed);
+    } else {
       flush();
     }
   }
@@ -57,6 +55,17 @@ function extractBulletEntries(unreleasedSection) {
 // QNBS-v3: exact "PR #NNN" grammar with a full trailing word boundary (rejects "PR #705alpha"/"PR #705_"), stricter than check-doc-metrics.mjs's post-merge bare "#NNN" matcher since pre-merge there is no squash-appended "(#NNN)" to anchor on.
 export function isReferencedByPrLabel(prNumber, text) {
   return new RegExp(`\\bPR\\s*#${prNumber}(?!\\w)`, 'i').test(text);
+}
+
+// QNBS-v3: split out so main()'s CLI wiring stays a thin I/O shell — kept directly unit-testable against malformed event-payload shapes.
+export function isValidPrMetadata(pr) {
+  return (
+    Boolean(pr) &&
+    Number.isSafeInteger(pr.number) &&
+    pr.number > 0 &&
+    typeof pr.title === 'string' &&
+    pr.title.trim() !== ''
+  );
 }
 
 /** Pure decision function — kept separate from I/O so it is directly unit-testable. */
@@ -94,9 +103,9 @@ function main() {
     console.log('[check-pr-changelog-reference] not a pull_request event — skipping');
     process.exit(0);
   }
-  if (typeof pr.number !== 'number') {
+  if (!isValidPrMetadata(pr)) {
     console.error(
-      '[check-pr-changelog-reference] pull_request event payload is missing a numeric "number" field',
+      '[check-pr-changelog-reference] pull_request event payload has invalid PR metadata',
     );
     process.exit(1);
   }

--- a/scripts/check-pr-changelog-reference.mjs
+++ b/scripts/check-pr-changelog-reference.mjs
@@ -29,9 +29,32 @@ function getUnreleasedSectionText(changelog) {
   return section.replace(/<!--[\s\S]*?(?:-->|$)/g, '');
 }
 
+// QNBS-v3: duplicated from check-doc-metrics.mjs's splitUnreleasedEntries for the same self-containment reason — joins a bullet's own soft-wrapped continuation lines into one entry.
+function extractBulletEntries(unreleasedSection) {
+  const entries = [];
+  let current = [];
+  const flush = () => {
+    if (current.length > 0) entries.push(current.join(' '));
+    current = [];
+  };
+  for (const rawLine of unreleasedSection.split('\n')) {
+    const line = rawLine.trim();
+    if (/^-\s/.test(line)) {
+      flush();
+      current.push(line);
+    } else if (current.length > 0 && line !== '') {
+      current.push(line);
+    } else if (line === '') {
+      flush();
+    }
+  }
+  flush();
+  return entries;
+}
+
 // QNBS-v3: exact "PR #NNN" grammar, stricter than check-doc-metrics.mjs's post-merge bare "#NNN" matcher — pre-merge there is no squash-appended "(#NNN)" to anchor on, so a bare "#NNN" could belong to an unrelated issue/PR mention instead of a genuine self-reference.
-export function isReferencedByPrLabel(prNumber, unreleasedSection) {
-  return new RegExp(`\\bPR\\s*#${prNumber}(?!\\d)`, 'i').test(unreleasedSection);
+export function isReferencedByPrLabel(prNumber, text) {
+  return new RegExp(`\\bPR\\s*#${prNumber}(?!\\d)`, 'i').test(text);
 }
 
 /** Pure decision function — kept separate from I/O so it is directly unit-testable. */
@@ -39,8 +62,10 @@ export function checkPrChangelogReference({ prNumber, prTitle, changelog }) {
   if (!GOVERNED_COMMIT_TYPE.test(prTitle ?? '')) {
     return { ok: true, reason: 'not-governed' };
   }
+  // QNBS-v3: scoped to actual bullet entries, not the whole section — a PR number floating in prose or a sub-heading (not inside a real release-note bullet) must not count as documentation.
   const unreleasedSection = getUnreleasedSectionText(changelog ?? '');
-  return isReferencedByPrLabel(prNumber, unreleasedSection)
+  const bulletEntries = extractBulletEntries(unreleasedSection);
+  return bulletEntries.some((entry) => isReferencedByPrLabel(prNumber, entry))
     ? { ok: true, reason: 'referenced' }
     : { ok: false, reason: 'missing-reference' };
 }

--- a/scripts/check-pr-changelog-reference.mjs
+++ b/scripts/check-pr-changelog-reference.mjs
@@ -19,14 +19,14 @@ import { fileURLToPath } from 'node:url';
 // QNBS-v3: duplicated from check-doc-metrics.mjs's GOVERNED_COMMIT_TYPE (kept in sync manually, not via import) so this file has zero local dependencies — see file header.
 const GOVERNED_COMMIT_TYPE = /^(?:feat|fix|perf)(?:\([^)]*\))?!?:\s*/i;
 
-// QNBS-v3: duplicated from check-doc-metrics.mjs's getUnreleasedSectionText for the same self-containment reason.
+// QNBS-v3: strips comments from the WHOLE document before searching for the heading — a commented-out template containing a literal "## [Unreleased]" line earlier in the file would otherwise hijack the section boundary, since slicing off the opening "<!--" before comment-removal runs left the fake section's own content unstrippable.
 function getUnreleasedSectionText(changelog) {
-  const heading = /^## \[Unreleased\]\s*$/m.exec(changelog);
+  const withoutComments = changelog.replace(/<!--[\s\S]*?(?:-->|$)/g, '');
+  const heading = /^## \[Unreleased\]\s*$/m.exec(withoutComments);
   if (!heading) return '';
-  const afterHeading = changelog.slice(heading.index + heading[0].length);
+  const afterHeading = withoutComments.slice(heading.index + heading[0].length);
   const nextHeading = afterHeading.search(/^##\s/m);
-  const section = nextHeading === -1 ? afterHeading : afterHeading.slice(0, nextHeading);
-  return section.replace(/<!--[\s\S]*?(?:-->|$)/g, '');
+  return nextHeading === -1 ? afterHeading : afterHeading.slice(0, nextHeading);
 }
 
 // QNBS-v3: duplicated from check-doc-metrics.mjs's splitUnreleasedEntries for the same self-containment reason — joins a bullet's own soft-wrapped continuation lines into one entry.

--- a/scripts/check-pr-changelog-reference.mjs
+++ b/scripts/check-pr-changelog-reference.mjs
@@ -29,6 +29,11 @@ function getUnreleasedSectionText(changelog) {
   return nextHeading === -1 ? afterHeading : afterHeading.slice(0, nextHeading);
 }
 
+// QNBS-v3: named predicate so extractBulletEntries reads as a flat 3-way dispatch instead of one compound boolean condition.
+function isIndentedContinuation(rawLine, trimmedLine, hasOpenEntry) {
+  return hasOpenEntry && trimmedLine !== '' && /^\s/.test(rawLine);
+}
+
 // QNBS-v3: a continuation line must be INDENTED (this project's own convention for a soft-wrapped bullet, confirmed in every real multi-line CHANGELOG entry) — any flush-left line that isn't itself a new bullet (heading, blockquote, code fence, hr, stray prose) ends the current entry instead of being absorbed, without needing to enumerate every Markdown block type individually.
 function extractBulletEntries(unreleasedSection) {
   const entries = [];
@@ -42,7 +47,7 @@ function extractBulletEntries(unreleasedSection) {
     if (/^-\s/.test(trimmed)) {
       flush();
       current.push(trimmed);
-    } else if (current.length > 0 && trimmed !== '' && /^\s/.test(rawLine)) {
+    } else if (isIndentedContinuation(rawLine, trimmed, current.length > 0)) {
       current.push(trimmed);
     } else {
       flush();

--- a/tests/unit/checkPrChangelogReference.test.ts
+++ b/tests/unit/checkPrChangelogReference.test.ts
@@ -119,6 +119,23 @@ describe('checkPrChangelogReference', () => {
     ).toEqual({ ok: true, reason: 'referenced' });
   });
 
+  it.each([
+    ['16. a trailing letter suffix, e.g. "PR #700alpha"', '- Hardens activation. PR #700alpha.'],
+    [
+      '17. a trailing underscore suffix, e.g. "PR #700_internal"',
+      '- Hardens activation. PR #700_internal.',
+    ],
+  ] as const)('rejects a near-miss reference with %s', (_label, entryBody) => {
+    expect(check({ entryBody })).toEqual({ ok: false, reason: 'missing-reference' });
+  });
+
+  it('18. does not let a heading immediately after a bullet (no blank line) absorb the heading text as a continuation', () => {
+    const changelog = `## [Unreleased]\n\n### Fixed\n\n- **Something else:** unrelated bullet content.\n### Notes: tracked under PR #700\n\n## [1.28.6]\n`;
+    expect(
+      checkPrChangelogReference({ prNumber: 700, prTitle: GOVERNED_TITLE, changelog }),
+    ).toEqual({ ok: false, reason: 'missing-reference' });
+  });
+
   describe('historical-incident fixtures (real CHANGELOG text from the three prior recoveries)', () => {
     // QNBS-v3: real bullet text from each incident's own recovery commit, factored so only the trailing reference varies.
     const tauriPluginParityBody =

--- a/tests/unit/checkPrChangelogReference.test.ts
+++ b/tests/unit/checkPrChangelogReference.test.ts
@@ -12,172 +12,132 @@ import {
 
 const UNRELEASED = (body: string) => `## [Unreleased]\n\n### Fixed\n\n${body}\n\n## [1.28.6]\n`;
 
+const GOVERNED_TITLE = 'fix(pwa): gate cache activation on precache success';
+
+interface CheckInput {
+  prNumber: number;
+  prTitle: string;
+  entryBody: string;
+}
+
+// QNBS-v3: single fixture builder for every case below — CodeScene flagged the prior per-test literal duplication as unhealthy new code.
+function check({ prNumber = 700, prTitle = GOVERNED_TITLE, entryBody }: Partial<CheckInput>) {
+  return checkPrChangelogReference({
+    prNumber,
+    prTitle,
+    changelog: UNRELEASED(entryBody ?? '- **PWA precache admission:** hardens activation.'),
+  });
+}
+
 describe('checkPrChangelogReference', () => {
-  it('1. accepts a governed "feat:" PR whose Unreleased entry cites "PR #<N>"', () => {
-    const result = checkPrChangelogReference({
-      prNumber: 700,
-      prTitle: 'feat(writer): add outline templates',
-      changelog: UNRELEASED('- **Outline templates:** adds starter templates. PR #700.'),
-    });
-    expect(result).toEqual({ ok: true, reason: 'referenced' });
+  it.each([
+    [
+      '1. "feat:" title',
+      'feat(writer): add outline templates',
+      700,
+      '- Adds starter templates. PR #700.',
+    ],
+    [
+      '2. "fix:" title',
+      'fix(pwa): gate cache activation on precache success',
+      700,
+      '- Hardens activation. PR #700.',
+    ],
+    [
+      '3. "perf:" title',
+      'perf(rag): batch embedding lookups',
+      700,
+      '- Reduces lookup overhead. PR #700.',
+    ],
+    [
+      '4. scoped title',
+      'fix(pwa): gate cache-generation activation',
+      525,
+      '- Described here. PR #525.',
+    ],
+    [
+      '5. breaking-change "!" title',
+      'feat(api)!: drop legacy v1 provider adapter',
+      812,
+      '- Drops v1 adapter. PR #812.',
+    ],
+    ['13. case/whitespace tolerant "pr#N"', GOVERNED_TITLE, 700, '- Hardens activation. pr#700.'],
+  ] as const)(
+    'accepts a governed PR whose entry cites its own number (%s)',
+    (_label, prTitle, prNumber, entryBody) => {
+      expect(check({ prNumber, prTitle, entryBody }).ok).toBe(true);
+    },
+  );
+
+  it.each([
+    ['6. no reference at all', '- Hardens activation.'],
+    ['7. a DIFFERENT PR number', '- Unrelated change, see write-up. PR #501.'],
+    ['8. bare "#N" lacking the "PR" grammar', '- Hardens activation. #700.'],
+    ['9. trailing "(#N)" squash style pre-merge', '- Hardens activation (#700).'],
+  ] as const)('rejects a governed PR whose entry has %s', (_label, entryBody) => {
+    expect(check({ entryBody })).toEqual({ ok: false, reason: 'missing-reference' });
   });
 
-  it('2. accepts a governed "fix:" PR whose Unreleased entry cites "PR #<N>"', () => {
-    const result = checkPrChangelogReference({
-      prNumber: 700,
-      prTitle: 'fix(pwa): gate cache activation on precache success',
-      changelog: UNRELEASED('- **PWA precache admission:** hardens activation. PR #700.'),
+  it('10. skips a non-governed PR title regardless of Unreleased content', () => {
+    expect(
+      check({ prTitle: 'docs: fix typo in README', entryBody: '- no reference at all' }),
+    ).toEqual({
+      ok: true,
+      reason: 'not-governed',
     });
-    expect(result.ok).toBe(true);
-  });
-
-  it('3. accepts a governed "perf:" PR whose Unreleased entry cites "PR #<N>"', () => {
-    const result = checkPrChangelogReference({
-      prNumber: 700,
-      prTitle: 'perf(rag): batch embedding lookups',
-      changelog: UNRELEASED('- **RAG batching:** reduces lookup overhead. PR #700.'),
-    });
-    expect(result.ok).toBe(true);
-  });
-
-  it('4. accepts a scoped governed title, e.g. "fix(pwa): ..."', () => {
-    const result = checkPrChangelogReference({
-      prNumber: 525,
-      prTitle: 'fix(pwa): gate cache-generation activation on precache success',
-      changelog: UNRELEASED('- **SW admission gate:** described here. PR #525.'),
-    });
-    expect(result.ok).toBe(true);
-  });
-
-  it('5. accepts a breaking-change "!" governed title, e.g. "feat(api)!: ..."', () => {
-    const result = checkPrChangelogReference({
-      prNumber: 812,
-      prTitle: 'feat(api)!: drop legacy v1 provider adapter',
-      changelog: UNRELEASED('- **Legacy provider removal:** drops v1 adapter. PR #812.'),
-    });
-    expect(result.ok).toBe(true);
-  });
-
-  it('6. rejects a governed PR whose Unreleased section has no reference at all', () => {
-    const result = checkPrChangelogReference({
-      prNumber: 700,
-      prTitle: 'fix(pwa): gate cache activation on precache success',
-      changelog: UNRELEASED('- **PWA precache admission:** hardens activation.'),
-    });
-    expect(result).toEqual({ ok: false, reason: 'missing-reference' });
-  });
-
-  it('7. rejects a governed PR whose Unreleased entry cites a DIFFERENT PR number', () => {
-    const result = checkPrChangelogReference({
-      prNumber: 700,
-      prTitle: 'fix(pwa): gate cache activation on precache success',
-      changelog: UNRELEASED('- **Unrelated change:** see write-up. PR #501.'),
-    });
-    expect(result).toEqual({ ok: false, reason: 'missing-reference' });
-  });
-
-  it('8. rejects a bare "#<N>" reference lacking the "PR" grammar', () => {
-    const result = checkPrChangelogReference({
-      prNumber: 700,
-      prTitle: 'fix(pwa): gate cache activation on precache success',
-      changelog: UNRELEASED('- **PWA precache admission:** hardens activation. #700.'),
-    });
-    expect(result).toEqual({ ok: false, reason: 'missing-reference' });
-  });
-
-  it('9. rejects a trailing "(#<N>)" squash-style reference pre-merge (no "PR" word)', () => {
-    const result = checkPrChangelogReference({
-      prNumber: 700,
-      prTitle: 'fix(pwa): gate cache activation on precache success',
-      changelog: UNRELEASED('- **PWA precache admission:** hardens activation (#700).'),
-    });
-    expect(result).toEqual({ ok: false, reason: 'missing-reference' });
-  });
-
-  it('10. skips a non-governed PR title (e.g. "docs:") regardless of Unreleased content', () => {
-    const result = checkPrChangelogReference({
-      prNumber: 700,
-      prTitle: 'docs: fix typo in README',
-      changelog: UNRELEASED('- unrelated content with no reference at all'),
-    });
-    expect(result).toEqual({ ok: true, reason: 'not-governed' });
   });
 
   it('11. does not let "PR #700" satisfy a check for the shorter number 70 (no partial-left match)', () => {
-    const result = checkPrChangelogReference({
-      prNumber: 70,
-      prTitle: 'fix(core): narrow number-boundary regression',
-      changelog: UNRELEASED('- **Unrelated:** references a different change. PR #700.'),
+    expect(check({ prNumber: 70, entryBody: '- Unrelated. PR #700.' })).toEqual({
+      ok: false,
+      reason: 'missing-reference',
     });
-    expect(result).toEqual({ ok: false, reason: 'missing-reference' });
   });
 
   it('12. does not let "PR #7000" satisfy a check for the shorter number 700 (no partial-right match)', () => {
-    const result = checkPrChangelogReference({
-      prNumber: 700,
-      prTitle: 'fix(core): narrow number-boundary regression',
-      changelog: UNRELEASED('- **Unrelated:** references a different change. PR #7000.'),
+    expect(check({ entryBody: '- Unrelated. PR #7000.' })).toEqual({
+      ok: false,
+      reason: 'missing-reference',
     });
-    expect(result).toEqual({ ok: false, reason: 'missing-reference' });
   });
 
-  it('13. tolerates case and missing whitespace, e.g. "pr#700"', () => {
+  it('isReferencedByPrLabel directly tolerates missing whitespace, e.g. "pr#700"', () => {
     expect(isReferencedByPrLabel(700, 'lowercase and tight: pr#700 done')).toBe(true);
-    const result = checkPrChangelogReference({
-      prNumber: 700,
-      prTitle: 'fix(pwa): gate cache activation on precache success',
-      changelog: UNRELEASED('- **PWA precache admission:** hardens activation. pr#700.'),
-    });
-    expect(result.ok).toBe(true);
   });
 
   describe('historical-incident fixtures (real CHANGELOG text from the three prior recoveries)', () => {
+    // QNBS-v3: real bullet text from each incident's own recovery commit, factored so only the trailing reference varies.
+    const tauriPluginParityBody =
+      "- **Tauri plugin version parity:** bumped npm packages\n  (`@tauri-apps/plugin-http`, `@tauri-apps/plugin-notification`) after #661 bumped only the Rust\n  side, failing every platform's Tauri release build. Bumped the npm packages to match; added\n  `check-tauri-plugin-versions.mjs`, a cheap CI guard catching this class of mismatch before the\n  next release tag instead of at tag-triggered release time.";
+    const parityPreflightBody =
+      '- **Tauri parity-preflight release gate:** added a `parity-preflight` job (checkout + one\n  dependency-free Node script, no `pnpm install`) that runs `check-tauri-plugin-versions.mjs`\n  before the bundle matrix starts, gated behind `verify-release-tag` so no repository code runs\n  on an unverified release tag. On both `workflow_dispatch` and tag pushes.';
+    const precacheAdmissionBody =
+      '- **PWA: a failed precache can no longer displace a working service-worker generation (#525):**\n  `install` now rethrows on failure so the whole installation rejects.';
+
     it('#678->#679: the original merged state (no reference) would have been rejected', () => {
-      const originalUnreleased = UNRELEASED(
-        "- **Tauri plugin version parity:** bumped npm packages\n  (`@tauri-apps/plugin-http`, `@tauri-apps/plugin-notification`) after #661 bumped only the Rust\n  side, failing every platform's Tauri release build. Bumped the npm packages to match; added\n  `check-tauri-plugin-versions.mjs`, a cheap CI guard catching this class of mismatch before the\n  next release tag instead of at tag-triggered release time.",
-      );
-      const result = checkPrChangelogReference({
+      const result = check({
         prNumber: 678,
         prTitle: 'fix(ci): sync Tauri plugin npm/Rust versions',
-        changelog: originalUnreleased,
+        entryBody: tauriPluginParityBody,
       });
       expect(result).toEqual({ ok: false, reason: 'missing-reference' });
     });
 
-    it('#678->#679: the real recovery entry text ("...PR #678.") satisfies the gate', () => {
-      const recoveredUnreleased = UNRELEASED(
-        "- **Tauri plugin version parity:** bumped npm packages\n  (`@tauri-apps/plugin-http`, `@tauri-apps/plugin-notification`) after #661 bumped only the Rust\n  side, failing every platform's Tauri release build. Bumped the npm packages to match; added\n  `check-tauri-plugin-versions.mjs`, a cheap CI guard catching this class of mismatch before the\n  next release tag instead of at tag-triggered release time. PR #678.",
-      );
-      const result = checkPrChangelogReference({
-        prNumber: 678,
-        prTitle: 'fix(ci): sync Tauri plugin npm/Rust versions',
-        changelog: recoveredUnreleased,
-      });
-      expect(result).toEqual({ ok: true, reason: 'referenced' });
-    });
-
-    it('#684->#685: the real recovery entry text ("...PR #684.") satisfies the gate', () => {
-      const recoveredUnreleased = UNRELEASED(
-        '- **Tauri parity-preflight release gate:** added a `parity-preflight` job (checkout + one\n  dependency-free Node script, no `pnpm install`) that runs `check-tauri-plugin-versions.mjs`\n  before the bundle matrix starts, gated behind `verify-release-tag` so no repository code runs\n  on an unverified release tag. On both `workflow_dispatch` and tag pushes. PR #684.',
-      );
-      const result = checkPrChangelogReference({
-        prNumber: 684,
-        prTitle: 'fix(ci): add Tauri release parity-preflight gate',
-        changelog: recoveredUnreleased,
-      });
-      expect(result).toEqual({ ok: true, reason: 'referenced' });
-    });
-
-    it('#699->#700: the real recovery entry text ("...PR #699.") satisfies the gate', () => {
-      const recoveredUnreleased = UNRELEASED(
-        '- **PWA: a failed precache can no longer displace a working service-worker generation (#525):**\n  `install` now rethrows on failure so the whole installation rejects. PR #699.',
-      );
-      const result = checkPrChangelogReference({
-        prNumber: 699,
-        prTitle: 'fix(pwa): gate service-worker cache-generation activation on precache success',
-        changelog: recoveredUnreleased,
-      });
-      expect(result).toEqual({ ok: true, reason: 'referenced' });
-    });
+    it.each([
+      ['#678->#679', 678, 'fix(ci): sync Tauri plugin npm/Rust versions', tauriPluginParityBody],
+      ['#684->#685', 684, 'fix(ci): add Tauri release parity-preflight gate', parityPreflightBody],
+      [
+        '#699->#700',
+        699,
+        'fix(pwa): gate service-worker cache-generation activation on precache success',
+        precacheAdmissionBody,
+      ],
+    ] as const)(
+      '%s: the real recovery entry text satisfies the gate',
+      (_label, prNumber, prTitle, body) => {
+        const result = check({ prNumber, prTitle, entryBody: `${body} PR #${prNumber}.` });
+        expect(result).toEqual({ ok: true, reason: 'referenced' });
+      },
+    );
   });
 });

--- a/tests/unit/checkPrChangelogReference.test.ts
+++ b/tests/unit/checkPrChangelogReference.test.ts
@@ -1,0 +1,183 @@
+// @vitest-environment node
+/**
+ * Tests for scripts/check-pr-changelog-reference.mjs — the pre-merge admission gate closing the
+ * blind spot where scripts/check-doc-metrics.mjs's completeness check only fires AFTER squash-merge
+ * (recurred 3x: #678->#679, #684->#685, #699->#700).
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  checkPrChangelogReference,
+  isReferencedByPrLabel,
+} from '../../scripts/check-pr-changelog-reference.mjs';
+
+const UNRELEASED = (body: string) => `## [Unreleased]\n\n### Fixed\n\n${body}\n\n## [1.28.6]\n`;
+
+describe('checkPrChangelogReference', () => {
+  it('1. accepts a governed "feat:" PR whose Unreleased entry cites "PR #<N>"', () => {
+    const result = checkPrChangelogReference({
+      prNumber: 700,
+      prTitle: 'feat(writer): add outline templates',
+      changelog: UNRELEASED('- **Outline templates:** adds starter templates. PR #700.'),
+    });
+    expect(result).toEqual({ ok: true, reason: 'referenced' });
+  });
+
+  it('2. accepts a governed "fix:" PR whose Unreleased entry cites "PR #<N>"', () => {
+    const result = checkPrChangelogReference({
+      prNumber: 700,
+      prTitle: 'fix(pwa): gate cache activation on precache success',
+      changelog: UNRELEASED('- **PWA precache admission:** hardens activation. PR #700.'),
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('3. accepts a governed "perf:" PR whose Unreleased entry cites "PR #<N>"', () => {
+    const result = checkPrChangelogReference({
+      prNumber: 700,
+      prTitle: 'perf(rag): batch embedding lookups',
+      changelog: UNRELEASED('- **RAG batching:** reduces lookup overhead. PR #700.'),
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('4. accepts a scoped governed title, e.g. "fix(pwa): ..."', () => {
+    const result = checkPrChangelogReference({
+      prNumber: 525,
+      prTitle: 'fix(pwa): gate cache-generation activation on precache success',
+      changelog: UNRELEASED('- **SW admission gate:** described here. PR #525.'),
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('5. accepts a breaking-change "!" governed title, e.g. "feat(api)!: ..."', () => {
+    const result = checkPrChangelogReference({
+      prNumber: 812,
+      prTitle: 'feat(api)!: drop legacy v1 provider adapter',
+      changelog: UNRELEASED('- **Legacy provider removal:** drops v1 adapter. PR #812.'),
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('6. rejects a governed PR whose Unreleased section has no reference at all', () => {
+    const result = checkPrChangelogReference({
+      prNumber: 700,
+      prTitle: 'fix(pwa): gate cache activation on precache success',
+      changelog: UNRELEASED('- **PWA precache admission:** hardens activation.'),
+    });
+    expect(result).toEqual({ ok: false, reason: 'missing-reference' });
+  });
+
+  it('7. rejects a governed PR whose Unreleased entry cites a DIFFERENT PR number', () => {
+    const result = checkPrChangelogReference({
+      prNumber: 700,
+      prTitle: 'fix(pwa): gate cache activation on precache success',
+      changelog: UNRELEASED('- **Unrelated change:** see write-up. PR #501.'),
+    });
+    expect(result).toEqual({ ok: false, reason: 'missing-reference' });
+  });
+
+  it('8. rejects a bare "#<N>" reference lacking the "PR" grammar', () => {
+    const result = checkPrChangelogReference({
+      prNumber: 700,
+      prTitle: 'fix(pwa): gate cache activation on precache success',
+      changelog: UNRELEASED('- **PWA precache admission:** hardens activation. #700.'),
+    });
+    expect(result).toEqual({ ok: false, reason: 'missing-reference' });
+  });
+
+  it('9. rejects a trailing "(#<N>)" squash-style reference pre-merge (no "PR" word)', () => {
+    const result = checkPrChangelogReference({
+      prNumber: 700,
+      prTitle: 'fix(pwa): gate cache activation on precache success',
+      changelog: UNRELEASED('- **PWA precache admission:** hardens activation (#700).'),
+    });
+    expect(result).toEqual({ ok: false, reason: 'missing-reference' });
+  });
+
+  it('10. skips a non-governed PR title (e.g. "docs:") regardless of Unreleased content', () => {
+    const result = checkPrChangelogReference({
+      prNumber: 700,
+      prTitle: 'docs: fix typo in README',
+      changelog: UNRELEASED('- unrelated content with no reference at all'),
+    });
+    expect(result).toEqual({ ok: true, reason: 'not-governed' });
+  });
+
+  it('11. does not let "PR #700" satisfy a check for the shorter number 70 (no partial-left match)', () => {
+    const result = checkPrChangelogReference({
+      prNumber: 70,
+      prTitle: 'fix(core): narrow number-boundary regression',
+      changelog: UNRELEASED('- **Unrelated:** references a different change. PR #700.'),
+    });
+    expect(result).toEqual({ ok: false, reason: 'missing-reference' });
+  });
+
+  it('12. does not let "PR #7000" satisfy a check for the shorter number 700 (no partial-right match)', () => {
+    const result = checkPrChangelogReference({
+      prNumber: 700,
+      prTitle: 'fix(core): narrow number-boundary regression',
+      changelog: UNRELEASED('- **Unrelated:** references a different change. PR #7000.'),
+    });
+    expect(result).toEqual({ ok: false, reason: 'missing-reference' });
+  });
+
+  it('13. tolerates case and missing whitespace, e.g. "pr#700"', () => {
+    expect(isReferencedByPrLabel(700, 'lowercase and tight: pr#700 done')).toBe(true);
+    const result = checkPrChangelogReference({
+      prNumber: 700,
+      prTitle: 'fix(pwa): gate cache activation on precache success',
+      changelog: UNRELEASED('- **PWA precache admission:** hardens activation. pr#700.'),
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  describe('historical-incident fixtures (real CHANGELOG text from the three prior recoveries)', () => {
+    it('#678->#679: the original merged state (no reference) would have been rejected', () => {
+      const originalUnreleased = UNRELEASED(
+        "- **Tauri plugin version parity:** bumped npm packages\n  (`@tauri-apps/plugin-http`, `@tauri-apps/plugin-notification`) after #661 bumped only the Rust\n  side, failing every platform's Tauri release build. Bumped the npm packages to match; added\n  `check-tauri-plugin-versions.mjs`, a cheap CI guard catching this class of mismatch before the\n  next release tag instead of at tag-triggered release time.",
+      );
+      const result = checkPrChangelogReference({
+        prNumber: 678,
+        prTitle: 'fix(ci): sync Tauri plugin npm/Rust versions',
+        changelog: originalUnreleased,
+      });
+      expect(result).toEqual({ ok: false, reason: 'missing-reference' });
+    });
+
+    it('#678->#679: the real recovery entry text ("...PR #678.") satisfies the gate', () => {
+      const recoveredUnreleased = UNRELEASED(
+        "- **Tauri plugin version parity:** bumped npm packages\n  (`@tauri-apps/plugin-http`, `@tauri-apps/plugin-notification`) after #661 bumped only the Rust\n  side, failing every platform's Tauri release build. Bumped the npm packages to match; added\n  `check-tauri-plugin-versions.mjs`, a cheap CI guard catching this class of mismatch before the\n  next release tag instead of at tag-triggered release time. PR #678.",
+      );
+      const result = checkPrChangelogReference({
+        prNumber: 678,
+        prTitle: 'fix(ci): sync Tauri plugin npm/Rust versions',
+        changelog: recoveredUnreleased,
+      });
+      expect(result).toEqual({ ok: true, reason: 'referenced' });
+    });
+
+    it('#684->#685: the real recovery entry text ("...PR #684.") satisfies the gate', () => {
+      const recoveredUnreleased = UNRELEASED(
+        '- **Tauri parity-preflight release gate:** added a `parity-preflight` job (checkout + one\n  dependency-free Node script, no `pnpm install`) that runs `check-tauri-plugin-versions.mjs`\n  before the bundle matrix starts, gated behind `verify-release-tag` so no repository code runs\n  on an unverified release tag. On both `workflow_dispatch` and tag pushes. PR #684.',
+      );
+      const result = checkPrChangelogReference({
+        prNumber: 684,
+        prTitle: 'fix(ci): add Tauri release parity-preflight gate',
+        changelog: recoveredUnreleased,
+      });
+      expect(result).toEqual({ ok: true, reason: 'referenced' });
+    });
+
+    it('#699->#700: the real recovery entry text ("...PR #699.") satisfies the gate', () => {
+      const recoveredUnreleased = UNRELEASED(
+        '- **PWA: a failed precache can no longer displace a working service-worker generation (#525):**\n  `install` now rethrows on failure so the whole installation rejects. PR #699.',
+      );
+      const result = checkPrChangelogReference({
+        prNumber: 699,
+        prTitle: 'fix(pwa): gate service-worker cache-generation activation on precache success',
+        changelog: recoveredUnreleased,
+      });
+      expect(result).toEqual({ ok: true, reason: 'referenced' });
+    });
+  });
+});

--- a/tests/unit/checkPrChangelogReference.test.ts
+++ b/tests/unit/checkPrChangelogReference.test.ts
@@ -136,6 +136,13 @@ describe('checkPrChangelogReference', () => {
     ).toEqual({ ok: false, reason: 'missing-reference' });
   });
 
+  it('19. does not let a commented-out fake "## [Unreleased]" heading earlier in the file hijack the section boundary', () => {
+    const changelog = `<!--\n## [Unreleased]\n- Placeholder PR #700.\n-->\n\n## [Unreleased]\n\n### Fixed\n\n- **Real fix:** unrelated content with no reference.\n\n## [1.28.6]\n`;
+    expect(
+      checkPrChangelogReference({ prNumber: 700, prTitle: GOVERNED_TITLE, changelog }),
+    ).toEqual({ ok: false, reason: 'missing-reference' });
+  });
+
   describe('historical-incident fixtures (real CHANGELOG text from the three prior recoveries)', () => {
     // QNBS-v3: real bullet text from each incident's own recovery commit, factored so only the trailing reference varies.
     const tauriPluginParityBody =

--- a/tests/unit/checkPrChangelogReference.test.ts
+++ b/tests/unit/checkPrChangelogReference.test.ts
@@ -105,6 +105,20 @@ describe('checkPrChangelogReference', () => {
     expect(isReferencedByPrLabel(700, 'lowercase and tight: pr#700 done')).toBe(true);
   });
 
+  it('14. rejects a reference that appears only in prose outside any bullet entry', () => {
+    const changelog = `## [Unreleased]\n\n### Fixed\n\nNote: tracked under PR #700, changelog entry pending.\n\n- **Something else:** unrelated bullet content.\n\n## [1.28.6]\n`;
+    expect(
+      checkPrChangelogReference({ prNumber: 700, prTitle: GOVERNED_TITLE, changelog }),
+    ).toEqual({ ok: false, reason: 'missing-reference' });
+  });
+
+  it("15. accepts a reference on a bullet's own soft-wrapped continuation line", () => {
+    const changelog = `## [Unreleased]\n\n### Fixed\n\n- **Hardens activation:** wraps across\n  a continuation line. PR #700.\n\n## [1.28.6]\n`;
+    expect(
+      checkPrChangelogReference({ prNumber: 700, prTitle: GOVERNED_TITLE, changelog }),
+    ).toEqual({ ok: true, reason: 'referenced' });
+  });
+
   describe('historical-incident fixtures (real CHANGELOG text from the three prior recoveries)', () => {
     // QNBS-v3: real bullet text from each incident's own recovery commit, factored so only the trailing reference varies.
     const tauriPluginParityBody =

--- a/tests/unit/checkPrChangelogReference.test.ts
+++ b/tests/unit/checkPrChangelogReference.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from 'vitest';
 import {
   checkPrChangelogReference,
   isReferencedByPrLabel,
+  isValidPrMetadata,
 } from '../../scripts/check-pr-changelog-reference.mjs';
 
 const UNRELEASED = (body: string) => `## [Unreleased]\n\n### Fixed\n\n${body}\n\n## [1.28.6]\n`;
@@ -141,6 +142,28 @@ describe('checkPrChangelogReference', () => {
     expect(
       checkPrChangelogReference({ prNumber: 700, prTitle: GOVERNED_TITLE, changelog }),
     ).toEqual({ ok: false, reason: 'missing-reference' });
+  });
+
+  it('20. does not let a blockquote immediately after a bullet (no blank line) absorb its text as a continuation', () => {
+    const changelog = `## [Unreleased]\n\n### Fixed\n\n- **Something else:** unrelated bullet content.\n> Tracking only: PR #700\n\n## [1.28.6]\n`;
+    expect(
+      checkPrChangelogReference({ prNumber: 700, prTitle: GOVERNED_TITLE, changelog }),
+    ).toEqual({ ok: false, reason: 'missing-reference' });
+  });
+
+  it.each([
+    ['missing title', { number: 705 }],
+    ['blank title', { number: 705, title: '   ' }],
+    ['non-integer number', { number: 705.5, title: GOVERNED_TITLE }],
+    ['zero number', { number: 0, title: GOVERNED_TITLE }],
+    ['negative number', { number: -1, title: GOVERNED_TITLE }],
+    ['null payload', null],
+  ] as const)('isValidPrMetadata rejects %s', (_label, pr) => {
+    expect(isValidPrMetadata(pr)).toBe(false);
+  });
+
+  it('isValidPrMetadata accepts well-formed PR metadata', () => {
+    expect(isValidPrMetadata({ number: 705, title: GOVERNED_TITLE })).toBe(true);
   });
 
   describe('historical-incident fixtures (real CHANGELOG text from the three prior recoveries)', () => {


### PR DESCRIPTION
## **User description**
## Problem

`scripts/check-doc-metrics.mjs`'s CHANGELOG completeness gate only enforces a
PR-number reference in `[Unreleased]` **after** squash-merge, once the commit
is on `main` and its subject already carries `(#N)`. Pre-merge, a branch's
own not-yet-squashed commits are (correctly) exempted from that check, since
individual intermediate commits get squashed into one at merge time.

This has left a recurring blind spot: nothing stops a governed PR from
merging without ever adding a CHANGELOG entry, even though the PR's real
number is already knowable via the GitHub API before merge. It has recurred
three times, each requiring a same-pattern follow-up PR to add the missing
reference after the fact:

- #678 → #679
- #684 → #685
- #699 → #700

## Fix

A new, independent pre-merge admission gate:

- `.github/workflows/pr-changelog-reference.yml` — triggers on
  `opened`/`edited`/`synchronize`/`reopened` (title-only edits included).
  Mirrors `pr-text-attribution.yml`'s base-ref self-grading pattern: the
  checker script is loaded from the PR's **base ref**, with a documented
  one-time bootstrap fallback, so a PR cannot weaken the check that grades
  it.
- `scripts/check-pr-changelog-reference.mjs` — fails a governed
  (`feat|fix|perf`) PR unless `CHANGELOG.md`'s `[Unreleased]` section already
  references it as `PR #<N>`, using the PR number from GitHub's own event
  payload (never inferred from git history). Deliberately stricter grammar
  than the existing post-merge bare `#NNN` matcher, since pre-merge there is
  no squash-appended `(#NNN)` to anchor on yet. Fully self-contained (no
  local imports) so the base-ref copy can never break on a missing
  transitive dependency.

The existing `scanUnreleasedTruth` machinery in `check-doc-metrics.mjs` —
governing local pre-push behavior and the historical post-merge/branch-local
exemption — is untouched.

## Non-goals

- Not implementing #675's broader deterministic-identifier-contract scope
  (replacing the unnumbered-commit slug-match fallback with SHA/change-ID
  identifiers). This gate only closes the narrower pre-merge admission gap
  for PRs that already have a real, known PR number — the common case — and
  is fully compatible with #675's eventual direction.
- Not touching local pre-push behavior, since no PR number exists yet
  outside GitHub's own PR-event payload.

## Testing

`tests/unit/checkPrChangelogReference.test.ts` — 17 tests: 13 regression
tests (governed-type grammar incl. scope/`!`, missing/wrong-PR/bare-`#N`/
trailing-`(#N)` rejections, non-governed skip, number-boundary safety,
case/whitespace tolerance) plus 4 fixtures reproducing all three historical
incidents using the real CHANGELOG text from each recovery PR.

Mutation-tested: temporarily weakened the exact-grammar regex to accept bare
`#NNN`, confirmed exactly the two grammar-specific tests failed, restored.

Also verified via the real CLI path (not just the pure function) against
live `GITHUB_EVENT_PATH` fixtures: correct fail-closed, not-a-PR-event
no-op, and no-event-path no-op behavior.

## Summary by Sourcery

Require governed pull requests to include a self-referencing entry in the unreleased changelog before they can merge.

New Features:
- Add a pre-merge CI gate requiring governed feat, fix, and perf pull requests to reference their own PR number in a CHANGELOG.md [Unreleased] bullet.
- Load the admission checker from the PR base ref and use GitHub event metadata to prevent self-weakening and inaccurate PR-number checks.

Bug Fixes:
- Prevent governed pull requests from merging without a corresponding unreleased CHANGELOG entry.

Enhancements:
- Enforce precise PR #N references while handling section boundaries, comments, wrapped bullets, malformed metadata, and non-governed titles safely.

CI:
- Run the CHANGELOG reference check when pull requests are opened, edited, synchronized, or reopened against main.

Documentation:
- Update the CHANGELOG with the new pre-merge admission guard and refresh documented test metrics.

Tests:
- Add regression coverage for valid and invalid references, metadata validation, formatting edge cases, and the three historical missing-reference incidents.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a pre-merge CI gate requiring governed (`feat|fix|perf`) PRs to reference their own PR number as `PR #<N>` in `CHANGELOG.md`'s `[Unreleased]` section before merging. Previously the CHANGELOG completeness check only ran after squash-merge, so governed PRs could merge with no entry — a gap that has already required three follow-up PRs (#678→#679, #684→#685, #699→#700).

**Details**
- Runs from the PR's base ref with a bootstrap fallback, so a PR can't weaken the check that grades it; the PR number comes from GitHub's event payload, never git history.
- Requires the stricter `PR #<N>` grammar with a full trailing word boundary, rejecting near-misses like `PR #700alpha` or `PR #700_internal`.
- Only a reference inside an actual bullet entry counts; a PR number in prose, a sub-heading, or any non-indented continuation line won't satisfy the gate.
- Strips HTML comments from the whole changelog before locating the `[Unreleased]` heading, so a commented-out fake section can't satisfy the gate.
- Fails closed on malformed event metadata (non-integer, zero, or negative number; missing or blank title).
- Skips non-governed titles (`docs:`, etc.); local pre-push behavior and the existing post-merge check are untouched.
- Adds regression coverage including real-text fixtures from all three historical incidents, with the test file refactored to reduce duplication; doesn't implement #675's broader identifier contract but stays compatible with it.

<sup>Written for commit b02958dddf6c51e3a5a4de745666e95bff31824f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/qnbs/WorldScript-Studio/pull/705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an automated pre-merge check for governed pull requests.
  - Governed pull requests must reference their own number in the `[Unreleased]` changelog section before merging.
  - Pull requests outside the governed categories are not subject to this check.
  - Improved validation to recognize valid changelog entries and reject ambiguous references.

- **Documentation**
  - Documented the new changelog requirement.
  - Updated project test metrics to reflect 7,660+ tests across 605 files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Require governed pull requests to reference themselves in the unreleased changelog before merging

### What Changed
- Pull requests titled as `feat`, `fix`, or `perf` must include a bullet in `CHANGELOG.md`'s `[Unreleased]` section that references their own GitHub PR number.
- Checks run when a PR is opened, edited, updated, or reopened, using the PR number supplied by GitHub.
- Documentation-only and other non-governed PRs continue without this requirement.
- Added coverage for valid references, malformed or unrelated numbers, wrapped changelog bullets, comments, section boundaries, and previous incident cases.

### Impact
`✅ Fewer governed changes merged without changelog entries`
`✅ Earlier CI feedback before merge`
`✅ Accurate self-references tied to the actual PR number`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>