### PR TITLE
fix(ai): close cloud-AI policy bypass in generateJson/generateImage/streamAiHelpResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,13 +50,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `generateImage`'s `default` case silently routed any other provider to Gemini too. Combined
   with a mismatch where the shared thunk-level policy pre-check read the global provider setting
   instead of the effective (project-preset-aware) provider, a generation request could silently
-  reach Google's real API despite local-only/privacy settings. All of these are now closed. Also
-  fixed two regressions the fix itself would otherwise have introduced: the thunk-level pre-check
-  now skips its own throw when `shouldRouteLocally()` is true, since `generateText`/`generateJson`
-  already reroute a nominally-cloud provider to local inference in that case — rejecting earlier
-  would have blocked that safe path; and `streamText` (used by AI Help chat) gained the same
-  positive local-routing override `generateText` already had, since it was silently missing it and
-  would otherwise have rejected local-mode help requests instead of answering them locally. PR #706.
+  reach Google's real API despite local-only/privacy settings. All of these are now closed, and the
+  thunk-level pre-check now validates the exact effective provider `resolvePositiveRoutingOpts()`
+  resolves to (local-reroute or OpenRouter-promotion included) via a side-effect-free
+  `peekPositiveRoutingProvider()`, rather than re-deriving its own approximation. `streamText`
+  (used by AI Help chat) gained the same positive local/OpenRouter routing `generateText` already
+  had, since it was silently missing it; both now share one `isOpenRouterTransientFailure()`
+  rate-limit/circuit-open detector and one `buildOpenRouterFallbackOpts()` fallback-options builder,
+  which also fixes a cancellation-during-fallback edge case and a same-provider double-invocation
+  edge case in the OpenRouter-promoted fallback path. PR #706.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `generateImage`'s `default` case silently routed any other provider to Gemini too. Combined
   with a mismatch where the shared thunk-level policy pre-check read the global provider setting
   instead of the effective (project-preset-aware) provider, a generation request could silently
-  reach Google's real API despite local-only/privacy settings. All four gaps are now closed. PR #706.
+  reach Google's real API despite local-only/privacy settings. All of these are now closed. Also
+  fixed two regressions the fix itself would otherwise have introduced: the thunk-level pre-check
+  now skips its own throw when `shouldRouteLocally()` is true, since `generateText`/`generateJson`
+  already reroute a nominally-cloud provider to local inference in that case — rejecting earlier
+  would have blocked that safe path; and `streamText` (used by AI Help chat) gained the same
+  positive local-routing override `generateText` already had, since it was silently missing it and
+  would otherwise have rejected local-mode help requests instead of answering them locally. PR #706.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   had, since it was silently missing it; both now share one `isOpenRouterTransientFailure()`
   rate-limit/circuit-open detector and one `buildOpenRouterFallbackOpts()` fallback-options builder,
   which also fixes a cancellation-during-fallback edge case and a same-provider double-invocation
-  edge case in the OpenRouter-promoted fallback path. PR #706.
+  edge case in the OpenRouter-promoted fallback path. `streamText`'s newly-reachable local-routing
+  path also now forwards the merged `AbortSignal` into `generateLocalText` (previously dropped, so
+  a cancelled local-mode stream ran to completion anyway) and clears a stale `_lastFallbackReason`
+  when a later request's primary provider succeeds outright, matching `generateText`'s existing
+  behavior. PR #706.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`.github/workflows/pr-changelog-reference.yml` + `check-pr-changelog-reference.mjs`, run from the
   PR's base ref to prevent self-weakening) now fails a governed PR's CI unless `[Unreleased]` already
   references it as `PR #<N>`. PR #705.
+- **Closed a cloud-AI privacy-policy bypass reachable via generateJson/generateImage/streamAiHelpResponse:**
+  these three entry points in `aiProviderService.ts` called Gemini directly without the
+  `assertCloudAiAllowed`/`shouldRouteLocally` gate that `generateText`/`streamText` already apply,
+  and `generateImage`'s `default` case silently routed any other provider to Gemini too. Combined
+  with a mismatch where the shared thunk-level policy pre-check read the global provider setting
+  instead of the effective (project-preset-aware) provider, a generation request could silently
+  reach Google's real API despite local-only/privacy settings. All four gaps are now closed. PR #706.
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="i18n 19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7670%2B_%2F_605_files-22C55E" alt="7670+ tests / 605 files">
+  <img src="https://img.shields.io/badge/Tests-7672%2B_%2F_605_files-22C55E" alt="7672+ tests / 605 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2942 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7670+ tests / 605 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7672+ tests / 605 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7670+ tests, 605 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7672+ tests, 605 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -714,7 +714,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendor **6200 KB**, other JavaScript **2500 KB**, and WASM **30000 KB**.
 
 **Current test metrics (2026-09-10, source-synchronized; CI remains authoritative for pass/fail):**
-- **7670+ unit tests** across **605 test files** — CI is authoritative for pass/fail
+- **7672+ unit tests** across **605 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2942 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="i18n 19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7668%2B_%2F_605_files-22C55E" alt="7668+ tests / 605 files">
+  <img src="https://img.shields.io/badge/Tests-7670%2B_%2F_605_files-22C55E" alt="7670+ tests / 605 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2942 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7668+ tests / 605 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7670+ tests / 605 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7668+ tests, 605 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7670+ tests, 605 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -714,7 +714,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendor **6200 KB**, other JavaScript **2500 KB**, and WASM **30000 KB**.
 
 **Current test metrics (2026-09-10, source-synchronized; CI remains authoritative for pass/fail):**
-- **7668+ unit tests** across **605 test files** — CI is authoritative for pass/fail
+- **7670+ unit tests** across **605 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2942 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="i18n 19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7662%2B_%2F_605_files-22C55E" alt="7662+ tests / 605 files">
+  <img src="https://img.shields.io/badge/Tests-7668%2B_%2F_605_files-22C55E" alt="7668+ tests / 605 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2942 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7662+ tests / 605 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7668+ tests / 605 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7662+ tests, 605 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7668+ tests, 605 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -714,7 +714,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendor **6200 KB**, other JavaScript **2500 KB**, and WASM **30000 KB**.
 
 **Current test metrics (2026-09-10, source-synchronized; CI remains authoritative for pass/fail):**
-- **7662+ unit tests** across **605 test files** — CI is authoritative for pass/fail
+- **7668+ unit tests** across **605 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2942 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="i18n 19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7675%2B_%2F_605_files-22C55E" alt="7675+ tests / 605 files">
+  <img src="https://img.shields.io/badge/Tests-7677%2B_%2F_605_files-22C55E" alt="7677+ tests / 605 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2942 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7675+ tests / 605 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7677+ tests / 605 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7675+ tests, 605 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7677+ tests, 605 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -714,7 +714,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendor **6200 KB**, other JavaScript **2500 KB**, and WASM **30000 KB**.
 
 **Current test metrics (2026-09-10, source-synchronized; CI remains authoritative for pass/fail):**
-- **7675+ unit tests** across **605 test files** — CI is authoritative for pass/fail
+- **7677+ unit tests** across **605 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2942 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="i18n 19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7672%2B_%2F_605_files-22C55E" alt="7672+ tests / 605 files">
+  <img src="https://img.shields.io/badge/Tests-7675%2B_%2F_605_files-22C55E" alt="7675+ tests / 605 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2942 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7672+ tests / 605 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7675+ tests / 605 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7672+ tests, 605 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7675+ tests, 605 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -714,7 +714,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendor **6200 KB**, other JavaScript **2500 KB**, and WASM **30000 KB**.
 
 **Current test metrics (2026-09-10, source-synchronized; CI remains authoritative for pass/fail):**
-- **7672+ unit tests** across **605 test files** — CI is authoritative for pass/fail
+- **7675+ unit tests** across **605 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2942 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/features/project/aiThunkUtils.ts
+++ b/features/project/aiThunkUtils.ts
@@ -2,7 +2,8 @@ import type { AsyncThunkConfig, GetThunkAPI } from '@reduxjs/toolkit';
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import type { RootState } from '../../app/store';
 import { assertCloudAiAllowedSync } from '../../services/ai/aiPolicy';
-import type { AIProvider, PrivacySettings } from '../../types';
+import type { PrivacySettings } from '../../types';
+import { buildAiOptions } from './thunks/thunkUtils';
 
 type DeduplicatedThunkAPI = GetThunkAPI<AsyncThunkConfig> & {
   registerDuplicateRequest: (prompt: string, viewType: string) => string;
@@ -66,10 +67,11 @@ export const createDeduplicatedThunk = <Returned, ThunkArg = void>(
 
       try {
         // QNBS-v3: Enforce cloud AI policy before every AI thunk — one place to enforce instead
-        //          of relying on each caller to manually call assertCloudAiAllowed().
+        //          of relying on each caller to manually call assertCloudAiAllowed(). Resolves the
+        //          effective (preset-aware) provider the same way buildAiOptions does, so an enabled
+        //          project preset can no longer bypass this check by diverging from the global setting.
         const state = thunkAPI.getState() as RootState;
-        const provider = (state.settings as unknown as { advancedAi?: { provider?: AIProvider } })
-          .advancedAi?.provider;
+        const provider = buildAiOptions(state).provider;
         if (provider) {
           const privacy = (state.settings as unknown as { privacy?: PrivacySettings }).privacy;
           assertCloudAiAllowedSync(provider, privacy);

--- a/features/project/aiThunkUtils.ts
+++ b/features/project/aiThunkUtils.ts
@@ -1,6 +1,7 @@
 import type { AsyncThunkConfig, GetThunkAPI } from '@reduxjs/toolkit';
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import type { RootState } from '../../app/store';
+import { shouldRouteLocally } from '../../services/ai/aiModeService';
 import { assertCloudAiAllowedSync } from '../../services/ai/aiPolicy';
 import type { PrivacySettings } from '../../types';
 import { buildAiOptions } from './thunks/thunkUtils';
@@ -66,13 +67,10 @@ export const createDeduplicatedThunk = <Returned, ThunkArg = void>(
       } as DeduplicatedThunkAPI;
 
       try {
-        // QNBS-v3: Enforce cloud AI policy before every AI thunk — one place to enforce instead
-        //          of relying on each caller to manually call assertCloudAiAllowed(). Resolves the
-        //          effective (preset-aware) provider the same way buildAiOptions does, so an enabled
-        //          project preset can no longer bypass this check by diverging from the global setting.
+        // QNBS-v3: enforces cloud AI policy for every AI thunk using the effective (preset-aware) provider, skipped when shouldRouteLocally() is true since the real per-call-site gates safely handle that reroute instead.
         const state = thunkAPI.getState() as RootState;
         const provider = buildAiOptions(state).provider;
-        if (provider) {
+        if (provider && !shouldRouteLocally()) {
           const privacy = (state.settings as unknown as { privacy?: PrivacySettings }).privacy;
           assertCloudAiAllowedSync(provider, privacy);
         }

--- a/features/project/aiThunkUtils.ts
+++ b/features/project/aiThunkUtils.ts
@@ -2,7 +2,7 @@ import type { AsyncThunkConfig, GetThunkAPI } from '@reduxjs/toolkit';
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import type { RootState } from '../../app/store';
 import { assertCloudAiAllowedSync } from '../../services/ai/aiPolicy';
-import { resolvePositiveRoutingOpts } from '../../services/aiProviderService';
+import { resolvePositiveRoutingOpts } from '../../services/ai/positiveRouting';
 import type { PrivacySettings } from '../../types';
 import { buildAiOptions } from './thunks/thunkUtils';
 

--- a/features/project/aiThunkUtils.ts
+++ b/features/project/aiThunkUtils.ts
@@ -2,7 +2,7 @@ import type { AsyncThunkConfig, GetThunkAPI } from '@reduxjs/toolkit';
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import type { RootState } from '../../app/store';
 import { assertCloudAiAllowedSync } from '../../services/ai/aiPolicy';
-import { resolvePositiveRoutingOpts } from '../../services/ai/positiveRouting';
+import { peekPositiveRoutingProvider } from '../../services/ai/positiveRouting';
 import type { PrivacySettings } from '../../types';
 import { buildAiOptions } from './thunks/thunkUtils';
 
@@ -67,9 +67,9 @@ export const createDeduplicatedThunk = <Returned, ThunkArg = void>(
       } as DeduplicatedThunkAPI;
 
       try {
-        // QNBS-v3: enforces cloud AI policy using resolvePositiveRoutingOpts()'s effective provider — the same function generateText/generateJson/streamText use to actually route the request — so a local- or OpenRouter-promoted call is checked against what it will really use, not the raw preset/global setting.
+        // QNBS-v3: checks the same effective provider generateText/generateJson/streamText actually route to, not the raw preset/global setting.
         const state = thunkAPI.getState() as RootState;
-        const provider = resolvePositiveRoutingOpts(buildAiOptions(state)).provider;
+        const provider = peekPositiveRoutingProvider(buildAiOptions(state));
         if (provider) {
           const privacy = (state.settings as unknown as { privacy?: PrivacySettings }).privacy;
           assertCloudAiAllowedSync(provider, privacy);

--- a/features/project/aiThunkUtils.ts
+++ b/features/project/aiThunkUtils.ts
@@ -1,8 +1,8 @@
 import type { AsyncThunkConfig, GetThunkAPI } from '@reduxjs/toolkit';
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import type { RootState } from '../../app/store';
-import { shouldRouteLocally } from '../../services/ai/aiModeService';
 import { assertCloudAiAllowedSync } from '../../services/ai/aiPolicy';
+import { resolvePositiveRoutingOpts } from '../../services/aiProviderService';
 import type { PrivacySettings } from '../../types';
 import { buildAiOptions } from './thunks/thunkUtils';
 
@@ -67,10 +67,10 @@ export const createDeduplicatedThunk = <Returned, ThunkArg = void>(
       } as DeduplicatedThunkAPI;
 
       try {
-        // QNBS-v3: enforces cloud AI policy for every AI thunk using the effective (preset-aware) provider, skipped when shouldRouteLocally() is true since the real per-call-site gates safely handle that reroute instead.
+        // QNBS-v3: enforces cloud AI policy using resolvePositiveRoutingOpts()'s effective provider — the same function generateText/generateJson/streamText use to actually route the request — so a local- or OpenRouter-promoted call is checked against what it will really use, not the raw preset/global setting.
         const state = thunkAPI.getState() as RootState;
-        const provider = buildAiOptions(state).provider;
-        if (provider && !shouldRouteLocally()) {
+        const provider = resolvePositiveRoutingOpts(buildAiOptions(state)).provider;
+        if (provider) {
           const privacy = (state.settings as unknown as { privacy?: PrivacySettings }).privacy;
           assertCloudAiAllowedSync(provider, privacy);
         }

--- a/services/ai/openRouterFallback.ts
+++ b/services/ai/openRouterFallback.ts
@@ -1,0 +1,48 @@
+/**
+ * openRouterFallback.ts
+ * ----------------------
+ * OpenRouter rate-limit/circuit-open fallback-promotion helpers, shared by generateText and
+ * streamText in aiProviderService.ts.
+ */
+// QNBS-v3: extracted out of aiProviderService.ts (an already-oversized hotspot file) rather than growing it further — the actual per-provider dispatch stays there and is passed in as `attempt`.
+import type { AIProvider } from '../../types';
+import type { AIRequestOptions } from '../aiProviderService';
+import { getActiveAiMode, getLocalFallbackModel } from './aiModeService';
+import { logRoutingDecision } from './routingLogger';
+
+// QNBS-v3: identifies a transient OpenRouter failure (rate-limit or open circuit) that should promote to OpenRouter's own configured fallback provider instead of just moving to the next chain entry.
+export function isOpenRouterTransientFailure(
+  nextProvider: AIProvider | undefined,
+  error: unknown,
+): boolean {
+  if (nextProvider !== 'openrouter') return false;
+  const msg = error instanceof Error ? error.message : String(error);
+  return msg.startsWith('OPENROUTER_RATE_LIMITED') || msg.startsWith('OPENROUTER_CIRCUIT_OPEN');
+}
+
+// QNBS-v3: reusing mergedOpts.model (an OpenRouter model id) would be meaningless for webllm's local registry lookup — gemini's own getModelForText() already defaults safely, so only webllm needs an explicit swap here.
+export function buildOpenRouterFallbackOpts(
+  mergedOpts: AIRequestOptions,
+  fallback: string,
+): AIRequestOptions {
+  const provider = fallback as AIRequestOptions['provider'];
+  if (provider === 'webllm') {
+    return { ...mergedOpts, provider, model: getLocalFallbackModel() as AIRequestOptions['model'] };
+  }
+  return { ...mergedOpts, provider };
+}
+
+// QNBS-v3: caller must have already committed `fallback` (e.g. to its own attemptedOpenRouterFallback tracker) before calling, since `attempt` can throw.
+export async function attemptOpenRouterFallback<T>(
+  mergedOpts: AIRequestOptions,
+  fallback: string,
+  attempt: (opts: AIRequestOptions) => Promise<T>,
+): Promise<T> {
+  logRoutingDecision({
+    mode: getActiveAiMode(),
+    originalProvider: 'openrouter',
+    chosenProvider: fallback,
+    reason: 'openrouter-fallback',
+  });
+  return attempt(buildOpenRouterFallbackOpts(mergedOpts, fallback));
+}

--- a/services/ai/positiveRouting.ts
+++ b/services/ai/positiveRouting.ts
@@ -17,8 +17,18 @@ import { logRoutingDecision } from './routingLogger';
 // QNBS-v3: on-device providers excluded from the mode override; includes 'ollama' unlike aiConstants.ts's own LOCAL_INFERENCE_PROVIDERS, a separate pre-existing disagreement left as-is here.
 const _LOCAL_INFERENCE_PROVIDERS = new Set<string>(['webllm', 'onnx', 'transformers', 'ollama']);
 
+function shouldRerouteToLocal(opts: AIRequestOptions): boolean {
+  if (_LOCAL_INFERENCE_PROVIDERS.has(opts.provider)) return false;
+  return shouldRouteLocally();
+}
+
+function shouldPromoteToOpenRouter(opts: AIRequestOptions): boolean {
+  if (opts.provider === 'openrouter' || _LOCAL_INFERENCE_PROVIDERS.has(opts.provider)) return false;
+  return shouldUseOpenRouter();
+}
+
 export function resolvePositiveRoutingOpts(opts: AIRequestOptions): AIRequestOptions {
-  if (shouldRouteLocally() && !_LOCAL_INFERENCE_PROVIDERS.has(opts.provider)) {
+  if (shouldRerouteToLocal(opts)) {
     const localModel = getLocalFallbackModel();
     logRoutingDecision({
       mode: getActiveAiMode(),
@@ -28,12 +38,8 @@ export function resolvePositiveRoutingOpts(opts: AIRequestOptions): AIRequestOpt
     });
     return { ...opts, provider: 'webllm', model: localModel as AIRequestOptions['model'] };
   }
-  if (
-    shouldUseOpenRouter() &&
-    !_LOCAL_INFERENCE_PROVIDERS.has(opts.provider) &&
-    opts.provider !== 'openrouter'
-  ) {
-    // QNBS-v3: when enabled and the caller specified a cloud provider other than openrouter, promote to OpenRouter (free-tier or user-configured model).
+  // QNBS-v3: when enabled and the caller specified a cloud provider other than openrouter, promote to OpenRouter (free-tier or user-configured model).
+  if (shouldPromoteToOpenRouter(opts)) {
     const orModel = getOpenRouterModel();
     logRoutingDecision({
       mode: getActiveAiMode(),

--- a/services/ai/positiveRouting.ts
+++ b/services/ai/positiveRouting.ts
@@ -1,0 +1,53 @@
+/**
+ * positiveRouting.ts
+ * -------------------
+ * Positive AI-mode routing (local-only → webllm, else OpenRouter-preferred, else passthrough).
+ */
+// QNBS-v3: extracted out of aiProviderService.ts so aiThunkUtils.ts's policy pre-check avoids pulling in the whole provider-adapter import graph just to resolve an effective provider.
+import type { AIRequestOptions } from '../aiProviderService';
+import {
+  getActiveAiMode,
+  getLocalFallbackModel,
+  getOpenRouterModel,
+  shouldRouteLocally,
+  shouldUseOpenRouter,
+} from './aiModeService';
+import { logRoutingDecision } from './routingLogger';
+
+// QNBS-v3: on-device providers excluded from the mode override; includes 'ollama' unlike aiConstants.ts's own LOCAL_INFERENCE_PROVIDERS, a separate pre-existing disagreement left as-is here.
+const _LOCAL_INFERENCE_PROVIDERS = new Set<string>(['webllm', 'onnx', 'transformers', 'ollama']);
+
+export function resolvePositiveRoutingOpts(opts: AIRequestOptions): AIRequestOptions {
+  if (shouldRouteLocally() && !_LOCAL_INFERENCE_PROVIDERS.has(opts.provider)) {
+    const localModel = getLocalFallbackModel();
+    logRoutingDecision({
+      mode: getActiveAiMode(),
+      originalProvider: opts.provider,
+      chosenProvider: 'webllm',
+      reason: 'mode-override',
+    });
+    return { ...opts, provider: 'webllm', model: localModel as AIRequestOptions['model'] };
+  }
+  if (
+    shouldUseOpenRouter() &&
+    !_LOCAL_INFERENCE_PROVIDERS.has(opts.provider) &&
+    opts.provider !== 'openrouter'
+  ) {
+    // QNBS-v3: when enabled and the caller specified a cloud provider other than openrouter, promote to OpenRouter (free-tier or user-configured model).
+    const orModel = getOpenRouterModel();
+    logRoutingDecision({
+      mode: getActiveAiMode(),
+      originalProvider: opts.provider,
+      chosenProvider: 'openrouter',
+      reason: 'openrouter-preferred',
+    });
+    return { ...opts, provider: 'openrouter', model: orModel as AIRequestOptions['model'] };
+  }
+  logRoutingDecision({
+    mode: getActiveAiMode(),
+    originalProvider: opts.provider,
+    chosenProvider: opts.provider,
+    reason: 'passthrough',
+  });
+  return opts;
+}

--- a/services/ai/positiveRouting.ts
+++ b/services/ai/positiveRouting.ts
@@ -12,6 +12,7 @@ import {
   shouldRouteLocally,
   shouldUseOpenRouter,
 } from './aiModeService';
+import type { RoutingReason } from './routingLogger';
 import { logRoutingDecision } from './routingLogger';
 
 // QNBS-v3: on-device providers excluded from the mode override; includes 'ollama' unlike aiConstants.ts's own LOCAL_INFERENCE_PROVIDERS, a separate pre-existing disagreement left as-is here.
@@ -27,33 +28,47 @@ function shouldPromoteToOpenRouter(opts: AIRequestOptions): boolean {
   return shouldUseOpenRouter();
 }
 
-export function resolvePositiveRoutingOpts(opts: AIRequestOptions): AIRequestOptions {
+interface RoutingResolution {
+  resolvedOpts: AIRequestOptions;
+  reason: RoutingReason;
+}
+
+// QNBS-v3: pure resolution, no logging — shared by the logging wrapper below and by peekPositiveRoutingProvider, which must not record a routing-decision entry for a probe that may never become a real request.
+function computeRoutingResolution(opts: AIRequestOptions): RoutingResolution {
   if (shouldRerouteToLocal(opts)) {
     const localModel = getLocalFallbackModel();
-    logRoutingDecision({
-      mode: getActiveAiMode(),
-      originalProvider: opts.provider,
-      chosenProvider: 'webllm',
+    return {
+      resolvedOpts: { ...opts, provider: 'webllm', model: localModel as AIRequestOptions['model'] },
       reason: 'mode-override',
-    });
-    return { ...opts, provider: 'webllm', model: localModel as AIRequestOptions['model'] };
+    };
   }
   // QNBS-v3: when enabled and the caller specified a cloud provider other than openrouter, promote to OpenRouter (free-tier or user-configured model).
   if (shouldPromoteToOpenRouter(opts)) {
     const orModel = getOpenRouterModel();
-    logRoutingDecision({
-      mode: getActiveAiMode(),
-      originalProvider: opts.provider,
-      chosenProvider: 'openrouter',
+    return {
+      resolvedOpts: {
+        ...opts,
+        provider: 'openrouter',
+        model: orModel as AIRequestOptions['model'],
+      },
       reason: 'openrouter-preferred',
-    });
-    return { ...opts, provider: 'openrouter', model: orModel as AIRequestOptions['model'] };
+    };
   }
+  return { resolvedOpts: opts, reason: 'passthrough' };
+}
+
+export function resolvePositiveRoutingOpts(opts: AIRequestOptions): AIRequestOptions {
+  const { resolvedOpts, reason } = computeRoutingResolution(opts);
   logRoutingDecision({
     mode: getActiveAiMode(),
     originalProvider: opts.provider,
-    chosenProvider: opts.provider,
-    reason: 'passthrough',
+    chosenProvider: resolvedOpts.provider,
+    reason,
   });
-  return opts;
+  return resolvedOpts;
+}
+
+// QNBS-v3: side-effect-free variant for the thunk policy pre-check — the real call re-resolves (and logs) again when it actually executes, so this must not double-log or record a decision for a request that may never be dispatched with this exact shape (e.g. generateImage, which never calls resolvePositiveRoutingOpts itself).
+export function peekPositiveRoutingProvider(opts: AIRequestOptions): AIRequestOptions['provider'] {
+  return computeRoutingResolution(opts).resolvedOpts.provider;
 }

--- a/services/aiProviderService.ts
+++ b/services/aiProviderService.ts
@@ -770,6 +770,7 @@ async function generateImageViaGemini(prompt: string, signal?: AbortSignal): Pro
   return generateImageGemini(prompt, signal);
 }
 
+// QNBS-v3: the default case fails closed — no repository authority defines a silent Gemini fallback for an unrecognized provider.
 export async function generateImage(
   prompt: string,
   opts: AIRequestOptions,
@@ -795,7 +796,6 @@ export async function generateImage(
         'Anthropic image generation is not available. Please use Gemini or Ollama for image content.',
       );
     default:
-      // QNBS-v3: no repository authority defines a silent Gemini fallback for an unrecognized provider — fail explicitly instead of guessing.
       throw new Error('Image generation is not supported for this provider.');
   }
 }

--- a/services/aiProviderService.ts
+++ b/services/aiProviderService.ts
@@ -764,6 +764,12 @@ export async function generateJson<T>(
   }
 }
 
+// QNBS-v3: image generation has no local-routing fallback, so the policy gate alone must block a cloud call in local-only/eco/privacy mode — extracted so generateImage's own switch stays one statement per case for CodeScene's complexity gate on this hotspot file.
+async function generateImageViaGemini(prompt: string, signal?: AbortSignal): Promise<string> {
+  await assertCloudAiAllowed('gemini');
+  return generateImageGemini(prompt, signal);
+}
+
 export async function generateImage(
   prompt: string,
   opts: AIRequestOptions,
@@ -771,9 +777,7 @@ export async function generateImage(
 ): Promise<string> {
   switch (opts.provider) {
     case 'gemini':
-      // QNBS-v3: image generation has no local-routing fallback, so the policy gate alone must block a cloud call in local-only/eco/privacy mode.
-      await assertCloudAiAllowed('gemini');
-      return generateImageGemini(prompt, signal);
+      return generateImageViaGemini(prompt, signal);
     case 'openai':
       throw new Error(
         'OpenAI image generation is currently not available via the browser version.',

--- a/services/aiProviderService.ts
+++ b/services/aiProviderService.ts
@@ -764,40 +764,35 @@ export async function generateJson<T>(
   }
 }
 
-// QNBS-v3: image generation has no local-routing fallback, so the policy gate alone must block a cloud call in local-only/eco/privacy mode — extracted so generateImage's own switch stays one statement per case for CodeScene's complexity gate on this hotspot file.
+// QNBS-v3: image generation has no local-routing fallback, so the policy gate alone must block a cloud call in local-only/eco/privacy mode.
 async function generateImageViaGemini(prompt: string, signal?: AbortSignal): Promise<string> {
   await assertCloudAiAllowed('gemini');
   return generateImageGemini(prompt, signal);
 }
 
-// QNBS-v3: the default case fails closed — no repository authority defines a silent Gemini fallback for an unrecognized provider.
+// QNBS-v3: lookup table instead of a branch chain — every entry besides 'gemini' is unsupported; an unlisted provider (including 'openrouter') fails closed via the same message rather than a silent Gemini fallback.
+const IMAGE_GENERATION_UNSUPPORTED_MESSAGE: Partial<Record<AIProvider, string>> = {
+  openai: 'OpenAI image generation is currently not available via the browser version.',
+  ollama: 'Ollama image generation is currently not supported. Please use Gemini for images.',
+  webllm: 'Local inference is text-only: use Gemini for image generation.',
+  onnx: 'Local inference is text-only: use Gemini for image generation.',
+  transformers: 'Local inference is text-only: use Gemini for image generation.',
+  anthropic:
+    'Anthropic image generation is not available. Please use Gemini or Ollama for image content.',
+};
+
 export async function generateImage(
   prompt: string,
   opts: AIRequestOptions,
   signal?: AbortSignal,
 ): Promise<string> {
-  switch (opts.provider) {
-    case 'gemini':
-      return generateImageViaGemini(prompt, signal);
-    case 'openai':
-      throw new Error(
-        'OpenAI image generation is currently not available via the browser version.',
-      );
-    case 'ollama':
-      throw new Error(
-        'Ollama image generation is currently not supported. Please use Gemini for images.',
-      );
-    case 'webllm':
-    case 'onnx':
-    case 'transformers':
-      throw new Error('Local inference is text-only: use Gemini for image generation.');
-    case 'anthropic':
-      throw new Error(
-        'Anthropic image generation is not available. Please use Gemini or Ollama for image content.',
-      );
-    default:
-      throw new Error('Image generation is not supported for this provider.');
+  if (opts.provider === 'gemini') {
+    return generateImageViaGemini(prompt, signal);
   }
+  throw new Error(
+    IMAGE_GENERATION_UNSUPPORTED_MESSAGE[opts.provider] ??
+      'Image generation is not supported for this provider.',
+  );
 }
 
 export async function streamText(

--- a/services/aiProviderService.ts
+++ b/services/aiProviderService.ts
@@ -730,7 +730,9 @@ export async function generateJson<T>(
   signal?: AbortSignal,
 ): Promise<T> {
   try {
-    if (opts.provider === 'gemini') {
+    // QNBS-v3: gate the Gemini-direct fast path behind the same cloud-AI policy every other entry point applies — this branch previously reached the SDK before any mode/privacy check.
+    if (opts.provider === 'gemini' && !shouldRouteLocally()) {
+      await assertCloudAiAllowed('gemini');
       return await generateJsonGemini(prompt, creativity, schema, signal, undefined, opts.model);
     }
 
@@ -765,6 +767,8 @@ export async function generateImage(
 ): Promise<string> {
   switch (opts.provider) {
     case 'gemini':
+      // QNBS-v3: image generation has no local-routing fallback, so the policy gate alone must block a cloud call in local-only/eco/privacy mode.
+      await assertCloudAiAllowed('gemini');
       return generateImageGemini(prompt, signal);
     case 'openai':
       throw new Error(
@@ -783,7 +787,8 @@ export async function generateImage(
         'Anthropic image generation is not available. Please use Gemini or Ollama for image content.',
       );
     default:
-      return generateImageGemini(prompt, signal);
+      // QNBS-v3: no repository authority defines a silent Gemini fallback for an unrecognized provider — fail explicitly instead of guessing.
+      throw new Error('Image generation is not supported for this provider.');
   }
 }
 
@@ -865,7 +870,9 @@ export async function streamAiHelpResponse(
   const helpPromptWithDocs = doc
     ? `You are a helpful assistant for WorldScript Studio. Prefer the documentation excerpts below when they answer the question; otherwise give concise general guidance. Format using Markdown.\n\n${mergedBody}`
     : `You are a helpful assistant for a creative writing app called WorldScript Studio. Answer the user's question concisely and clearly. Format your answer using Markdown. Question: ${sanitizePromptValue(question)}`;
-  if (opts.provider === 'gemini') {
+  // QNBS-v3: gate the Gemini-direct fast path behind the same cloud-AI policy every other entry point applies — this branch previously reached the SDK before any mode/privacy check.
+  if (opts.provider === 'gemini' && !shouldRouteLocally()) {
+    await assertCloudAiAllowed('gemini');
     return streamAiHelpResponseGemini(
       mergedBody,
       callbacks.onChunk,

--- a/services/aiProviderService.ts
+++ b/services/aiProviderService.ts
@@ -10,8 +10,6 @@ import { detectWebGpuSupport } from '@domain/ai-core';
 import { z } from 'zod';
 import type { AIProvider, AiCreativity, AiModel, GeminiSchema, LocalBackendPreset } from '../types';
 import {
-  getActiveAiMode,
-  getLocalFallbackModel,
   getOpenRouterFallbackProvider,
   shouldRouteLocally,
   shouldUseOpenRouter,
@@ -28,9 +26,9 @@ import {
   normalizeOpenAiCompatibleBaseUrl,
   resolveOpenAiCompatibleRoot,
 } from './ai/modelNormalization';
+import { attemptOpenRouterFallback, isOpenRouterTransientFailure } from './ai/openRouterFallback';
 import { resolvePositiveRoutingOpts } from './ai/positiveRouting';
 import { generateOpenRouterText, streamOpenRouter } from './ai/providers/openrouterProvider';
-import { logRoutingDecision } from './ai/routingLogger';
 import { attachCause, sanitizePromptValue, stripJsonFences } from './aiUtils';
 import { isServerlessProxyCapable } from './deployTarget';
 import {
@@ -591,53 +589,6 @@ async function generateTextSingleProvider(
   }
 }
 
-// QNBS-v3: shared by generateText and streamText — identifies a transient OpenRouter failure (rate-limit or open circuit) that should promote to OpenRouter's own configured fallback provider instead of just moving to the next chain entry.
-function isOpenRouterTransientFailure(
-  nextProvider: AIProvider | undefined,
-  error: unknown,
-): boolean {
-  if (nextProvider !== 'openrouter') return false;
-  const msg = error instanceof Error ? error.message : String(error);
-  return msg.startsWith('OPENROUTER_RATE_LIMITED') || msg.startsWith('OPENROUTER_CIRCUIT_OPEN');
-}
-
-// QNBS-v3: reusing mergedOpts.model (an OpenRouter model id) would be meaningless for webllm's local registry lookup, so the fallback needs a provider-appropriate model — gemini's own getModelForText() already defaults safely, so only webllm needs an explicit swap here.
-function buildOpenRouterFallbackOpts(
-  mergedOpts: AIRequestOptions,
-  fallback: string,
-): AIRequestOptions {
-  const provider = fallback as AIRequestOptions['provider'];
-  if (provider === 'webllm') {
-    return { ...mergedOpts, provider, model: getLocalFallbackModel() as AIRequestOptions['model'] };
-  }
-  return { ...mergedOpts, provider };
-}
-
-// QNBS-v3: extracted so generateText's loop body carries fewer inline branches — the caller must have already committed `fallback` (e.g. to attemptedOpenRouterFallback) before calling, since this can throw on a failed retry.
-async function attemptOpenRouterTextFallback(
-  prompt: string,
-  creativity: AiCreativity,
-  mergedOpts: AIRequestOptions,
-  fallback: string,
-): Promise<string> {
-  logRoutingDecision({
-    mode: getActiveAiMode(),
-    originalProvider: 'openrouter',
-    chosenProvider: fallback,
-    reason: 'openrouter-fallback',
-  });
-  const { withTransientRetry } = await import('./ai/aiRetry');
-  return withTransientRetry(
-    () =>
-      generateTextSingleProvider(
-        prompt,
-        creativity,
-        buildOpenRouterFallbackOpts(mergedOpts, fallback),
-      ),
-    { attempts: 2 },
-  );
-}
-
 export async function generateText(
   prompt: string,
   creativity: AiCreativity,
@@ -686,11 +637,16 @@ export async function generateText(
           const fallback = getOpenRouterFallbackProvider();
           attemptedOpenRouterFallback = fallback;
           try {
-            const result = await attemptOpenRouterTextFallback(
-              prompt,
-              creativity,
+            const result = await attemptOpenRouterFallback(
               mergedOpts,
               fallback,
+              async (fallbackOpts) => {
+                const { withTransientRetry } = await import('./ai/aiRetry');
+                return withTransientRetry(
+                  () => generateTextSingleProvider(prompt, creativity, fallbackOpts),
+                  { attempts: 2 },
+                );
+              },
             );
             _lastFallbackReason = `OpenRouter rate-limited; fell back to ${fallback}.`;
             return result;
@@ -795,30 +751,6 @@ export async function generateImage(
   );
 }
 
-// QNBS-v3: extracted so streamText's loop body carries fewer inline branches — the caller must have already committed `fallback` (e.g. to attemptedOpenRouterFallback) before calling, since this can throw on a failed stream attempt.
-async function attemptOpenRouterStreamFallback(
-  prompt: string,
-  creativity: AiCreativity,
-  mergedOpts: AIRequestOptions,
-  callbacks: AIStreamCallbacks,
-  fallback: string,
-  signal?: AbortSignal,
-): Promise<void> {
-  logRoutingDecision({
-    mode: getActiveAiMode(),
-    originalProvider: 'openrouter',
-    chosenProvider: fallback,
-    reason: 'openrouter-fallback',
-  });
-  await streamProvider(
-    prompt,
-    creativity,
-    buildOpenRouterFallbackOpts(mergedOpts, fallback),
-    callbacks,
-    signal,
-  );
-}
-
 export async function streamText(
   prompt: string,
   creativity: AiCreativity,
@@ -875,13 +807,8 @@ export async function streamText(
           const fallback = getOpenRouterFallbackProvider();
           attemptedOpenRouterFallback = fallback;
           try {
-            await attemptOpenRouterStreamFallback(
-              prompt,
-              creativity,
-              mergedOpts,
-              callbacks,
-              fallback,
-              signal,
+            await attemptOpenRouterFallback(mergedOpts, fallback, (fallbackOpts) =>
+              streamProvider(prompt, creativity, fallbackOpts, callbacks, signal),
             );
             _lastFallbackReason = `OpenRouter rate-limited; fell back to ${fallback}.`;
             return;

--- a/services/aiProviderService.ts
+++ b/services/aiProviderService.ts
@@ -11,8 +11,10 @@ import { z } from 'zod';
 import type { AIProvider, AiCreativity, AiModel, GeminiSchema, LocalBackendPreset } from '../types';
 import {
   getActiveAiMode,
+  getLocalFallbackModel,
   getOpenRouterFallbackProvider,
   shouldRouteLocally,
+  shouldUseOpenRouter,
 } from './ai/aiModeService';
 import { assertCloudAiAllowed } from './ai/aiPolicy';
 // QNBS-v3: connection tests use the same current Anthropic default as the catalog and proxy.
@@ -599,6 +601,18 @@ function isOpenRouterTransientFailure(
   return msg.startsWith('OPENROUTER_RATE_LIMITED') || msg.startsWith('OPENROUTER_CIRCUIT_OPEN');
 }
 
+// QNBS-v3: reusing mergedOpts.model (an OpenRouter model id) would be meaningless for webllm's local registry lookup, so the fallback needs a provider-appropriate model — gemini's own getModelForText() already defaults safely, so only webllm needs an explicit swap here.
+function buildOpenRouterFallbackOpts(
+  mergedOpts: AIRequestOptions,
+  fallback: string,
+): AIRequestOptions {
+  const provider = fallback as AIRequestOptions['provider'];
+  if (provider === 'webllm') {
+    return { ...mergedOpts, provider, model: getLocalFallbackModel() as AIRequestOptions['model'] };
+  }
+  return { ...mergedOpts, provider };
+}
+
 export async function generateText(
   prompt: string,
   creativity: AiCreativity,
@@ -614,10 +628,12 @@ export async function generateText(
   const mergedOpts = withMergedAbortSignal(resolvedOpts, signal ?? controller.signal);
   const chain = resolveProviderFallbackChain(mergedOpts);
   let lastError: unknown;
+  // QNBS-v3: tracks an OpenRouter-promoted fallback provider already attempted this call, so the outer loop doesn't invoke it a second time (and double-bill/duplicate) if the chain also lists it later.
+  let attemptedOpenRouterFallback: string | undefined;
   try {
     for (let i = 0; i < chain.length; i++) {
       const nextProvider = chain[i];
-      if (nextProvider === undefined) continue;
+      if (nextProvider === undefined || nextProvider === attemptedOpenRouterFallback) continue;
       try {
         const { withTransientRetry } = await import('./ai/aiRetry');
         const result = await withTransientRetry(
@@ -643,6 +659,7 @@ export async function generateText(
         // provider rather than continuing blindly down the chain to avoid masking the root cause.
         if (isOpenRouterTransientFailure(nextProvider, err)) {
           const fallback = getOpenRouterFallbackProvider();
+          attemptedOpenRouterFallback = fallback;
           logRoutingDecision({
             mode: getActiveAiMode(),
             originalProvider: 'openrouter',
@@ -653,10 +670,11 @@ export async function generateText(
             const { withTransientRetry } = await import('./ai/aiRetry');
             const result = await withTransientRetry(
               () =>
-                generateTextSingleProvider(prompt, creativity, {
-                  ...mergedOpts,
-                  provider: fallback as AIRequestOptions['provider'],
-                }),
+                generateTextSingleProvider(
+                  prompt,
+                  creativity,
+                  buildOpenRouterFallbackOpts(mergedOpts, fallback),
+                ),
               { attempts: 2 },
             );
             _lastFallbackReason = `OpenRouter rate-limited; fell back to ${fallback}.`;
@@ -689,9 +707,9 @@ export async function generateText(
   }
 }
 
-// QNBS-v3: shared by generateJson and streamAiHelpResponse so each call site's own branching stays flat for CodeScene's complexity gate on this already-hot file.
+// QNBS-v3: shared by generateJson and streamAiHelpResponse so each call site's own branching stays flat for CodeScene's complexity gate on this already-hot file — also excludes OpenRouter-preferred mode so these paths fall through to generateText's own resolvePositiveRoutingOpts-based promotion instead of bypassing it with a direct Gemini SDK call.
 function isGeminiDirectCloudPath(provider: AIProvider): boolean {
-  return provider === 'gemini' && !shouldRouteLocally();
+  return provider === 'gemini' && !shouldRouteLocally() && !shouldUseOpenRouter();
 }
 
 export async function generateJson<T>(
@@ -778,6 +796,8 @@ export async function streamText(
   const mergedOpts = withMergedAbortSignal(resolvedOpts, signal ?? controller.signal);
   const chain = resolveProviderFallbackChain(mergedOpts);
   let lastError: unknown;
+  // QNBS-v3: tracks an OpenRouter-promoted fallback provider already attempted this call, so the outer loop doesn't invoke it a second time (and double-bill/duplicate chunks) if the chain also lists it later.
+  let attemptedOpenRouterFallback: string | undefined;
   // QNBS-v3: after the chain is exhausted, deliver a registered heuristic result through the stream
   // (onChunk + onDone) instead of erroring — so streaming features (Writer tools) stay useful offline.
   const tryHeuristicStream = (): boolean => {
@@ -793,7 +813,7 @@ export async function streamText(
   try {
     for (let i = 0; i < chain.length; i++) {
       const nextProvider = chain[i];
-      if (nextProvider === undefined) continue;
+      if (nextProvider === undefined || nextProvider === attemptedOpenRouterFallback) continue;
       try {
         await streamProvider(
           prompt,
@@ -814,6 +834,7 @@ export async function streamText(
         // QNBS-v3: mirrors generateText's OpenRouter rate-limit/circuit-open promotion — without this, a stream promoted to OpenRouter by resolvePositiveRoutingOpts would fail hard on a transient OpenRouter outage instead of falling back.
         if (isOpenRouterTransientFailure(nextProvider, error)) {
           const fallback = getOpenRouterFallbackProvider();
+          attemptedOpenRouterFallback = fallback;
           logRoutingDecision({
             mode: getActiveAiMode(),
             originalProvider: 'openrouter',
@@ -824,12 +845,19 @@ export async function streamText(
             await streamProvider(
               prompt,
               creativity,
-              { ...mergedOpts, provider: fallback as AIRequestOptions['provider'] },
+              buildOpenRouterFallbackOpts(mergedOpts, fallback),
               callbacks,
               signal,
             );
+            _lastFallbackReason = `OpenRouter rate-limited; fell back to ${fallback}.`;
             return;
           } catch (fallbackError) {
+            // QNBS-v3: mirrors the outer catch's cancellation guard — a cancel during the promoted fallback must not be treated as a provider failure either.
+            if (isAbortError(fallbackError) || mergedOpts.signal?.aborted || signal?.aborted) {
+              throw fallbackError instanceof Error
+                ? fallbackError
+                : new Error(String(fallbackError));
+            }
             lastError = fallbackError;
           }
         }

--- a/services/aiProviderService.ts
+++ b/services/aiProviderService.ts
@@ -496,7 +496,14 @@ async function streamProvider(
       const merged = oWithLora.systemPrompt?.trim()
         ? `${sanitizePromptValue(oWithLora.systemPrompt)}\n\n${sanitizePromptValue(prompt)}`
         : sanitizePromptValue(prompt);
-      const local = await generateLocalText(merged, oWithLora.model);
+      // QNBS-v3: forward the merged signal so a cancelled/offline-rerouted local stream actually stops instead of running to completion — generateLocalText's 5th param is a real abort hook, not a no-op.
+      const local = await generateLocalText(
+        merged,
+        oWithLora.model,
+        undefined,
+        undefined,
+        oWithLora.signal,
+      );
       callbacks.onChunk(local.text);
       callbacks.onDone?.();
       return;
@@ -793,6 +800,12 @@ export async function streamText(
           callbacks,
           signal,
         );
+        // QNBS-v3: mirrors generateText's fallback-reason bookkeeping — without this, a stale reason from an earlier failed/promoted request would keep showing in GpuMetricsPanel after this request's primary provider succeeds outright.
+        if (i > 0) {
+          _lastFallbackReason = `Primary provider ${mergedOpts.provider} failed; fell back to ${nextProvider}.`;
+        } else {
+          _lastFallbackReason = '';
+        }
         return;
       } catch (error) {
         // QNBS-v3: A user-cancelled request is NOT a provider failure. Don't fall back to the next

--- a/services/aiProviderService.ts
+++ b/services/aiProviderService.ts
@@ -594,16 +594,8 @@ async function generateTextSingleProvider(
   }
 }
 
-export async function generateText(
-  prompt: string,
-  creativity: AiCreativity,
-  opts: AIRequestOptions,
-  signal?: AbortSignal,
-): Promise<string> {
-  // QNBS-v3: Positive routing — apply AI execution mode overrides before dedup keying (G2).
-  // Priority: (1) local-only modes → webllm; (2) OpenRouter enabled → prefer OR for cloud calls;
-  // (3) passthrough — use whatever provider the caller specified.
-  let resolvedOpts = opts;
+// QNBS-v3: positive AI-mode routing (local-only → webllm, else OpenRouter-preferred, else passthrough) shared by generateText and streamText so both reroute before building their fallback chain — streamText was previously missing this step entirely.
+function resolvePositiveRoutingOpts(opts: AIRequestOptions): AIRequestOptions {
   if (shouldRouteLocally() && !_LOCAL_INFERENCE_PROVIDERS.has(opts.provider)) {
     const localModel = getLocalFallbackModel();
     logRoutingDecision({
@@ -612,8 +604,9 @@ export async function generateText(
       chosenProvider: 'webllm',
       reason: 'mode-override',
     });
-    resolvedOpts = { ...opts, provider: 'webllm', model: localModel as AIRequestOptions['model'] };
-  } else if (
+    return { ...opts, provider: 'webllm', model: localModel as AIRequestOptions['model'] };
+  }
+  if (
     shouldUseOpenRouter() &&
     !_LOCAL_INFERENCE_PROVIDERS.has(opts.provider) &&
     opts.provider !== 'openrouter'
@@ -627,15 +620,24 @@ export async function generateText(
       chosenProvider: 'openrouter',
       reason: 'openrouter-preferred',
     });
-    resolvedOpts = { ...opts, provider: 'openrouter', model: orModel as AIRequestOptions['model'] };
-  } else {
-    logRoutingDecision({
-      mode: getActiveAiMode(),
-      originalProvider: opts.provider,
-      chosenProvider: opts.provider,
-      reason: 'passthrough',
-    });
+    return { ...opts, provider: 'openrouter', model: orModel as AIRequestOptions['model'] };
   }
+  logRoutingDecision({
+    mode: getActiveAiMode(),
+    originalProvider: opts.provider,
+    chosenProvider: opts.provider,
+    reason: 'passthrough',
+  });
+  return opts;
+}
+
+export async function generateText(
+  prompt: string,
+  creativity: AiCreativity,
+  opts: AIRequestOptions,
+  signal?: AbortSignal,
+): Promise<string> {
+  const resolvedOpts = resolvePositiveRoutingOpts(opts);
   const { key, controller } = _deduplicateRequest(
     resolvedOpts.provider,
     resolvedOpts.model,
@@ -802,8 +804,13 @@ export async function streamText(
   callbacks: AIStreamCallbacks,
   signal?: AbortSignal,
 ): Promise<void> {
-  const { key, controller } = _deduplicateRequest(opts.provider, opts.model, prompt);
-  const mergedOpts = withMergedAbortSignal(opts, signal ?? controller.signal);
+  const resolvedOpts = resolvePositiveRoutingOpts(opts);
+  const { key, controller } = _deduplicateRequest(
+    resolvedOpts.provider,
+    resolvedOpts.model,
+    prompt,
+  );
+  const mergedOpts = withMergedAbortSignal(resolvedOpts, signal ?? controller.signal);
   const chain = resolveProviderFallbackChain(mergedOpts);
   let lastError: unknown;
   // QNBS-v3: after the chain is exhausted, deliver a registered heuristic result through the stream

--- a/services/aiProviderService.ts
+++ b/services/aiProviderService.ts
@@ -722,6 +722,11 @@ export async function generateText(
   }
 }
 
+// QNBS-v3: shared by generateJson and streamAiHelpResponse so each call site's own branching stays flat for CodeScene's complexity gate on this already-hot file.
+function isGeminiDirectCloudPath(provider: AIProvider): boolean {
+  return provider === 'gemini' && !shouldRouteLocally();
+}
+
 export async function generateJson<T>(
   prompt: string,
   creativity: AiCreativity,
@@ -730,8 +735,7 @@ export async function generateJson<T>(
   signal?: AbortSignal,
 ): Promise<T> {
   try {
-    // QNBS-v3: gate the Gemini-direct fast path behind the same cloud-AI policy every other entry point applies — this branch previously reached the SDK before any mode/privacy check.
-    if (opts.provider === 'gemini' && !shouldRouteLocally()) {
+    if (isGeminiDirectCloudPath(opts.provider)) {
       await assertCloudAiAllowed('gemini');
       return await generateJsonGemini(prompt, creativity, schema, signal, undefined, opts.model);
     }
@@ -870,8 +874,7 @@ export async function streamAiHelpResponse(
   const helpPromptWithDocs = doc
     ? `You are a helpful assistant for WorldScript Studio. Prefer the documentation excerpts below when they answer the question; otherwise give concise general guidance. Format using Markdown.\n\n${mergedBody}`
     : `You are a helpful assistant for a creative writing app called WorldScript Studio. Answer the user's question concisely and clearly. Format your answer using Markdown. Question: ${sanitizePromptValue(question)}`;
-  // QNBS-v3: gate the Gemini-direct fast path behind the same cloud-AI policy every other entry point applies — this branch previously reached the SDK before any mode/privacy check.
-  if (opts.provider === 'gemini' && !shouldRouteLocally()) {
+  if (isGeminiDirectCloudPath(opts.provider)) {
     await assertCloudAiAllowed('gemini');
     return streamAiHelpResponseGemini(
       mergedBody,

--- a/services/aiProviderService.ts
+++ b/services/aiProviderService.ts
@@ -594,8 +594,8 @@ async function generateTextSingleProvider(
   }
 }
 
-// QNBS-v3: positive AI-mode routing (local-only → webllm, else OpenRouter-preferred, else passthrough) shared by generateText and streamText so both reroute before building their fallback chain — streamText was previously missing this step entirely.
-function resolvePositiveRoutingOpts(opts: AIRequestOptions): AIRequestOptions {
+// QNBS-v3: positive AI-mode routing (local-only → webllm, else OpenRouter-preferred, else passthrough) shared by generateText and streamText so both reroute before building their fallback chain — streamText was previously missing this step entirely. Also exported for aiThunkUtils.ts's policy pre-check, so it can gate on the same effective provider a real call will actually use.
+export function resolvePositiveRoutingOpts(opts: AIRequestOptions): AIRequestOptions {
   if (shouldRouteLocally() && !_LOCAL_INFERENCE_PROVIDERS.has(opts.provider)) {
     const localModel = getLocalFallbackModel();
     logRoutingDecision({
@@ -629,6 +629,16 @@ function resolvePositiveRoutingOpts(opts: AIRequestOptions): AIRequestOptions {
     reason: 'passthrough',
   });
   return opts;
+}
+
+// QNBS-v3: shared by generateText and streamText — identifies a transient OpenRouter failure (rate-limit or open circuit) that should promote to OpenRouter's own configured fallback provider instead of just moving to the next chain entry.
+function isOpenRouterTransientFailure(
+  nextProvider: AIProvider | undefined,
+  error: unknown,
+): boolean {
+  if (nextProvider !== 'openrouter') return false;
+  const msg = error instanceof Error ? error.message : String(error);
+  return msg.startsWith('OPENROUTER_RATE_LIMITED') || msg.startsWith('OPENROUTER_CIRCUIT_OPEN');
 }
 
 export async function generateText(
@@ -673,10 +683,7 @@ export async function generateText(
         _lastFallbackReason = `Provider ${nextProvider ?? 'unknown'} failed: ${msg}`;
         // QNBS-v3: OpenRouter rate-limit or circuit-open — log and promote to its configured fallback
         // provider rather than continuing blindly down the chain to avoid masking the root cause.
-        if (
-          nextProvider === 'openrouter' &&
-          (msg.startsWith('OPENROUTER_RATE_LIMITED') || msg.startsWith('OPENROUTER_CIRCUIT_OPEN'))
-        ) {
+        if (isOpenRouterTransientFailure(nextProvider, err)) {
           const fallback = getOpenRouterFallbackProvider();
           logRoutingDecision({
             mode: getActiveAiMode(),
@@ -846,11 +853,33 @@ export async function streamText(
           throw error instanceof Error ? error : new Error(String(error));
         }
         lastError = error;
+        // QNBS-v3: mirrors generateText's OpenRouter rate-limit/circuit-open promotion — without this, a stream promoted to OpenRouter by resolvePositiveRoutingOpts would fail hard on a transient OpenRouter outage instead of falling back.
+        if (isOpenRouterTransientFailure(nextProvider, error)) {
+          const fallback = getOpenRouterFallbackProvider();
+          logRoutingDecision({
+            mode: getActiveAiMode(),
+            originalProvider: 'openrouter',
+            chosenProvider: fallback,
+            reason: 'openrouter-fallback',
+          });
+          try {
+            await streamProvider(
+              prompt,
+              creativity,
+              { ...mergedOpts, provider: fallback as AIRequestOptions['provider'] },
+              callbacks,
+              signal,
+            );
+            return;
+          } catch (fallbackError) {
+            lastError = fallbackError;
+          }
+        }
         if (i === chain.length - 1) {
           // QNBS-v3: onError is owned by this orchestration layer — fire it exactly once, after
           // the whole fallback chain is exhausted, so a failing provider never surfaces a terminal
           // error callback while a subsequent fallback provider is still about to succeed.
-          const terminal = error instanceof Error ? error : new Error(String(error));
+          const terminal = lastError instanceof Error ? lastError : new Error(String(lastError));
           if (tryHeuristicStream()) return;
           callbacks.onError?.(terminal);
           throw terminal;

--- a/services/aiProviderService.ts
+++ b/services/aiProviderService.ts
@@ -11,11 +11,8 @@ import { z } from 'zod';
 import type { AIProvider, AiCreativity, AiModel, GeminiSchema, LocalBackendPreset } from '../types';
 import {
   getActiveAiMode,
-  getLocalFallbackModel,
   getOpenRouterFallbackProvider,
-  getOpenRouterModel,
   shouldRouteLocally,
-  shouldUseOpenRouter,
 } from './ai/aiModeService';
 import { assertCloudAiAllowed } from './ai/aiPolicy';
 // QNBS-v3: connection tests use the same current Anthropic default as the catalog and proxy.
@@ -29,6 +26,7 @@ import {
   normalizeOpenAiCompatibleBaseUrl,
   resolveOpenAiCompatibleRoot,
 } from './ai/modelNormalization';
+import { resolvePositiveRoutingOpts } from './ai/positiveRouting';
 import { generateOpenRouterText, streamOpenRouter } from './ai/providers/openrouterProvider';
 import { logRoutingDecision } from './ai/routingLogger';
 import { attachCause, sanitizePromptValue, stripJsonFences } from './aiUtils';
@@ -112,9 +110,6 @@ export function isAbortError(error: unknown): boolean {
     (error as { name?: unknown }).name === 'AbortError'
   );
 }
-
-// QNBS-v3: Providers that run on-device — excluded from cloud-policy gate and ai-mode override.
-const _LOCAL_INFERENCE_PROVIDERS = new Set<string>(['webllm', 'onnx', 'transformers', 'ollama']);
 
 // ─── Fallback reason tracking ────────────────────────────────────────────────
 // QNBS-v3: Records why the last fallback occurred so the UI can explain it to the user.
@@ -592,43 +587,6 @@ async function generateTextSingleProvider(
       return providerTextSchema.parse({ text }).text;
     }
   }
-}
-
-// QNBS-v3: positive AI-mode routing (local-only → webllm, else OpenRouter-preferred, else passthrough) shared by generateText and streamText so both reroute before building their fallback chain — streamText was previously missing this step entirely. Also exported for aiThunkUtils.ts's policy pre-check, so it can gate on the same effective provider a real call will actually use.
-export function resolvePositiveRoutingOpts(opts: AIRequestOptions): AIRequestOptions {
-  if (shouldRouteLocally() && !_LOCAL_INFERENCE_PROVIDERS.has(opts.provider)) {
-    const localModel = getLocalFallbackModel();
-    logRoutingDecision({
-      mode: getActiveAiMode(),
-      originalProvider: opts.provider,
-      chosenProvider: 'webllm',
-      reason: 'mode-override',
-    });
-    return { ...opts, provider: 'webllm', model: localModel as AIRequestOptions['model'] };
-  }
-  if (
-    shouldUseOpenRouter() &&
-    !_LOCAL_INFERENCE_PROVIDERS.has(opts.provider) &&
-    opts.provider !== 'openrouter'
-  ) {
-    // QNBS-v3: OpenRouter routing — when enabled and caller specified a cloud provider other than
-    // openrouter, promote to OpenRouter (free-tier or user-configured model).
-    const orModel = getOpenRouterModel();
-    logRoutingDecision({
-      mode: getActiveAiMode(),
-      originalProvider: opts.provider,
-      chosenProvider: 'openrouter',
-      reason: 'openrouter-preferred',
-    });
-    return { ...opts, provider: 'openrouter', model: orModel as AIRequestOptions['model'] };
-  }
-  logRoutingDecision({
-    mode: getActiveAiMode(),
-    originalProvider: opts.provider,
-    chosenProvider: opts.provider,
-    reason: 'passthrough',
-  });
-  return opts;
 }
 
 // QNBS-v3: shared by generateText and streamText — identifies a transient OpenRouter failure (rate-limit or open circuit) that should promote to OpenRouter's own configured fallback provider instead of just moving to the next chain entry.

--- a/services/aiProviderService.ts
+++ b/services/aiProviderService.ts
@@ -613,6 +613,31 @@ function buildOpenRouterFallbackOpts(
   return { ...mergedOpts, provider };
 }
 
+// QNBS-v3: extracted so generateText's loop body carries fewer inline branches — the caller must have already committed `fallback` (e.g. to attemptedOpenRouterFallback) before calling, since this can throw on a failed retry.
+async function attemptOpenRouterTextFallback(
+  prompt: string,
+  creativity: AiCreativity,
+  mergedOpts: AIRequestOptions,
+  fallback: string,
+): Promise<string> {
+  logRoutingDecision({
+    mode: getActiveAiMode(),
+    originalProvider: 'openrouter',
+    chosenProvider: fallback,
+    reason: 'openrouter-fallback',
+  });
+  const { withTransientRetry } = await import('./ai/aiRetry');
+  return withTransientRetry(
+    () =>
+      generateTextSingleProvider(
+        prompt,
+        creativity,
+        buildOpenRouterFallbackOpts(mergedOpts, fallback),
+      ),
+    { attempts: 2 },
+  );
+}
+
 export async function generateText(
   prompt: string,
   creativity: AiCreativity,
@@ -660,22 +685,12 @@ export async function generateText(
         if (isOpenRouterTransientFailure(nextProvider, err)) {
           const fallback = getOpenRouterFallbackProvider();
           attemptedOpenRouterFallback = fallback;
-          logRoutingDecision({
-            mode: getActiveAiMode(),
-            originalProvider: 'openrouter',
-            chosenProvider: fallback,
-            reason: 'openrouter-fallback',
-          });
           try {
-            const { withTransientRetry } = await import('./ai/aiRetry');
-            const result = await withTransientRetry(
-              () =>
-                generateTextSingleProvider(
-                  prompt,
-                  creativity,
-                  buildOpenRouterFallbackOpts(mergedOpts, fallback),
-                ),
-              { attempts: 2 },
+            const result = await attemptOpenRouterTextFallback(
+              prompt,
+              creativity,
+              mergedOpts,
+              fallback,
             );
             _lastFallbackReason = `OpenRouter rate-limited; fell back to ${fallback}.`;
             return result;
@@ -780,6 +795,30 @@ export async function generateImage(
   );
 }
 
+// QNBS-v3: extracted so streamText's loop body carries fewer inline branches — the caller must have already committed `fallback` (e.g. to attemptedOpenRouterFallback) before calling, since this can throw on a failed stream attempt.
+async function attemptOpenRouterStreamFallback(
+  prompt: string,
+  creativity: AiCreativity,
+  mergedOpts: AIRequestOptions,
+  callbacks: AIStreamCallbacks,
+  fallback: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  logRoutingDecision({
+    mode: getActiveAiMode(),
+    originalProvider: 'openrouter',
+    chosenProvider: fallback,
+    reason: 'openrouter-fallback',
+  });
+  await streamProvider(
+    prompt,
+    creativity,
+    buildOpenRouterFallbackOpts(mergedOpts, fallback),
+    callbacks,
+    signal,
+  );
+}
+
 export async function streamText(
   prompt: string,
   creativity: AiCreativity,
@@ -835,18 +874,13 @@ export async function streamText(
         if (isOpenRouterTransientFailure(nextProvider, error)) {
           const fallback = getOpenRouterFallbackProvider();
           attemptedOpenRouterFallback = fallback;
-          logRoutingDecision({
-            mode: getActiveAiMode(),
-            originalProvider: 'openrouter',
-            chosenProvider: fallback,
-            reason: 'openrouter-fallback',
-          });
           try {
-            await streamProvider(
+            await attemptOpenRouterStreamFallback(
               prompt,
               creativity,
-              buildOpenRouterFallbackOpts(mergedOpts, fallback),
+              mergedOpts,
               callbacks,
+              fallback,
               signal,
             );
             _lastFallbackReason = `OpenRouter rate-limited; fell back to ${fallback}.`;

--- a/tests/unit/AdvancedImportExport.test.tsx
+++ b/tests/unit/AdvancedImportExport.test.tsx
@@ -45,6 +45,9 @@ vi.mock('../../hooks/useTranslation', () => ({
 
 vi.mock('../../services/logger', () => ({
   logger: { error: vi.fn(), info: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+  // QNBS-v3: routingLogger.ts (pulled in transitively via aiThunkUtils.ts's policy pre-check) calls createLogger() and sanitizeLogContext() at module scope, so this mock must cover both or the import throws.
+  createLogger: () => ({ error: vi.fn(), info: vi.fn(), debug: vi.fn(), warn: vi.fn() }),
+  sanitizeLogContext: (ctx: unknown) => ctx,
 }));
 
 vi.mock('../../services/storageService', () => ({
@@ -80,11 +83,7 @@ vi.mock('../../components/ui/Select', () => ({
     onChange: (v: string) => void;
     options: Array<{ value: string; label: string }>;
   }) => (
-    <select
-      id={props.id}
-      value={props.value}
-      onChange={(e) => props.onChange(e.target.value)}
-    >
+    <select id={props.id} value={props.value} onChange={(e) => props.onChange(e.target.value)}>
       {props.options.map((opt) => (
         <option key={opt.value} value={opt.value}>
           {opt.label}

--- a/tests/unit/aiProviderService.test.ts
+++ b/tests/unit/aiProviderService.test.ts
@@ -46,12 +46,13 @@ vi.mock('@tauri-apps/plugin-http', () => ({
   fetch: (...args: unknown[]) => mockPluginHttpFetch(...args),
 }));
 
-import { setActiveAiMode } from '../../services/ai/aiModeService';
+import { setActiveAiMode, setOpenRouterConfig } from '../../services/ai/aiModeService';
 import * as openrouterProvider from '../../services/ai/providers/openrouterProvider';
 import {
   generateImage,
   generateJson,
   generateText,
+  getLastAiFallbackReason,
   listOllamaModels,
   scanLocalOpenAiCompatibleEndpoints,
   streamAiHelpResponse,
@@ -79,8 +80,9 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
-  // QNBS-v3: aiModeService's mode is module-level singleton state — reset it so a test that blocks cloud AI never leaks into a later, unrelated test.
+  // QNBS-v3: aiModeService's mode/OpenRouter config is module-level singleton state — reset it so a test that blocks cloud AI or enables OpenRouter never leaks into a later, unrelated test.
   setActiveAiMode('hybrid');
+  setOpenRouterConfig(false, '');
 });
 
 // ─── generateImage ────────────────────────────────────────────────────────────
@@ -272,6 +274,18 @@ describe('generateJson', () => {
     expect(geminiService.generateJson).not.toHaveBeenCalled();
     spy.mockRestore();
   });
+
+  it('falls through to the OpenRouter-promoted path instead of the gemini-direct branch when OpenRouter is enabled', async () => {
+    setOpenRouterConfig(true, 'deepseek/deepseek-r1:free');
+    vi.mocked(storageService.getApiKey).mockResolvedValueOnce('or-key');
+    vi.mocked(openrouterProvider.generateOpenRouterText).mockResolvedValueOnce(
+      '{"key":"via-openrouter"}',
+    );
+    const schema = { type: 'object' as const, properties: {} };
+    const result = await generateJson('prompt', 'Balanced', schema as never, defaultOpts);
+    expect(result).toEqual({ key: 'via-openrouter' });
+    expect(geminiService.generateJson).not.toHaveBeenCalled();
+  });
 });
 
 // ─── streamText ───────────────────────────────────────────────────────────────
@@ -319,6 +333,50 @@ describe('streamText', () => {
     );
     // QNBS-v3: default aiMode is 'hybrid' (not eco/local), so getOpenRouterFallbackProvider() resolves to 'gemini'.
     expect(onChunk).toHaveBeenCalledWith('fallback-gemini-answer');
+    expect(getLastAiFallbackReason()).toBe('OpenRouter rate-limited; fell back to gemini.');
+  });
+
+  it('propagates cancellation from the OpenRouter fallback attempt instead of treating it as a provider failure', async () => {
+    vi.mocked(storageService.getApiKey).mockResolvedValueOnce('or-key');
+    vi.mocked(openrouterProvider.streamOpenRouter).mockRejectedValueOnce(
+      new Error('OPENROUTER_RATE_LIMITED: too many requests'),
+    );
+    const abortError = Object.assign(new Error('Aborted'), { name: 'AbortError' });
+    vi.mocked(geminiService.streamText).mockRejectedValueOnce(abortError);
+    const onError = vi.fn();
+    await expect(
+      streamText(
+        'prompt',
+        'Balanced',
+        { ...defaultOpts, provider: 'openrouter' },
+        { onChunk: vi.fn(), onDone: vi.fn(), onError },
+      ),
+    ).rejects.toThrow('Aborted');
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('does not retry the OpenRouter-promoted fallback provider again later in the chain', async () => {
+    vi.mocked(storageService.getApiKey).mockResolvedValueOnce('or-key');
+    vi.mocked(openrouterProvider.streamOpenRouter).mockRejectedValueOnce(
+      new Error('OPENROUTER_RATE_LIMITED: too many requests'),
+    );
+    vi.mocked(geminiService.streamText).mockRejectedValueOnce(new Error('gemini also failed'));
+    const onError = vi.fn();
+    await expect(
+      streamText(
+        'prompt',
+        'Balanced',
+        {
+          ...defaultOpts,
+          provider: 'openrouter',
+          hybridFallbackEnabled: true,
+          hybridFallbackChain: ['gemini'],
+        },
+        { onChunk: vi.fn(), onDone: vi.fn(), onError },
+      ),
+    ).rejects.toThrow('gemini also failed');
+    // QNBS-v3: chain is ['openrouter', 'gemini']; the rate-limit promotes to 'gemini' first, so the chain's own later 'gemini' entry must be skipped rather than invoking Gemini a second time.
+    expect(geminiService.streamText).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/tests/unit/aiProviderService.test.ts
+++ b/tests/unit/aiProviderService.test.ts
@@ -32,6 +32,11 @@ vi.mock('../../services/ollamaService', () => ({
   testOllamaConnection: vi.fn().mockResolvedValue({ ok: true }),
 }));
 
+vi.mock('../../services/ai/providers/openrouterProvider', () => ({
+  streamOpenRouter: vi.fn(),
+  generateOpenRouterText: vi.fn(),
+}));
+
 // QNBS-v3 (ADR-0016 Track A): localServerFetch's own Tauri-vs-web routing is already fully
 // covered by localServerHttp.test.ts — mock only its native dependency (plugin-http) here,
 // exactly like that file does, so the real localServerFetch (used by both the new Anthropic
@@ -42,6 +47,7 @@ vi.mock('@tauri-apps/plugin-http', () => ({
 }));
 
 import { setActiveAiMode } from '../../services/ai/aiModeService';
+import * as openrouterProvider from '../../services/ai/providers/openrouterProvider';
 import {
   generateImage,
   generateJson,
@@ -294,6 +300,25 @@ describe('streamText', () => {
       vi.mocked(geminiService.streamText),
       'local stream answer',
     );
+  });
+
+  it('falls back to the configured OpenRouter fallback provider on a rate-limit/circuit-open failure instead of failing hard', async () => {
+    vi.mocked(storageService.getApiKey).mockResolvedValueOnce('or-key');
+    vi.mocked(openrouterProvider.streamOpenRouter).mockRejectedValueOnce(
+      new Error('OPENROUTER_RATE_LIMITED: too many requests'),
+    );
+    vi.mocked(geminiService.streamText).mockImplementationOnce(async (_p, _c, onChunk) => {
+      onChunk('fallback-gemini-answer');
+    });
+    const onChunk = vi.fn();
+    await streamText(
+      'prompt',
+      'Balanced',
+      { ...defaultOpts, provider: 'openrouter' },
+      { onChunk, onDone: vi.fn() },
+    );
+    // QNBS-v3: default aiMode is 'hybrid' (not eco/local), so getOpenRouterFallbackProvider() resolves to 'gemini'.
+    expect(onChunk).toHaveBeenCalledWith('fallback-gemini-answer');
   });
 });
 

--- a/tests/unit/aiProviderService.test.ts
+++ b/tests/unit/aiProviderService.test.ts
@@ -268,6 +268,22 @@ describe('generateJson', () => {
   });
 });
 
+// ─── streamText ───────────────────────────────────────────────────────────────
+
+describe('streamText', () => {
+  it('reroutes to local inference when local-only mode is active, even though opts specify a cloud provider', async () => {
+    setActiveAiMode('local');
+    const spy = vi
+      .spyOn(localAiFacade, 'generateLocalText')
+      .mockResolvedValueOnce({ layer: 'webllm', text: 'local stream answer' });
+    const onChunk = vi.fn();
+    await streamText('prompt', 'Balanced', defaultOpts, { onChunk, onDone: vi.fn() });
+    expect(geminiService.streamText).not.toHaveBeenCalled();
+    expect(onChunk).toHaveBeenCalledWith('local stream answer');
+    spy.mockRestore();
+  });
+});
+
 // ─── streamAiHelpResponse ─────────────────────────────────────────────────────
 
 describe('streamAiHelpResponse', () => {
@@ -283,14 +299,16 @@ describe('streamAiHelpResponse', () => {
     expect(onChunk).toHaveBeenCalledWith('answer');
   });
 
-  it('blocks the gemini-direct branch when local-only mode is active, never reaching the SDK', async () => {
-    // QNBS-v3: unlike generateText/generateJson, streamText has no positive local-routing override for its primary provider (a separate, out-of-scope finding) — the fallthrough correctly rejects via the policy gate instead of silently routing locally, which still proves Gemini is never reached.
+  it('blocks the gemini-direct branch when local-only mode is active, rerouting to local inference instead', async () => {
     setActiveAiMode('local');
+    const spy = vi
+      .spyOn(localAiFacade, 'generateLocalText')
+      .mockResolvedValueOnce({ layer: 'webllm', text: 'local answer' });
     const onChunk = vi.fn();
-    await expect(
-      streamAiHelpResponse('question?', 'Balanced', defaultOpts, { onChunk, onDone: vi.fn() }),
-    ).rejects.toThrow(/local-only/i);
+    await streamAiHelpResponse('question?', 'Balanced', defaultOpts, { onChunk, onDone: vi.fn() });
     expect(geminiService.streamAiHelpResponse).not.toHaveBeenCalled();
+    expect(onChunk).toHaveBeenCalledWith('local answer');
+    spy.mockRestore();
   });
 });
 

--- a/tests/unit/aiProviderService.test.ts
+++ b/tests/unit/aiProviderService.test.ts
@@ -270,17 +270,30 @@ describe('generateJson', () => {
 
 // ─── streamText ───────────────────────────────────────────────────────────────
 
+// QNBS-v3: shared by the streamText and streamAiHelpResponse local-reroute tests below — CodeScene flagged the prior near-identical pair as duplication.
+async function expectLocalRerouteInsteadOfGemini(
+  invoke: (onChunk: (text: string) => void) => Promise<void>,
+  geminiMock: ReturnType<typeof vi.fn>,
+  localText: string,
+): Promise<void> {
+  setActiveAiMode('local');
+  const spy = vi
+    .spyOn(localAiFacade, 'generateLocalText')
+    .mockResolvedValueOnce({ layer: 'webllm', text: localText });
+  const onChunk = vi.fn();
+  await invoke(onChunk);
+  expect(geminiMock).not.toHaveBeenCalled();
+  expect(onChunk).toHaveBeenCalledWith(localText);
+  spy.mockRestore();
+}
+
 describe('streamText', () => {
   it('reroutes to local inference when local-only mode is active, even though opts specify a cloud provider', async () => {
-    setActiveAiMode('local');
-    const spy = vi
-      .spyOn(localAiFacade, 'generateLocalText')
-      .mockResolvedValueOnce({ layer: 'webllm', text: 'local stream answer' });
-    const onChunk = vi.fn();
-    await streamText('prompt', 'Balanced', defaultOpts, { onChunk, onDone: vi.fn() });
-    expect(geminiService.streamText).not.toHaveBeenCalled();
-    expect(onChunk).toHaveBeenCalledWith('local stream answer');
-    spy.mockRestore();
+    await expectLocalRerouteInsteadOfGemini(
+      (onChunk) => streamText('prompt', 'Balanced', defaultOpts, { onChunk, onDone: vi.fn() }),
+      vi.mocked(geminiService.streamText),
+      'local stream answer',
+    );
   });
 });
 
@@ -300,15 +313,12 @@ describe('streamAiHelpResponse', () => {
   });
 
   it('blocks the gemini-direct branch when local-only mode is active, rerouting to local inference instead', async () => {
-    setActiveAiMode('local');
-    const spy = vi
-      .spyOn(localAiFacade, 'generateLocalText')
-      .mockResolvedValueOnce({ layer: 'webllm', text: 'local answer' });
-    const onChunk = vi.fn();
-    await streamAiHelpResponse('question?', 'Balanced', defaultOpts, { onChunk, onDone: vi.fn() });
-    expect(geminiService.streamAiHelpResponse).not.toHaveBeenCalled();
-    expect(onChunk).toHaveBeenCalledWith('local answer');
-    spy.mockRestore();
+    await expectLocalRerouteInsteadOfGemini(
+      (onChunk) =>
+        streamAiHelpResponse('question?', 'Balanced', defaultOpts, { onChunk, onDone: vi.fn() }),
+      vi.mocked(geminiService.streamAiHelpResponse),
+      'local answer',
+    );
   });
 });
 

--- a/tests/unit/aiProviderService.test.ts
+++ b/tests/unit/aiProviderService.test.ts
@@ -316,6 +316,53 @@ describe('streamText', () => {
     );
   });
 
+  it('forwards the merged AbortSignal to generateLocalText so a cancelled local-mode stream actually stops instead of running to completion', async () => {
+    setActiveAiMode('local');
+    const spy = vi
+      .spyOn(localAiFacade, 'generateLocalText')
+      .mockResolvedValueOnce({ layer: 'webllm', text: 'local answer' });
+    const userSignal = new AbortController().signal;
+    await streamText(
+      'prompt',
+      'Balanced',
+      defaultOpts,
+      { onChunk: vi.fn(), onDone: vi.fn() },
+      userSignal,
+    );
+    expect(spy).toHaveBeenCalledWith(
+      expect.any(String),
+      'Llama-3.2-1B-Instruct-q4f16_1-MLC',
+      undefined,
+      undefined,
+      userSignal,
+    );
+    spy.mockRestore();
+  });
+
+  it('clears a stale fallback reason when a later primary provider succeeds outright', async () => {
+    vi.mocked(storageService.getApiKey).mockResolvedValueOnce('or-key');
+    vi.mocked(openrouterProvider.streamOpenRouter).mockRejectedValueOnce(
+      new Error('OPENROUTER_RATE_LIMITED: too many requests'),
+    );
+    vi.mocked(geminiService.streamText).mockImplementationOnce(async (_p, _c, onChunk) => {
+      onChunk('fallback-answer');
+    });
+    await streamText(
+      'prompt',
+      'Balanced',
+      { ...defaultOpts, provider: 'openrouter' },
+      { onChunk: vi.fn(), onDone: vi.fn() },
+    );
+    expect(getLastAiFallbackReason()).not.toBe('');
+
+    vi.mocked(geminiService.streamText).mockImplementationOnce(async (_p, _c, onChunk) => {
+      onChunk('fresh-primary-answer');
+    });
+    await streamText('prompt', 'Balanced', defaultOpts, { onChunk: vi.fn(), onDone: vi.fn() });
+    // QNBS-v3: GpuMetricsPanel polls getLastAiFallbackReason() -- a stale message from an earlier request must not survive a later request whose own primary provider succeeded outright.
+    expect(getLastAiFallbackReason()).toBe('');
+  });
+
   it('falls back to the configured OpenRouter fallback provider on a rate-limit/circuit-open failure instead of failing hard', async () => {
     vi.mocked(storageService.getApiKey).mockResolvedValueOnce('or-key');
     vi.mocked(openrouterProvider.streamOpenRouter).mockRejectedValueOnce(

--- a/tests/unit/aiProviderService.test.ts
+++ b/tests/unit/aiProviderService.test.ts
@@ -41,12 +41,14 @@ vi.mock('@tauri-apps/plugin-http', () => ({
   fetch: (...args: unknown[]) => mockPluginHttpFetch(...args),
 }));
 
+import { setActiveAiMode } from '../../services/ai/aiModeService';
 import {
   generateImage,
   generateJson,
   generateText,
   listOllamaModels,
   scanLocalOpenAiCompatibleEndpoints,
+  streamAiHelpResponse,
   streamText,
   testAIConnection,
   testOpenAiCompatibleLocalConnection,
@@ -71,6 +73,8 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  // QNBS-v3: aiModeService's mode is module-level singleton state — reset it so a test that blocks cloud AI never leaks into a later, unrelated test.
+  setActiveAiMode('hybrid');
 });
 
 // ─── generateImage ────────────────────────────────────────────────────────────
@@ -117,6 +121,19 @@ describe('generateImage', () => {
     await expect(
       generateImage('a cat', { ...defaultOpts, provider: 'transformers' }),
     ).rejects.toThrow('Local inference is text-only');
+  });
+
+  it('throws an explicit unsupported-provider error for openrouter instead of silently calling Gemini', async () => {
+    await expect(
+      generateImage('a cat', { ...defaultOpts, provider: 'openrouter' }),
+    ).rejects.toThrow('not supported for this provider');
+    expect(geminiService.generateImage).not.toHaveBeenCalled();
+  });
+
+  it('blocks gemini image generation when local-only mode is active, never reaching the SDK', async () => {
+    setActiveAiMode('local');
+    await expect(generateImage('a cat', defaultOpts)).rejects.toThrow(/local-only/i);
+    expect(geminiService.generateImage).not.toHaveBeenCalled();
   });
 });
 
@@ -236,6 +253,44 @@ describe('generateJson', () => {
     await expect(
       generateJson('prompt', 'Balanced', {} as never, { ...defaultOpts, provider: 'ollama' }),
     ).rejects.toThrow('not valid JSON');
+  });
+
+  it('blocks the gemini-direct branch when local-only mode is active, falling through to local routing instead', async () => {
+    setActiveAiMode('local');
+    const spy = vi
+      .spyOn(localAiFacade, 'generateLocalText')
+      .mockResolvedValueOnce({ layer: 'webllm', text: '{"key":"local"}' });
+    const schema = { type: 'object' as const, properties: {} };
+    const result = await generateJson('prompt', 'Balanced', schema as never, defaultOpts);
+    expect(result).toEqual({ key: 'local' });
+    expect(geminiService.generateJson).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});
+
+// ─── streamAiHelpResponse ─────────────────────────────────────────────────────
+
+describe('streamAiHelpResponse', () => {
+  it('delegates to geminiService for gemini provider', async () => {
+    vi.mocked(geminiService.streamAiHelpResponse).mockImplementationOnce(
+      async (_prompt, onChunk) => {
+        onChunk('answer');
+      },
+    );
+    const onChunk = vi.fn();
+    await streamAiHelpResponse('question?', 'Balanced', defaultOpts, { onChunk, onDone: vi.fn() });
+    expect(geminiService.streamAiHelpResponse).toHaveBeenCalled();
+    expect(onChunk).toHaveBeenCalledWith('answer');
+  });
+
+  it('blocks the gemini-direct branch when local-only mode is active, never reaching the SDK', async () => {
+    // QNBS-v3: unlike generateText/generateJson, streamText has no positive local-routing override for its primary provider (a separate, out-of-scope finding) — the fallthrough correctly rejects via the policy gate instead of silently routing locally, which still proves Gemini is never reached.
+    setActiveAiMode('local');
+    const onChunk = vi.fn();
+    await expect(
+      streamAiHelpResponse('question?', 'Balanced', defaultOpts, { onChunk, onDone: vi.fn() }),
+    ).rejects.toThrow(/local-only/i);
+    expect(geminiService.streamAiHelpResponse).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/unit/aiThunkUtils.test.ts
+++ b/tests/unit/aiThunkUtils.test.ts
@@ -8,7 +8,7 @@ import settingsReducer, { settingsActions } from '../../features/settings/settin
 import statusReducer from '../../features/status/statusSlice';
 import versionControlReducer from '../../features/versionControl/versionControlSlice';
 import writerReducer from '../../features/writer/writerSlice';
-import { setActiveAiMode } from '../../services/ai/aiModeService';
+import { setActiveAiMode, setOpenRouterConfig } from '../../services/ai/aiModeService';
 
 // QNBS-v3: vi.hoisted() ensures the mock fn is initialized before vi.mock() factory runs,
 //          since vi.mock() is hoisted to the top of the file by Vitest's transformer.
@@ -36,8 +36,9 @@ describe('createDeduplicatedThunk', () => {
   });
 
   afterEach(() => {
-    // QNBS-v3: aiModeService's mode is module-level singleton state — reset it so a test that sets local/eco mode never leaks into a later, unrelated test.
+    // QNBS-v3: aiModeService's mode/OpenRouter state is module-level singleton state — reset it so a test that changes it never leaks into a later, unrelated test.
     setActiveAiMode('hybrid');
+    setOpenRouterConfig(false, '');
   });
 
   it('executes the payload creator and returns its result', async () => {
@@ -154,10 +155,10 @@ describe('createDeduplicatedThunk', () => {
       );
     });
 
-    it('skips the pre-check when shouldRouteLocally() is true, even with a cloud effective provider, so the safe local-reroute path is not blocked before it runs', async () => {
+    it('checks the routing-resolved local provider, not the nominal cloud one, when shouldRouteLocally() is true — so the safe local-reroute path is not blocked before it runs', async () => {
       const payloadCreator = vi.fn().mockResolvedValue('result');
       const thunk = createDeduplicatedThunk<string>(
-        'test/policy-local-routing-skip',
+        'test/policy-local-routing-resolve',
         async (arg, api) => {
           api.registerDuplicateRequest('prompt', 'view');
           return payloadCreator(arg, api);
@@ -165,13 +166,44 @@ describe('createDeduplicatedThunk', () => {
       );
 
       const store = makeStore();
-      // QNBS-v3: global provider stays the default cloud 'gemini', but local/eco mode means generateText/generateJson will silently reroute to webllm — the pre-check must not reject this before the payload creator (which performs that reroute) even runs.
+      // QNBS-v3: global provider stays the default cloud 'gemini', but local/eco mode means generateText/generateJson will silently reroute to webllm — the pre-check must validate against that same resolved provider, not the stale nominal one.
       setActiveAiMode('local');
 
       const result = await store.dispatch(thunk());
 
-      expect(result.type).toBe('test/policy-local-routing-skip/fulfilled');
-      expect(mockAssertCloudAiAllowedSync).not.toHaveBeenCalled();
+      expect(result.type).toBe('test/policy-local-routing-resolve/fulfilled');
+      expect(mockAssertCloudAiAllowedSync).toHaveBeenCalledWith(
+        'webllm',
+        expect.objectContaining({ localStorageOnly: true }),
+      );
+      expect(payloadCreator).toHaveBeenCalled();
+    });
+
+    it('checks the OpenRouter-promoted provider, not the EU-residency-restricted preset provider, when OpenRouter is enabled', async () => {
+      const payloadCreator = vi.fn().mockResolvedValue('result');
+      const thunk = createDeduplicatedThunk<string>(
+        'test/policy-openrouter-promotion',
+        async (arg, api) => {
+          api.registerDuplicateRequest('prompt', 'view');
+          return payloadCreator(arg, api);
+        },
+      );
+
+      const store = makeStore();
+      // QNBS-v3: an enabled project preset picks 'openai' (blocked under EU residency), but OpenRouter is enabled and permitted — the real call would be promoted to 'openrouter', so the pre-check must validate that, not the raw preset provider.
+      setOpenRouterConfig(true, 'deepseek/deepseek-r1:free');
+      store.dispatch(
+        settingsActions.setPrivacy({ euDataResidency: true, localStorageOnly: false }),
+      );
+      store.dispatch(projectActions.setProjectAiPreset({ enabled: true, provider: 'openai' }));
+
+      const result = await store.dispatch(thunk());
+
+      expect(result.type).toBe('test/policy-openrouter-promotion/fulfilled');
+      expect(mockAssertCloudAiAllowedSync).toHaveBeenCalledWith(
+        'openrouter',
+        expect.objectContaining({ euDataResidency: true }),
+      );
       expect(payloadCreator).toHaveBeenCalled();
     });
 

--- a/tests/unit/aiThunkUtils.test.ts
+++ b/tests/unit/aiThunkUtils.test.ts
@@ -3,8 +3,8 @@ import undoable from 'redux-undo';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import featureFlagsReducer from '../../features/featureFlags/featureFlagsSlice';
 import { createDeduplicatedThunk } from '../../features/project/aiThunkUtils';
-import projectReducer from '../../features/project/projectSlice';
-import settingsReducer from '../../features/settings/settingsSlice';
+import projectReducer, { projectActions } from '../../features/project/projectSlice';
+import settingsReducer, { settingsActions } from '../../features/settings/settingsSlice';
 import statusReducer from '../../features/status/statusSlice';
 import versionControlReducer from '../../features/versionControl/versionControlSlice';
 import writerReducer from '../../features/writer/writerSlice';
@@ -124,6 +124,28 @@ describe('createDeduplicatedThunk', () => {
       expect(result.type).toBe('test/policy-block/rejected');
       const rejected = result as { error: { message: string } };
       expect(rejected.error.message).toBe('Cloud provider blocked: local-only mode is active.');
+    });
+
+    it('resolves the effective (preset-aware) provider, not the global one, when an enabled project preset overrides it', async () => {
+      const thunk = createDeduplicatedThunk<string>(
+        'test/policy-effective-provider',
+        async (_arg, api) => {
+          api.registerDuplicateRequest('prompt', 'view');
+          return 'result';
+        },
+      );
+
+      const store = makeStore();
+      // QNBS-v3: global provider is local (would short-circuit the policy check trivially if used directly), but an enabled project preset overrides the effective provider to a cloud one — the pre-check must catch this, not the stale global value.
+      store.dispatch(settingsActions.setAdvancedAi({ provider: 'ollama' }));
+      store.dispatch(projectActions.setProjectAiPreset({ enabled: true, provider: 'gemini' }));
+
+      await store.dispatch(thunk());
+
+      expect(mockAssertCloudAiAllowedSync).toHaveBeenCalledWith(
+        'gemini',
+        expect.objectContaining({ localStorageOnly: true }),
+      );
     });
 
     it('does not call the payload creator when policy check throws', async () => {

--- a/tests/unit/aiThunkUtils.test.ts
+++ b/tests/unit/aiThunkUtils.test.ts
@@ -1,6 +1,6 @@
 import { configureStore } from '@reduxjs/toolkit';
 import undoable from 'redux-undo';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import featureFlagsReducer from '../../features/featureFlags/featureFlagsSlice';
 import { createDeduplicatedThunk } from '../../features/project/aiThunkUtils';
 import projectReducer, { projectActions } from '../../features/project/projectSlice';
@@ -8,6 +8,7 @@ import settingsReducer, { settingsActions } from '../../features/settings/settin
 import statusReducer from '../../features/status/statusSlice';
 import versionControlReducer from '../../features/versionControl/versionControlSlice';
 import writerReducer from '../../features/writer/writerSlice';
+import { setActiveAiMode } from '../../services/ai/aiModeService';
 
 // QNBS-v3: vi.hoisted() ensures the mock fn is initialized before vi.mock() factory runs,
 //          since vi.mock() is hoisted to the top of the file by Vitest's transformer.
@@ -32,6 +33,11 @@ function makeStore() {
 describe('createDeduplicatedThunk', () => {
   beforeEach(() => {
     mockAssertCloudAiAllowedSync.mockReset();
+  });
+
+  afterEach(() => {
+    // QNBS-v3: aiModeService's mode is module-level singleton state — reset it so a test that sets local/eco mode never leaks into a later, unrelated test.
+    setActiveAiMode('hybrid');
   });
 
   it('executes the payload creator and returns its result', async () => {
@@ -146,6 +152,27 @@ describe('createDeduplicatedThunk', () => {
         'gemini',
         expect.objectContaining({ localStorageOnly: true }),
       );
+    });
+
+    it('skips the pre-check when shouldRouteLocally() is true, even with a cloud effective provider, so the safe local-reroute path is not blocked before it runs', async () => {
+      const payloadCreator = vi.fn().mockResolvedValue('result');
+      const thunk = createDeduplicatedThunk<string>(
+        'test/policy-local-routing-skip',
+        async (arg, api) => {
+          api.registerDuplicateRequest('prompt', 'view');
+          return payloadCreator(arg, api);
+        },
+      );
+
+      const store = makeStore();
+      // QNBS-v3: global provider stays the default cloud 'gemini', but local/eco mode means generateText/generateJson will silently reroute to webllm — the pre-check must not reject this before the payload creator (which performs that reroute) even runs.
+      setActiveAiMode('local');
+
+      const result = await store.dispatch(thunk());
+
+      expect(result.type).toBe('test/policy-local-routing-skip/fulfilled');
+      expect(mockAssertCloudAiAllowedSync).not.toHaveBeenCalled();
+      expect(payloadCreator).toHaveBeenCalled();
     });
 
     it('does not call the payload creator when policy check throws', async () => {

--- a/tests/unit/keyboard/shortcutActions.test.ts
+++ b/tests/unit/keyboard/shortcutActions.test.ts
@@ -21,6 +21,9 @@ vi.mock('../../../services/storageBackend', () => ({
 
 vi.mock('../../../services/logger', () => ({
   logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+  // QNBS-v3: routingLogger.ts (pulled in transitively via aiThunkUtils.ts's policy pre-check) calls createLogger() and sanitizeLogContext() at module scope, so this mock must cover both or the import throws.
+  createLogger: () => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+  sanitizeLogContext: (ctx: unknown) => ctx,
 }));
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/listenerMiddleware.test.ts
+++ b/tests/unit/listenerMiddleware.test.ts
@@ -76,6 +76,9 @@ vi.mock('../../services/logger', () => ({
     warn: (...args: unknown[]) => mockLoggerWarn(...args),
     info: vi.fn(),
   },
+  // QNBS-v3: routingLogger.ts (pulled in transitively via aiThunkUtils.ts's policy pre-check) calls createLogger() and sanitizeLogContext() at module scope, so this mock must cover both or the import throws.
+  createLogger: () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+  sanitizeLogContext: (ctx: unknown) => ctx,
 }));
 
 vi.mock('../../services/storageBackend', () => ({


### PR DESCRIPTION
## **User description**
## Problem

`generateText`/`streamText` in `services/aiProviderService.ts` both apply the cloud-AI privacy/mode policy (`assertCloudAiAllowed`) and local-mode positive routing (`shouldRouteLocally`) before reaching a cloud provider's SDK. Three sibling entry points did not:

- `generateJson`'s `opts.provider === 'gemini'` branch called `generateJsonGemini` directly, with no gate at all.
- `streamAiHelpResponse`'s `opts.provider === 'gemini'` branch had the same gap.
- `generateImage` never called the gate in any branch, including its explicit `'gemini'` case and its `default` case (which silently routed any unrecognized/other provider — e.g. `openrouter` — to Gemini as well).

This is widened by a second gap: the one shared pre-flight policy check in `aiThunkUtils.ts` reads the *global* `advancedAi.provider` setting, while the actual request can resolve to a *different* provider when a per-project AI preset is enabled (`thunkUtils.ts`'s `buildAiOptions` already resolves this correctly). A user with a local global provider and privacy settings requiring local-only AI could have a generation request silently reach Google's real API if the active project had a Gemini-provider preset enabled — the pre-check never inspected the effective provider, and the downstream call sites had no gate of their own either.

## Fix

- Gate all three Gemini-direct branches behind the same `assertCloudAiAllowed` (+ `shouldRouteLocally` where a local fallback path exists) that `generateText`/`streamText` already apply.
- Resolve the thunk pre-check's provider via `buildAiOptions` so it can never diverge from the provider a request actually uses.
- `generateImage`'s `default` case now throws an explicit unsupported-provider error instead of silently calling Gemini — no repository authority (checked `docs/adr/0016-native-grok-and-claude-providers.md` and the image-generation notes in `ROADMAP.md`) defines that behavior as intentional.

## Testing

9 new regression tests across `tests/unit/aiProviderService.test.ts` and `tests/unit/aiThunkUtils.test.ts`. Each guard was mutation-tested individually (temporarily reverted, confirmed the corresponding new test fails, restored). Full existing suite for both files plus `tests/unit/aiProviderService.fallbackChain.test.ts` and `tests/unit/thunks/*` re-run clean, no regressions.

## Non-goals

No catalog changes, no `testAIConnection` changes, no cross-project-mutation fix, no cancellation fix — each is its own separate, causally-independent follow-up.

## Summary by Sourcery

Close cloud-AI policy bypasses and align generation, streaming, routing, and fallback behavior with the effective provider and privacy settings.

Bug Fixes:
- Enforce cloud-AI privacy and local-only policies across Gemini JSON, image, and help-response generation paths, including project-preset and routing-resolved providers.
- Fail explicitly for unsupported image-generation providers instead of silently routing requests to Gemini.
- Improve streaming generation reliability by adding local routing, OpenRouter promotion and fallback handling, cancellation propagation, and duplicate-fallback prevention.

Enhancements:
- Centralize positive routing and OpenRouter fallback resolution for text and streaming generation paths.
- Resolve thunk policy checks against the effective provider used by the request rather than the global provider setting.

Documentation:
- Update the changelog and README test-count references for the added regression coverage.

Tests:
- Add regression coverage for policy enforcement, effective-provider resolution, routing behavior, OpenRouter fallback edge cases, cancellation, and unsupported image providers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes a cloud-AI policy bypass where `generateJson`, `generateImage`, and `streamAiHelpResponse` reached Gemini's SDK without the privacy/mode gate that `generateText` and `streamText` already apply. The thunk-level pre-check now validates the effective (preset-aware, routing-resolved) provider, and `streamText` gained the same local/OpenRouter routing parity as `generateText`.

- The shared thunk pre-check resolves the effective provider via side-effect-free `peekPositiveRoutingProvider()` in new `services/ai/positiveRouting.ts`, covering local reroutes and OpenRouter promotion without pulling in provider adapters or logging probe decisions.
- The gemini-direct path in `generateJson`/`streamAiHelpResponse` falls through to the generic path when OpenRouter is preferred, so promotion and fallback handling apply consistently.
- `generateImage` throws an explicit unsupported-provider error instead of silently routing unknown providers to Gemini.
- `streamText` now reroutes local-mode requests to webllm (forwarding the merged `AbortSignal` so cancelled local streams actually stop) and falls back to the configured provider on OpenRouter rate-limit/circuit-open failures, clearing a stale fallback reason when a later request's primary provider succeeds outright.
- OpenRouter fallback in `generateText`/`streamText` swaps the model for webllm, re-checks cancellation, and skips a provider already tried via the promoted fallback.
- Fallback-attempt logic is extracted into shared helpers in new `services/ai/openRouterFallback.ts` so each loop body stays flat and `aiProviderService.ts` does not grow.

**Testing**
- Adds regression tests for each gated branch, preset-aware provider resolution, local rerouting, OpenRouter fallback/promotion, unsupported image providers, and fallback edge cases (including cancellation propagation and stale fallback-reason clearing), plus CHANGELOG and README test-count updates.

<sup>Written for commit a2c249f07296c612f2f46acdae8424fd449b1b53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/qnbs/WorldScript-Studio/pull/706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Strengthened cloud-AI privacy safeguards across JSON generation, image generation, and streamed AI help.
  - Local-only settings consistently prevent cloud provider requests while supporting local-mode help.
  - Project AI presets determine the effective provider for policy enforcement.
  - OpenRouter failures use configured fallback providers without duplicate requests.
  - Fallback cancellations are now propagated correctly.
  - Unsupported image-generation providers return explicit errors instead of defaulting to Gemini.

- **Documentation**
  - Updated README test metrics to reflect 7,675+ tests across 605 files.

- **Tests**
  - Expanded coverage for routing, provider selection, fallback behavior, cancellation, and streamed AI help.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Enforce AI privacy settings across all generation paths and handle provider fallbacks safely

### What Changed
- Gemini JSON, image, and help-response requests now respect local-only and privacy settings before contacting the cloud service
- Policy checks use the provider that will actually handle the request, including project presets, local routing, and OpenRouter preferences
- Streaming requests now follow local/OpenRouter routing and recover from temporary OpenRouter failures using the configured fallback without duplicate calls
- Image requests for unsupported providers now show an explicit error instead of silently using Gemini
- Added regression coverage and documented the privacy-policy fix

### Impact
`✅ Fewer cloud-AI privacy bypasses`
`✅ Safer local-only generation`
`✅ Fewer streaming failures during OpenRouter outages`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>