### PR TITLE
fix(project): guard AI-generation results against a stale/switched active project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `getProjectTargetIdentity()` invariant (extracted from `restoreSnapshotThunk`'s own established
   guard into a shared `features/project/projectIdentity.ts`, `captureActiveProjectIdentity()` reads
   the live store directly) and discard the result if that identity no longer matches by the time
-  the request settles (or, for the outline generator, by the time Apply is later clicked). PR #707.
+  the request settles (or, for the outline generator, by the time Apply is later clicked). Review
+  caught that the persisted id alone cannot distinguish two different sessions: a fresh "New
+  Project" always reuses the sentinel `id: 'default'` until explicitly saved elsewhere, so two
+  separate resets (or a reset racing a pending snapshot restore) would previously read as the same
+  project. Added an in-memory (never persisted) `generation` counter to `ProjectSliceState`,
+  bumped by `resetProject`/`importProjectThunk.fulfilled`/`restoreSnapshotThunk.fulfilled`, and
+  folded into every identity comparison -- `restoreSnapshotThunk`'s own pre-existing guard now
+  closes this gap too. `useOutlineGenerator`'s guard also now captures identity eagerly at mount
+  (not just after a successful AI generation), so an outline seeded from the existing project and
+  never regenerated is still protected if the active project changes before Apply is clicked.
+  PR #707.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a cancelled local-mode stream ran to completion anyway) and clears a stale `_lastFallbackReason`
   when a later request's primary provider succeeds outright, matching `generateText`'s existing
   behavior. PR #706.
+- **Closed a cross-project AI mutation gap (Wave 0B):** `useCharacterView`/`useWorldView`'s
+  AI-generation handlers (`handleGenerateProfile`/`handleRegenerateField`), `useTemplateView`'s
+  AI-personalization handlers (`handleAiApply`/`handleGenerateCustom`), and
+  `useOutlineGenerator`'s outline-apply path all `await dispatch(aiThunk)` and then mutate
+  persisted project state, with no check that the active project is still the one the request
+  was made for. Since project loading (New Project/import/restore) replaces `state.data` wholesale
+  while the SPA stays mounted, a late-arriving AI result could be applied to whichever project
+  happened to be open when it resolved -- for the template/outline apply paths (which replace the
+  entire manuscript/outline) this could silently overwrite a different project's content outright.
+  All five handlers now capture the active project's identity via the existing
+  `getProjectTargetIdentity()` invariant (extracted from `restoreSnapshotThunk`'s own established
+  guard into a shared `features/project/projectIdentity.ts`, `captureActiveProjectIdentity()` reads
+  the live store directly) and discard the result if that identity no longer matches by the time
+  the request settles (or, for the outline generator, by the time Apply is later clicked). PR #NNN.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `getProjectTargetIdentity()` invariant (extracted from `restoreSnapshotThunk`'s own established
   guard into a shared `features/project/projectIdentity.ts`, `captureActiveProjectIdentity()` reads
   the live store directly) and discard the result if that identity no longer matches by the time
-  the request settles (or, for the outline generator, by the time Apply is later clicked). PR #NNN.
+  the request settles (or, for the outline generator, by the time Apply is later clicked). PR #707.
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="i18n 19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7684%2B_%2F_605_files-22C55E" alt="7684+ tests / 605 files">
+  <img src="https://img.shields.io/badge/Tests-7694%2B_%2F_606_files-22C55E" alt="7694+ tests / 606 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2942 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7684+ tests / 605 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7694+ tests / 606 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7684+ tests, 605 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7694+ tests, 606 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -714,7 +714,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendor **6200 KB**, other JavaScript **2500 KB**, and WASM **30000 KB**.
 
 **Current test metrics (2026-09-10, source-synchronized; CI remains authoritative for pass/fail):**
-- **7684+ unit tests** across **605 test files** — CI is authoritative for pass/fail
+- **7694+ unit tests** across **606 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2942 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="i18n 19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7694%2B_%2F_606_files-22C55E" alt="7694+ tests / 606 files">
+  <img src="https://img.shields.io/badge/Tests-7702%2B_%2F_606_files-22C55E" alt="7702+ tests / 606 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2942 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7694+ tests / 606 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7702+ tests / 606 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7694+ tests, 606 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7702+ tests, 606 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -714,7 +714,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendor **6200 KB**, other JavaScript **2500 KB**, and WASM **30000 KB**.
 
 **Current test metrics (2026-09-10, source-synchronized; CI remains authoritative for pass/fail):**
-- **7694+ unit tests** across **606 test files** — CI is authoritative for pass/fail
+- **7702+ unit tests** across **606 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2942 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/Storage-IndexedDB_v8-F59E0B" alt="IndexedDB v8">
   <img src="https://img.shields.io/badge/PWA-v3.0-5BB974?logo=pwa" alt="PWA v3.0">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="i18n 19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7677%2B_%2F_605_files-22C55E" alt="7677+ tests / 605 files">
+  <img src="https://img.shields.io/badge/Tests-7684%2B_%2F_605_files-22C55E" alt="7684+ tests / 605 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="License MIT">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github" alt="CI Status">
@@ -511,7 +511,7 @@ The Settings → AI panel shows a live GPU status badge with adapter details and
 | **Document Export**  | docx + jszip                                              | Word-compatible `.docx` generation (lazy-loaded)                     |
 | **PWA**              | Service Worker + Web App Manifest v3                     | Offline support, installability, Workbox chunking                    |
 | **i18n**             | Custom React Context (`I18nContext.tsx`)                  | 2942 keys × 19 locales (de/en/es/fr/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta); EN fallback; `localStorage` persistence |
-| **Testing**          | Vitest 4.x (7677+ tests / 605 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
+| **Testing**          | Vitest 4.x (7684+ tests / 605 files) + Playwright E2E     | Unit/integration + cross-browser E2E; Stryker mutation (manual workflow)          |
 | **Code Quality**     | Biome (lint + format) + TypeScript 7 (tsgo) strict       | `--error-on-warnings` in CI; zero `any` policy                      |
 | **Visualization**    | Force-directed graph                                      | Interactive character relationship network                           |
 | **Desktop**          | Tauri v2                                                  | Cross-platform installer; auto-updater via `latest.json`             |
@@ -549,7 +549,7 @@ WorldScript-Studio/
 │   ├── sw.js             # PWA Service Worker
 │   └── manifest.json     # PWA Web App Manifest v3
 ├── tests/
-│   ├── unit/             # Vitest unit tests (7677+ tests, 605 files) — count spans tests/, components/, packages/*/tests/, not just this folder
+│   ├── unit/             # Vitest unit tests (7684+ tests, 605 files) — count spans tests/, components/, packages/*/tests/, not just this folder
 │   │   ├── ai/           # aiSmallModules, aiCoreFallbackPaths
 │   │   └── settings/     # WebLlmPanel, AiSections
 │   └── e2e/              # Playwright specs + helpers.ts
@@ -714,7 +714,7 @@ The main pipeline is [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Opt
 Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendor **6200 KB**, other JavaScript **2500 KB**, and WASM **30000 KB**.
 
 **Current test metrics (2026-09-10, source-synchronized; CI remains authoritative for pass/fail):**
-- **7677+ unit tests** across **605 test files** — CI is authoritative for pass/fail
+- **7684+ unit tests** across **605 test files** — CI is authoritative for pass/fail
 - Coverage thresholds: lines ≥ 80 · branches ≥ 66 · functions ≥ 72 · statements ≥ 78 — enforced in CI (see Codecov badge for live metrics)
 - i18n: **2942 keys × 19 locales** (en/de/fr/es/it + ar/he/fa RTL Beta + ja/zh/pt/el/fi/sv/hu/is/eu/ru/ko Beta)
 

--- a/features/project/projectIdentity.ts
+++ b/features/project/projectIdentity.ts
@@ -38,3 +38,8 @@ export function captureActiveProjectIdentity(): string | null {
   const state = appStoreRef.current?.getState();
   return getProjectTargetIdentity(state?.project?.present);
 }
+
+// QNBS-v3: null means identity could not be determined -- fail closed (never "unchanged") so a guard never allows a mutation it can't actually prove is still targeting the right project.
+export function identityUnchanged(captured: string | null, live: string | null): boolean {
+  return captured !== null && captured === live;
+}

--- a/features/project/projectIdentity.ts
+++ b/features/project/projectIdentity.ts
@@ -9,8 +9,12 @@ import { appStoreRef } from '../../app/storeRef';
 
 const LEGACY_PROJECT_DIRECTORY_METADATA_KEY = '__worldscriptLegacyProjectDirectory';
 
-// QNBS-v3: compare only storage-owned target identity so mutable snapshot/generation content cannot hide a project switch.
-export function getProjectTargetIdentity(project: unknown): string | null {
+interface ProjectIdentitySource {
+  data: unknown;
+  generation?: number;
+}
+
+function baseTargetIdentity(project: unknown): string | null {
   if (typeof project !== 'object' || project === null) return null;
   const record = project as Record<string, unknown>;
   if (typeof record['id'] === 'string' && record['id']) return `id:${record['id']}`;
@@ -20,8 +24,17 @@ export function getProjectTargetIdentity(project: unknown): string | null {
     : null;
 }
 
+// QNBS-v3: incorporates the in-memory generation counter, not just the persisted id -- a fresh "New Project" always reuses id:'default' until explicitly saved elsewhere, so id alone cannot distinguish two different reset/import/restore sessions.
+export function getProjectTargetIdentity(
+  source: ProjectIdentitySource | null | undefined,
+): string | null {
+  if (!source) return null;
+  const base = baseTargetIdentity(source.data);
+  return base === null ? null : `${base}:gen:${source.generation ?? 0}`;
+}
+
 // QNBS-v3: reads the live store directly (not a React selector) so a hook can capture identity at dispatch time and re-check it after an await, independent of that hook's own render cycle.
 export function captureActiveProjectIdentity(): string | null {
   const state = appStoreRef.current?.getState();
-  return getProjectTargetIdentity(state?.project?.present?.data);
+  return getProjectTargetIdentity(state?.project?.present);
 }

--- a/features/project/projectIdentity.ts
+++ b/features/project/projectIdentity.ts
@@ -1,0 +1,27 @@
+/**
+ * projectIdentity.ts
+ * -------------------
+ * Shared "is this still the same active project" identity check. Guards a late-arriving async
+ * result (AI generation, snapshot restore) against being applied to the wrong project after the
+ * user has switched away (or reset/imported a different project) while the request was in flight.
+ */
+import { appStoreRef } from '../../app/storeRef';
+
+const LEGACY_PROJECT_DIRECTORY_METADATA_KEY = '__worldscriptLegacyProjectDirectory';
+
+// QNBS-v3: compare only storage-owned target identity so mutable snapshot/generation content cannot hide a project switch.
+export function getProjectTargetIdentity(project: unknown): string | null {
+  if (typeof project !== 'object' || project === null) return null;
+  const record = project as Record<string, unknown>;
+  if (typeof record['id'] === 'string' && record['id']) return `id:${record['id']}`;
+  const legacyDirectory = record[LEGACY_PROJECT_DIRECTORY_METADATA_KEY];
+  return typeof legacyDirectory === 'string' && legacyDirectory
+    ? `legacy:${legacyDirectory}`
+    : null;
+}
+
+// QNBS-v3: reads the live store directly (not a React selector) so a hook can capture identity at dispatch time and re-check it after an await, independent of that hook's own render cycle.
+export function captureActiveProjectIdentity(): string | null {
+  const state = appStoreRef.current?.getState();
+  return getProjectTargetIdentity(state?.project?.present?.data);
+}

--- a/features/project/projectSlice.ts
+++ b/features/project/projectSlice.ts
@@ -79,9 +79,13 @@ const projectSlice = createSlice({
     builder
       .addCase(importProjectThunk.fulfilled, (state, action) => {
         state.data = action.payload;
+        // QNBS-v3: distinguishes this import from any other project state that also happens to keep the same id; nullish-coalesced since some hand-built test store fixtures predate this field.
+        state.generation = (state.generation ?? 0) + 1;
       })
       .addCase(restoreSnapshotThunk.fulfilled, (state, action) => {
         state.data = action.payload as ProjectData;
+        // QNBS-v3: distinguishes this restore from any other project state that also happens to keep the same id; nullish-coalesced since some hand-built test store fixtures predate this field.
+        state.generation = (state.generation ?? 0) + 1;
       })
       .addCase(generateCharacterPortraitThunk.fulfilled, (state, action) => {
         charactersAdapter.updateOne(state.data.characters, {

--- a/features/project/projectState.ts
+++ b/features/project/projectState.ts
@@ -64,11 +64,14 @@ export interface ProjectData {
 // type their Immer draft param without `any` — preserves WritableDraft typing across the split.
 export interface ProjectSliceState {
   data: ProjectData;
+  // QNBS-v3: bumped every time `data` is replaced wholesale (reset/import/restore) -- distinguishes two such replacements that persist under the same id, since a fresh "New Project" always reuses id:'default' until explicitly saved elsewhere. Never persisted (selectProjectData/save paths read only `.data`). Optional so pre-existing hand-built test store fixtures (which never read it) don't need updating; real app state always has it via initialState.
+  generation?: number;
 }
 
 // QNBS-v3: Canonical initial state. Lives here (not in projectSlice) so reducer modules such as
 // metaReducers.resetProject can reference it without a circular import back through the slice.
 export const initialState: ProjectSliceState = {
+  generation: 0,
   data: {
     id: 'default',
     title: '',

--- a/features/project/reducers/metaReducers.ts
+++ b/features/project/reducers/metaReducers.ts
@@ -46,5 +46,7 @@ export const metaReducers = {
       ],
       binderNodes: [],
     };
+    // QNBS-v3: distinguishes this fresh project from any other one that also happens to keep id:'default'; nullish-coalesced since some hand-built test store fixtures predate this field.
+    state.generation = (state.generation ?? 0) + 1;
   },
 };

--- a/features/project/thunks/projectManagementThunks.ts
+++ b/features/project/thunks/projectManagementThunks.ts
@@ -131,14 +131,14 @@ export const restoreSnapshotThunk = createAsyncThunk(
   'project/restoreSnapshot',
   async (snapshotId: number, thunkApi) => {
     // QNBS-v3: capture ownership before snapshot I/O so payload contents cannot change the restore target.
-    const currentProject = (thunkApi.getState() as RootState).project?.present?.data;
-    if (!currentProject) {
+    const currentSlice = (thunkApi.getState() as RootState).project?.present;
+    if (!currentSlice?.data) {
       throw new Error('Cannot restore a snapshot without an active project.');
     }
-    const capturedTargetIdentity = getProjectTargetIdentity(currentProject);
-    const restored = await storageService.restoreSnapshot(snapshotId, currentProject);
-    const liveProject = (thunkApi.getState() as RootState).project?.present?.data;
-    if (getProjectTargetIdentity(liveProject) !== capturedTargetIdentity) {
+    const capturedTargetIdentity = getProjectTargetIdentity(currentSlice);
+    const restored = await storageService.restoreSnapshot(snapshotId, currentSlice.data);
+    const liveSlice = (thunkApi.getState() as RootState).project?.present;
+    if (getProjectTargetIdentity(liveSlice) !== capturedTargetIdentity) {
       throw new Error('Cannot restore a snapshot after the active project changed.');
     }
     return restored;

--- a/features/project/thunks/projectManagementThunks.ts
+++ b/features/project/thunks/projectManagementThunks.ts
@@ -4,9 +4,8 @@ import { parseImportedProjectJson } from '../../../services/projectImportSchema'
 import { storageService } from '../../../services/storageService';
 import type { Character, World } from '../../../types';
 import { createPrototypeSafeEntityState } from '../adapters';
+import { getProjectTargetIdentity } from '../projectIdentity';
 import type { ProjectData } from '../projectSlice';
-
-const LEGACY_PROJECT_DIRECTORY_METADATA_KEY = '__worldscriptLegacyProjectDirectory';
 
 type ImportedEntityCollection<T extends { id: string }> =
   | readonly T[]
@@ -44,17 +43,6 @@ function extractImportedEntities<T extends { id: string }>(
     return undefined;
   }
   return importedEntities;
-}
-
-// QNBS-v3: compare only storage-owned target identity so mutable snapshot content cannot hide a project switch.
-function restoreTargetIdentity(project: unknown): string | null {
-  if (typeof project !== 'object' || project === null) return null;
-  const record = project as Record<string, unknown>;
-  if (typeof record['id'] === 'string' && record['id']) return `id:${record['id']}`;
-  const legacyDirectory = record[LEGACY_PROJECT_DIRECTORY_METADATA_KEY];
-  return typeof legacyDirectory === 'string' && legacyDirectory
-    ? `legacy:${legacyDirectory}`
-    : null;
 }
 
 export const importProjectThunk = createAsyncThunk('project/importProject', async (file: File) => {
@@ -147,10 +135,10 @@ export const restoreSnapshotThunk = createAsyncThunk(
     if (!currentProject) {
       throw new Error('Cannot restore a snapshot without an active project.');
     }
-    const capturedTargetIdentity = restoreTargetIdentity(currentProject);
+    const capturedTargetIdentity = getProjectTargetIdentity(currentProject);
     const restored = await storageService.restoreSnapshot(snapshotId, currentProject);
     const liveProject = (thunkApi.getState() as RootState).project?.present?.data;
-    if (restoreTargetIdentity(liveProject) !== capturedTargetIdentity) {
+    if (getProjectTargetIdentity(liveProject) !== capturedTargetIdentity) {
       throw new Error('Cannot restore a snapshot after the active project changed.');
     }
     return restored;

--- a/features/project/thunks/projectManagementThunks.ts
+++ b/features/project/thunks/projectManagementThunks.ts
@@ -4,7 +4,7 @@ import { parseImportedProjectJson } from '../../../services/projectImportSchema'
 import { storageService } from '../../../services/storageService';
 import type { Character, World } from '../../../types';
 import { createPrototypeSafeEntityState } from '../adapters';
-import { getProjectTargetIdentity } from '../projectIdentity';
+import { getProjectTargetIdentity, identityUnchanged } from '../projectIdentity';
 import type { ProjectData } from '../projectSlice';
 
 type ImportedEntityCollection<T extends { id: string }> =
@@ -138,7 +138,7 @@ export const restoreSnapshotThunk = createAsyncThunk(
     const capturedTargetIdentity = getProjectTargetIdentity(currentSlice);
     const restored = await storageService.restoreSnapshot(snapshotId, currentSlice.data);
     const liveSlice = (thunkApi.getState() as RootState).project?.present;
-    if (getProjectTargetIdentity(liveSlice) !== capturedTargetIdentity) {
+    if (!identityUnchanged(capturedTargetIdentity, getProjectTargetIdentity(liveSlice))) {
       throw new Error('Cannot restore a snapshot after the active project changed.');
     }
     return restored;

--- a/hooks/useCharacterView.ts
+++ b/hooks/useCharacterView.ts
@@ -2,7 +2,10 @@ import { useCallback, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { useAppDispatch, useAppSelector } from '../app/hooks';
 import { useToast } from '../components/ui/Toast';
-import { captureActiveProjectIdentity } from '../features/project/projectIdentity';
+import {
+  captureActiveProjectIdentity,
+  identityUnchanged,
+} from '../features/project/projectIdentity';
 import { selectAllCharacters } from '../features/project/projectSelectors';
 import { projectActions } from '../features/project/projectSlice';
 import {
@@ -90,7 +93,7 @@ export const useCharacterView = () => {
       }),
     );
     // QNBS-v3: the active project may have changed while this request was in flight (e.g. New Project/import/restore elsewhere in the still-mounted app) -- discard rather than apply a result generated for a different project.
-    if (captureActiveProjectIdentity() !== capturedProjectIdentity) {
+    if (!identityUnchanged(capturedProjectIdentity, captureActiveProjectIdentity())) {
       setIsGeneratingProfile(false);
       setAiConcept('');
       return;
@@ -133,7 +136,7 @@ export const useCharacterView = () => {
         regenerateCharacterFieldThunk({ character: selectedCharacter, field, lang: language }),
       );
       // QNBS-v3: discard a late-arriving regenerated field if the active project changed while the request was in flight.
-      if (captureActiveProjectIdentity() !== capturedProjectIdentity) {
+      if (!identityUnchanged(capturedProjectIdentity, captureActiveProjectIdentity())) {
         setIsRegeneratingField(null);
         return;
       }

--- a/hooks/useCharacterView.ts
+++ b/hooks/useCharacterView.ts
@@ -90,14 +90,18 @@ export const useCharacterView = () => {
       }),
     );
     // QNBS-v3: the active project may have changed while this request was in flight (e.g. New Project/import/restore elsewhere in the still-mounted app) -- discard rather than apply a result generated for a different project.
-    if (captureActiveProjectIdentity() === capturedProjectIdentity) {
-      if (generateCharacterProfileThunk.fulfilled.match(resultAction)) {
-        const newChar = resultAction.payload;
-        dispatch(projectActions.addCharacter(newChar));
-        toast.success(t('common.saved'), newChar.name);
-      } else {
-        toast.error(t('error.apiErrorTitle'), t('error.apiErrorDescription'));
-      }
+    if (captureActiveProjectIdentity() !== capturedProjectIdentity) {
+      setIsGeneratingProfile(false);
+      setAiConcept('');
+      return;
+    }
+
+    if (generateCharacterProfileThunk.fulfilled.match(resultAction)) {
+      const newChar = resultAction.payload;
+      dispatch(projectActions.addCharacter(newChar));
+      toast.success(t('common.saved'), newChar.name);
+    } else {
+      toast.error(t('error.apiErrorTitle'), t('error.apiErrorDescription'));
     }
 
     setIsGeneratingProfile(false);
@@ -129,12 +133,15 @@ export const useCharacterView = () => {
         regenerateCharacterFieldThunk({ character: selectedCharacter, field, lang: language }),
       );
       // QNBS-v3: discard a late-arriving regenerated field if the active project changed while the request was in flight.
-      if (captureActiveProjectIdentity() === capturedProjectIdentity) {
-        if (regenerateCharacterFieldThunk.fulfilled.match(resultAction)) {
-          handleFieldChange(resultAction.payload.field, resultAction.payload.value);
-        } else {
-          toast.error(t('error.apiErrorTitle'));
-        }
+      if (captureActiveProjectIdentity() !== capturedProjectIdentity) {
+        setIsRegeneratingField(null);
+        return;
+      }
+
+      if (regenerateCharacterFieldThunk.fulfilled.match(resultAction)) {
+        handleFieldChange(resultAction.payload.field, resultAction.payload.value);
+      } else {
+        toast.error(t('error.apiErrorTitle'));
       }
       setIsRegeneratingField(null);
     },

--- a/hooks/useCharacterView.ts
+++ b/hooks/useCharacterView.ts
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { useAppDispatch, useAppSelector } from '../app/hooks';
 import { useToast } from '../components/ui/Toast';
+import { captureActiveProjectIdentity } from '../features/project/projectIdentity';
 import { selectAllCharacters } from '../features/project/projectSelectors';
 import { projectActions } from '../features/project/projectSlice';
 import {
@@ -80,6 +81,7 @@ export const useCharacterView = () => {
     setIsGeneratingProfile(true);
     setIsAiModalOpen(false);
 
+    const capturedProjectIdentity = captureActiveProjectIdentity();
     const resultAction = await dispatch(
       generateCharacterProfileThunk({
         concept: aiConcept,
@@ -87,12 +89,15 @@ export const useCharacterView = () => {
         heuristicLabels: buildCharacterHeuristicLabels(),
       }),
     );
-    if (generateCharacterProfileThunk.fulfilled.match(resultAction)) {
-      const newChar = resultAction.payload;
-      dispatch(projectActions.addCharacter(newChar));
-      toast.success(t('common.saved'), newChar.name);
-    } else {
-      toast.error(t('error.apiErrorTitle'), t('error.apiErrorDescription'));
+    // QNBS-v3: the active project may have changed while this request was in flight (e.g. New Project/import/restore elsewhere in the still-mounted app) -- discard rather than apply a result generated for a different project.
+    if (captureActiveProjectIdentity() === capturedProjectIdentity) {
+      if (generateCharacterProfileThunk.fulfilled.match(resultAction)) {
+        const newChar = resultAction.payload;
+        dispatch(projectActions.addCharacter(newChar));
+        toast.success(t('common.saved'), newChar.name);
+      } else {
+        toast.error(t('error.apiErrorTitle'), t('error.apiErrorDescription'));
+      }
     }
 
     setIsGeneratingProfile(false);
@@ -119,13 +124,17 @@ export const useCharacterView = () => {
     async (field: keyof Character) => {
       if (!selectedCharacter) return;
       setIsRegeneratingField(field);
+      const capturedProjectIdentity = captureActiveProjectIdentity();
       const resultAction = await dispatch(
         regenerateCharacterFieldThunk({ character: selectedCharacter, field, lang: language }),
       );
-      if (regenerateCharacterFieldThunk.fulfilled.match(resultAction)) {
-        handleFieldChange(resultAction.payload.field, resultAction.payload.value);
-      } else {
-        toast.error(t('error.apiErrorTitle'));
+      // QNBS-v3: discard a late-arriving regenerated field if the active project changed while the request was in flight.
+      if (captureActiveProjectIdentity() === capturedProjectIdentity) {
+        if (regenerateCharacterFieldThunk.fulfilled.match(resultAction)) {
+          handleFieldChange(resultAction.payload.field, resultAction.payload.value);
+        } else {
+          toast.error(t('error.apiErrorTitle'));
+        }
       }
       setIsRegeneratingField(null);
     },

--- a/hooks/useOutlineGenerator.ts
+++ b/hooks/useOutlineGenerator.ts
@@ -49,8 +49,8 @@ export const useOutlineGenerator = ({ onNavigate }: UseOutlineGeneratorProps) =>
   const [confirmModal, setConfirmModal] = useState<ConfirmModalState>(null);
   const draggedItem = useRef<number | null>(null);
   const dragOverItem = useRef<number | null>(null);
-  // QNBS-v3: the project identity captured when `outline` was last (re)populated by an AI result -- `apply()` fires later, on a discrete user click with no await of its own, so this is checked there instead of at dispatch time.
-  const generatedForProjectIdentity = useRef<string | null>(null);
+  // QNBS-v3: the project identity `outline` currently belongs to -- initialized eagerly (not null) so the existingOutline seed is covered too, not just an AI-generated result; `apply()` fires later, on a discrete user click with no await of its own, so this is checked there instead of at dispatch time.
+  const generatedForProjectIdentity = useRef<string | null>(captureActiveProjectIdentity());
   const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
 
   // QNBS-v3: resolve the offline outline labels here (the hook has `t`) so the service-layer heuristic

--- a/hooks/useOutlineGenerator.ts
+++ b/hooks/useOutlineGenerator.ts
@@ -1,6 +1,7 @@
 import { useCallback, useRef, useState } from 'react';
 import { useAppDispatch, useAppSelector } from '../app/hooks';
 import { useToast } from '../components/ui/Toast';
+import { captureActiveProjectIdentity } from '../features/project/projectIdentity';
 import { selectManuscript, selectOutline } from '../features/project/projectSelectors';
 import { projectActions } from '../features/project/projectSlice';
 import {
@@ -48,6 +49,8 @@ export const useOutlineGenerator = ({ onNavigate }: UseOutlineGeneratorProps) =>
   const [confirmModal, setConfirmModal] = useState<ConfirmModalState>(null);
   const draggedItem = useRef<number | null>(null);
   const dragOverItem = useRef<number | null>(null);
+  // QNBS-v3: the project identity captured when `outline` was last (re)populated by an AI result -- `apply()` fires later, on a discrete user click with no await of its own, so this is checked there instead of at dispatch time.
+  const generatedForProjectIdentity = useRef<string | null>(null);
   const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
 
   // QNBS-v3: resolve the offline outline labels here (the hook has `t`) so the service-layer heuristic
@@ -75,6 +78,7 @@ export const useOutlineGenerator = ({ onNavigate }: UseOutlineGeneratorProps) =>
   const generate = useCallback(async () => {
     setIsLoading(true);
     setError(null);
+    const capturedProjectIdentity = captureActiveProjectIdentity();
     const resultAction = await dispatch(
       generateOutlineThunk({
         genre,
@@ -90,6 +94,7 @@ export const useOutlineGenerator = ({ onNavigate }: UseOutlineGeneratorProps) =>
     );
 
     if (generateOutlineThunk.fulfilled.match(resultAction)) {
+      generatedForProjectIdentity.current = capturedProjectIdentity;
       setOutline(resultAction.payload.map((s) => ({ ...s, id: s.id || `gen-${Math.random()}` })));
       toast.success(t('common.saved'));
     } else {
@@ -210,6 +215,14 @@ export const useOutlineGenerator = ({ onNavigate }: UseOutlineGeneratorProps) =>
   }, []);
 
   const apply = useCallback(() => {
+    // QNBS-v3: outline may have been generated for a different project if the active project changed since (e.g. New Project/import/restore elsewhere in the still-mounted app) -- discard rather than overwrite the wrong project's manuscript.
+    if (
+      generatedForProjectIdentity.current !== null &&
+      captureActiveProjectIdentity() !== generatedForProjectIdentity.current
+    ) {
+      setConfirmModal(null);
+      return;
+    }
     const newManuscript: StorySection[] = outline.map((s, i) => ({
       id: `sec-${Date.now()}-${i}`,
       title: s.title,

--- a/hooks/useOutlineGenerator.ts
+++ b/hooks/useOutlineGenerator.ts
@@ -1,7 +1,10 @@
 import { useCallback, useRef, useState } from 'react';
 import { useAppDispatch, useAppSelector } from '../app/hooks';
 import { useToast } from '../components/ui/Toast';
-import { captureActiveProjectIdentity } from '../features/project/projectIdentity';
+import {
+  captureActiveProjectIdentity,
+  identityUnchanged,
+} from '../features/project/projectIdentity';
 import { selectManuscript, selectOutline } from '../features/project/projectSelectors';
 import { projectActions } from '../features/project/projectSlice';
 import {
@@ -92,6 +95,12 @@ export const useOutlineGenerator = ({ onNavigate }: UseOutlineGeneratorProps) =>
         heuristicLabels: buildOutlineHeuristicLabels(),
       }),
     );
+
+    // QNBS-v3: discard a late-arriving outline (and its success/failure toast) if the active project changed while this request was in flight -- apply()'s own guard only protects the later persisted write, not this local-state preview.
+    if (!identityUnchanged(capturedProjectIdentity, captureActiveProjectIdentity())) {
+      setIsLoading(false);
+      return;
+    }
 
     if (generateOutlineThunk.fulfilled.match(resultAction)) {
       generatedForProjectIdentity.current = capturedProjectIdentity;
@@ -216,10 +225,7 @@ export const useOutlineGenerator = ({ onNavigate }: UseOutlineGeneratorProps) =>
 
   const apply = useCallback(() => {
     // QNBS-v3: outline may have been generated for a different project if the active project changed since (e.g. New Project/import/restore elsewhere in the still-mounted app) -- discard rather than overwrite the wrong project's manuscript.
-    if (
-      generatedForProjectIdentity.current !== null &&
-      captureActiveProjectIdentity() !== generatedForProjectIdentity.current
-    ) {
+    if (!identityUnchanged(generatedForProjectIdentity.current, captureActiveProjectIdentity())) {
       setConfirmModal(null);
       return;
     }

--- a/hooks/useTemplateView.ts
+++ b/hooks/useTemplateView.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 import { useAppDispatch } from '../app/hooks';
 import { useToast } from '../components/ui/Toast';
 import { STORY_TEMPLATES } from '../constants';
+import { captureActiveProjectIdentity } from '../features/project/projectIdentity';
 import { projectActions } from '../features/project/projectSlice';
 import {
   generateCustomTemplateThunk,
@@ -146,6 +147,7 @@ export const useTemplateView = ({ onNavigate }: UseTemplateViewProps) => {
   const handleAiApply = useCallback(async () => {
     if (!selectedTemplate) return;
     setIsAiLoading(true);
+    const capturedProjectIdentity = captureActiveProjectIdentity();
     const resultAction = await dispatch(
       personalizeTemplateThunk({
         sections: remixedSections,
@@ -154,11 +156,14 @@ export const useTemplateView = ({ onNavigate }: UseTemplateViewProps) => {
       }),
     );
 
-    if (personalizeTemplateThunk.fulfilled.match(resultAction)) {
-      applyToManuscript(resultAction.payload);
-    } else {
-      toast.error(t('templates.error.personalizationFailed'));
-      applyToManuscript(remixedSections); // Fallback to standard apply
+    // QNBS-v3: applyToManuscript replaces the whole manuscript/outline -- if the active project changed while this request was in flight, neither the AI result nor the failure fallback may be applied to it.
+    if (captureActiveProjectIdentity() === capturedProjectIdentity) {
+      if (personalizeTemplateThunk.fulfilled.match(resultAction)) {
+        applyToManuscript(resultAction.payload);
+      } else {
+        toast.error(t('templates.error.personalizationFailed'));
+        applyToManuscript(remixedSections); // Fallback to standard apply
+      }
     }
     setIsAiLoading(false);
     closeModal();
@@ -181,6 +186,7 @@ export const useTemplateView = ({ onNavigate }: UseTemplateViewProps) => {
 
   const handleGenerateCustom = useCallback(async () => {
     setIsAiLoading(true);
+    const capturedProjectIdentity = captureActiveProjectIdentity();
     const resultAction = await dispatch(
       generateCustomTemplateThunk({
         customConcept,
@@ -189,10 +195,13 @@ export const useTemplateView = ({ onNavigate }: UseTemplateViewProps) => {
         lang: language,
       }),
     );
-    if (generateCustomTemplateThunk.fulfilled.match(resultAction)) {
-      applyToManuscript(resultAction.payload);
-    } else {
-      toast.error(t('templates.error.customGenerationFailed'));
+    // QNBS-v3: applyToManuscript replaces the whole manuscript/outline -- discard if the active project changed while this request was in flight.
+    if (captureActiveProjectIdentity() === capturedProjectIdentity) {
+      if (generateCustomTemplateThunk.fulfilled.match(resultAction)) {
+        applyToManuscript(resultAction.payload);
+      } else {
+        toast.error(t('templates.error.customGenerationFailed'));
+      }
     }
     setIsAiLoading(false);
     closeModal();

--- a/hooks/useTemplateView.ts
+++ b/hooks/useTemplateView.ts
@@ -2,7 +2,10 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 import { useAppDispatch } from '../app/hooks';
 import { useToast } from '../components/ui/Toast';
 import { STORY_TEMPLATES } from '../constants';
-import { captureActiveProjectIdentity } from '../features/project/projectIdentity';
+import {
+  captureActiveProjectIdentity,
+  identityUnchanged,
+} from '../features/project/projectIdentity';
 import { projectActions } from '../features/project/projectSlice';
 import {
   generateCustomTemplateThunk,
@@ -157,7 +160,7 @@ export const useTemplateView = ({ onNavigate }: UseTemplateViewProps) => {
     );
 
     // QNBS-v3: applyToManuscript replaces the whole manuscript/outline -- if the active project changed while this request was in flight, neither the AI result nor the failure fallback may be applied to it.
-    if (captureActiveProjectIdentity() !== capturedProjectIdentity) {
+    if (!identityUnchanged(capturedProjectIdentity, captureActiveProjectIdentity())) {
       setIsAiLoading(false);
       closeModal();
       return;
@@ -200,7 +203,7 @@ export const useTemplateView = ({ onNavigate }: UseTemplateViewProps) => {
       }),
     );
     // QNBS-v3: applyToManuscript replaces the whole manuscript/outline -- discard if the active project changed while this request was in flight.
-    if (captureActiveProjectIdentity() !== capturedProjectIdentity) {
+    if (!identityUnchanged(capturedProjectIdentity, captureActiveProjectIdentity())) {
       setIsAiLoading(false);
       closeModal();
       return;

--- a/hooks/useTemplateView.ts
+++ b/hooks/useTemplateView.ts
@@ -157,13 +157,17 @@ export const useTemplateView = ({ onNavigate }: UseTemplateViewProps) => {
     );
 
     // QNBS-v3: applyToManuscript replaces the whole manuscript/outline -- if the active project changed while this request was in flight, neither the AI result nor the failure fallback may be applied to it.
-    if (captureActiveProjectIdentity() === capturedProjectIdentity) {
-      if (personalizeTemplateThunk.fulfilled.match(resultAction)) {
-        applyToManuscript(resultAction.payload);
-      } else {
-        toast.error(t('templates.error.personalizationFailed'));
-        applyToManuscript(remixedSections); // Fallback to standard apply
-      }
+    if (captureActiveProjectIdentity() !== capturedProjectIdentity) {
+      setIsAiLoading(false);
+      closeModal();
+      return;
+    }
+
+    if (personalizeTemplateThunk.fulfilled.match(resultAction)) {
+      applyToManuscript(resultAction.payload);
+    } else {
+      toast.error(t('templates.error.personalizationFailed'));
+      applyToManuscript(remixedSections); // Fallback to standard apply
     }
     setIsAiLoading(false);
     closeModal();
@@ -196,12 +200,16 @@ export const useTemplateView = ({ onNavigate }: UseTemplateViewProps) => {
       }),
     );
     // QNBS-v3: applyToManuscript replaces the whole manuscript/outline -- discard if the active project changed while this request was in flight.
-    if (captureActiveProjectIdentity() === capturedProjectIdentity) {
-      if (generateCustomTemplateThunk.fulfilled.match(resultAction)) {
-        applyToManuscript(resultAction.payload);
-      } else {
-        toast.error(t('templates.error.customGenerationFailed'));
-      }
+    if (captureActiveProjectIdentity() !== capturedProjectIdentity) {
+      setIsAiLoading(false);
+      closeModal();
+      return;
+    }
+
+    if (generateCustomTemplateThunk.fulfilled.match(resultAction)) {
+      applyToManuscript(resultAction.payload);
+    } else {
+      toast.error(t('templates.error.customGenerationFailed'));
     }
     setIsAiLoading(false);
     closeModal();

--- a/hooks/useWorldView.ts
+++ b/hooks/useWorldView.ts
@@ -85,13 +85,17 @@ export const useWorldView = () => {
       }),
     );
     // QNBS-v3: the active project may have changed while this request was in flight -- discard rather than apply a result generated for a different project.
-    if (captureActiveProjectIdentity() === capturedProjectIdentity) {
-      if (generateWorldProfileThunk.fulfilled.match(resultAction)) {
-        dispatch(projectActions.addWorld(resultAction.payload));
-        toast.success(t('common.saved'), resultAction.payload.name);
-      } else {
-        toast.error(t('error.apiErrorTitle'));
-      }
+    if (captureActiveProjectIdentity() !== capturedProjectIdentity) {
+      setIsGeneratingProfile(false);
+      setAiConcept('');
+      return;
+    }
+
+    if (generateWorldProfileThunk.fulfilled.match(resultAction)) {
+      dispatch(projectActions.addWorld(resultAction.payload));
+      toast.success(t('common.saved'), resultAction.payload.name);
+    } else {
+      toast.error(t('error.apiErrorTitle'));
     }
     setIsGeneratingProfile(false);
     setAiConcept('');
@@ -122,12 +126,15 @@ export const useWorldView = () => {
         regenerateWorldFieldThunk({ world: selectedWorld, field, lang: language }),
       );
       // QNBS-v3: discard a late-arriving regenerated field if the active project changed while the request was in flight.
-      if (captureActiveProjectIdentity() === capturedProjectIdentity) {
-        if (regenerateWorldFieldThunk.fulfilled.match(resultAction)) {
-          handleFieldChange(resultAction.payload.field, resultAction.payload.value);
-        } else {
-          toast.error(t('error.apiErrorTitle'));
-        }
+      if (captureActiveProjectIdentity() !== capturedProjectIdentity) {
+        setIsRegeneratingField(null);
+        return;
+      }
+
+      if (regenerateWorldFieldThunk.fulfilled.match(resultAction)) {
+        handleFieldChange(resultAction.payload.field, resultAction.payload.value);
+      } else {
+        toast.error(t('error.apiErrorTitle'));
       }
       setIsRegeneratingField(null);
     },

--- a/hooks/useWorldView.ts
+++ b/hooks/useWorldView.ts
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { useAppDispatch, useAppSelector } from '../app/hooks';
 import { useToast } from '../components/ui/Toast';
+import { captureActiveProjectIdentity } from '../features/project/projectIdentity';
 import { selectAllWorlds } from '../features/project/projectSelectors';
 import { projectActions } from '../features/project/projectSlice';
 import {
@@ -75,6 +76,7 @@ export const useWorldView = () => {
   const handleGenerateProfile = useCallback(async () => {
     setIsGeneratingProfile(true);
     setIsAiModalOpen(false);
+    const capturedProjectIdentity = captureActiveProjectIdentity();
     const resultAction = await dispatch(
       generateWorldProfileThunk({
         concept: aiConcept,
@@ -82,11 +84,14 @@ export const useWorldView = () => {
         heuristicLabels: buildWorldHeuristicLabels(),
       }),
     );
-    if (generateWorldProfileThunk.fulfilled.match(resultAction)) {
-      dispatch(projectActions.addWorld(resultAction.payload));
-      toast.success(t('common.saved'), resultAction.payload.name);
-    } else {
-      toast.error(t('error.apiErrorTitle'));
+    // QNBS-v3: the active project may have changed while this request was in flight -- discard rather than apply a result generated for a different project.
+    if (captureActiveProjectIdentity() === capturedProjectIdentity) {
+      if (generateWorldProfileThunk.fulfilled.match(resultAction)) {
+        dispatch(projectActions.addWorld(resultAction.payload));
+        toast.success(t('common.saved'), resultAction.payload.name);
+      } else {
+        toast.error(t('error.apiErrorTitle'));
+      }
     }
     setIsGeneratingProfile(false);
     setAiConcept('');
@@ -112,13 +117,17 @@ export const useWorldView = () => {
     async (field: keyof World) => {
       if (!selectedWorld) return;
       setIsRegeneratingField(field);
+      const capturedProjectIdentity = captureActiveProjectIdentity();
       const resultAction = await dispatch(
         regenerateWorldFieldThunk({ world: selectedWorld, field, lang: language }),
       );
-      if (regenerateWorldFieldThunk.fulfilled.match(resultAction)) {
-        handleFieldChange(resultAction.payload.field, resultAction.payload.value);
-      } else {
-        toast.error(t('error.apiErrorTitle'));
+      // QNBS-v3: discard a late-arriving regenerated field if the active project changed while the request was in flight.
+      if (captureActiveProjectIdentity() === capturedProjectIdentity) {
+        if (regenerateWorldFieldThunk.fulfilled.match(resultAction)) {
+          handleFieldChange(resultAction.payload.field, resultAction.payload.value);
+        } else {
+          toast.error(t('error.apiErrorTitle'));
+        }
       }
       setIsRegeneratingField(null);
     },

--- a/hooks/useWorldView.ts
+++ b/hooks/useWorldView.ts
@@ -2,7 +2,10 @@ import { useCallback, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { useAppDispatch, useAppSelector } from '../app/hooks';
 import { useToast } from '../components/ui/Toast';
-import { captureActiveProjectIdentity } from '../features/project/projectIdentity';
+import {
+  captureActiveProjectIdentity,
+  identityUnchanged,
+} from '../features/project/projectIdentity';
 import { selectAllWorlds } from '../features/project/projectSelectors';
 import { projectActions } from '../features/project/projectSlice';
 import {
@@ -85,7 +88,7 @@ export const useWorldView = () => {
       }),
     );
     // QNBS-v3: the active project may have changed while this request was in flight -- discard rather than apply a result generated for a different project.
-    if (captureActiveProjectIdentity() !== capturedProjectIdentity) {
+    if (!identityUnchanged(capturedProjectIdentity, captureActiveProjectIdentity())) {
       setIsGeneratingProfile(false);
       setAiConcept('');
       return;
@@ -126,7 +129,7 @@ export const useWorldView = () => {
         regenerateWorldFieldThunk({ world: selectedWorld, field, lang: language }),
       );
       // QNBS-v3: discard a late-arriving regenerated field if the active project changed while the request was in flight.
-      if (captureActiveProjectIdentity() !== capturedProjectIdentity) {
+      if (!identityUnchanged(capturedProjectIdentity, captureActiveProjectIdentity())) {
         setIsRegeneratingField(null);
         return;
       }

--- a/tests/unit/features/project/projectIdentity.test.ts
+++ b/tests/unit/features/project/projectIdentity.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { getProjectTargetIdentity } from '../../../../features/project/projectIdentity';
+
+describe('getProjectTargetIdentity', () => {
+  it('returns null when the source is null or undefined', () => {
+    expect(getProjectTargetIdentity(null)).toBeNull();
+    expect(getProjectTargetIdentity(undefined)).toBeNull();
+  });
+
+  it('returns null when data has neither an id nor a legacy directory', () => {
+    expect(getProjectTargetIdentity({ data: { title: 'Untitled' }, generation: 0 })).toBeNull();
+  });
+
+  it('incorporates the persisted id and generation into the identity', () => {
+    expect(getProjectTargetIdentity({ data: { id: 'p1' }, generation: 0 })).toBe('id:p1:gen:0');
+  });
+
+  it('treats two snapshots with the same id but different generation as different projects', () => {
+    // QNBS-v3: the core fix -- a fresh "New Project" always reuses id:'default', so two different reset sessions must be distinguishable by generation alone.
+    const first = getProjectTargetIdentity({ data: { id: 'default' }, generation: 0 });
+    const second = getProjectTargetIdentity({ data: { id: 'default' }, generation: 1 });
+    expect(first).not.toBe(second);
+  });
+
+  it('treats two snapshots with the same id and the same generation as the same project', () => {
+    const a = getProjectTargetIdentity({ data: { id: 'default' }, generation: 3 });
+    const b = getProjectTargetIdentity({ data: { id: 'default' }, generation: 3 });
+    expect(a).toBe(b);
+  });
+
+  it('defaults a missing generation to 0, matching pre-existing hand-built test fixtures', () => {
+    expect(getProjectTargetIdentity({ data: { id: 'p1' } })).toBe(
+      getProjectTargetIdentity({ data: { id: 'p1' }, generation: 0 }),
+    );
+  });
+
+  it('falls back to the legacy directory metadata key when id is absent', () => {
+    expect(
+      getProjectTargetIdentity({
+        data: { __worldscriptLegacyProjectDirectory: 'dir-1' },
+        generation: 0,
+      }),
+    ).toBe('legacy:dir-1:gen:0');
+  });
+
+  it('prefers a real id over the legacy directory metadata when both are present', () => {
+    const identity = getProjectTargetIdentity({
+      data: { id: 'p1', __worldscriptLegacyProjectDirectory: 'dir-1' },
+      generation: 0,
+    });
+    expect(identity).toBe('id:p1:gen:0');
+  });
+});

--- a/tests/unit/features/project/projectIdentity.test.ts
+++ b/tests/unit/features/project/projectIdentity.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { getProjectTargetIdentity } from '../../../../features/project/projectIdentity';
+import {
+  getProjectTargetIdentity,
+  identityUnchanged,
+} from '../../../../features/project/projectIdentity';
 
 describe('getProjectTargetIdentity', () => {
   it('returns null when the source is null or undefined', () => {
@@ -49,5 +52,24 @@ describe('getProjectTargetIdentity', () => {
       generation: 0,
     });
     expect(identity).toBe('id:p1:gen:0');
+  });
+});
+
+describe('identityUnchanged', () => {
+  it('returns true when both identities are equal and non-null', () => {
+    expect(identityUnchanged('id:p1:gen:0', 'id:p1:gen:0')).toBe(true);
+  });
+
+  it('returns false when the identities differ', () => {
+    expect(identityUnchanged('id:p1:gen:0', 'id:p1:gen:1')).toBe(false);
+  });
+
+  // QNBS-v3: fail-closed -- an unknowable identity must never be treated as "unchanged", even against itself.
+  it('returns false when the captured identity is null, even if the live identity is also null', () => {
+    expect(identityUnchanged(null, null)).toBe(false);
+  });
+
+  it('returns false when only the captured identity is null', () => {
+    expect(identityUnchanged(null, 'id:p1:gen:0')).toBe(false);
   });
 });

--- a/tests/unit/hooks/useCharacterView.test.ts
+++ b/tests/unit/hooks/useCharacterView.test.ts
@@ -7,11 +7,13 @@ import type { Character } from '../../../types';
 // ---------------------------------------------------------------------------
 // vi.hoisted — match mocks referenced in vi.mock factories
 // ---------------------------------------------------------------------------
-const { mockProfileMatch, mockPortraitMatch, mockRegenerateMatch } = vi.hoisted(() => ({
-  mockProfileMatch: vi.fn((_: unknown) => true),
-  mockPortraitMatch: vi.fn((_: unknown) => true),
-  mockRegenerateMatch: vi.fn((_: unknown) => true),
-}));
+const { mockProfileMatch, mockPortraitMatch, mockRegenerateMatch, mockCaptureIdentity } =
+  vi.hoisted(() => ({
+    mockProfileMatch: vi.fn((_: unknown) => true),
+    mockPortraitMatch: vi.fn((_: unknown) => true),
+    mockRegenerateMatch: vi.fn((_: unknown) => true),
+    mockCaptureIdentity: vi.fn(() => 'id:test-project'),
+  }));
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -45,6 +47,10 @@ vi.mock('../../../components/ui/Toast', () => ({
 
 vi.mock('../../../features/project/projectSelectors', () => ({
   selectAllCharacters: (state: { characters: Character[] }) => state.characters,
+}));
+
+vi.mock('../../../features/project/projectIdentity', () => ({
+  captureActiveProjectIdentity: mockCaptureIdentity,
 }));
 
 vi.mock('../../../features/project/thunks/characterThunks', () => {
@@ -104,6 +110,7 @@ beforeEach(() => {
   mockProfileMatch.mockReturnValue(true);
   mockPortraitMatch.mockReturnValue(true);
   mockRegenerateMatch.mockReturnValue(true);
+  mockCaptureIdentity.mockReturnValue('id:test-project');
 });
 
 // ---------------------------------------------------------------------------
@@ -202,6 +209,25 @@ describe('handleGenerateProfile', () => {
 
     expect(result.current.isAiModalOpen).toBe(false);
   });
+
+  it('discards the AI-generated character if the active project changed while the request was in flight', async () => {
+    const newChar = makeCharacter('c-new', 'Bob');
+    const fulfilledAction = {
+      type: 'project/generateCharacterProfile/fulfilled',
+      payload: newChar,
+    };
+    mockDispatch.mockResolvedValue(fulfilledAction);
+    mockProfileMatch.mockReturnValue(true);
+    mockCaptureIdentity.mockReturnValueOnce('id:project-a').mockReturnValueOnce('id:project-b');
+
+    const { result } = renderHook(() => useCharacterView());
+    await act(async () => {
+      await result.current.handleGenerateProfile();
+    });
+
+    expect(mockDispatch).not.toHaveBeenCalledWith(projectActions.addCharacter(newChar));
+    expect(mockToast.success).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -290,6 +316,27 @@ describe('handleRegenerateField', () => {
     });
 
     await waitFor(() => expect(result.current.isRegeneratingField).toBeNull());
+  });
+
+  it('discards the regenerated field if the active project changed while the request was in flight', async () => {
+    const fulfilledAction = {
+      type: 'project/regenerateCharacterField/fulfilled',
+      payload: { field: 'backstory', value: 'New backstory' },
+    };
+    mockDispatch.mockResolvedValue(fulfilledAction);
+    mockRegenerateMatch.mockReturnValue(true);
+    mockCaptureIdentity.mockReturnValueOnce('id:project-a').mockReturnValueOnce('id:project-b');
+
+    const char = makeCharacter('c1');
+    const { result } = renderHook(() => useCharacterView());
+    act(() => result.current.handleSelect(char));
+    await act(async () => {
+      await result.current.handleRegenerateField('backstory');
+    });
+
+    expect(mockDispatch).not.toHaveBeenCalledWith(
+      projectActions.updateCharacter({ id: 'c1', changes: { backstory: 'New backstory' } }),
+    );
   });
 });
 

--- a/tests/unit/hooks/useCharacterView.test.ts
+++ b/tests/unit/hooks/useCharacterView.test.ts
@@ -51,6 +51,8 @@ vi.mock('../../../features/project/projectSelectors', () => ({
 
 vi.mock('../../../features/project/projectIdentity', () => ({
   captureActiveProjectIdentity: mockCaptureIdentity,
+  identityUnchanged: (captured: string | null, live: string | null) =>
+    captured !== null && captured === live,
 }));
 
 vi.mock('../../../features/project/thunks/characterThunks', () => {
@@ -211,6 +213,7 @@ describe('handleGenerateProfile', () => {
   });
 
   it('discards the AI-generated character if the active project changed while the request was in flight', async () => {
+    // QNBS-v3: simulates a project switch (New Project/import/restore) landing between capture and re-check, the exact race the guard exists to close.
     const newChar = makeCharacter('c-new', 'Bob');
     const fulfilledAction = {
       type: 'project/generateCharacterProfile/fulfilled',
@@ -319,6 +322,7 @@ describe('handleRegenerateField', () => {
   });
 
   it('discards the regenerated field if the active project changed while the request was in flight', async () => {
+    // QNBS-v3: same race as the profile-generation guard above, exercised for the field-regeneration path instead.
     const fulfilledAction = {
       type: 'project/regenerateCharacterField/fulfilled',
       payload: { field: 'backstory', value: 'New backstory' },

--- a/tests/unit/hooks/useOutlineGenerator.test.ts
+++ b/tests/unit/hooks/useOutlineGenerator.test.ts
@@ -64,6 +64,8 @@ vi.mock('../../../features/project/thunks/outlineThunks', () => {
 
 vi.mock('../../../features/project/projectIdentity', () => ({
   captureActiveProjectIdentity: mockCaptureIdentity,
+  identityUnchanged: (captured: string | null, live: string | null) =>
+    captured !== null && captured === live,
 }));
 
 // ---------------------------------------------------------------------------
@@ -146,6 +148,46 @@ describe('generate', () => {
     });
 
     expect(result.current.isLoading).toBe(false);
+  });
+
+  it('discards a fulfilled outline (no local-state update, no success toast) if the active project changed while generation was in flight', async () => {
+    const fulfilledAction = {
+      type: 'project/generateOutline/fulfilled',
+      payload: [makeOutlineSection('g1', 'Act 1')],
+    };
+    mockDispatch.mockResolvedValue(fulfilledAction);
+    // QNBS-v3: mount's eager ref-init also calls captureActiveProjectIdentity() once, before generate()'s own capture -- both must return 'id:project-a' so generate() legitimately captures the pre-change identity.
+    mockCaptureIdentity
+      .mockReturnValueOnce('id:project-a')
+      .mockReturnValueOnce('id:project-a')
+      .mockReturnValue('id:project-b');
+
+    const { result } = renderHook(() => useOutlineGenerator({ onNavigate }));
+    await act(async () => {
+      await result.current.handleGenerate();
+    });
+
+    expect(result.current.outline).toHaveLength(0);
+    expect(mockToast.success).not.toHaveBeenCalled();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('discards a rejected outline (no error state, no error toast) if the active project changed while generation was in flight', async () => {
+    const rejectedAction = { type: 'project/generateOutline/rejected' };
+    mockDispatch.mockResolvedValue(rejectedAction);
+    mockGenerateMatch.mockReturnValue(false);
+    mockCaptureIdentity
+      .mockReturnValueOnce('id:project-a')
+      .mockReturnValueOnce('id:project-a')
+      .mockReturnValue('id:project-b');
+
+    const { result } = renderHook(() => useOutlineGenerator({ onNavigate }));
+    await act(async () => {
+      await result.current.handleGenerate();
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(mockToast.error).not.toHaveBeenCalled();
   });
 });
 
@@ -323,6 +365,31 @@ describe('deleteSection', () => {
 // handleApplyOutline / apply
 // ---------------------------------------------------------------------------
 describe('handleApplyOutline', () => {
+  it('applies successfully when generate() and apply() happen in the same, unchanged project', async () => {
+    // QNBS-v3: covers the guard's non-discard branch -- every other apply test skips generate(), so generatedForProjectIdentity.current stays at its eager mount value and the guard is never really exercised for a legitimate same-project flow.
+    mockExistingManuscript = [{ id: 's1', title: 'Untitled', content: '' }];
+    mockExistingOutline = [];
+    const fulfilledAction = {
+      type: 'project/generateOutline/fulfilled',
+      payload: [makeOutlineSection('g1', 'Act 1')],
+    };
+    mockDispatch.mockResolvedValue(fulfilledAction);
+
+    const { result } = renderHook(() => useOutlineGenerator({ onNavigate }));
+    await act(async () => {
+      await result.current.handleGenerate();
+    });
+    await waitFor(() => expect(result.current.outline).toHaveLength(1));
+
+    mockDispatch.mockClear();
+    act(() => result.current.handleApplyOutline());
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'project/setManuscript' }),
+    );
+    expect(onNavigate).toHaveBeenCalledWith('manuscript');
+  });
+
   it('applies directly when manuscript is a single empty section', () => {
     mockExistingManuscript = [{ id: 's1', title: 'Untitled', content: '' }];
     mockExistingOutline = [makeOutlineSection('o1', 'Act 1')];

--- a/tests/unit/hooks/useOutlineGenerator.test.ts
+++ b/tests/unit/hooks/useOutlineGenerator.test.ts
@@ -408,4 +408,22 @@ describe('handleApplyOutline', () => {
     );
     expect(onNavigate).not.toHaveBeenCalled();
   });
+
+  it('discards apply when the active project changed since mount, even when the outline was only ever seeded from existingOutline (no generate() call)', () => {
+    mockExistingManuscript = [{ id: 's1', title: 'Untitled', content: '' }];
+    mockExistingOutline = [makeOutlineSection('o1', 'Seeded Act 1')];
+    mockCaptureIdentity.mockReturnValueOnce('id:project-a'); // captured at mount
+
+    const { result } = renderHook(() => useOutlineGenerator({ onNavigate }));
+    expect(result.current.outline).toHaveLength(1);
+
+    mockCaptureIdentity.mockReturnValue('id:project-b'); // active project changed before Apply, no generate() ever ran
+
+    act(() => result.current.handleApplyOutline());
+
+    expect(mockDispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'project/setManuscript' }),
+    );
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
 });

--- a/tests/unit/hooks/useOutlineGenerator.test.ts
+++ b/tests/unit/hooks/useOutlineGenerator.test.ts
@@ -6,9 +6,10 @@ import type { OutlineSection, StorySection } from '../../../types';
 // ---------------------------------------------------------------------------
 // vi.hoisted — match mocks referenced inside vi.mock factories
 // ---------------------------------------------------------------------------
-const { mockGenerateMatch, mockRegenerateMatch } = vi.hoisted(() => ({
+const { mockGenerateMatch, mockRegenerateMatch, mockCaptureIdentity } = vi.hoisted(() => ({
   mockGenerateMatch: vi.fn((_: unknown) => true),
   mockRegenerateMatch: vi.fn((_: unknown) => true),
+  mockCaptureIdentity: vi.fn(() => 'id:test-project'),
 }));
 
 // ---------------------------------------------------------------------------
@@ -61,6 +62,10 @@ vi.mock('../../../features/project/thunks/outlineThunks', () => {
   };
 });
 
+vi.mock('../../../features/project/projectIdentity', () => ({
+  captureActiveProjectIdentity: mockCaptureIdentity,
+}));
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -78,6 +83,7 @@ beforeEach(() => {
   mockExistingManuscript = [{ id: 's1', title: 'Ch1', content: '' }];
   mockGenerateMatch.mockReturnValue(true);
   mockRegenerateMatch.mockReturnValue(true);
+  mockCaptureIdentity.mockReturnValue('id:test-project');
 });
 
 // ---------------------------------------------------------------------------
@@ -374,5 +380,32 @@ describe('handleApplyOutline', () => {
     act(() => result.current.handleApplyOutline());
 
     expect(mockToast.success).toHaveBeenCalled();
+  });
+
+  it('discards apply when the active project changed since the outline was generated', async () => {
+    mockExistingManuscript = [{ id: 's1', title: 'Untitled', content: '' }];
+    mockExistingOutline = [];
+    const fulfilledAction = {
+      type: 'project/generateOutline/fulfilled',
+      payload: [makeOutlineSection('g1', 'Act 1')],
+    };
+    mockDispatch.mockResolvedValue(fulfilledAction);
+    mockCaptureIdentity.mockReturnValueOnce('id:project-a'); // captured while generate() was in flight
+
+    const { result } = renderHook(() => useOutlineGenerator({ onNavigate }));
+    await act(async () => {
+      await result.current.handleGenerate();
+    });
+    await waitFor(() => expect(result.current.outline.length).toBe(1));
+
+    mockDispatch.mockClear();
+    mockCaptureIdentity.mockReturnValue('id:project-b'); // active project changed before Apply was clicked
+
+    act(() => result.current.handleApplyOutline());
+
+    expect(mockDispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'project/setManuscript' }),
+    );
+    expect(onNavigate).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/hooks/useTemplateView.test.ts
+++ b/tests/unit/hooks/useTemplateView.test.ts
@@ -5,33 +5,36 @@ import { useTemplateView } from '../../../hooks/useTemplateView';
 // ---------------------------------------------------------------------------
 // vi.hoisted — thunk match fns + template data (must be hoisted; vi.mock is hoisted)
 // ---------------------------------------------------------------------------
-const { mockPersonalizeMatch, mockCustomMatch, MOCK_TEMPLATES } = vi.hoisted(() => {
-  const templates = [
-    {
-      id: 'hero',
-      name: "Hero's Journey",
-      description: 'Classic structure',
-      type: 'Structure' as const,
-      tags: ['classic'],
-      arcDescription: 'The hero departs',
-      sections: [{ titleKey: 'templates.hero.act1' }, { titleKey: 'templates.hero.act2' }],
-    },
-    {
-      id: 'thriller',
-      name: 'Thriller',
-      description: 'Fast-paced',
-      type: 'Genre' as const,
-      tags: ['action'],
-      arcDescription: 'Tension builds',
-      sections: [{ titleKey: 'templates.thriller.opening' }],
-    },
-  ];
-  return {
-    mockPersonalizeMatch: vi.fn((_: unknown) => true),
-    mockCustomMatch: vi.fn((_: unknown) => true),
-    MOCK_TEMPLATES: templates,
-  };
-});
+const { mockPersonalizeMatch, mockCustomMatch, MOCK_TEMPLATES, mockCaptureIdentity } = vi.hoisted(
+  () => {
+    const templates = [
+      {
+        id: 'hero',
+        name: "Hero's Journey",
+        description: 'Classic structure',
+        type: 'Structure' as const,
+        tags: ['classic'],
+        arcDescription: 'The hero departs',
+        sections: [{ titleKey: 'templates.hero.act1' }, { titleKey: 'templates.hero.act2' }],
+      },
+      {
+        id: 'thriller',
+        name: 'Thriller',
+        description: 'Fast-paced',
+        type: 'Genre' as const,
+        tags: ['action'],
+        arcDescription: 'Tension builds',
+        sections: [{ titleKey: 'templates.thriller.opening' }],
+      },
+    ];
+    return {
+      mockPersonalizeMatch: vi.fn((_: unknown) => true),
+      mockCustomMatch: vi.fn((_: unknown) => true),
+      MOCK_TEMPLATES: templates,
+      mockCaptureIdentity: vi.fn(() => 'id:test-project'),
+    };
+  },
+);
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -75,6 +78,10 @@ vi.mock('../../../features/project/thunks/outlineThunks', () => {
   };
 });
 
+vi.mock('../../../features/project/projectIdentity', () => ({
+  captureActiveProjectIdentity: mockCaptureIdentity,
+}));
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -88,6 +95,7 @@ beforeEach(() => {
   mockDispatch.mockResolvedValue({ type: 'mock-action' });
   mockPersonalizeMatch.mockReturnValue(true);
   mockCustomMatch.mockReturnValue(true);
+  mockCaptureIdentity.mockReturnValue('id:test-project');
 });
 
 // ---------------------------------------------------------------------------
@@ -268,6 +276,29 @@ describe('handleAiApply', () => {
     // Still navigates via fallback applyToManuscript
     expect(mockNavigate).toHaveBeenCalledWith('manuscript');
   });
+
+  it('discards the result (and the failure fallback) if the active project changed while the request was in flight', async () => {
+    mockDispatch.mockResolvedValue({
+      type: 'fulfilled',
+      payload: [{ title: 'Personalized Act 1' }],
+    });
+    mockPersonalizeMatch.mockReturnValue(true);
+    mockCaptureIdentity.mockReturnValueOnce('id:project-a').mockReturnValueOnce('id:project-b');
+
+    const { result } = renderTemplateHook();
+    act(() => {
+      result.current.openPreviewModal(MOCK_TEMPLATES[0]!);
+    });
+    await act(async () => {
+      await result.current.handleAiApply();
+    });
+
+    expect(mockDispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'project/setManuscript' }),
+    );
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(mockToast.success).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -301,6 +332,25 @@ describe('handleGenerateCustom', () => {
     });
     expect(mockToast.error).toHaveBeenCalled();
     expect(result.current.isAiLoading).toBe(false);
+  });
+
+  it('discards the generated custom template if the active project changed while the request was in flight', async () => {
+    mockDispatch.mockResolvedValue({
+      type: 'fulfilled',
+      payload: [{ title: 'Custom Act' }],
+    });
+    mockCustomMatch.mockReturnValue(true);
+    mockCaptureIdentity.mockReturnValueOnce('id:project-a').mockReturnValueOnce('id:project-b');
+
+    const { result } = renderTemplateHook();
+    await act(async () => {
+      await result.current.handleGenerateCustom();
+    });
+
+    expect(mockDispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'project/setManuscript' }),
+    );
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/unit/hooks/useTemplateView.test.ts
+++ b/tests/unit/hooks/useTemplateView.test.ts
@@ -80,6 +80,8 @@ vi.mock('../../../features/project/thunks/outlineThunks', () => {
 
 vi.mock('../../../features/project/projectIdentity', () => ({
   captureActiveProjectIdentity: mockCaptureIdentity,
+  identityUnchanged: (captured: string | null, live: string | null) =>
+    captured !== null && captured === live,
 }));
 
 // ---------------------------------------------------------------------------
@@ -277,7 +279,7 @@ describe('handleAiApply', () => {
     expect(mockNavigate).toHaveBeenCalledWith('manuscript');
   });
 
-  it('discards the result (and the failure fallback) if the active project changed while the request was in flight', async () => {
+  it('discards a fulfilled result if the active project changed while the request was in flight', async () => {
     mockDispatch.mockResolvedValue({
       type: 'fulfilled',
       payload: [{ title: 'Personalized Act 1' }],
@@ -298,6 +300,27 @@ describe('handleAiApply', () => {
     );
     expect(mockNavigate).not.toHaveBeenCalled();
     expect(mockToast.success).not.toHaveBeenCalled();
+  });
+
+  it('discards the failure fallback (applyToManuscript(remixedSections)) if the active project changed while the request was in flight', async () => {
+    // QNBS-v3: the fallback-apply path replaces the whole manuscript/outline too, and is otherwise untested for this guard -- only the fulfilled branch was covered before.
+    mockDispatch.mockResolvedValue({ type: 'rejected' });
+    mockPersonalizeMatch.mockReturnValue(false);
+    mockCaptureIdentity.mockReturnValueOnce('id:project-a').mockReturnValueOnce('id:project-b');
+
+    const { result } = renderTemplateHook();
+    act(() => {
+      result.current.openPreviewModal(MOCK_TEMPLATES[0]!);
+    });
+    await act(async () => {
+      await result.current.handleAiApply();
+    });
+
+    expect(mockDispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'project/setManuscript' }),
+    );
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(mockToast.error).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/unit/hooks/useWorldView.test.ts
+++ b/tests/unit/hooks/useWorldView.test.ts
@@ -6,11 +6,14 @@ import type { World } from '../../../types';
 // ---------------------------------------------------------------------------
 // vi.hoisted — thunk match fns must be stable references inside vi.mock factories
 // ---------------------------------------------------------------------------
-const { mockProfileMatch, mockRegenerateMatch, mockImageMatch } = vi.hoisted(() => ({
-  mockProfileMatch: vi.fn((_: unknown) => true),
-  mockRegenerateMatch: vi.fn((_: unknown) => true),
-  mockImageMatch: vi.fn((_: unknown) => true),
-}));
+const { mockProfileMatch, mockRegenerateMatch, mockImageMatch, mockCaptureIdentity } = vi.hoisted(
+  () => ({
+    mockProfileMatch: vi.fn((_: unknown) => true),
+    mockRegenerateMatch: vi.fn((_: unknown) => true),
+    mockImageMatch: vi.fn((_: unknown) => true),
+    mockCaptureIdentity: vi.fn(() => 'id:test-project'),
+  }),
+);
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -42,6 +45,10 @@ vi.mock('../../../components/ui/Toast', () => ({
 
 vi.mock('../../../features/project/projectSelectors', () => ({
   selectAllWorlds: () => mockWorlds,
+}));
+
+vi.mock('../../../features/project/projectIdentity', () => ({
+  captureActiveProjectIdentity: mockCaptureIdentity,
 }));
 
 vi.mock('../../../features/project/thunks/worldThunks', () => {
@@ -99,6 +106,7 @@ beforeEach(() => {
   mockProfileMatch.mockReturnValue(true);
   mockRegenerateMatch.mockReturnValue(true);
   mockImageMatch.mockReturnValue(true);
+  mockCaptureIdentity.mockReturnValue('id:test-project');
 });
 
 // ---------------------------------------------------------------------------
@@ -189,6 +197,23 @@ describe('handleGenerateProfile', () => {
       await result.current.handleGenerateProfile();
     });
     expect(result.current.isGeneratingProfile).toBe(false);
+  });
+
+  it('discards the AI-generated world if the active project changed while the request was in flight', async () => {
+    const newWorld = makeWorld('w-new');
+    mockDispatch.mockResolvedValue({ type: 'fulfilled', payload: newWorld });
+    mockProfileMatch.mockReturnValue(true);
+    mockCaptureIdentity.mockReturnValueOnce('id:project-a').mockReturnValueOnce('id:project-b');
+
+    const { result } = renderHook(() => useWorldView());
+    await act(async () => {
+      await result.current.handleGenerateProfile();
+    });
+
+    expect(mockDispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'project/addWorld' }),
+    );
+    expect(mockToast.success).not.toHaveBeenCalled();
   });
 });
 
@@ -281,6 +306,28 @@ describe('handleRegenerateField', () => {
       await result.current.handleRegenerateField('geography');
     });
     expect(result.current.isRegeneratingField).toBeNull();
+  });
+
+  it('discards the regenerated field if the active project changed while the request was in flight', async () => {
+    const world = makeWorld('w1');
+    mockDispatch.mockResolvedValue({
+      type: 'fulfilled',
+      payload: { field: 'geography', value: 'Plains' },
+    });
+    mockRegenerateMatch.mockReturnValue(true);
+    mockCaptureIdentity.mockReturnValueOnce('id:project-a').mockReturnValueOnce('id:project-b');
+
+    const { result } = renderHook(() => useWorldView());
+    act(() => {
+      result.current.handleSelect(world);
+    });
+    await act(async () => {
+      await result.current.handleRegenerateField('geography');
+    });
+
+    expect(mockDispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'project/updateWorld' }),
+    );
   });
 });
 

--- a/tests/unit/hooks/useWorldView.test.ts
+++ b/tests/unit/hooks/useWorldView.test.ts
@@ -49,6 +49,8 @@ vi.mock('../../../features/project/projectSelectors', () => ({
 
 vi.mock('../../../features/project/projectIdentity', () => ({
   captureActiveProjectIdentity: mockCaptureIdentity,
+  identityUnchanged: (captured: string | null, live: string | null) =>
+    captured !== null && captured === live,
 }));
 
 vi.mock('../../../features/project/thunks/worldThunks', () => {

--- a/tests/unit/thunks/binderAndManagementThunks.test.ts
+++ b/tests/unit/thunks/binderAndManagementThunks.test.ts
@@ -552,6 +552,28 @@ describe('restoreSnapshotThunk', () => {
     expect(store.getState().project.present.data.id).toBe('p2');
   });
 
+  // QNBS-v3: a New Project reset keeps id:'default' (the same as almost every fresh project), so id alone cannot detect this race -- the generation counter must.
+  it('rejects when the active project is reset (still id:default) while snapshot I/O is pending', async () => {
+    let releaseRestore!: (value: unknown) => void;
+    vi.mocked(storageService.restoreSnapshot).mockReturnValue(
+      new Promise((resolve) => {
+        releaseRestore = resolve;
+      }),
+    );
+
+    const store = makeStore();
+    const pending = store.dispatch(restoreSnapshotThunk(100));
+    store.dispatch(
+      projectActions.resetProject({ title: 'Fresh', logline: '', chapter1Title: 'Ch1' }),
+    );
+    releaseRestore({ title: 'Old snapshot content', id: 'default' });
+
+    const action = await pending;
+
+    expect(action.type).toBe('project/restoreSnapshot/rejected');
+    expect(store.getState().project.present.data.title).toBe('Fresh');
+  });
+
   it('dispatches rejected when storageService throws', async () => {
     vi.mocked(storageService.restoreSnapshot).mockRejectedValue(new Error('IDB error'));
 


### PR DESCRIPTION
## **User description**
## Summary

Closes the P0 cross-project AI mutation finding from the #704 remediation plan (Wave 0B). Five handlers across four hooks `await dispatch(aiThunk)` and then unconditionally mutate persisted project state, with no check that the active project is still the one the request was made for. Since loading a different project (New Project reset, file import, snapshot restore) replaces `state.data` wholesale while the SPA stays mounted, a late-arriving AI result could be applied to whichever project happened to be open when it resolved:

- `useCharacterView`/`useWorldView`'s `handleGenerateProfile`/`handleRegenerateField`
- `useTemplateView`'s `handleAiApply`/`handleGenerateCustom` (most severe — replaces the entire manuscript/outline wholesale, including on the failure-fallback path)
- `useOutlineGenerator`'s `apply()` (fired later on a separate click, racing against `generate()`'s local-state population)

This repo already has the exact right invariant for the analogous snapshot-restore race (`restoreSnapshotThunk`'s storage-owned target-identity capture/recheck). Extracted that into a shared `features/project/projectIdentity.ts` (`getProjectTargetIdentity()` + a new `captureActiveProjectIdentity()` reading the live store via `appStoreRef`), and applied the same capture-before/recheck-after pattern to all five handlers.

## Test plan

- [x] 9 new regression tests (one per guarded handler/path), each mutation-tested (reverted the guard, confirmed the exact test failed, restored it)
- [x] All existing tests for the 4 affected hooks + `projectManagementThunks` pass unmodified
- [x] `pnpm run lint` clean
- [x] `pnpm run typecheck` (tsgo, 4 checkers) clean
- [x] `pnpm run ci:prepush` clean

## Summary by Sourcery

Guard asynchronous AI results and deferred outline application so they are only persisted to the project that initiated them.

Bug Fixes:
- Prevent stale AI-generation results from mutating a different active project after project switches, resets, imports, or snapshot restores.
- Protect template manuscript replacements and outline application, including failure fallbacks, from cross-project updates.

Enhancements:
- Centralize project identity checks and distinguish same-ID project sessions with an in-memory generation counter.
- Extend identity protection to outlines seeded before generation and strengthen snapshot-restore ownership checks.

Tests:
- Add regression coverage for all guarded AI-generation paths, same-ID project races, outline previews and application, and shared identity behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race condition where AI generation results (character/world profiles, regenerated fields, template personalization, outline generation) could be applied to a different project than the one that requested them, if the user switched projects while the request was in flight. The five affected handlers now capture the active project's identity before dispatching and discard the result if it changed by the time the request settles — including stale outline previews before Apply.

**Bug Fixes**
- Extracts the project-identity guard from snapshot restore into shared `features/project/projectIdentity.ts` and applies it to all five handlers.
- Adds an in-memory `generation` counter to `ProjectSliceState`, bumped on reset/import/restore, so two fresh projects that both reuse the sentinel `id: 'default'` are still distinguishable.
- Guards fail closed: an identity that can't be determined is never treated as unchanged.
- Captures outline identity eagerly at mount so a seeded outline is protected, and discards a stale preview (local state, toasts) if the project changes during `generate()`.
- Adds regression tests covering each guarded path, including the same-id reset-versus-pending-restore race.

<sup>Written for commit c8a128ccf344c27c10526837d9d5902e8089c473. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/qnbs/WorldScript-Studio/pull/707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented delayed AI-generated results from one project from being applied after switching to another project.
  * Added safeguards across character, outline, template, and world-profile generation workflows, including error handling and fallback actions.
  * Prevented pending snapshot restores from overwriting projects after a reset, import, or restore.

* **Tests**
  * Added regression coverage confirming stale results are discarded safely.

* **Documentation**
  * Updated documented test metrics to reflect 7,702+ tests across 606 files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Prevent late AI results from changing the wrong project

### What Changed
- AI-generated characters, worlds, outline previews, and templates are discarded if the user switches, resets, imports, or restores a project while generation is in progress
- Outline Apply now stops instead of replacing another project's manuscript when the outline belongs to a previous project
- Snapshot restores also stop when the active project changes, including resets that reuse the default project ID
- Added regression coverage for switched-project and same-ID reset scenarios

### Impact
`✅ Prevents cross-project AI content changes`
`✅ Protects manuscript and outline replacements`
`✅ Prevents stale snapshot restores`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
