### PR TITLE
fix(project): reject stale async AI mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Async AI image writes and Character Interview chunks now reject stale project
+  incarnations:** direct image persistence and interview-stream updates capture the originating
+  project identity and refuse late results after a project switch or same-ID replacement, with
+  focused regression coverage. PR #733.
 - **AI-generated character/world/scene images can no longer overwrite another project's image
   (#704, #708):** image storage keys on both the IndexedDB and desktop filesystem backends are
   now project-qualified using a collision-resistant hash of the full project id (not a lossy

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <img src="https://img.shields.io/badge/TypeScript-tsgo_native_preview-3178C6?logo=typescript&logoColor=white" alt="TypeScript native preview (tsgo)">
   <img src="https://img.shields.io/badge/Desktop-Tauri_2-FFC131?logo=tauri&logoColor=black" alt="Tauri 2">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7773%2B_%2F_606_files-22C55E" alt="7773+ tests / 606 files">
+  <img src="https://img.shields.io/badge/Tests-7781%2B_%2F_606_files-22C55E" alt="7781+ tests / 606 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github&label=CI" alt="CI status">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="MIT License">
@@ -809,7 +809,7 @@ The normal web PR pipeline is not the complete native release qualification surf
 | DOCX | `docx` + JSZip | Word-compatible export |
 | PWA | Service Worker + Web App Manifest | Offline shell/installability |
 | i18n | Custom React i18n context | 2942 keys × 19 locales |
-| Testing | Vitest 4.x (7773+ tests / 606 files) + Playwright | Unit/integration/E2E |
+| Testing | Vitest 4.x (7781+ tests / 606 files) + Playwright | Unit/integration/E2E |
 | Quality | Biome + tsgo + CodeQL/security tooling | Static and CI gates |
 | Desktop | Tauri 2 | Current native shell |
 
@@ -886,7 +886,7 @@ WorldScript-Studio/
 ├── locales/                 # Source locale trees
 ├── public/                  # PWA assets, manifest, SW, runtime locale bundles
 ├── tests/
-│   ├── unit/                # Vitest unit tests (7773+ tests; file count includes package test directories)
+│   ├── unit/                # Vitest unit tests (7781+ tests; file count includes package test directories)
 │   └── e2e/                 # Playwright
 ├── docs/                    # Canonical product/engineering documentation + ADRs
 ├── src-tauri/               # Tauri v2 desktop shell / Rust
@@ -1031,7 +1031,7 @@ Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendo
 
 Current source-synchronized README metrics:
 
-- **7773+ unit tests** across **606 test files**
+- **7781+ unit tests** across **606 test files**
 - i18n: **2942 keys × 19 locales**
 
 CI remains authoritative for actual pass/fail and live coverage.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <img src="https://img.shields.io/badge/TypeScript-tsgo_native_preview-3178C6?logo=typescript&logoColor=white" alt="TypeScript native preview (tsgo)">
   <img src="https://img.shields.io/badge/Desktop-Tauri_2-FFC131?logo=tauri&logoColor=black" alt="Tauri 2">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7765%2B_%2F_606_files-22C55E" alt="7765+ tests / 606 files">
+  <img src="https://img.shields.io/badge/Tests-7767%2B_%2F_606_files-22C55E" alt="7767+ tests / 606 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github&label=CI" alt="CI status">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="MIT License">
@@ -809,7 +809,7 @@ The normal web PR pipeline is not the complete native release qualification surf
 | DOCX | `docx` + JSZip | Word-compatible export |
 | PWA | Service Worker + Web App Manifest | Offline shell/installability |
 | i18n | Custom React i18n context | 2942 keys × 19 locales |
-| Testing | Vitest 4.x (7765+ tests / 606 files) + Playwright | Unit/integration/E2E |
+| Testing | Vitest 4.x (7767+ tests / 606 files) + Playwright | Unit/integration/E2E |
 | Quality | Biome + tsgo + CodeQL/security tooling | Static and CI gates |
 | Desktop | Tauri 2 | Current native shell |
 
@@ -886,7 +886,7 @@ WorldScript-Studio/
 ├── locales/                 # Source locale trees
 ├── public/                  # PWA assets, manifest, SW, runtime locale bundles
 ├── tests/
-│   ├── unit/                # Vitest unit tests (7765+ tests; file count includes package test directories)
+│   ├── unit/                # Vitest unit tests (7767+ tests; file count includes package test directories)
 │   └── e2e/                 # Playwright
 ├── docs/                    # Canonical product/engineering documentation + ADRs
 ├── src-tauri/               # Tauri v2 desktop shell / Rust
@@ -1031,7 +1031,7 @@ Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendo
 
 Current source-synchronized README metrics:
 
-- **7765+ unit tests** across **606 test files**
+- **7767+ unit tests** across **606 test files**
 - i18n: **2942 keys × 19 locales**
 
 CI remains authoritative for actual pass/fail and live coverage.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <img src="https://img.shields.io/badge/TypeScript-tsgo_native_preview-3178C6?logo=typescript&logoColor=white" alt="TypeScript native preview (tsgo)">
   <img src="https://img.shields.io/badge/Desktop-Tauri_2-FFC131?logo=tauri&logoColor=black" alt="Tauri 2">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7761%2B_%2F_606_files-22C55E" alt="7761+ tests / 606 files">
+  <img src="https://img.shields.io/badge/Tests-7763%2B_%2F_606_files-22C55E" alt="7763+ tests / 606 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github&label=CI" alt="CI status">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="MIT License">
@@ -809,7 +809,7 @@ The normal web PR pipeline is not the complete native release qualification surf
 | DOCX | `docx` + JSZip | Word-compatible export |
 | PWA | Service Worker + Web App Manifest | Offline shell/installability |
 | i18n | Custom React i18n context | 2942 keys × 19 locales |
-| Testing | Vitest 4.x (7761+ tests / 606 files) + Playwright | Unit/integration/E2E |
+| Testing | Vitest 4.x (7763+ tests / 606 files) + Playwright | Unit/integration/E2E |
 | Quality | Biome + tsgo + CodeQL/security tooling | Static and CI gates |
 | Desktop | Tauri 2 | Current native shell |
 
@@ -886,7 +886,7 @@ WorldScript-Studio/
 ├── locales/                 # Source locale trees
 ├── public/                  # PWA assets, manifest, SW, runtime locale bundles
 ├── tests/
-│   ├── unit/                # Vitest unit tests (7761+ tests, 606 files)
+│   ├── unit/                # Vitest unit tests (7763+ tests, 606 files)
 │   └── e2e/                 # Playwright
 ├── docs/                    # Canonical product/engineering documentation + ADRs
 ├── src-tauri/               # Tauri v2 desktop shell / Rust
@@ -1031,7 +1031,7 @@ Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendo
 
 Current source-synchronized README metrics:
 
-- **7761+ unit tests** across **606 test files**
+- **7763+ unit tests** across **606 test files**
 - i18n: **2942 keys × 19 locales**
 
 CI remains authoritative for actual pass/fail and live coverage.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <img src="https://img.shields.io/badge/TypeScript-tsgo_native_preview-3178C6?logo=typescript&logoColor=white" alt="TypeScript native preview (tsgo)">
   <img src="https://img.shields.io/badge/Desktop-Tauri_2-FFC131?logo=tauri&logoColor=black" alt="Tauri 2">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7770%2B_%2F_606_files-22C55E" alt="7770+ tests / 606 files">
+  <img src="https://img.shields.io/badge/Tests-7773%2B_%2F_606_files-22C55E" alt="7773+ tests / 606 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github&label=CI" alt="CI status">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="MIT License">
@@ -809,7 +809,7 @@ The normal web PR pipeline is not the complete native release qualification surf
 | DOCX | `docx` + JSZip | Word-compatible export |
 | PWA | Service Worker + Web App Manifest | Offline shell/installability |
 | i18n | Custom React i18n context | 2942 keys × 19 locales |
-| Testing | Vitest 4.x (7770+ tests / 606 files) + Playwright | Unit/integration/E2E |
+| Testing | Vitest 4.x (7773+ tests / 606 files) + Playwright | Unit/integration/E2E |
 | Quality | Biome + tsgo + CodeQL/security tooling | Static and CI gates |
 | Desktop | Tauri 2 | Current native shell |
 
@@ -886,7 +886,7 @@ WorldScript-Studio/
 ├── locales/                 # Source locale trees
 ├── public/                  # PWA assets, manifest, SW, runtime locale bundles
 ├── tests/
-│   ├── unit/                # Vitest unit tests (7770+ tests; file count includes package test directories)
+│   ├── unit/                # Vitest unit tests (7773+ tests; file count includes package test directories)
 │   └── e2e/                 # Playwright
 ├── docs/                    # Canonical product/engineering documentation + ADRs
 ├── src-tauri/               # Tauri v2 desktop shell / Rust
@@ -1031,7 +1031,7 @@ Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendo
 
 Current source-synchronized README metrics:
 
-- **7770+ unit tests** across **606 test files**
+- **7773+ unit tests** across **606 test files**
 - i18n: **2942 keys × 19 locales**
 
 CI remains authoritative for actual pass/fail and live coverage.

--- a/README.md
+++ b/README.md
@@ -886,7 +886,7 @@ WorldScript-Studio/
 ├── locales/                 # Source locale trees
 ├── public/                  # PWA assets, manifest, SW, runtime locale bundles
 ├── tests/
-│   ├── unit/                # Vitest unit tests (7763+ tests, 606 files)
+│   ├── unit/                # Vitest unit tests (7763+ tests; file count includes package test directories)
 │   └── e2e/                 # Playwright
 ├── docs/                    # Canonical product/engineering documentation + ADRs
 ├── src-tauri/               # Tauri v2 desktop shell / Rust

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <img src="https://img.shields.io/badge/TypeScript-tsgo_native_preview-3178C6?logo=typescript&logoColor=white" alt="TypeScript native preview (tsgo)">
   <img src="https://img.shields.io/badge/Desktop-Tauri_2-FFC131?logo=tauri&logoColor=black" alt="Tauri 2">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7750%2B_%2F_606_files-22C55E" alt="7750+ tests / 606 files">
+  <img src="https://img.shields.io/badge/Tests-7754%2B_%2F_606_files-22C55E" alt="7754+ tests / 606 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github&label=CI" alt="CI status">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="MIT License">
@@ -809,7 +809,7 @@ The normal web PR pipeline is not the complete native release qualification surf
 | DOCX | `docx` + JSZip | Word-compatible export |
 | PWA | Service Worker + Web App Manifest | Offline shell/installability |
 | i18n | Custom React i18n context | 2942 keys × 19 locales |
-| Testing | Vitest 4.x (7750+ tests / 606 files) + Playwright | Unit/integration/E2E |
+| Testing | Vitest 4.x (7754+ tests / 606 files) + Playwright | Unit/integration/E2E |
 | Quality | Biome + tsgo + CodeQL/security tooling | Static and CI gates |
 | Desktop | Tauri 2 | Current native shell |
 
@@ -886,7 +886,7 @@ WorldScript-Studio/
 ├── locales/                 # Source locale trees
 ├── public/                  # PWA assets, manifest, SW, runtime locale bundles
 ├── tests/
-│   ├── unit/                # Vitest unit tests (7750+ tests, 606 files)
+│   ├── unit/                # Vitest unit tests (7754+ tests, 606 files)
 │   └── e2e/                 # Playwright
 ├── docs/                    # Canonical product/engineering documentation + ADRs
 ├── src-tauri/               # Tauri v2 desktop shell / Rust
@@ -1031,7 +1031,7 @@ Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendo
 
 Current source-synchronized README metrics:
 
-- **7750+ unit tests** across **606 test files**
+- **7754+ unit tests** across **606 test files**
 - i18n: **2942 keys × 19 locales**
 
 CI remains authoritative for actual pass/fail and live coverage.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <img src="https://img.shields.io/badge/TypeScript-tsgo_native_preview-3178C6?logo=typescript&logoColor=white" alt="TypeScript native preview (tsgo)">
   <img src="https://img.shields.io/badge/Desktop-Tauri_2-FFC131?logo=tauri&logoColor=black" alt="Tauri 2">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7754%2B_%2F_606_files-22C55E" alt="7754+ tests / 606 files">
+  <img src="https://img.shields.io/badge/Tests-7761%2B_%2F_606_files-22C55E" alt="7761+ tests / 606 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github&label=CI" alt="CI status">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="MIT License">
@@ -809,7 +809,7 @@ The normal web PR pipeline is not the complete native release qualification surf
 | DOCX | `docx` + JSZip | Word-compatible export |
 | PWA | Service Worker + Web App Manifest | Offline shell/installability |
 | i18n | Custom React i18n context | 2942 keys × 19 locales |
-| Testing | Vitest 4.x (7754+ tests / 606 files) + Playwright | Unit/integration/E2E |
+| Testing | Vitest 4.x (7761+ tests / 606 files) + Playwright | Unit/integration/E2E |
 | Quality | Biome + tsgo + CodeQL/security tooling | Static and CI gates |
 | Desktop | Tauri 2 | Current native shell |
 
@@ -886,7 +886,7 @@ WorldScript-Studio/
 ├── locales/                 # Source locale trees
 ├── public/                  # PWA assets, manifest, SW, runtime locale bundles
 ├── tests/
-│   ├── unit/                # Vitest unit tests (7754+ tests, 606 files)
+│   ├── unit/                # Vitest unit tests (7761+ tests, 606 files)
 │   └── e2e/                 # Playwright
 ├── docs/                    # Canonical product/engineering documentation + ADRs
 ├── src-tauri/               # Tauri v2 desktop shell / Rust
@@ -1031,7 +1031,7 @@ Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendo
 
 Current source-synchronized README metrics:
 
-- **7754+ unit tests** across **606 test files**
+- **7761+ unit tests** across **606 test files**
 - i18n: **2942 keys × 19 locales**
 
 CI remains authoritative for actual pass/fail and live coverage.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <img src="https://img.shields.io/badge/TypeScript-tsgo_native_preview-3178C6?logo=typescript&logoColor=white" alt="TypeScript native preview (tsgo)">
   <img src="https://img.shields.io/badge/Desktop-Tauri_2-FFC131?logo=tauri&logoColor=black" alt="Tauri 2">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7767%2B_%2F_606_files-22C55E" alt="7767+ tests / 606 files">
+  <img src="https://img.shields.io/badge/Tests-7770%2B_%2F_606_files-22C55E" alt="7770+ tests / 606 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github&label=CI" alt="CI status">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="MIT License">
@@ -809,7 +809,7 @@ The normal web PR pipeline is not the complete native release qualification surf
 | DOCX | `docx` + JSZip | Word-compatible export |
 | PWA | Service Worker + Web App Manifest | Offline shell/installability |
 | i18n | Custom React i18n context | 2942 keys × 19 locales |
-| Testing | Vitest 4.x (7767+ tests / 606 files) + Playwright | Unit/integration/E2E |
+| Testing | Vitest 4.x (7770+ tests / 606 files) + Playwright | Unit/integration/E2E |
 | Quality | Biome + tsgo + CodeQL/security tooling | Static and CI gates |
 | Desktop | Tauri 2 | Current native shell |
 
@@ -886,7 +886,7 @@ WorldScript-Studio/
 ├── locales/                 # Source locale trees
 ├── public/                  # PWA assets, manifest, SW, runtime locale bundles
 ├── tests/
-│   ├── unit/                # Vitest unit tests (7767+ tests; file count includes package test directories)
+│   ├── unit/                # Vitest unit tests (7770+ tests; file count includes package test directories)
 │   └── e2e/                 # Playwright
 ├── docs/                    # Canonical product/engineering documentation + ADRs
 ├── src-tauri/               # Tauri v2 desktop shell / Rust
@@ -1031,7 +1031,7 @@ Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendo
 
 Current source-synchronized README metrics:
 
-- **7767+ unit tests** across **606 test files**
+- **7770+ unit tests** across **606 test files**
 - i18n: **2942 keys × 19 locales**
 
 CI remains authoritative for actual pass/fail and live coverage.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <img src="https://img.shields.io/badge/TypeScript-tsgo_native_preview-3178C6?logo=typescript&logoColor=white" alt="TypeScript native preview (tsgo)">
   <img src="https://img.shields.io/badge/Desktop-Tauri_2-FFC131?logo=tauri&logoColor=black" alt="Tauri 2">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7763%2B_%2F_606_files-22C55E" alt="7763+ tests / 606 files">
+  <img src="https://img.shields.io/badge/Tests-7765%2B_%2F_606_files-22C55E" alt="7765+ tests / 606 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github&label=CI" alt="CI status">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="MIT License">
@@ -809,7 +809,7 @@ The normal web PR pipeline is not the complete native release qualification surf
 | DOCX | `docx` + JSZip | Word-compatible export |
 | PWA | Service Worker + Web App Manifest | Offline shell/installability |
 | i18n | Custom React i18n context | 2942 keys × 19 locales |
-| Testing | Vitest 4.x (7763+ tests / 606 files) + Playwright | Unit/integration/E2E |
+| Testing | Vitest 4.x (7765+ tests / 606 files) + Playwright | Unit/integration/E2E |
 | Quality | Biome + tsgo + CodeQL/security tooling | Static and CI gates |
 | Desktop | Tauri 2 | Current native shell |
 
@@ -886,7 +886,7 @@ WorldScript-Studio/
 ├── locales/                 # Source locale trees
 ├── public/                  # PWA assets, manifest, SW, runtime locale bundles
 ├── tests/
-│   ├── unit/                # Vitest unit tests (7763+ tests; file count includes package test directories)
+│   ├── unit/                # Vitest unit tests (7765+ tests; file count includes package test directories)
 │   └── e2e/                 # Playwright
 ├── docs/                    # Canonical product/engineering documentation + ADRs
 ├── src-tauri/               # Tauri v2 desktop shell / Rust
@@ -1031,7 +1031,7 @@ Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendo
 
 Current source-synchronized README metrics:
 
-- **7763+ unit tests** across **606 test files**
+- **7765+ unit tests** across **606 test files**
 - i18n: **2942 keys × 19 locales**
 
 CI remains authoritative for actual pass/fail and live coverage.

--- a/app/listenerMiddleware.ts
+++ b/app/listenerMiddleware.ts
@@ -359,6 +359,7 @@ addDebouncedListener(
 listenerMiddleware.startListening({
   matcher: isRejected,
   effect: (action, listenerApi) => {
+    // QNBS-v3: stale results are expected after a project switch and must not become user-facing failures.
     if (action.meta.aborted || isStaleProjectOperationRejection(action)) return;
 
     let errorDescription = action.error?.message ?? 'An unexpected error occurred.';

--- a/app/listenerMiddleware.ts
+++ b/app/listenerMiddleware.ts
@@ -359,7 +359,7 @@ addDebouncedListener(
 listenerMiddleware.startListening({
   matcher: isRejected,
   effect: (action, listenerApi) => {
-    // QNBS-v3: stale results are expected after a project switch and must not become user-facing failures.
+    // QNBS-v3: [Expected stale rejection / Suppress false failure notifications / Keep project switches quiet]
     if (action.meta.aborted || isStaleProjectOperationRejection(action)) return;
 
     let errorDescription = action.error?.message ?? 'An unexpected error occurred.';

--- a/app/listenerMiddleware.ts
+++ b/app/listenerMiddleware.ts
@@ -3,7 +3,7 @@ import { createListenerMiddleware, isRejected } from '@reduxjs/toolkit';
 import { analyticsActions } from '../features/analytics/analyticsSlice';
 // QNBS-v3: canonical selector — replaces a local type that misapplied the persisted-state shape to the live store
 import { proForgeActions } from '../features/proForge/proForgeSlice';
-import { STALE_PROJECT_OPERATION_ERROR_NAME } from '../features/project/projectIdentity';
+import { isStaleProjectOperationError } from '../features/project/projectIdentity';
 import { selectProjectData } from '../features/project/projectSelectors';
 import type { ProjectData } from '../features/project/projectSlice';
 import { statusActions } from '../features/status/statusSlice';
@@ -377,8 +377,8 @@ listenerMiddleware.startListening({
   },
 });
 
-function isStaleProjectOperationRejection(action: { error?: { name?: string } }): boolean {
-  return action.error?.name === STALE_PROJECT_OPERATION_ERROR_NAME;
+function isStaleProjectOperationRejection(action: { error?: unknown }): boolean {
+  return isStaleProjectOperationError(action.error);
 }
 
 listenerMiddleware.startListening({

--- a/app/listenerMiddleware.ts
+++ b/app/listenerMiddleware.ts
@@ -359,7 +359,7 @@ addDebouncedListener(
 listenerMiddleware.startListening({
   matcher: isRejected,
   effect: (action, listenerApi) => {
-    // QNBS-v3: [Expected stale rejection / Suppress false failure notifications / Keep project switches quiet]
+    // QNBS-v3: [Grund: expected stale rejection / Impact: suppress false failure notifications / Kreativer Mehrwert: keep project switches quiet]
     if (action.meta.aborted || isStaleProjectOperationRejection(action)) return;
 
     let errorDescription = action.error?.message ?? 'An unexpected error occurred.';

--- a/app/listenerMiddleware.ts
+++ b/app/listenerMiddleware.ts
@@ -359,8 +359,7 @@ addDebouncedListener(
 listenerMiddleware.startListening({
   matcher: isRejected,
   effect: (action, listenerApi) => {
-    if (action.meta.aborted) return;
-    if (action.error?.name === STALE_PROJECT_OPERATION_ERROR_NAME) return;
+    if (action.meta.aborted || isStaleProjectOperationRejection(action)) return;
 
     let errorDescription = action.error?.message ?? 'An unexpected error occurred.';
     if (errorDescription.includes('quota') || errorDescription.includes('API key')) {
@@ -376,6 +375,10 @@ listenerMiddleware.startListening({
     );
   },
 });
+
+function isStaleProjectOperationRejection(action: { error?: { name?: string } }): boolean {
+  return action.error?.name === STALE_PROJECT_OPERATION_ERROR_NAME;
+}
 
 listenerMiddleware.startListening({
   predicate: (_action, currentState, previousState) => {

--- a/app/listenerMiddleware.ts
+++ b/app/listenerMiddleware.ts
@@ -3,6 +3,7 @@ import { createListenerMiddleware, isRejected } from '@reduxjs/toolkit';
 import { analyticsActions } from '../features/analytics/analyticsSlice';
 // QNBS-v3: canonical selector — replaces a local type that misapplied the persisted-state shape to the live store
 import { proForgeActions } from '../features/proForge/proForgeSlice';
+import { STALE_PROJECT_OPERATION_ERROR_NAME } from '../features/project/projectIdentity';
 import { selectProjectData } from '../features/project/projectSelectors';
 import type { ProjectData } from '../features/project/projectSlice';
 import { statusActions } from '../features/status/statusSlice';
@@ -359,6 +360,7 @@ listenerMiddleware.startListening({
   matcher: isRejected,
   effect: (action, listenerApi) => {
     if (action.meta.aborted) return;
+    if (action.error?.name === STALE_PROJECT_OPERATION_ERROR_NAME) return;
 
     let errorDescription = action.error?.message ?? 'An unexpected error occurred.';
     if (errorDescription.includes('quota') || errorDescription.includes('API key')) {

--- a/components/CharacterView.tsx
+++ b/components/CharacterView.tsx
@@ -43,6 +43,36 @@ const loadStoredCharacterImage = async (id: string, projectId: string): Promise<
     : null;
 };
 
+const startCharacterImageLoad = ({
+  id,
+  hasImage,
+  projectId,
+  projectIdentity,
+  setImageUrl,
+}: {
+  id: string | undefined;
+  hasImage: boolean | undefined;
+  projectId: string;
+  projectIdentity: string | null;
+  setImageUrl: (imageUrl: string | null) => void;
+}): (() => void) => {
+  setImageUrl(null);
+  if (!id || !hasImage || !projectIdentity) return () => {};
+
+  let isMounted = true;
+  void loadStoredCharacterImage(id, projectId)
+    .then((image) => {
+      if (isMounted) setImageUrl(image);
+    })
+    .catch((error) => {
+      // QNBS-v3: an unavailable image must retain the placeholder instead of causing an unhandled async rejection.
+      logger.warn('Failed to load character image', { error: String(error) });
+    });
+  return () => {
+    isMounted = false;
+  };
+};
+
 const useStoredImage = (id: string | undefined, hasImage: boolean | undefined) => {
   const projectId = useAppSelector(
     (state) => getProjectTargetStorageId(state.project?.present) ?? 'default',
@@ -51,31 +81,10 @@ const useStoredImage = (id: string | undefined, hasImage: boolean | undefined) =
     getProjectTargetIdentity(state.project?.present),
   );
   const [imageUrl, setImageUrl] = useState<string | null>(null);
-  useEffect(() => {
-    setImageUrl(null); // Reset on change
-    if (!id || !hasImage) {
-      return;
-    }
-    if (!projectIdentity) {
-      return;
-    }
-    let isMounted = true;
-    const fetchImage = async () => {
-      try {
-        const image = await loadStoredCharacterImage(id, projectId);
-        if (isMounted && image) {
-          setImageUrl(image);
-        }
-      } catch (error) {
-        // QNBS-v3: an unavailable image must retain the placeholder instead of causing an unhandled async rejection.
-        logger.warn('Failed to load character image', { error: String(error) });
-      }
-    };
-    fetchImage();
-    return () => {
-      isMounted = false;
-    };
-  }, [id, hasImage, projectId, projectIdentity]);
+  useEffect(
+    () => startCharacterImageLoad({ id, hasImage, projectId, projectIdentity, setImageUrl }),
+    [id, hasImage, projectId, projectIdentity],
+  );
   return imageUrl;
 };
 

--- a/components/CharacterView.tsx
+++ b/components/CharacterView.tsx
@@ -36,15 +36,18 @@ import { Spinner } from './ui/Spinner';
 // QNBS-v3: reads through the selected backend so Tauri uploads and views use the same storage location.
 const useStoredImage = (id: string | undefined, hasImage: boolean | undefined) => {
   const projectId = useAppSelector(
-    (state) => getProjectTargetStorageId(state.project.present) ?? 'default',
+    (state) => getProjectTargetStorageId(state.project?.present) ?? 'default',
   );
   const projectIdentity = useAppSelector((state) =>
-    getProjectTargetIdentity(state.project.present),
+    getProjectTargetIdentity(state.project?.present),
   );
   const [imageUrl, setImageUrl] = useState<string | null>(null);
   useEffect(() => {
     setImageUrl(null); // Reset on change
-    if (!id || !hasImage || !projectIdentity) {
+    if (!id || !hasImage) {
+      return;
+    }
+    if (!projectIdentity) {
       return;
     }
     let isMounted = true;

--- a/components/CharacterView.tsx
+++ b/components/CharacterView.tsx
@@ -64,9 +64,7 @@ const startCharacterImageLoad = ({
   let isMounted = true;
   void loadStoredCharacterImage(id, projectId)
     .then((image) => {
-      const isCurrentProject =
-        projectIdentity === null ||
-        identityUnchanged(projectIdentity, captureActiveProjectIdentity());
+      const isCurrentProject = identityUnchanged(projectIdentity, captureActiveProjectIdentity());
       if (isMounted && isCurrentProject) setImageUrl(image);
     })
     .catch((error) => {

--- a/components/CharacterView.tsx
+++ b/components/CharacterView.tsx
@@ -34,6 +34,15 @@ import { Select } from './ui/Select';
 import { Spinner } from './ui/Spinner';
 
 // QNBS-v3: reads through the selected backend so Tauri uploads and views use the same storage location.
+const loadStoredCharacterImage = async (id: string, projectId: string): Promise<string | null> => {
+  const image = await storageService.getImage(id, projectId);
+  return image
+    ? image.startsWith('data:image/')
+      ? image
+      : `data:image/png;base64,${image}`
+    : null;
+};
+
 const useStoredImage = (id: string | undefined, hasImage: boolean | undefined) => {
   const projectId = useAppSelector(
     (state) => getProjectTargetStorageId(state.project?.present) ?? 'default',
@@ -53,10 +62,9 @@ const useStoredImage = (id: string | undefined, hasImage: boolean | undefined) =
     let isMounted = true;
     const fetchImage = async () => {
       try {
-        // QNBS-v3: passes projectId so the lookup resolves the project-qualified key, not a bare entity id shared across projects.
-        const image = await storageService.getImage(id, projectId);
+        const image = await loadStoredCharacterImage(id, projectId);
         if (isMounted && image) {
-          setImageUrl(image.startsWith('data:image/') ? image : `data:image/png;base64,${image}`);
+          setImageUrl(image);
         }
       } catch (error) {
         // QNBS-v3: an unavailable image must retain the placeholder instead of causing an unhandled async rejection.

--- a/components/CharacterView.tsx
+++ b/components/CharacterView.tsx
@@ -3,7 +3,10 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useAppDispatch, useAppSelector } from '../app/hooks';
 import { ICONS } from '../constants';
 import { CharacterViewContext, useCharacterViewContext } from '../contexts/CharacterViewContext';
-import { selectProjectData } from '../features/project/projectSelectors';
+import {
+  getProjectTargetIdentity,
+  getProjectTargetStorageId,
+} from '../features/project/projectIdentity';
 import { uploadCharacterImageThunk } from '../features/project/thunks/characterThunks';
 import { useCharacterView } from '../hooks/useCharacterView';
 import { logger } from '../services/logger';
@@ -32,11 +35,16 @@ import { Spinner } from './ui/Spinner';
 
 // QNBS-v3: reads through the selected backend so Tauri uploads and views use the same storage location.
 const useStoredImage = (id: string | undefined, hasImage: boolean | undefined) => {
-  const projectId = useAppSelector((state) => selectProjectData(state)?.id || 'default');
+  const projectId = useAppSelector(
+    (state) => getProjectTargetStorageId(state.project.present) ?? 'default',
+  );
+  const projectIdentity = useAppSelector((state) =>
+    getProjectTargetIdentity(state.project.present),
+  );
   const [imageUrl, setImageUrl] = useState<string | null>(null);
   useEffect(() => {
     setImageUrl(null); // Reset on change
-    if (!id || !hasImage) {
+    if (!id || !hasImage || !projectIdentity) {
       return;
     }
     let isMounted = true;
@@ -56,7 +64,7 @@ const useStoredImage = (id: string | undefined, hasImage: boolean | undefined) =
     return () => {
       isMounted = false;
     };
-  }, [id, hasImage, projectId]);
+  }, [id, hasImage, projectId, projectIdentity]);
   return imageUrl;
 };
 

--- a/components/CharacterView.tsx
+++ b/components/CharacterView.tsx
@@ -4,8 +4,10 @@ import { useAppDispatch, useAppSelector } from '../app/hooks';
 import { ICONS } from '../constants';
 import { CharacterViewContext, useCharacterViewContext } from '../contexts/CharacterViewContext';
 import {
+  captureActiveProjectIdentity,
   getProjectTargetIdentity,
   getProjectTargetStorageId,
+  identityUnchanged,
 } from '../features/project/projectIdentity';
 import { uploadCharacterImageThunk } from '../features/project/thunks/characterThunks';
 import { useCharacterView } from '../hooks/useCharacterView';
@@ -59,11 +61,13 @@ const startCharacterImageLoad = ({
   setImageUrl(null);
   if (!id || !hasImage) return () => {};
 
-  const loadScopeKey = projectIdentity ?? projectId;
   let isMounted = true;
   void loadStoredCharacterImage(id, projectId)
     .then((image) => {
-      if (isMounted && loadScopeKey) setImageUrl(image);
+      const isCurrentProject =
+        projectIdentity === null ||
+        identityUnchanged(projectIdentity, captureActiveProjectIdentity());
+      if (isMounted && isCurrentProject) setImageUrl(image);
     })
     .catch((error) => {
       // QNBS-v3: an unavailable image must retain the placeholder instead of causing an unhandled async rejection.

--- a/components/CharacterView.tsx
+++ b/components/CharacterView.tsx
@@ -57,12 +57,13 @@ const startCharacterImageLoad = ({
   setImageUrl: (imageUrl: string | null) => void;
 }): (() => void) => {
   setImageUrl(null);
-  if (!id || !hasImage || !projectIdentity) return () => {};
+  if (!id || !hasImage) return () => {};
 
+  const loadScopeKey = projectIdentity ?? projectId;
   let isMounted = true;
   void loadStoredCharacterImage(id, projectId)
     .then((image) => {
-      if (isMounted) setImageUrl(image);
+      if (isMounted && loadScopeKey) setImageUrl(image);
     })
     .catch((error) => {
       // QNBS-v3: an unavailable image must retain the placeholder instead of causing an unhandled async rejection.

--- a/components/WorldView.tsx
+++ b/components/WorldView.tsx
@@ -43,6 +43,36 @@ const loadStoredWorldImage = async (id: string, projectId: string): Promise<stri
     : null;
 };
 
+const startWorldImageLoad = ({
+  id,
+  hasImage,
+  projectId,
+  projectIdentity,
+  setImageUrl,
+}: {
+  id: string | undefined;
+  hasImage: boolean | undefined;
+  projectId: string;
+  projectIdentity: string | null;
+  setImageUrl: (imageUrl: string | null) => void;
+}): (() => void) => {
+  setImageUrl(null);
+  if (!id || !hasImage || !projectIdentity) return () => {};
+
+  let isMounted = true;
+  void loadStoredWorldImage(id, projectId)
+    .then((image) => {
+      if (isMounted) setImageUrl(image);
+    })
+    .catch((error) => {
+      // QNBS-v3: an unavailable image must retain the placeholder instead of causing an unhandled async rejection.
+      logger.warn('Failed to load world image', { error: String(error) });
+    });
+  return () => {
+    isMounted = false;
+  };
+};
+
 const useStoredImage = (id: string | undefined, hasImage: boolean | undefined) => {
   const projectId = useAppSelector(
     (state) => getProjectTargetStorageId(state.project?.present) ?? 'default',
@@ -51,31 +81,10 @@ const useStoredImage = (id: string | undefined, hasImage: boolean | undefined) =
     getProjectTargetIdentity(state.project?.present),
   );
   const [imageUrl, setImageUrl] = useState<string | null>(null);
-  useEffect(() => {
-    setImageUrl(null); // Reset on change
-    if (!id || !hasImage) {
-      return;
-    }
-    if (!projectIdentity) {
-      return;
-    }
-    let isMounted = true;
-    const fetchImage = async () => {
-      try {
-        const image = await loadStoredWorldImage(id, projectId);
-        if (isMounted && image) {
-          setImageUrl(image);
-        }
-      } catch (error) {
-        // QNBS-v3: an unavailable image must retain the placeholder instead of causing an unhandled async rejection.
-        logger.warn('Failed to load world image', { error: String(error) });
-      }
-    };
-    fetchImage();
-    return () => {
-      isMounted = false;
-    };
-  }, [id, hasImage, projectId, projectIdentity]);
+  useEffect(
+    () => startWorldImageLoad({ id, hasImage, projectId, projectIdentity, setImageUrl }),
+    [id, hasImage, projectId, projectIdentity],
+  );
   return imageUrl;
 };
 

--- a/components/WorldView.tsx
+++ b/components/WorldView.tsx
@@ -57,12 +57,13 @@ const startWorldImageLoad = ({
   setImageUrl: (imageUrl: string | null) => void;
 }): (() => void) => {
   setImageUrl(null);
-  if (!id || !hasImage || !projectIdentity) return () => {};
+  if (!id || !hasImage) return () => {};
 
+  const loadScopeKey = projectIdentity ?? projectId;
   let isMounted = true;
   void loadStoredWorldImage(id, projectId)
     .then((image) => {
-      if (isMounted) setImageUrl(image);
+      if (isMounted && loadScopeKey) setImageUrl(image);
     })
     .catch((error) => {
       // QNBS-v3: an unavailable image must retain the placeholder instead of causing an unhandled async rejection.

--- a/components/WorldView.tsx
+++ b/components/WorldView.tsx
@@ -34,6 +34,15 @@ import { Spinner } from './ui/Spinner';
 import { Textarea } from './ui/Textarea';
 
 // QNBS-v3: reads through the selected backend so Tauri uploads and views use the same storage location.
+const loadStoredWorldImage = async (id: string, projectId: string): Promise<string | null> => {
+  const image = await storageService.getImage(id, projectId);
+  return image
+    ? image.startsWith('data:image/')
+      ? image
+      : `data:image/png;base64,${image}`
+    : null;
+};
+
 const useStoredImage = (id: string | undefined, hasImage: boolean | undefined) => {
   const projectId = useAppSelector(
     (state) => getProjectTargetStorageId(state.project?.present) ?? 'default',
@@ -53,10 +62,9 @@ const useStoredImage = (id: string | undefined, hasImage: boolean | undefined) =
     let isMounted = true;
     const fetchImage = async () => {
       try {
-        // QNBS-v3: passes projectId so the lookup resolves the project-qualified key, not a bare entity id shared across projects.
-        const image = await storageService.getImage(id, projectId);
+        const image = await loadStoredWorldImage(id, projectId);
         if (isMounted && image) {
-          setImageUrl(image.startsWith('data:image/') ? image : `data:image/png;base64,${image}`);
+          setImageUrl(image);
         }
       } catch (error) {
         // QNBS-v3: an unavailable image must retain the placeholder instead of causing an unhandled async rejection.

--- a/components/WorldView.tsx
+++ b/components/WorldView.tsx
@@ -64,9 +64,7 @@ const startWorldImageLoad = ({
   let isMounted = true;
   void loadStoredWorldImage(id, projectId)
     .then((image) => {
-      const isCurrentProject =
-        projectIdentity === null ||
-        identityUnchanged(projectIdentity, captureActiveProjectIdentity());
+      const isCurrentProject = identityUnchanged(projectIdentity, captureActiveProjectIdentity());
       if (isMounted && isCurrentProject) setImageUrl(image);
     })
     .catch((error) => {

--- a/components/WorldView.tsx
+++ b/components/WorldView.tsx
@@ -36,15 +36,18 @@ import { Textarea } from './ui/Textarea';
 // QNBS-v3: reads through the selected backend so Tauri uploads and views use the same storage location.
 const useStoredImage = (id: string | undefined, hasImage: boolean | undefined) => {
   const projectId = useAppSelector(
-    (state) => getProjectTargetStorageId(state.project.present) ?? 'default',
+    (state) => getProjectTargetStorageId(state.project?.present) ?? 'default',
   );
   const projectIdentity = useAppSelector((state) =>
-    getProjectTargetIdentity(state.project.present),
+    getProjectTargetIdentity(state.project?.present),
   );
   const [imageUrl, setImageUrl] = useState<string | null>(null);
   useEffect(() => {
     setImageUrl(null); // Reset on change
-    if (!id || !hasImage || !projectIdentity) {
+    if (!id || !hasImage) {
+      return;
+    }
+    if (!projectIdentity) {
       return;
     }
     let isMounted = true;

--- a/components/WorldView.tsx
+++ b/components/WorldView.tsx
@@ -4,8 +4,10 @@ import { useAppDispatch, useAppSelector } from '../app/hooks';
 import { ICONS } from '../constants';
 import { useWorldViewContext, WorldViewContext } from '../contexts/WorldViewContext';
 import {
+  captureActiveProjectIdentity,
   getProjectTargetIdentity,
   getProjectTargetStorageId,
+  identityUnchanged,
 } from '../features/project/projectIdentity';
 import { uploadWorldImageThunk } from '../features/project/thunks/worldThunks';
 import { useWorldView } from '../hooks/useWorldView';
@@ -59,11 +61,13 @@ const startWorldImageLoad = ({
   setImageUrl(null);
   if (!id || !hasImage) return () => {};
 
-  const loadScopeKey = projectIdentity ?? projectId;
   let isMounted = true;
   void loadStoredWorldImage(id, projectId)
     .then((image) => {
-      if (isMounted && loadScopeKey) setImageUrl(image);
+      const isCurrentProject =
+        projectIdentity === null ||
+        identityUnchanged(projectIdentity, captureActiveProjectIdentity());
+      if (isMounted && isCurrentProject) setImageUrl(image);
     })
     .catch((error) => {
       // QNBS-v3: an unavailable image must retain the placeholder instead of causing an unhandled async rejection.

--- a/components/WorldView.tsx
+++ b/components/WorldView.tsx
@@ -3,7 +3,10 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useAppDispatch, useAppSelector } from '../app/hooks';
 import { ICONS } from '../constants';
 import { useWorldViewContext, WorldViewContext } from '../contexts/WorldViewContext';
-import { selectProjectData } from '../features/project/projectSelectors';
+import {
+  getProjectTargetIdentity,
+  getProjectTargetStorageId,
+} from '../features/project/projectIdentity';
 import { uploadWorldImageThunk } from '../features/project/thunks/worldThunks';
 import { useWorldView } from '../hooks/useWorldView';
 import { logger } from '../services/logger';
@@ -32,11 +35,16 @@ import { Textarea } from './ui/Textarea';
 
 // QNBS-v3: reads through the selected backend so Tauri uploads and views use the same storage location.
 const useStoredImage = (id: string | undefined, hasImage: boolean | undefined) => {
-  const projectId = useAppSelector((state) => selectProjectData(state)?.id || 'default');
+  const projectId = useAppSelector(
+    (state) => getProjectTargetStorageId(state.project.present) ?? 'default',
+  );
+  const projectIdentity = useAppSelector((state) =>
+    getProjectTargetIdentity(state.project.present),
+  );
   const [imageUrl, setImageUrl] = useState<string | null>(null);
   useEffect(() => {
     setImageUrl(null); // Reset on change
-    if (!id || !hasImage) {
+    if (!id || !hasImage || !projectIdentity) {
       return;
     }
     let isMounted = true;
@@ -56,7 +64,7 @@ const useStoredImage = (id: string | undefined, hasImage: boolean | undefined) =
     return () => {
       isMounted = false;
     };
-  }, [id, hasImage, projectId]);
+  }, [id, hasImage, projectId, projectIdentity]);
   return imageUrl;
 };
 

--- a/features/project/projectIdentity.ts
+++ b/features/project/projectIdentity.ts
@@ -45,6 +45,16 @@ export function getProjectTargetIdentity(
   return base === null ? null : `${base}:gen:${source.generation ?? 0}`;
 }
 
+// QNBS-v3: legacy directory identity is stable storage ownership, while the in-memory generation remains an async-operation fence only.
+export function getProjectTargetStorageId(
+  source: ProjectIdentitySource | null | undefined,
+): string | null {
+  if (!source) return null;
+  const base = baseTargetIdentity(source.data);
+  if (base === null) return null;
+  return base.startsWith('id:') ? base.slice('id:'.length) : base;
+}
+
 // QNBS-v3: reads the live store directly (not a React selector) so a hook can capture identity at dispatch time and re-check it after an await, independent of that hook's own render cycle.
 export function captureActiveProjectIdentity(): string | null {
   const state = appStoreRef.current?.getState();

--- a/features/project/projectIdentity.ts
+++ b/features/project/projectIdentity.ts
@@ -45,7 +45,7 @@ function baseTargetIdentity(project: unknown): string | null {
     : null;
 }
 
-// QNBS-v3: incorporates the in-memory generation counter, not just the persisted id -- a fresh "New Project" always reuses id:'default' until explicitly saved elsewhere, so id alone cannot distinguish two different reset/import/restore sessions.
+// QNBS-v3: [Generation fence / Reject same-ID stale mutations / Preserve project-incarnation ownership]
 export function getProjectTargetIdentity(
   source: ProjectIdentitySource | null | undefined,
 ): string | null {
@@ -54,7 +54,7 @@ export function getProjectTargetIdentity(
   return base === null ? null : `${base}:gen:${source.generation ?? 0}`;
 }
 
-// QNBS-v3: legacy directory identity is stable storage ownership, while the in-memory generation remains an async-operation fence only.
+// QNBS-v3: [Legacy directory identity / Keep storage owner stable / Preserve compatibility without generation aliases]
 export function getProjectTargetStorageId(
   source: ProjectIdentitySource | null | undefined,
 ): string | null {

--- a/features/project/projectIdentity.ts
+++ b/features/project/projectIdentity.ts
@@ -26,6 +26,15 @@ export class StaleProjectOperationError extends Error {
   }
 }
 
+export function isStaleProjectOperationError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'name' in error &&
+    error.name === STALE_PROJECT_OPERATION_ERROR_NAME
+  );
+}
+
 function baseTargetIdentity(project: unknown): string | null {
   if (typeof project !== 'object' || project === null) return null;
   const record = project as Record<string, unknown>;

--- a/features/project/projectIdentity.ts
+++ b/features/project/projectIdentity.ts
@@ -26,6 +26,7 @@ export class StaleProjectOperationError extends Error {
   }
 }
 
+// QNBS-v3: [Grund: serialized stale-error classification / Impact: suppress expected caller noise / Kreativer Mehrwert: keep global diagnostics actionable]
 export function isStaleProjectOperationError(error: unknown): boolean {
   return (
     typeof error === 'object' &&

--- a/features/project/projectIdentity.ts
+++ b/features/project/projectIdentity.ts
@@ -45,7 +45,7 @@ function baseTargetIdentity(project: unknown): string | null {
     : null;
 }
 
-// QNBS-v3: [Generation fence / Reject same-ID stale mutations / Preserve project-incarnation ownership]
+// QNBS-v3: [Grund: generation fence / Impact: reject same-ID stale mutations / Kreativer Mehrwert: preserve project-incarnation ownership]
 export function getProjectTargetIdentity(
   source: ProjectIdentitySource | null | undefined,
 ): string | null {
@@ -54,7 +54,7 @@ export function getProjectTargetIdentity(
   return base === null ? null : `${base}:gen:${source.generation ?? 0}`;
 }
 
-// QNBS-v3: [Legacy directory identity / Keep storage owner stable / Preserve compatibility without generation aliases]
+// QNBS-v3: [Grund: legacy directory identity / Impact: keep storage owner stable / Kreativer Mehrwert: preserve compatibility without aliases]
 export function getProjectTargetStorageId(
   source: ProjectIdentitySource | null | undefined,
 ): string | null {

--- a/features/project/projectIdentity.ts
+++ b/features/project/projectIdentity.ts
@@ -14,6 +14,18 @@ interface ProjectIdentitySource {
   generation?: number;
 }
 
+export const STALE_PROJECT_OPERATION_ERROR_NAME = 'StaleProjectOperationError';
+
+/** Error used when an async result can no longer prove that its origin project is active. */
+export class StaleProjectOperationError extends Error {
+  readonly code = 'STALE_PROJECT_OPERATION';
+
+  constructor(operation: string) {
+    super(`Discarded stale project operation: ${operation}`);
+    this.name = STALE_PROJECT_OPERATION_ERROR_NAME;
+  }
+}
+
 function baseTargetIdentity(project: unknown): string | null {
   if (typeof project !== 'object' || project === null) return null;
   const record = project as Record<string, unknown>;
@@ -42,4 +54,16 @@ export function captureActiveProjectIdentity(): string | null {
 // QNBS-v3: null means identity could not be determined -- fail closed (never "unchanged") so a guard never allows a mutation it can't actually prove is still targeting the right project.
 export function identityUnchanged(captured: string | null, live: string | null): boolean {
   return captured !== null && captured === live;
+}
+
+// QNBS-v3: centralizes the fail-closed throw so direct async project mutations produce one
+// serialized rejection and the global error listener can suppress stale-result noise.
+export function assertProjectIdentityUnchanged(
+  captured: string | null,
+  live: string | null,
+  operation: string,
+): void {
+  if (!identityUnchanged(captured, live)) {
+    throw new StaleProjectOperationError(operation);
+  }
 }

--- a/features/project/projectSlice.ts
+++ b/features/project/projectSlice.ts
@@ -1,5 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit';
 import { charactersAdapter, worldsAdapter } from './adapters';
+import { getProjectTargetIdentity, identityUnchanged } from './projectIdentity';
 import { initialState, type ProjectData } from './projectState';
 // QNBS-v3: Reducer cases are split into domain modules under ./reducers/* so this slice stays thin.
 // Action names, the `project/*` namespace, the single redux-undo wrapper (app/store.ts), and the
@@ -117,9 +118,18 @@ const projectSlice = createSlice({
           action,
         ): action is {
           type: 'project/streamInterviewChunk';
-          payload: { characterId: string; interviewId: string; aiMsgId: string; content: string };
+          payload: {
+            characterId: string;
+            interviewId: string;
+            aiMsgId: string;
+            content: string;
+            originIdentity: string;
+          };
         } => action.type === 'project/streamInterviewChunk',
         (state, action) => {
+          if (!identityUnchanged(action.payload.originIdentity, getProjectTargetIdentity(state))) {
+            return;
+          }
           const { characterId, interviewId, aiMsgId, content } = action.payload;
           const interviews = state.data.characterInterviews?.[characterId] ?? [];
           const interview = interviews.find((iv) => iv.id === interviewId);

--- a/features/project/projectSlice.ts
+++ b/features/project/projectSlice.ts
@@ -127,7 +127,7 @@ const projectSlice = createSlice({
           };
         } => action.type === 'project/streamInterviewChunk',
         (state, action) => {
-          // QNBS-v3: reject chunks from a replaced incarnation before they can mutate the active interview.
+          // QNBS-v3: [Origin chunk identity / Reject stale stream mutation / Preserve current-project interview state]
           if (!identityUnchanged(action.payload.originIdentity, getProjectTargetIdentity(state))) {
             return;
           }

--- a/features/project/projectSlice.ts
+++ b/features/project/projectSlice.ts
@@ -127,6 +127,7 @@ const projectSlice = createSlice({
           };
         } => action.type === 'project/streamInterviewChunk',
         (state, action) => {
+          // QNBS-v3: reject chunks from a replaced incarnation before they can mutate the active interview.
           if (!identityUnchanged(action.payload.originIdentity, getProjectTargetIdentity(state))) {
             return;
           }

--- a/features/project/projectSlice.ts
+++ b/features/project/projectSlice.ts
@@ -127,7 +127,7 @@ const projectSlice = createSlice({
           };
         } => action.type === 'project/streamInterviewChunk',
         (state, action) => {
-          // QNBS-v3: [Origin chunk identity / Reject stale stream mutation / Preserve current-project interview state]
+          // QNBS-v3: [Grund: origin chunk identity / Impact: reject stale stream mutation / Kreativer Mehrwert: preserve current-project interview state]
           if (!identityUnchanged(action.payload.originIdentity, getProjectTargetIdentity(state))) {
             return;
           }

--- a/features/project/thunks/characterThunks.ts
+++ b/features/project/thunks/characterThunks.ts
@@ -95,7 +95,7 @@ export const generateCharacterPortraitThunk = createDeduplicatedThunk(
       getProjectTargetIdentity((getState() as RootState).project.present),
       'character portrait generation before storage',
     );
-    // QNBS-v3: the backend must re-check incarnation authority at its final image-write point, not only before/after the asynchronous storage call.
+    // QNBS-v3: [Origin persistence authority / Reject stale writes at the backend boundary / Preserve portrait asset ownership]
     await storageService.saveImage(characterId, base64, projectId, () =>
       assertProjectIdentityUnchanged(
         originIdentity,
@@ -115,8 +115,10 @@ export const generateCharacterPortraitThunk = createDeduplicatedThunk(
 export const uploadCharacterImageThunk = createAsyncThunk(
   'project/uploadCharacterImage',
   async ({ characterId, file }: { characterId: string; file: File }, { getState }) => {
-    // QNBS-v3: threaded into saveImage so the stored key is project-qualified, not a bare entity id shared across projects.
-    const projectId = (getState() as RootState).project.present?.data?.id || 'default';
+    const state = getState() as RootState;
+    const originIdentity = getProjectTargetIdentity(state.project.present);
+    // QNBS-v3: [Origin storage owner / Keep upload/read namespaces aligned / Preserve legacy project visibility]
+    const projectId = getProjectTargetStorageId(state.project.present) ?? 'default';
     return new Promise<{ characterId: string }>((resolve, reject) => {
       const reader = new FileReader();
       // QNBS-v3: onload/onerror/onabort (not onloadend) plus Promise.catch(reject) so every terminal FileReader/saveImage outcome settles this Promise instead of leaving it pending.
@@ -126,10 +128,38 @@ export const uploadCharacterImageThunk = createAsyncThunk(
           reject(new Error('FileReader did not produce a string result'));
           return;
         }
+        // QNBS-v3: [MIME-preserving upload / Keep backend round-trips lossless / Preserve user-selected image format]
+        try {
+          assertProjectIdentityUnchanged(
+            originIdentity,
+            getProjectTargetIdentity((getState() as RootState).project.present),
+            'character image upload before storage',
+          );
+        } catch (error) {
+          reject(error);
+          return;
+        }
         // QNBS-v3: retain the data-URL MIME type so uploaded JPEG/WebP images survive filesystem round-trips.
         storageService
-          .saveImage(characterId, result, projectId)
-          .then(() => resolve({ characterId }))
+          .saveImage(characterId, result, projectId, () =>
+            assertProjectIdentityUnchanged(
+              originIdentity,
+              getProjectTargetIdentity((getState() as RootState).project.present),
+              'character image upload persistence',
+            ),
+          )
+          .then(() => {
+            try {
+              assertProjectIdentityUnchanged(
+                originIdentity,
+                getProjectTargetIdentity((getState() as RootState).project.present),
+                'character image upload completion',
+              );
+              resolve({ characterId });
+            } catch (error) {
+              reject(error);
+            }
+          })
           .catch(reject);
       };
       reader.onerror = () =>

--- a/features/project/thunks/characterThunks.ts
+++ b/features/project/thunks/characterThunks.ts
@@ -6,6 +6,7 @@ import type { CharacterHeuristicLabels } from '../../../services/ai/heuristicFal
 import { storageService } from '../../../services/storageService';
 import type { Character } from '../../../types';
 import { createDeduplicatedThunk } from '../aiThunkUtils';
+import { assertProjectIdentityUnchanged, getProjectTargetIdentity } from '../projectIdentity';
 import { buildAiCreativity, buildAiOptions, loadAiProvider, loadPrompts } from './thunkUtils';
 
 export const generateCharacterProfileThunk = createDeduplicatedThunk(
@@ -75,6 +76,7 @@ export const generateCharacterPortraitThunk = createDeduplicatedThunk(
   ) => {
     const fullDescription = style ? `${description}. Style: ${style}` : description;
     const state = getState() as RootState;
+    const originIdentity = getProjectTargetIdentity(state.project.present);
     // QNBS-v3: threaded into saveImage so the stored key is project-qualified, not a bare entity id shared across projects.
     const projectId = state.project.present?.data?.id || 'default';
     const aiOptions = buildAiOptions(state);
@@ -83,7 +85,17 @@ export const generateCharacterPortraitThunk = createDeduplicatedThunk(
     const { prompt } = getPrompts('characterPortrait', { description: fullDescription, lang });
     registerDuplicateRequest(prompt, 'characterPortrait');
     const base64 = await generateImage(prompt, aiOptions, signal);
+    assertProjectIdentityUnchanged(
+      originIdentity,
+      getProjectTargetIdentity((getState() as RootState).project.present),
+      'character portrait generation before storage',
+    );
     await storageService.saveImage(characterId, base64, projectId);
+    assertProjectIdentityUnchanged(
+      originIdentity,
+      getProjectTargetIdentity((getState() as RootState).project.present),
+      'character portrait generation after storage',
+    );
     return { characterId };
   },
 );

--- a/features/project/thunks/characterThunks.ts
+++ b/features/project/thunks/characterThunks.ts
@@ -6,7 +6,11 @@ import type { CharacterHeuristicLabels } from '../../../services/ai/heuristicFal
 import { storageService } from '../../../services/storageService';
 import type { Character } from '../../../types';
 import { createDeduplicatedThunk } from '../aiThunkUtils';
-import { assertProjectIdentityUnchanged, getProjectTargetIdentity } from '../projectIdentity';
+import {
+  assertProjectIdentityUnchanged,
+  getProjectTargetIdentity,
+  getProjectTargetStorageId,
+} from '../projectIdentity';
 import { buildAiCreativity, buildAiOptions, loadAiProvider, loadPrompts } from './thunkUtils';
 
 export const generateCharacterProfileThunk = createDeduplicatedThunk(
@@ -76,9 +80,10 @@ export const generateCharacterPortraitThunk = createDeduplicatedThunk(
   ) => {
     const fullDescription = style ? `${description}. Style: ${style}` : description;
     const state = getState() as RootState;
+    // QNBS-v3: capture the incarnation before generation so a same-ID replacement cannot inherit the result.
     const originIdentity = getProjectTargetIdentity(state.project.present);
     // QNBS-v3: threaded into saveImage so the stored key is project-qualified, not a bare entity id shared across projects.
-    const projectId = state.project.present?.data?.id || 'default';
+    const projectId = getProjectTargetStorageId(state.project.present) ?? 'default';
     const aiOptions = buildAiOptions(state);
     const { getPrompts } = await loadPrompts();
     const { generateImage } = await loadAiProvider();
@@ -90,7 +95,14 @@ export const generateCharacterPortraitThunk = createDeduplicatedThunk(
       getProjectTargetIdentity((getState() as RootState).project.present),
       'character portrait generation before storage',
     );
-    await storageService.saveImage(characterId, base64, projectId);
+    // QNBS-v3: the backend must re-check incarnation authority at its final image-write point, not only before/after the asynchronous storage call.
+    await storageService.saveImage(characterId, base64, projectId, () =>
+      assertProjectIdentityUnchanged(
+        originIdentity,
+        getProjectTargetIdentity((getState() as RootState).project.present),
+        'character portrait persistence',
+      ),
+    );
     assertProjectIdentityUnchanged(
       originIdentity,
       getProjectTargetIdentity((getState() as RootState).project.present),

--- a/features/project/thunks/interviewThunks.ts
+++ b/features/project/thunks/interviewThunks.ts
@@ -115,7 +115,7 @@ export const streamInterviewResponseThunk = createAsyncThunk(
         if (stale) return;
         const liveIdentity = getProjectTargetIdentity((getState() as RootState).project.present);
         if (!identityUnchanged(originIdentity, liveIdentity)) {
-          // QNBS-v3: [Origin stream identity / Reject late chunks / Preserve active interview ownership]
+          // QNBS-v3: [Grund: origin stream identity / Impact: reject late chunks / Kreativer Mehrwert: preserve active interview ownership]
           stale = true;
           return;
         }

--- a/features/project/thunks/interviewThunks.ts
+++ b/features/project/thunks/interviewThunks.ts
@@ -120,6 +120,7 @@ export const streamInterviewResponseThunk = createAsyncThunk(
         if (stale) return;
         const liveIdentity = getProjectTargetIdentity((getState() as RootState).project.present);
         if (!identityUnchanged(originIdentity, liveIdentity)) {
+          // QNBS-v3: stop accepting chunks as soon as the originating project incarnation is replaced.
           stale = true;
           return;
         }
@@ -149,6 +150,12 @@ export const streamInterviewResponseThunk = createAsyncThunk(
     );
 
     if (stale) throw new StaleProjectOperationError('character interview stream');
+    // QNBS-v3: a stream can finish without another chunk after a project switch, so completion needs its own authority check.
+    assertProjectIdentityUnchanged(
+      originIdentity,
+      getProjectTargetIdentity((getState() as RootState).project.present),
+      'character interview stream completion',
+    );
 
     void aiOptions; // aiOptions used in future multi-provider path
     return { characterId, interviewId, aiMsgId, content: accumulated };

--- a/features/project/thunks/interviewThunks.ts
+++ b/features/project/thunks/interviewThunks.ts
@@ -3,6 +3,12 @@ import { v4 as uuidv4 } from 'uuid';
 import type { RootState } from '../../../app/store';
 import { streamText } from '../../../services/geminiService';
 import type { CharacterArchetype, CharacterInterview, InterviewMessage } from '../../../types';
+import {
+  assertProjectIdentityUnchanged,
+  getProjectTargetIdentity,
+  identityUnchanged,
+  StaleProjectOperationError,
+} from '../projectIdentity';
 import { selectAllCharacters } from '../projectSelectors';
 import { projectActions } from '../projectSlice';
 import { buildAiCreativity, buildAiOptions } from './thunkUtils';
@@ -55,6 +61,12 @@ export const streamInterviewResponseThunk = createAsyncThunk(
   ) => {
     const state = getState() as RootState;
     const { characterId, interviewId, question } = params;
+    const originIdentity = getProjectTargetIdentity(state.project.present);
+    assertProjectIdentityUnchanged(
+      originIdentity,
+      getProjectTargetIdentity(state.project.present),
+      'character interview start',
+    );
 
     const characters = selectAllCharacters(state);
     const character = characters.find((c) => c.id === characterId);
@@ -100,10 +112,17 @@ export const streamInterviewResponseThunk = createAsyncThunk(
     });
 
     let accumulated = '';
+    let stale = false;
     await streamText(
       prompt,
       creativity,
       (chunk) => {
+        if (stale) return;
+        const liveIdentity = getProjectTargetIdentity((getState() as RootState).project.present);
+        if (!identityUnchanged(originIdentity, liveIdentity)) {
+          stale = true;
+          return;
+        }
         accumulated += chunk;
         // QNBS-v3: update the AI message in place via updateCharacterInterview to avoid N dispatches
         dispatch(
@@ -117,11 +136,19 @@ export const streamInterviewResponseThunk = createAsyncThunk(
         // We re-dispatch a synthetic update to keep Redux as the single source of truth
         dispatch({
           type: 'project/streamInterviewChunk',
-          payload: { characterId, interviewId, aiMsgId, content: accumulated },
+          payload: {
+            characterId,
+            interviewId,
+            aiMsgId,
+            content: accumulated,
+            originIdentity,
+          },
         });
       },
       signal,
     );
+
+    if (stale) throw new StaleProjectOperationError('character interview stream');
 
     void aiOptions; // aiOptions used in future multi-provider path
     return { characterId, interviewId, aiMsgId, content: accumulated };

--- a/features/project/thunks/interviewThunks.ts
+++ b/features/project/thunks/interviewThunks.ts
@@ -62,11 +62,6 @@ export const streamInterviewResponseThunk = createAsyncThunk(
     const state = getState() as RootState;
     const { characterId, interviewId, question } = params;
     const originIdentity = getProjectTargetIdentity(state.project.present);
-    assertProjectIdentityUnchanged(
-      originIdentity,
-      getProjectTargetIdentity(state.project.present),
-      'character interview start',
-    );
 
     const characters = selectAllCharacters(state);
     const character = characters.find((c) => c.id === characterId);
@@ -120,7 +115,7 @@ export const streamInterviewResponseThunk = createAsyncThunk(
         if (stale) return;
         const liveIdentity = getProjectTargetIdentity((getState() as RootState).project.present);
         if (!identityUnchanged(originIdentity, liveIdentity)) {
-          // QNBS-v3: stop accepting chunks as soon as the originating project incarnation is replaced.
+          // QNBS-v3: [Origin stream identity / Reject late chunks / Preserve active interview ownership]
           stale = true;
           return;
         }

--- a/features/project/thunks/worldThunks.ts
+++ b/features/project/thunks/worldThunks.ts
@@ -88,7 +88,7 @@ export const generateWorldImageThunk = createDeduplicatedThunk(
       getProjectTargetIdentity((getState() as RootState).project.present),
       'world image generation before storage',
     );
-    // QNBS-v3: the backend must re-check incarnation authority at its final image-write point, not only before/after the asynchronous storage call.
+    // QNBS-v3: [Origin persistence authority / Reject stale writes at the backend boundary / Preserve world asset ownership]
     await storageService.saveImage(worldId, base64, projectId, () =>
       assertProjectIdentityUnchanged(
         originIdentity,
@@ -108,8 +108,10 @@ export const generateWorldImageThunk = createDeduplicatedThunk(
 export const uploadWorldImageThunk = createAsyncThunk(
   'project/uploadWorldImage',
   async ({ worldId, file }: { worldId: string; file: File }, { getState }) => {
-    // QNBS-v3: threaded into saveImage so the stored key is project-qualified, not a bare entity id shared across projects.
-    const projectId = (getState() as RootState).project.present?.data?.id || 'default';
+    const state = getState() as RootState;
+    const originIdentity = getProjectTargetIdentity(state.project.present);
+    // QNBS-v3: [Origin storage owner / Keep upload/read namespaces aligned / Preserve legacy project visibility]
+    const projectId = getProjectTargetStorageId(state.project.present) ?? 'default';
     return new Promise<{ worldId: string }>((resolve, reject) => {
       const reader = new FileReader();
       // QNBS-v3: onload/onerror/onabort (not onloadend) plus Promise.catch(reject) so every terminal FileReader/saveImage outcome settles this Promise instead of leaving it pending.
@@ -119,10 +121,38 @@ export const uploadWorldImageThunk = createAsyncThunk(
           reject(new Error('FileReader did not produce a string result'));
           return;
         }
+        // QNBS-v3: [MIME-preserving upload / Keep backend round-trips lossless / Preserve user-selected image format]
+        try {
+          assertProjectIdentityUnchanged(
+            originIdentity,
+            getProjectTargetIdentity((getState() as RootState).project.present),
+            'world image upload before storage',
+          );
+        } catch (error) {
+          reject(error);
+          return;
+        }
         // QNBS-v3: retain the data-URL MIME type so uploaded JPEG/WebP images survive filesystem round-trips.
         storageService
-          .saveImage(worldId, result, projectId)
-          .then(() => resolve({ worldId }))
+          .saveImage(worldId, result, projectId, () =>
+            assertProjectIdentityUnchanged(
+              originIdentity,
+              getProjectTargetIdentity((getState() as RootState).project.present),
+              'world image upload persistence',
+            ),
+          )
+          .then(() => {
+            try {
+              assertProjectIdentityUnchanged(
+                originIdentity,
+                getProjectTargetIdentity((getState() as RootState).project.present),
+                'world image upload completion',
+              );
+              resolve({ worldId });
+            } catch (error) {
+              reject(error);
+            }
+          })
           .catch(reject);
       };
       reader.onerror = () =>

--- a/features/project/thunks/worldThunks.ts
+++ b/features/project/thunks/worldThunks.ts
@@ -88,7 +88,7 @@ export const generateWorldImageThunk = createDeduplicatedThunk(
       getProjectTargetIdentity((getState() as RootState).project.present),
       'world image generation before storage',
     );
-    // QNBS-v3: [Origin persistence authority / Reject stale writes at the backend boundary / Preserve world asset ownership]
+    // QNBS-v3: [Grund: origin persistence authority / Impact: reject stale writes at backend boundary / Kreativer Mehrwert: preserve world asset ownership]
     await storageService.saveImage(worldId, base64, projectId, () =>
       assertProjectIdentityUnchanged(
         originIdentity,

--- a/features/project/thunks/worldThunks.ts
+++ b/features/project/thunks/worldThunks.ts
@@ -5,6 +5,7 @@ import type { WorldHeuristicLabels } from '../../../services/ai/heuristicFallbac
 import { storageService } from '../../../services/storageService';
 import type { World } from '../../../types';
 import { createDeduplicatedThunk } from '../aiThunkUtils';
+import { assertProjectIdentityUnchanged, getProjectTargetIdentity } from '../projectIdentity';
 import { buildAiCreativity, buildAiOptions, loadAiProvider, loadPrompts } from './thunkUtils';
 
 export const generateWorldProfileThunk = createDeduplicatedThunk(
@@ -68,6 +69,7 @@ export const generateWorldImageThunk = createDeduplicatedThunk(
     { getState, signal, registerDuplicateRequest },
   ) => {
     const state = getState() as RootState;
+    const originIdentity = getProjectTargetIdentity(state.project.present);
     // QNBS-v3: threaded into saveImage so the stored key is project-qualified, not a bare entity id shared across projects.
     const projectId = state.project.present?.data?.id || 'default';
     const aiOptions = buildAiOptions(state);
@@ -76,7 +78,17 @@ export const generateWorldImageThunk = createDeduplicatedThunk(
     const { prompt } = getPrompts('worldImage', { description, lang });
     registerDuplicateRequest(prompt, 'worldImage');
     const base64 = await generateImage(prompt, aiOptions, signal);
+    assertProjectIdentityUnchanged(
+      originIdentity,
+      getProjectTargetIdentity((getState() as RootState).project.present),
+      'world image generation before storage',
+    );
     await storageService.saveImage(worldId, base64, projectId);
+    assertProjectIdentityUnchanged(
+      originIdentity,
+      getProjectTargetIdentity((getState() as RootState).project.present),
+      'world image generation after storage',
+    );
     return { worldId };
   },
 );

--- a/features/project/thunks/worldThunks.ts
+++ b/features/project/thunks/worldThunks.ts
@@ -5,7 +5,11 @@ import type { WorldHeuristicLabels } from '../../../services/ai/heuristicFallbac
 import { storageService } from '../../../services/storageService';
 import type { World } from '../../../types';
 import { createDeduplicatedThunk } from '../aiThunkUtils';
-import { assertProjectIdentityUnchanged, getProjectTargetIdentity } from '../projectIdentity';
+import {
+  assertProjectIdentityUnchanged,
+  getProjectTargetIdentity,
+  getProjectTargetStorageId,
+} from '../projectIdentity';
 import { buildAiCreativity, buildAiOptions, loadAiProvider, loadPrompts } from './thunkUtils';
 
 export const generateWorldProfileThunk = createDeduplicatedThunk(
@@ -69,9 +73,10 @@ export const generateWorldImageThunk = createDeduplicatedThunk(
     { getState, signal, registerDuplicateRequest },
   ) => {
     const state = getState() as RootState;
+    // QNBS-v3: capture the incarnation before generation so a same-ID replacement cannot inherit the result.
     const originIdentity = getProjectTargetIdentity(state.project.present);
     // QNBS-v3: threaded into saveImage so the stored key is project-qualified, not a bare entity id shared across projects.
-    const projectId = state.project.present?.data?.id || 'default';
+    const projectId = getProjectTargetStorageId(state.project.present) ?? 'default';
     const aiOptions = buildAiOptions(state);
     const { getPrompts } = await loadPrompts();
     const { generateImage } = await loadAiProvider();
@@ -83,7 +88,14 @@ export const generateWorldImageThunk = createDeduplicatedThunk(
       getProjectTargetIdentity((getState() as RootState).project.present),
       'world image generation before storage',
     );
-    await storageService.saveImage(worldId, base64, projectId);
+    // QNBS-v3: the backend must re-check incarnation authority at its final image-write point, not only before/after the asynchronous storage call.
+    await storageService.saveImage(worldId, base64, projectId, () =>
+      assertProjectIdentityUnchanged(
+        originIdentity,
+        getProjectTargetIdentity((getState() as RootState).project.present),
+        'world image persistence',
+      ),
+    );
     assertProjectIdentityUnchanged(
       originIdentity,
       getProjectTargetIdentity((getState() as RootState).project.present),

--- a/features/project/thunks/writingThunks.ts
+++ b/features/project/thunks/writingThunks.ts
@@ -1,7 +1,11 @@
 import type { RootState } from '../../../app/store';
 import { storageService } from '../../../services/storageService';
 import { createDeduplicatedThunk } from '../aiThunkUtils';
-import { assertProjectIdentityUnchanged, getProjectTargetIdentity } from '../projectIdentity';
+import {
+  assertProjectIdentityUnchanged,
+  getProjectTargetIdentity,
+  getProjectTargetStorageId,
+} from '../projectIdentity';
 import { buildAiCreativity, buildAiOptions, loadAiProvider, loadPrompts } from './thunkUtils';
 
 export const generateLoglineSuggestionsThunk = createDeduplicatedThunk(
@@ -70,9 +74,10 @@ export const generateSceneImageThunk = createDeduplicatedThunk(
     { getState, signal, registerDuplicateRequest },
   ) => {
     const state = getState() as RootState;
+    // QNBS-v3: capture the incarnation before generation so a same-ID replacement cannot inherit the result.
     const originIdentity = getProjectTargetIdentity(state.project.present);
     // QNBS-v3: threaded into saveImage so the stored key is project-qualified, not a bare entity id shared across projects.
-    const projectId = state.project.present?.data?.id || 'default';
+    const projectId = getProjectTargetStorageId(state.project.present) ?? 'default';
     const aiOptions = buildAiOptions(state);
     const { getPrompts } = await loadPrompts();
     const { generateImage } = await loadAiProvider();
@@ -90,7 +95,14 @@ export const generateSceneImageThunk = createDeduplicatedThunk(
       getProjectTargetIdentity((getState() as RootState).project.present),
       'scene image generation before storage',
     );
-    await storageService.saveImage(imageKey, base64, projectId);
+    // QNBS-v3: the backend must re-check incarnation authority at its final image-write point, not only before/after the asynchronous storage call.
+    await storageService.saveImage(imageKey, base64, projectId, () =>
+      assertProjectIdentityUnchanged(
+        originIdentity,
+        getProjectTargetIdentity((getState() as RootState).project.present),
+        'scene image persistence',
+      ),
+    );
     assertProjectIdentityUnchanged(
       originIdentity,
       getProjectTargetIdentity((getState() as RootState).project.present),

--- a/features/project/thunks/writingThunks.ts
+++ b/features/project/thunks/writingThunks.ts
@@ -1,6 +1,7 @@
 import type { RootState } from '../../../app/store';
 import { storageService } from '../../../services/storageService';
 import { createDeduplicatedThunk } from '../aiThunkUtils';
+import { assertProjectIdentityUnchanged, getProjectTargetIdentity } from '../projectIdentity';
 import { buildAiCreativity, buildAiOptions, loadAiProvider, loadPrompts } from './thunkUtils';
 
 export const generateLoglineSuggestionsThunk = createDeduplicatedThunk(
@@ -69,6 +70,7 @@ export const generateSceneImageThunk = createDeduplicatedThunk(
     { getState, signal, registerDuplicateRequest },
   ) => {
     const state = getState() as RootState;
+    const originIdentity = getProjectTargetIdentity(state.project.present);
     // QNBS-v3: threaded into saveImage so the stored key is project-qualified, not a bare entity id shared across projects.
     const projectId = state.project.present?.data?.id || 'default';
     const aiOptions = buildAiOptions(state);
@@ -83,7 +85,17 @@ export const generateSceneImageThunk = createDeduplicatedThunk(
     registerDuplicateRequest(prompt, 'sceneVisualization');
     const base64 = await generateImage(prompt, aiOptions, signal);
     const imageKey = `scene-${payload.sectionId}`;
+    assertProjectIdentityUnchanged(
+      originIdentity,
+      getProjectTargetIdentity((getState() as RootState).project.present),
+      'scene image generation before storage',
+    );
     await storageService.saveImage(imageKey, base64, projectId);
+    assertProjectIdentityUnchanged(
+      originIdentity,
+      getProjectTargetIdentity((getState() as RootState).project.present),
+      'scene image generation after storage',
+    );
     const dataUrl = base64.includes('data:image') ? base64 : `data:image/png;base64,${base64}`;
     return { imageKey, dataUrl };
   },

--- a/hooks/useCharacterView.ts
+++ b/hooks/useCharacterView.ts
@@ -228,13 +228,20 @@ export const useCharacterView = () => {
       }
       const deletingCharacter = characterToDelete;
       // QNBS-v3: the real delete API, not saveImage(id, '') -- an empty-string save only overwrote the project-qualified key, leaving any pre-qualification legacy blob for this id intact and resurfacable via getImage's fallback.
-      await storageService.deleteImage(deletingCharacter.id, projectId, () =>
-        assertProjectIdentityUnchanged(
-          characterDeleteIdentity,
-          captureActiveProjectIdentity(),
-          'character image deletion',
-        ),
-      );
+      try {
+        await storageService.deleteImage(deletingCharacter.id, projectId, () =>
+          assertProjectIdentityUnchanged(
+            characterDeleteIdentity,
+            captureActiveProjectIdentity(),
+            'character image deletion',
+          ),
+        );
+      } catch (error) {
+        if (!isStaleProjectOperationError(error)) throw error;
+        setCharacterToDeleteState(null);
+        setCharacterDeleteIdentity(null);
+        return;
+      }
       if (!identityUnchanged(characterDeleteIdentity, captureActiveProjectIdentity())) {
         setCharacterToDeleteState(null);
         setCharacterDeleteIdentity(null);

--- a/hooks/useCharacterView.ts
+++ b/hooks/useCharacterView.ts
@@ -4,10 +4,11 @@ import { useAppDispatch, useAppSelector } from '../app/hooks';
 import { useToast } from '../components/ui/Toast';
 import {
   captureActiveProjectIdentity,
+  getProjectTargetStorageId,
   identityUnchanged,
   isStaleProjectOperationError,
 } from '../features/project/projectIdentity';
-import { selectAllCharacters, selectProjectData } from '../features/project/projectSelectors';
+import { selectAllCharacters } from '../features/project/projectSelectors';
 import { projectActions } from '../features/project/projectSlice';
 import {
   generateCharacterPortraitThunk,
@@ -23,7 +24,9 @@ export const useCharacterView = () => {
   const { t, language } = useTranslation();
   const dispatch = useAppDispatch();
   const characters = useAppSelector(selectAllCharacters);
-  const projectId = useAppSelector((state) => selectProjectData(state)?.id || 'default');
+  const projectId = useAppSelector(
+    (state) => getProjectTargetStorageId(state.project.present) ?? 'default',
+  );
   const toast = useToast();
 
   const [selectedCharacter, setSelectedCharacter] = useState<Character | null>(null);
@@ -39,7 +42,13 @@ export const useCharacterView = () => {
   const [portraitStyle, setPortraitStyle] = useState('digital painting');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-  const [characterToDelete, setCharacterToDelete] = useState<Character | null>(null);
+  const [characterToDelete, setCharacterToDeleteState] = useState<Character | null>(null);
+  const [characterDeleteIdentity, setCharacterDeleteIdentity] = useState<string | null>(null);
+
+  const setCharacterToDelete = useCallback((character: Character | null) => {
+    setCharacterToDeleteState(character);
+    setCharacterDeleteIdentity(character ? captureActiveProjectIdentity() : null);
+  }, []);
 
   // QNBS-v3: Manual add must open the dossier immediately — dispatch-only left users on an empty grid and broke E2E + discoverability.
   const handleAddNewManually = useCallback(() => {
@@ -208,20 +217,40 @@ export const useCharacterView = () => {
         setCharacterToDelete(char);
       }
     },
-    [characters],
+    [characters, setCharacterToDelete],
   );
 
   const confirmDelete = useCallback(async () => {
     if (characterToDelete) {
+      // QNBS-v3: [Delete intent identity / Reject a dialog opened in another incarnation / Preserve destructive-action authority]
+      if (!identityUnchanged(characterDeleteIdentity, captureActiveProjectIdentity())) {
+        setCharacterToDeleteState(null);
+        setCharacterDeleteIdentity(null);
+        return;
+      }
+      const deletingCharacter = characterToDelete;
       // QNBS-v3: the real delete API, not saveImage(id, '') -- an empty-string save only overwrote the project-qualified key, leaving any pre-qualification legacy blob for this id intact and resurfacable via getImage's fallback.
-      await storageService.deleteImage(characterToDelete.id, projectId);
-      dispatch(projectActions.deleteCharacter(characterToDelete.id));
+      await storageService.deleteImage(deletingCharacter.id, projectId);
+      if (!identityUnchanged(characterDeleteIdentity, captureActiveProjectIdentity())) {
+        setCharacterToDeleteState(null);
+        setCharacterDeleteIdentity(null);
+        return;
+      }
+      dispatch(projectActions.deleteCharacter(deletingCharacter.id));
       setCharacterToDelete(null);
       setIsDossierOpen(false);
       setSelectedCharacter(null);
-      toast.info(t('characters.deleteLabel', { name: characterToDelete.name }));
+      toast.info(t('characters.deleteLabel', { name: deletingCharacter.name }));
     }
-  }, [dispatch, characterToDelete, toast, t, projectId]);
+  }, [
+    dispatch,
+    characterToDelete,
+    characterDeleteIdentity,
+    toast,
+    t,
+    projectId,
+    setCharacterToDelete,
+  ]);
 
   return {
     t,

--- a/hooks/useCharacterView.ts
+++ b/hooks/useCharacterView.ts
@@ -5,6 +5,7 @@ import { useToast } from '../components/ui/Toast';
 import {
   captureActiveProjectIdentity,
   identityUnchanged,
+  isStaleProjectOperationError,
 } from '../features/project/projectIdentity';
 import { selectAllCharacters, selectProjectData } from '../features/project/projectSelectors';
 import { projectActions } from '../features/project/projectSlice';
@@ -163,7 +164,10 @@ export const useCharacterView = () => {
         lang: language,
       }),
     );
-    if (!generateCharacterPortraitThunk.fulfilled.match(resultAction)) {
+    if (
+      !generateCharacterPortraitThunk.fulfilled.match(resultAction) &&
+      !isStaleProjectOperationError(resultAction.error)
+    ) {
       const errorText = t('characters.error.portraitFailed');
       setErrorMessage(errorText);
       toast.error(errorText);
@@ -185,7 +189,10 @@ export const useCharacterView = () => {
         lang: language,
       }),
     );
-    if (!generateCharacterPortraitThunk.fulfilled.match(resultAction)) {
+    if (
+      !generateCharacterPortraitThunk.fulfilled.match(resultAction) &&
+      !isStaleProjectOperationError(resultAction.error)
+    ) {
       const errorText = t('characters.error.portraitFailed');
       setErrorMessage(errorText);
       toast.error(errorText);

--- a/hooks/useCharacterView.ts
+++ b/hooks/useCharacterView.ts
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { useAppDispatch, useAppSelector } from '../app/hooks';
 import { useToast } from '../components/ui/Toast';
 import {
+  assertProjectIdentityUnchanged,
   captureActiveProjectIdentity,
   getProjectTargetStorageId,
   identityUnchanged,
@@ -227,7 +228,13 @@ export const useCharacterView = () => {
       }
       const deletingCharacter = characterToDelete;
       // QNBS-v3: the real delete API, not saveImage(id, '') -- an empty-string save only overwrote the project-qualified key, leaving any pre-qualification legacy blob for this id intact and resurfacable via getImage's fallback.
-      await storageService.deleteImage(deletingCharacter.id, projectId);
+      await storageService.deleteImage(deletingCharacter.id, projectId, () =>
+        assertProjectIdentityUnchanged(
+          characterDeleteIdentity,
+          captureActiveProjectIdentity(),
+          'character image deletion',
+        ),
+      );
       if (!identityUnchanged(characterDeleteIdentity, captureActiveProjectIdentity())) {
         setCharacterToDeleteState(null);
         setCharacterDeleteIdentity(null);

--- a/hooks/useCharacterView.ts
+++ b/hooks/useCharacterView.ts
@@ -173,16 +173,13 @@ export const useCharacterView = () => {
         lang: language,
       }),
     );
-    if (
-      !generateCharacterPortraitThunk.fulfilled.match(resultAction) &&
-      !isStaleProjectOperationError(resultAction.error)
-    ) {
+    if (generateCharacterPortraitThunk.fulfilled.match(resultAction)) {
+      // QNBS-v3: only fulfilled generation may mark the local selection as having an avatar.
+      setSelectedCharacter((c) => (c ? { ...c, hasAvatar: true } : null));
+    } else if (!isStaleProjectOperationError(resultAction.error)) {
       const errorText = t('characters.error.portraitFailed');
       setErrorMessage(errorText);
       toast.error(errorText);
-    } else {
-      // Trigger re-render by updating local state, redux state will update via extraReducer
-      setSelectedCharacter((c) => (c ? { ...c, hasAvatar: true } : null));
     }
     setIsGeneratingPortrait(false);
   }, [dispatch, selectedCharacter, portraitStyle, language, t, toast]);

--- a/hooks/useManuscriptView.ts
+++ b/hooks/useManuscriptView.ts
@@ -327,6 +327,7 @@ export const useManuscriptView = ({
       setSceneImagePreviewUrl(result.dataUrl);
       toast.success(t('manuscript.visualize.successTitle'), t('manuscript.visualize.successBody'));
     } catch (error) {
+      // QNBS-v3: [Grund: stale scene result is expected after a project switch / Impact: suppress false error toasts / Kreativer Mehrwert: keep authoring feedback actionable]
       if (!isStaleProjectOperationError(error)) {
         toast.error(t('error.apiErrorTitle'));
       }

--- a/hooks/useManuscriptView.ts
+++ b/hooks/useManuscriptView.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAppDispatch, useAppSelector } from '../app/hooks';
 import { useTransientUiStore } from '../app/transientUiStore';
 import { useToast } from '../components/ui/Toast';
+import { isStaleProjectOperationError } from '../features/project/projectIdentity';
 import {
   selectAllCharacters,
   selectAllWorlds,
@@ -325,8 +326,10 @@ export const useManuscriptView = ({
       ).unwrap();
       setSceneImagePreviewUrl(result.dataUrl);
       toast.success(t('manuscript.visualize.successTitle'), t('manuscript.visualize.successBody'));
-    } catch {
-      toast.error(t('error.apiErrorTitle'));
+    } catch (error) {
+      if (!isStaleProjectOperationError(error)) {
+        toast.error(t('error.apiErrorTitle'));
+      }
     } finally {
       setIsSceneVisualizing(false);
     }

--- a/hooks/useWorldView.ts
+++ b/hooks/useWorldView.ts
@@ -266,13 +266,20 @@ export const useWorldView = () => {
       }
       const deletingWorld = worldToDelete;
       // QNBS-v3: the real delete API, not saveImage(id, '') -- an empty-string save only overwrote the project-qualified key, leaving any pre-qualification legacy blob for this id intact and resurfacable via getImage's fallback.
-      await storageService.deleteImage(deletingWorld.id, projectId, () =>
-        assertProjectIdentityUnchanged(
-          worldDeleteIdentity,
-          captureActiveProjectIdentity(),
-          'world image deletion',
-        ),
-      );
+      try {
+        await storageService.deleteImage(deletingWorld.id, projectId, () =>
+          assertProjectIdentityUnchanged(
+            worldDeleteIdentity,
+            captureActiveProjectIdentity(),
+            'world image deletion',
+          ),
+        );
+      } catch (error) {
+        if (!isStaleProjectOperationError(error)) throw error;
+        setWorldToDeleteState(null);
+        setWorldDeleteIdentity(null);
+        return;
+      }
       if (!identityUnchanged(worldDeleteIdentity, captureActiveProjectIdentity())) {
         setWorldToDeleteState(null);
         setWorldDeleteIdentity(null);

--- a/hooks/useWorldView.ts
+++ b/hooks/useWorldView.ts
@@ -5,6 +5,7 @@ import { useToast } from '../components/ui/Toast';
 import {
   captureActiveProjectIdentity,
   identityUnchanged,
+  isStaleProjectOperationError,
 } from '../features/project/projectIdentity';
 import { selectAllWorlds, selectProjectData } from '../features/project/projectSelectors';
 import { projectActions } from '../features/project/projectSlice';
@@ -157,7 +158,7 @@ export const useWorldView = () => {
     );
     if (generateWorldImageThunk.fulfilled.match(resultAction)) {
       setSelectedWorld((w) => (w ? { ...w, hasAmbianceImage: true } : null));
-    } else {
+    } else if (!isStaleProjectOperationError(resultAction.error)) {
       toast.error(t('worlds.error.imageFailed'));
     }
     setIsGeneratingImage(false);
@@ -170,7 +171,10 @@ export const useWorldView = () => {
     const resultAction = await dispatch(
       generateWorldImageThunk({ worldId: selectedWorld.id, description, lang: language }),
     );
-    if (!generateWorldImageThunk.fulfilled.match(resultAction)) {
+    if (
+      !generateWorldImageThunk.fulfilled.match(resultAction) &&
+      !isStaleProjectOperationError(resultAction.error)
+    ) {
       toast.error(t('worlds.error.imageFailed'));
     }
     setRefinementPrompt('');

--- a/hooks/useWorldView.ts
+++ b/hooks/useWorldView.ts
@@ -4,10 +4,11 @@ import { useAppDispatch, useAppSelector } from '../app/hooks';
 import { useToast } from '../components/ui/Toast';
 import {
   captureActiveProjectIdentity,
+  getProjectTargetStorageId,
   identityUnchanged,
   isStaleProjectOperationError,
 } from '../features/project/projectIdentity';
-import { selectAllWorlds, selectProjectData } from '../features/project/projectSelectors';
+import { selectAllWorlds } from '../features/project/projectSelectors';
 import { projectActions } from '../features/project/projectSlice';
 import {
   generateWorldImageThunk,
@@ -23,7 +24,9 @@ export const useWorldView = () => {
   const { t, language } = useTranslation();
   const dispatch = useAppDispatch();
   const worlds = useAppSelector(selectAllWorlds);
-  const projectId = useAppSelector((state) => selectProjectData(state)?.id || 'default');
+  const projectId = useAppSelector(
+    (state) => getProjectTargetStorageId(state.project.present) ?? 'default',
+  );
   const toast = useToast();
 
   const [selectedWorld, setSelectedWorld] = useState<World | null>(null);
@@ -37,7 +40,13 @@ export const useWorldView = () => {
   const [isRefiningImage, setIsRefiningImage] = useState(false);
   const [refinementPrompt, setRefinementPrompt] = useState('');
 
-  const [worldToDelete, setWorldToDelete] = useState<World | null>(null);
+  const [worldToDelete, setWorldToDeleteState] = useState<World | null>(null);
+  const [worldDeleteIdentity, setWorldDeleteIdentity] = useState<string | null>(null);
+
+  const setWorldToDelete = useCallback((world: World | null) => {
+    setWorldToDeleteState(world);
+    setWorldDeleteIdentity(world ? captureActiveProjectIdentity() : null);
+  }, []);
 
   // QNBS-v3: Manual add must open the atlas immediately — dispatch-only left users on the grid
   //          with a silent "New World" card and no editor (inconsistent with Characters, which
@@ -243,20 +252,32 @@ export const useWorldView = () => {
       const world = worlds.find((w) => w.id === id);
       if (world) setWorldToDelete(world);
     },
-    [worlds],
+    [worlds, setWorldToDelete],
   );
 
   const confirmDelete = useCallback(async () => {
     if (worldToDelete) {
+      // QNBS-v3: [Delete intent identity / Reject a dialog opened in another incarnation / Preserve destructive-action authority]
+      if (!identityUnchanged(worldDeleteIdentity, captureActiveProjectIdentity())) {
+        setWorldToDeleteState(null);
+        setWorldDeleteIdentity(null);
+        return;
+      }
+      const deletingWorld = worldToDelete;
       // QNBS-v3: the real delete API, not saveImage(id, '') -- an empty-string save only overwrote the project-qualified key, leaving any pre-qualification legacy blob for this id intact and resurfacable via getImage's fallback.
-      await storageService.deleteImage(worldToDelete.id, projectId);
-      dispatch(projectActions.deleteWorld(worldToDelete.id));
+      await storageService.deleteImage(deletingWorld.id, projectId);
+      if (!identityUnchanged(worldDeleteIdentity, captureActiveProjectIdentity())) {
+        setWorldToDeleteState(null);
+        setWorldDeleteIdentity(null);
+        return;
+      }
+      dispatch(projectActions.deleteWorld(deletingWorld.id));
       setWorldToDelete(null);
       setIsAtlasOpen(false);
       setSelectedWorld(null);
-      toast.info(t('worlds.deleteLabel', { name: worldToDelete.name }));
+      toast.info(t('worlds.deleteLabel', { name: deletingWorld.name }));
     }
-  }, [dispatch, worldToDelete, toast, t, projectId]);
+  }, [dispatch, worldToDelete, worldDeleteIdentity, toast, t, projectId, setWorldToDelete]);
 
   return {
     t,

--- a/hooks/useWorldView.ts
+++ b/hooks/useWorldView.ts
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { useAppDispatch, useAppSelector } from '../app/hooks';
 import { useToast } from '../components/ui/Toast';
 import {
+  assertProjectIdentityUnchanged,
   captureActiveProjectIdentity,
   getProjectTargetStorageId,
   identityUnchanged,
@@ -265,7 +266,13 @@ export const useWorldView = () => {
       }
       const deletingWorld = worldToDelete;
       // QNBS-v3: the real delete API, not saveImage(id, '') -- an empty-string save only overwrote the project-qualified key, leaving any pre-qualification legacy blob for this id intact and resurfacable via getImage's fallback.
-      await storageService.deleteImage(deletingWorld.id, projectId);
+      await storageService.deleteImage(deletingWorld.id, projectId, () =>
+        assertProjectIdentityUnchanged(
+          worldDeleteIdentity,
+          captureActiveProjectIdentity(),
+          'world image deletion',
+        ),
+      );
       if (!identityUnchanged(worldDeleteIdentity, captureActiveProjectIdentity())) {
         setWorldToDeleteState(null);
         setWorldDeleteIdentity(null);

--- a/services/fs/assetFsStore.ts
+++ b/services/fs/assetFsStore.ts
@@ -5,7 +5,7 @@
  */
 
 import { logger } from '../logger';
-import type { BinderAssetMeta, BinderAssetPayload } from '../storageBackend';
+import type { BinderAssetMeta, BinderAssetPayload, ImageWriteAdmission } from '../storageBackend';
 import { retryFs, sanitizePathSegment, writeFileAtomic, writeTextFileAtomic } from './fsCore';
 import { FsSnapshotStore } from './snapshotFsStore';
 
@@ -79,14 +79,19 @@ export class FsAssetStore extends FsSnapshotStore {
     return existing === projectId;
   }
 
-  async saveImage(id: string, base64Data: string, projectId = 'default'): Promise<void> {
+  async saveImage(
+    id: string,
+    base64Data: string,
+    projectId = 'default',
+    writeAdmission?: ImageWriteAdmission,
+  ): Promise<void> {
     const apis = await this.getApis();
     const { dir, file } = await this.qualifiedImagePaths(projectId, id);
     if (!(await apis.exists(dir))) {
       await apis.mkdir(dir, { recursive: true });
     }
     // QNBS-v3: data URLs retain an uploaded image's MIME type; legacy raw payloads remain readable as PNG below.
-    await writeTextFileAtomic(apis, file, base64Data);
+    await writeTextFileAtomic(apis, file, base64Data, writeAdmission);
   }
 
   async getImage(id: string, projectId = 'default'): Promise<string | null> {

--- a/services/fs/assetFsStore.ts
+++ b/services/fs/assetFsStore.ts
@@ -85,6 +85,8 @@ export class FsAssetStore extends FsSnapshotStore {
     projectId = 'default',
     writeAdmission?: ImageWriteAdmission,
   ): Promise<void> {
+    // QNBS-v3: [Admission before temp-file creation / Reject already-stale writes without disk residue / Preserve filesystem authority]
+    writeAdmission?.();
     const apis = await this.getApis();
     const { dir, file } = await this.qualifiedImagePaths(projectId, id);
     if (!(await apis.exists(dir))) {

--- a/services/fs/assetFsStore.ts
+++ b/services/fs/assetFsStore.ts
@@ -5,7 +5,12 @@
  */
 
 import { logger } from '../logger';
-import type { BinderAssetMeta, BinderAssetPayload, ImageWriteAdmission } from '../storageBackend';
+import type {
+  BinderAssetMeta,
+  BinderAssetPayload,
+  ImageDeleteAdmission,
+  ImageWriteAdmission,
+} from '../storageBackend';
 import { retryFs, sanitizePathSegment, writeFileAtomic, writeTextFileAtomic } from './fsCore';
 import { FsSnapshotStore } from './snapshotFsStore';
 
@@ -123,7 +128,11 @@ export class FsAssetStore extends FsSnapshotStore {
     }
   }
 
-  async deleteImage(id: string, projectId = 'default'): Promise<void> {
+  async deleteImage(
+    id: string,
+    projectId = 'default',
+    deleteAdmission?: ImageDeleteAdmission,
+  ): Promise<void> {
     try {
       // QNBS-v3: serialized + write-authority-checked like deleteBinderAsset -- an unserialized ownership check could go stale against a concurrent project creation and delete another project's unattributed legacy image.
       await this.withLegacyRoutingOperation(async () => {
@@ -135,15 +144,17 @@ export class FsAssetStore extends FsSnapshotStore {
         if (soleOwner) {
           const legacyFile = await this.legacyImagePath(id);
           if (await apis.exists(legacyFile)) {
+            deleteAdmission?.();
             await retryFs(() => apis.remove(legacyFile));
           }
         }
         if (await apis.exists(qualifiedFile)) {
+          deleteAdmission?.();
           await retryFs(() => apis.remove(qualifiedFile));
         }
       }, projectId);
     } catch (error) {
-      if (this.isProjectWriteAuthorityError(error)) throw error;
+      if (deleteAdmission || this.isProjectWriteAuthorityError(error)) throw error;
       logger.error('Failed to delete image:', error);
     }
   }

--- a/services/fs/assetFsStore.ts
+++ b/services/fs/assetFsStore.ts
@@ -157,6 +157,8 @@ export class FsAssetStore extends FsSnapshotStore {
         if (await apis.exists(qualifiedFile)) {
           await removeImageFile(qualifiedFile);
         }
+        // QNBS-v3: final delete admission / reject stale no-op deletions / keep entity mutation authority truthful.
+        deleteAdmission?.();
       }, projectId);
     } catch (error) {
       if (deleteAdmission || this.isProjectWriteAuthorityError(error)) throw error;

--- a/services/fs/assetFsStore.ts
+++ b/services/fs/assetFsStore.ts
@@ -141,16 +141,21 @@ export class FsAssetStore extends FsSnapshotStore {
         // QNBS-v3: preserve-first -- only remove the unattributed legacy copy when ownership is already provable; otherwise it may belong to a different (possibly already-deleted) project, so leave it untouched rather than risk destroying another project's image.
         const soleOwner = await this.checkLegacyImageOwnership(projectId);
         // QNBS-v3: legacy MUST be removed before the qualified file, not after -- if legacy removal throws, the catch below aborts before the qualified file is touched, so getImage's legacy fallback can never resurrect a half-deleted image. The reverse order would let a failure after the qualified delete leave the legacy copy to resurrect it.
+        const removeImageFile = async (path: string) => {
+          await retryFs(async () => {
+            // QNBS-v3: re-admit every retry attempt so a same-ID replacement cannot be deleted after a transient filesystem failure.
+            deleteAdmission?.();
+            await apis.remove(path);
+          });
+        };
         if (soleOwner) {
           const legacyFile = await this.legacyImagePath(id);
           if (await apis.exists(legacyFile)) {
-            deleteAdmission?.();
-            await retryFs(() => apis.remove(legacyFile));
+            await removeImageFile(legacyFile);
           }
         }
         if (await apis.exists(qualifiedFile)) {
-          deleteAdmission?.();
-          await retryFs(() => apis.remove(qualifiedFile));
+          await removeImageFile(qualifiedFile);
         }
       }, projectId);
     } catch (error) {

--- a/services/fs/fsCore.ts
+++ b/services/fs/fsCore.ts
@@ -95,12 +95,14 @@ async function writeAndReplace(
   apis: TauriApis,
   path: string,
   write: (temporary: string) => Promise<void>,
+  beforeReplace?: () => void,
 ): Promise<void> {
   const previous = atomicWriteTails.get(path);
   const current = (previous?.catch(() => undefined) ?? Promise.resolve()).then(async () => {
     const temporary = temporaryPath(path);
     try {
       await retryFs(() => write(temporary));
+      beforeReplace?.();
       await retryFs(() => apis.rename(temporary, path));
     } catch (error) {
       // QNBS-v3: retry cleanup, then log (not throw) — the caller must always see the original write/rename error, with an orphaned-temp-file warning surfaced for diagnostics.
@@ -126,8 +128,18 @@ async function writeAndReplace(
 }
 
 // QNBS-v3: replace authoritative files only after a complete sibling write, preserving the last valid file on interruption.
-export function writeTextFileAtomic(apis: TauriApis, path: string, content: string): Promise<void> {
-  return writeAndReplace(apis, path, (temporary) => apis.writeTextFile(temporary, content));
+export function writeTextFileAtomic(
+  apis: TauriApis,
+  path: string,
+  content: string,
+  beforeReplace?: () => void,
+): Promise<void> {
+  return writeAndReplace(
+    apis,
+    path,
+    (temporary) => apis.writeTextFile(temporary, content),
+    beforeReplace,
+  );
 }
 
 // QNBS-v3: binary assets use the same same-directory replace so readers never observe a partial file.

--- a/services/fs/fsCore.ts
+++ b/services/fs/fsCore.ts
@@ -102,6 +102,7 @@ async function writeAndReplace(
     const temporary = temporaryPath(path);
     try {
       await retryFs(() => write(temporary));
+      // QNBS-v3: [Grund: final replace admission / Impact: reject stale filesystem mutations / Kreativer Mehrwert: preserve atomic project assets]
       beforeReplace?.();
       await retryFs(() => apis.rename(temporary, path));
     } catch (error) {

--- a/services/storage/idbAssetStore.ts
+++ b/services/storage/idbAssetStore.ts
@@ -10,7 +10,12 @@ import {
   IMAGES_STORE,
   LEGACY_IMAGE_OWNER_KEY,
 } from '../dbConstants';
-import type { BinderAssetMeta, BinderAssetPayload, ImageWriteAdmission } from '../storageBackend';
+import type {
+  BinderAssetMeta,
+  BinderAssetPayload,
+  ImageDeleteAdmission,
+  ImageWriteAdmission,
+} from '../storageBackend';
 import {
   makeBinderAssetIdsPrefix,
   makeBinderAssetStorageKey,
@@ -129,7 +134,11 @@ export class IdbAssetStore extends IdbSnapshotStore {
     return this.decodeImageRecord(legacy);
   }
 
-  async deleteImage(id: string, projectId = 'default'): Promise<void> {
+  async deleteImage(
+    id: string,
+    projectId = 'default',
+    deleteAdmission?: ImageDeleteAdmission,
+  ): Promise<void> {
     return withProtectedWriteAdmission(async () => {
       // QNBS-v3: A locked session must not be able to destroy protected images it cannot read.
       await assertIdbProtectedWriteAllowed();
@@ -140,6 +149,7 @@ export class IdbAssetStore extends IdbSnapshotStore {
       const keysToDelete = legacyOwned ? [qualifiedKey, id] : [qualifiedKey];
       const store = await this.getObjectStore(IMAGES_STORE, 'readwrite');
       // QNBS-v3: clear both the qualified and legacy key so a stale legacy record can never resurface via getImage's fallback after an explicit delete. Both deletes share one IDB transaction, so a failure on either aborts and rolls back both -- no partial-delete resurrection risk here, unlike the filesystem backend's independent file operations.
+      deleteAdmission?.();
       await Promise.all(
         keysToDelete.map(
           (key) =>

--- a/services/storage/idbAssetStore.ts
+++ b/services/storage/idbAssetStore.ts
@@ -10,7 +10,7 @@ import {
   IMAGES_STORE,
   LEGACY_IMAGE_OWNER_KEY,
 } from '../dbConstants';
-import type { BinderAssetMeta, BinderAssetPayload } from '../storageBackend';
+import type { BinderAssetMeta, BinderAssetPayload, ImageWriteAdmission } from '../storageBackend';
 import {
   makeBinderAssetIdsPrefix,
   makeBinderAssetStorageKey,
@@ -72,7 +72,12 @@ export class IdbAssetStore extends IdbSnapshotStore {
     return existing === projectId;
   }
 
-  async saveImage(id: string, base64: string, projectId = 'default'): Promise<void> {
+  async saveImage(
+    id: string,
+    base64: string,
+    projectId = 'default',
+    writeAdmission?: ImageWriteAdmission,
+  ): Promise<void> {
     return withProtectedWriteAdmission(async () => {
       // QNBS-v3: Resolve the write key BEFORE opening the transaction — `await idbEncryptWithKey`
       //          yields the event loop, which auto-commits an already-open IDB transaction
@@ -84,6 +89,7 @@ export class IdbAssetStore extends IdbSnapshotStore {
       await assertNoActiveEncryptionMigration();
       const key = await makeImageStorageKey(projectId, id);
       const store = await this.getObjectStore(IMAGES_STORE, 'readwrite');
+      writeAdmission?.();
       return new Promise<void>((resolve, reject) => {
         const request = store.put(payload, key);
         request.onsuccess = () => resolve();

--- a/services/storageBackend.ts
+++ b/services/storageBackend.ts
@@ -13,6 +13,9 @@ export interface BinderAssetPayload {
   meta: BinderAssetMeta;
 }
 
+/** Synchronous admission check evaluated at the backend's image-write point. */
+export type ImageWriteAdmission = () => void;
+
 // QNBS-v3: shared result keeps the affected identity and verified quarantine path explicit across backends.
 /** Result of moving a corrupt desktop project out of the active project namespace. */
 export interface ProjectQuarantineResult {
@@ -97,7 +100,12 @@ export interface StorageBackend {
   quarantineProject?(projectId: string): Promise<ProjectQuarantineResult>;
 
   // QNBS-v3: projectId is trailing/optional (defaults to 'default' at each implementer) so call sites that predate project-qualification keep compiling unchanged -- only call sites that need real qualification pass it explicitly.
-  saveImage(id: string, base64Data: string, projectId?: string): Promise<void>;
+  saveImage(
+    id: string,
+    base64Data: string,
+    projectId?: string,
+    writeAdmission?: ImageWriteAdmission,
+  ): Promise<void>;
   getImage(id: string, projectId?: string): Promise<string | null>;
   // QNBS-v3: qualified-only variants for transaction/rollback callers -- unlike getImage/deleteImage, these never consult the legacy fallback, never claim/touch legacy ownership, and never swallow a read/delete failure to null/success. A rollback needs to know the exact pre-mutation state of the exact key it is about to overwrite, not the UI-friendly merged view.
   getQualifiedImage(id: string, projectId?: string): Promise<string | null>;

--- a/services/storageBackend.ts
+++ b/services/storageBackend.ts
@@ -16,6 +16,9 @@ export interface BinderAssetPayload {
 /** Synchronous admission check evaluated at the backend's image-write point. */
 export type ImageWriteAdmission = () => void;
 
+/** Synchronous admission check evaluated at the backend's image-delete point. */
+export type ImageDeleteAdmission = () => void;
+
 // QNBS-v3: shared result keeps the affected identity and verified quarantine path explicit across backends.
 /** Result of moving a corrupt desktop project out of the active project namespace. */
 export interface ProjectQuarantineResult {
@@ -130,7 +133,11 @@ export interface StorageBackend {
   listSnapshots(): Promise<ProjectSnapshot[]>;
   deleteSnapshot(snapshotId: number): Promise<void>;
 
-  deleteImage(id: string, projectId?: string): Promise<void>;
+  deleteImage(
+    id: string,
+    projectId?: string,
+    deleteAdmission?: ImageDeleteAdmission,
+  ): Promise<void>;
 
   hasSavedData(): Promise<boolean>;
 

--- a/services/storageBackend.ts
+++ b/services/storageBackend.ts
@@ -16,6 +16,7 @@ export interface BinderAssetPayload {
 /** Synchronous admission check evaluated at the backend's image-write point. */
 export type ImageWriteAdmission = () => void;
 
+// QNBS-v3: [Grund: shared delete authority / Impact: reject stale image removals / Kreativer Mehrwert: keep every backend on one admission contract]
 /** Synchronous admission check evaluated at the backend's image-delete point. */
 export type ImageDeleteAdmission = () => void;
 

--- a/services/storageService.ts
+++ b/services/storageService.ts
@@ -125,7 +125,9 @@ class StorageManager {
     writeAdmission?: ImageWriteAdmission,
   ): Promise<void> {
     const backend = await this.getBackend();
-    return backend.saveImage(id, base64Data, projectId, writeAdmission);
+    return writeAdmission
+      ? backend.saveImage(id, base64Data, projectId, writeAdmission)
+      : backend.saveImage(id, base64Data, projectId);
   }
 
   async getImage(id: string, projectId?: string): Promise<string | null> {
@@ -215,7 +217,9 @@ class StorageManager {
     deleteAdmission?: ImageDeleteAdmission,
   ): Promise<void> {
     const backend = await this.getBackend();
-    return backend.deleteImage(id, projectId, deleteAdmission);
+    return deleteAdmission
+      ? backend.deleteImage(id, projectId, deleteAdmission)
+      : backend.deleteImage(id, projectId);
   }
 
   async hasSavedData(): Promise<boolean> {

--- a/services/storageService.ts
+++ b/services/storageService.ts
@@ -2,6 +2,7 @@ import type { ProjectSnapshot, Settings, StoryCodex, StoryProject } from '../typ
 import type {
   BinderAssetMeta,
   BinderAssetPayload,
+  ImageDeleteAdmission,
   ImageWriteAdmission,
   ProjectQuarantineResult,
   SaveProjectInput,
@@ -12,6 +13,7 @@ import type {
 export type {
   BinderAssetMeta,
   BinderAssetPayload,
+  ImageDeleteAdmission,
   ImageWriteAdmission,
   ProjectQuarantineResult,
   SaveProjectEnvelope,
@@ -207,9 +209,13 @@ class StorageManager {
   }
 
   // QNBS-v3: same trailing-optional projectId compatibility shape as saveImage/getImage above.
-  async deleteImage(id: string, projectId?: string): Promise<void> {
+  async deleteImage(
+    id: string,
+    projectId?: string,
+    deleteAdmission?: ImageDeleteAdmission,
+  ): Promise<void> {
     const backend = await this.getBackend();
-    return backend.deleteImage(id, projectId);
+    return backend.deleteImage(id, projectId, deleteAdmission);
   }
 
   async hasSavedData(): Promise<boolean> {

--- a/services/storageService.ts
+++ b/services/storageService.ts
@@ -2,6 +2,7 @@ import type { ProjectSnapshot, Settings, StoryCodex, StoryProject } from '../typ
 import type {
   BinderAssetMeta,
   BinderAssetPayload,
+  ImageWriteAdmission,
   ProjectQuarantineResult,
   SaveProjectInput,
   SnapshotRestoreTarget,
@@ -11,6 +12,7 @@ import type {
 export type {
   BinderAssetMeta,
   BinderAssetPayload,
+  ImageWriteAdmission,
   ProjectQuarantineResult,
   SaveProjectEnvelope,
   SaveProjectInput,
@@ -114,9 +116,14 @@ class StorageManager {
   }
 
   // QNBS-v3: projectId is trailing/optional, mirroring StorageBackend, so callers that predate project-qualification still compile unchanged and defer to each backend's own 'default' fallback.
-  async saveImage(id: string, base64Data: string, projectId?: string): Promise<void> {
+  async saveImage(
+    id: string,
+    base64Data: string,
+    projectId?: string,
+    writeAdmission?: ImageWriteAdmission,
+  ): Promise<void> {
     const backend = await this.getBackend();
-    return backend.saveImage(id, base64Data, projectId);
+    return backend.saveImage(id, base64Data, projectId, writeAdmission);
   }
 
   async getImage(id: string, projectId?: string): Promise<string | null> {

--- a/tests/unit/CharacterView.test.tsx
+++ b/tests/unit/CharacterView.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { appStoreRef } from '../../app/storeRef';
 import { CharacterView } from '../../components/CharacterView';
 import { storageService } from '../../services/storageService';
 
@@ -11,6 +12,12 @@ const mockHandleAddNewManually = vi.fn();
 const mockHandleAddNewWithAI = vi.fn();
 const mockHandleSelect = vi.fn();
 const mockConfirmDelete = vi.fn();
+const mockProjectState = {
+  settings: { editorFont: 'serif', fontSize: 16, lineSpacing: 1.5 },
+  project: {
+    present: null as { data: { id: string }; generation: number } | null,
+  },
+};
 
 const baseContextValue = {
   t: (k: string) => k,
@@ -51,9 +58,7 @@ vi.mock('../../hooks/useCharacterView', () => ({
 
 vi.mock('../../app/hooks', () => ({
   useAppDispatch: vi.fn(() => vi.fn()),
-  useAppSelector: vi.fn((selector: (s: unknown) => unknown) =>
-    selector({ settings: { editorFont: 'serif', fontSize: 16, lineSpacing: 1.5 } }),
-  ),
+  useAppSelector: vi.fn((selector: (s: unknown) => unknown) => selector(mockProjectState)),
 }));
 
 vi.mock('../../hooks/useSpeechRecognition', () => ({
@@ -78,6 +83,18 @@ vi.mock('../../services/storageService', () => ({
 vi.mock('../../features/project/thunks/characterThunks', () => ({
   uploadCharacterImageThunk: vi.fn(),
 }));
+
+beforeEach(() => {
+  mockProjectState.project.present = null;
+  appStoreRef.current = {
+    getState: () => mockProjectState,
+    dispatch: vi.fn(),
+  } as never;
+});
+
+afterEach(() => {
+  appStoreRef.current = null;
+});
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -198,5 +215,40 @@ describe('CharacterView', () => {
       expect(storageService.getImage).toHaveBeenCalledWith('c-broken', 'default'),
     );
     expect(screen.queryByAltText('Robin')).toBeNull();
+  });
+
+  // QNBS-v3: [Grund: deferred read identity fence / Impact: reject stale image completion / Kreativer Mehrwert: keep a replacement incarnation visually isolated]
+  it('does not apply a deferred avatar read after the project incarnation changes', async () => {
+    mockProjectState.project.present = { data: { id: 'p1' }, generation: 0 };
+    let resolveImage!: (value: string) => void;
+    vi.mocked(storageService.getImage).mockReturnValueOnce(
+      new Promise<string>((resolve) => {
+        resolveImage = resolve;
+      }),
+    );
+    const { useCharacterView } = await import('../../hooks/useCharacterView');
+    vi.mocked(useCharacterView).mockReturnValueOnce({
+      ...baseContextValue,
+      characters: [
+        {
+          id: 'c-stale',
+          name: 'Stale Avatar',
+          appearance: '',
+          motivation: '',
+          backstory: '',
+          notes: '',
+          personalityTraits: '',
+          hasAvatar: true,
+        },
+      ],
+    } as never);
+    render(<CharacterView />);
+    await waitFor(() => expect(storageService.getImage).toHaveBeenCalledWith('c-stale', 'p1'));
+
+    mockProjectState.project.present.generation = 1;
+    resolveImage('data:image/png;base64,STALE');
+    await Promise.resolve();
+
+    expect(screen.queryByAltText('Stale Avatar')).toBeNull();
   });
 });

--- a/tests/unit/CharacterView.test.tsx
+++ b/tests/unit/CharacterView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { appStoreRef } from '../../app/storeRef';
 import { CharacterView } from '../../components/CharacterView';
@@ -15,7 +15,7 @@ const mockConfirmDelete = vi.fn();
 const mockProjectState = {
   settings: { editorFont: 'serif', fontSize: 16, lineSpacing: 1.5 },
   project: {
-    present: null as { data: { id: string }; generation: number } | null,
+    present: { data: { id: 'p1' }, generation: 0 },
   },
 };
 
@@ -85,7 +85,7 @@ vi.mock('../../features/project/thunks/characterThunks', () => ({
 }));
 
 beforeEach(() => {
-  mockProjectState.project.present = null;
+  mockProjectState.project.present = { data: { id: 'p1' }, generation: 0 };
   appStoreRef.current = {
     getState: () => mockProjectState,
     dispatch: vi.fn(),
@@ -211,15 +211,12 @@ describe('CharacterView', () => {
     } as never);
     render(<CharacterView />);
     // QNBS-v3: id now leads, projectId trails, matching the reordered getImage signature.
-    await waitFor(() =>
-      expect(storageService.getImage).toHaveBeenCalledWith('c-broken', 'default'),
-    );
+    await waitFor(() => expect(storageService.getImage).toHaveBeenCalledWith('c-broken', 'p1'));
     expect(screen.queryByAltText('Robin')).toBeNull();
   });
 
   // QNBS-v3: [Grund: deferred read identity fence / Impact: reject stale image completion / Kreativer Mehrwert: keep a replacement incarnation visually isolated]
   it('does not apply a deferred avatar read after the project incarnation changes', async () => {
-    mockProjectState.project.present = { data: { id: 'p1' }, generation: 0 };
     let resolveImage!: (value: string) => void;
     vi.mocked(storageService.getImage).mockReturnValueOnce(
       new Promise<string>((resolve) => {
@@ -246,8 +243,10 @@ describe('CharacterView', () => {
     await waitFor(() => expect(storageService.getImage).toHaveBeenCalledWith('c-stale', 'p1'));
 
     mockProjectState.project.present.generation = 1;
-    resolveImage('data:image/png;base64,STALE');
-    await Promise.resolve();
+    await act(async () => {
+      resolveImage('data:image/png;base64,STALE');
+      await Promise.resolve();
+    });
 
     expect(screen.queryByAltText('Stale Avatar')).toBeNull();
   });

--- a/tests/unit/WorldView.test.tsx
+++ b/tests/unit/WorldView.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { appStoreRef } from '../../app/storeRef';
 import { WorldView } from '../../components/WorldView';
 import { storageService } from '../../services/storageService';
 
@@ -44,15 +45,20 @@ const baseContextValue = {
   handleLocationChange: vi.fn(),
 };
 
+const mockProjectState = {
+  settings: { editorFont: 'serif', fontSize: 16, lineSpacing: 1.5 },
+  project: {
+    present: null as { data: { id: string }; generation: number } | null,
+  },
+};
+
 vi.mock('../../hooks/useWorldView', () => ({
   useWorldView: vi.fn(() => baseContextValue),
 }));
 
 vi.mock('../../app/hooks', () => ({
   useAppDispatch: vi.fn(() => vi.fn()),
-  useAppSelector: vi.fn((selector: (s: unknown) => unknown) =>
-    selector({ settings: { editorFont: 'serif', fontSize: 16, lineSpacing: 1.5 } }),
-  ),
+  useAppSelector: vi.fn((selector: (s: unknown) => unknown) => selector(mockProjectState)),
 }));
 
 vi.mock('../../hooks/useSpeechRecognition', () => ({
@@ -73,6 +79,18 @@ vi.mock('../../services/storageService', () => ({
     getImage: vi.fn().mockResolvedValue(null),
   },
 }));
+
+beforeEach(() => {
+  mockProjectState.project.present = null;
+  appStoreRef.current = {
+    getState: () => mockProjectState,
+    dispatch: vi.fn(),
+  } as never;
+});
+
+afterEach(() => {
+  appStoreRef.current = null;
+});
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -197,5 +215,41 @@ describe('WorldView', () => {
       expect(storageService.getImage).toHaveBeenCalledWith('w-broken', 'default'),
     );
     expect(screen.queryByAltText('Cindralis')).toBeNull();
+  });
+
+  // QNBS-v3: [Grund: deferred read identity fence / Impact: reject stale image completion / Kreativer Mehrwert: keep a replacement incarnation visually isolated]
+  it('does not apply a deferred ambiance read after the project incarnation changes', async () => {
+    mockProjectState.project.present = { data: { id: 'p1' }, generation: 0 };
+    let resolveImage!: (value: string) => void;
+    vi.mocked(storageService.getImage).mockReturnValueOnce(
+      new Promise<string>((resolve) => {
+        resolveImage = resolve;
+      }),
+    );
+    const { useWorldView } = await import('../../hooks/useWorldView');
+    vi.mocked(useWorldView).mockReturnValueOnce({
+      ...baseContextValue,
+      worlds: [
+        {
+          id: 'w-stale',
+          name: 'Stale Ambiance',
+          description: '',
+          geography: '',
+          magicSystem: '',
+          notes: '',
+          hasAmbianceImage: true,
+          locations: [],
+          timeline: [],
+        },
+      ],
+    } as never);
+    render(<WorldView />);
+    await waitFor(() => expect(storageService.getImage).toHaveBeenCalledWith('w-stale', 'p1'));
+
+    mockProjectState.project.present.generation = 1;
+    resolveImage('data:image/png;base64,STALE');
+    await Promise.resolve();
+
+    expect(screen.queryByAltText('Stale Ambiance')).toBeNull();
   });
 });

--- a/tests/unit/WorldView.test.tsx
+++ b/tests/unit/WorldView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { appStoreRef } from '../../app/storeRef';
 import { WorldView } from '../../components/WorldView';
@@ -48,7 +48,7 @@ const baseContextValue = {
 const mockProjectState = {
   settings: { editorFont: 'serif', fontSize: 16, lineSpacing: 1.5 },
   project: {
-    present: null as { data: { id: string }; generation: number } | null,
+    present: { data: { id: 'p1' }, generation: 0 },
   },
 };
 
@@ -81,7 +81,7 @@ vi.mock('../../services/storageService', () => ({
 }));
 
 beforeEach(() => {
-  mockProjectState.project.present = null;
+  mockProjectState.project.present = { data: { id: 'p1' }, generation: 0 };
   appStoreRef.current = {
     getState: () => mockProjectState,
     dispatch: vi.fn(),
@@ -211,22 +211,49 @@ describe('WorldView', () => {
     } as never);
     render(<WorldView />);
     // QNBS-v3: id now leads, projectId trails, matching the reordered getImage signature.
-    await waitFor(() =>
-      expect(storageService.getImage).toHaveBeenCalledWith('w-broken', 'default'),
-    );
+    await waitFor(() => expect(storageService.getImage).toHaveBeenCalledWith('w-broken', 'p1'));
     expect(screen.queryByAltText('Cindralis')).toBeNull();
   });
 
   // QNBS-v3: [Grund: deferred read identity fence / Impact: reject stale image completion / Kreativer Mehrwert: keep a replacement incarnation visually isolated]
   it('does not apply a deferred ambiance read after the project incarnation changes', async () => {
-    mockProjectState.project.present = { data: { id: 'p1' }, generation: 0 };
-    let resolveImage!: (value: string) => void;
+    let resolveInitialImage!: (value: string) => void;
     vi.mocked(storageService.getImage).mockReturnValueOnce(
       new Promise<string>((resolve) => {
-        resolveImage = resolve;
+        resolveInitialImage = resolve;
       }),
     );
     const { useWorldView } = await import('../../hooks/useWorldView');
+    vi.mocked(useWorldView).mockReturnValueOnce({
+      ...baseContextValue,
+      worlds: [
+        {
+          id: 'w-stable',
+          name: 'Stable Ambiance',
+          description: '',
+          geography: '',
+          magicSystem: '',
+          notes: '',
+          hasAmbianceImage: true,
+          locations: [],
+          timeline: [],
+        },
+      ],
+    } as never);
+    const { rerender } = render(<WorldView />);
+    await waitFor(() => expect(storageService.getImage).toHaveBeenCalledWith('w-stable', 'p1'));
+    await act(async () => {
+      resolveInitialImage('data:image/png;base64,INITIAL');
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(screen.getByAltText('Stable Ambiance')).toBeTruthy());
+
+    let resolveStaleImage!: (value: string) => void;
+    vi.mocked(storageService.getImage).mockReturnValueOnce(
+      new Promise<string>((resolve) => {
+        resolveStaleImage = resolve;
+      }),
+    );
     vi.mocked(useWorldView).mockReturnValueOnce({
       ...baseContextValue,
       worlds: [
@@ -243,12 +270,13 @@ describe('WorldView', () => {
         },
       ],
     } as never);
-    render(<WorldView />);
+    rerender(<WorldView />);
     await waitFor(() => expect(storageService.getImage).toHaveBeenCalledWith('w-stale', 'p1'));
-
     mockProjectState.project.present.generation = 1;
-    resolveImage('data:image/png;base64,STALE');
-    await Promise.resolve();
+    await act(async () => {
+      resolveStaleImage('data:image/png;base64,STALE');
+      await Promise.resolve();
+    });
 
     expect(screen.queryByAltText('Stale Ambiance')).toBeNull();
   });

--- a/tests/unit/features/project/projectIdentity.test.ts
+++ b/tests/unit/features/project/projectIdentity.test.ts
@@ -3,6 +3,7 @@ import {
   getProjectTargetIdentity,
   getProjectTargetStorageId,
   identityUnchanged,
+  isStaleProjectOperationError,
 } from '../../../../features/project/projectIdentity';
 
 describe('getProjectTargetIdentity', () => {
@@ -92,5 +93,16 @@ describe('identityUnchanged', () => {
 
   it('returns false when only the captured identity is null', () => {
     expect(identityUnchanged(null, 'id:p1:gen:0')).toBe(false);
+  });
+});
+
+describe('isStaleProjectOperationError', () => {
+  it('recognizes serialized stale-operation rejections', () => {
+    expect(isStaleProjectOperationError({ name: 'StaleProjectOperationError' })).toBe(true);
+  });
+
+  it('does not classify unrelated errors or non-errors as stale', () => {
+    expect(isStaleProjectOperationError(new Error('other failure'))).toBe(false);
+    expect(isStaleProjectOperationError(null)).toBe(false);
   });
 });

--- a/tests/unit/features/project/projectIdentity.test.ts
+++ b/tests/unit/features/project/projectIdentity.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   getProjectTargetIdentity,
+  getProjectTargetStorageId,
   identityUnchanged,
 } from '../../../../features/project/projectIdentity';
 
@@ -52,6 +53,26 @@ describe('getProjectTargetIdentity', () => {
       generation: 0,
     });
     expect(identity).toBe('id:p1:gen:0');
+  });
+});
+
+describe('getProjectTargetStorageId', () => {
+  it('keeps ordinary project IDs stable', () => {
+    expect(getProjectTargetStorageId({ data: { id: 'p1' }, generation: 4 })).toBe('p1');
+  });
+
+  it('uses stable legacy directory identity without the transient generation fence', () => {
+    // QNBS-v3: legacy image ownership must remain reloadable while still avoiding the shared default namespace.
+    expect(
+      getProjectTargetStorageId({
+        data: { __worldscriptLegacyProjectDirectory: 'legacy-dir' },
+        generation: 4,
+      }),
+    ).toBe('legacy:legacy-dir');
+  });
+
+  it('returns null when no stable storage identity exists', () => {
+    expect(getProjectTargetStorageId({ data: { title: 'Untitled' } })).toBeNull();
   });
 });
 

--- a/tests/unit/hooks/useCharacterView.test.ts
+++ b/tests/unit/hooks/useCharacterView.test.ts
@@ -66,6 +66,9 @@ vi.mock('../../../features/project/projectIdentity', () => ({
   getProjectTargetStorageId: () => 'c-project-1',
   identityUnchanged: (captured: string | null, live: string | null) =>
     captured !== null && captured === live,
+  assertProjectIdentityUnchanged: (captured: string | null, live: string | null) => {
+    if (captured === null || captured !== live) throw new Error('stale project operation');
+  },
   isStaleProjectOperationError: mockIsStaleError,
 }));
 
@@ -433,6 +436,27 @@ describe('handleGeneratePortrait', () => {
     expect(result.current.selectedCharacter?.hasAvatar).toBe(false);
     expect(mockToast.error).not.toHaveBeenCalled();
   });
+
+  it('silently discards a stale refined portrait result', async () => {
+    mockDispatch.mockResolvedValue({
+      type: 'project/generateCharacterPortrait/rejected',
+      error: { name: 'StaleProjectOperationError' },
+    });
+    mockPortraitMatch.mockReturnValue(false);
+    mockIsStaleError.mockReturnValue(true);
+
+    const { result } = renderHook(() => useCharacterView());
+    act(() => {
+      result.current.handleSelect(makeCharacter('c1'));
+      result.current.setRefinementPrompt('more detail');
+    });
+    await act(async () => {
+      await result.current.handleRefinePortrait();
+    });
+
+    expect(mockToast.error).not.toHaveBeenCalled();
+    expect(result.current.isRefiningPortrait).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -468,6 +492,8 @@ describe('confirmDelete', () => {
     // QNBS-v3: asserts the real active project id (not a hardcoded fallback every project would share) is forwarded to deleteImage.
     expect(mockDeleteImage).toHaveBeenCalledWith('c1', 'c-project-1', expect.any(Function));
     expect(mockDispatch).toHaveBeenCalledWith(projectActions.deleteCharacter('c1'));
+    const admission = mockDeleteImage.mock.calls[0]?.[2] as (() => void) | undefined;
+    admission?.();
   });
 
   it('resets state and calls toast.info after deletion', async () => {
@@ -492,6 +518,35 @@ describe('confirmDelete', () => {
     act(() => result.current.setCharacterToDelete(char));
     mockIsStaleError.mockReturnValue(true);
     mockDeleteImage.mockRejectedValueOnce({ name: 'StaleProjectOperationError' });
+
+    await act(async () => {
+      await result.current.confirmDelete();
+    });
+
+    expect(result.current.characterToDelete).toBeNull();
+    expect(mockDispatch).not.toHaveBeenCalledWith(projectActions.deleteCharacter('c1'));
+  });
+
+  it('clears a confirmation when the active project changes before delete starts', async () => {
+    const { result } = renderHook(() => useCharacterView());
+    act(() => result.current.setCharacterToDelete(makeCharacter('c1')));
+    mockCaptureIdentity.mockReturnValue('id:replacement');
+
+    await act(async () => {
+      await result.current.confirmDelete();
+    });
+
+    expect(result.current.characterToDelete).toBeNull();
+    expect(mockDeleteImage).not.toHaveBeenCalled();
+  });
+
+  it('clears a confirmation when the active project changes after storage', async () => {
+    const char = makeCharacter('c1', 'Hero');
+    const { result } = renderHook(() => useCharacterView());
+    act(() => result.current.setCharacterToDelete(char));
+    mockDeleteImage.mockImplementationOnce(async () => {
+      mockCaptureIdentity.mockReturnValue('id:replacement');
+    });
 
     await act(async () => {
       await result.current.confirmDelete();

--- a/tests/unit/hooks/useCharacterView.test.ts
+++ b/tests/unit/hooks/useCharacterView.test.ts
@@ -486,6 +486,21 @@ describe('confirmDelete', () => {
     expect(mockToast.info).toHaveBeenCalled();
   });
 
+  it('clears a stale delete confirmation without dispatching a deletion', async () => {
+    const char = makeCharacter('c1', 'Hero');
+    const { result } = renderHook(() => useCharacterView());
+    act(() => result.current.setCharacterToDelete(char));
+    mockIsStaleError.mockReturnValue(true);
+    mockDeleteImage.mockRejectedValueOnce({ name: 'StaleProjectOperationError' });
+
+    await act(async () => {
+      await result.current.confirmDelete();
+    });
+
+    expect(result.current.characterToDelete).toBeNull();
+    expect(mockDispatch).not.toHaveBeenCalledWith(projectActions.deleteCharacter('c1'));
+  });
+
   it('does nothing when characterToDelete is null', async () => {
     const { result } = renderHook(() => useCharacterView());
     await act(async () => {

--- a/tests/unit/hooks/useCharacterView.test.ts
+++ b/tests/unit/hooks/useCharacterView.test.ts
@@ -28,8 +28,11 @@ let mockCharacters: Character[] = [];
 
 vi.mock('../../../app/hooks', () => ({
   useAppDispatch: () => mockDispatch,
-  useAppSelector: (selector: (s: { characters: Character[] }) => unknown) =>
-    selector({ characters: mockCharacters }),
+  useAppSelector: (selector: (s: unknown) => unknown) =>
+    selector({
+      characters: mockCharacters,
+      project: { present: { data: { id: 'c-project-1' } } },
+    }),
 }));
 
 vi.mock('../../../hooks/useTranslation', () => ({
@@ -54,6 +57,7 @@ vi.mock('../../../features/project/projectSelectors', () => ({
 
 vi.mock('../../../features/project/projectIdentity', () => ({
   captureActiveProjectIdentity: mockCaptureIdentity,
+  getProjectTargetStorageId: () => 'c-project-1',
   identityUnchanged: (captured: string | null, live: string | null) =>
     captured !== null && captured === live,
   isStaleProjectOperationError: () => false,

--- a/tests/unit/hooks/useCharacterView.test.ts
+++ b/tests/unit/hooks/useCharacterView.test.ts
@@ -97,7 +97,8 @@ vi.mock('../../../services/storageService', () => ({
   storageService: {
     saveImage: (id: unknown, data: unknown, projectId: unknown) =>
       mockSaveImage(id, data, projectId),
-    deleteImage: (id: unknown, projectId: unknown) => mockDeleteImage(id, projectId),
+    deleteImage: (id: unknown, projectId: unknown, admission: unknown) =>
+      mockDeleteImage(id, projectId, admission),
   },
 }));
 
@@ -465,7 +466,7 @@ describe('confirmDelete', () => {
     });
 
     // QNBS-v3: asserts the real active project id (not a hardcoded fallback every project would share) is forwarded to deleteImage.
-    expect(mockDeleteImage).toHaveBeenCalledWith('c1', 'c-project-1');
+    expect(mockDeleteImage).toHaveBeenCalledWith('c1', 'c-project-1', expect.any(Function));
     expect(mockDispatch).toHaveBeenCalledWith(projectActions.deleteCharacter('c1'));
   });
 

--- a/tests/unit/hooks/useCharacterView.test.ts
+++ b/tests/unit/hooks/useCharacterView.test.ts
@@ -56,6 +56,7 @@ vi.mock('../../../features/project/projectIdentity', () => ({
   captureActiveProjectIdentity: mockCaptureIdentity,
   identityUnchanged: (captured: string | null, live: string | null) =>
     captured !== null && captured === live,
+  isStaleProjectOperationError: () => false,
 }));
 
 vi.mock('../../../features/project/thunks/characterThunks', () => {

--- a/tests/unit/hooks/useCharacterView.test.ts
+++ b/tests/unit/hooks/useCharacterView.test.ts
@@ -7,13 +7,19 @@ import type { Character } from '../../../types';
 // ---------------------------------------------------------------------------
 // vi.hoisted — match mocks referenced in vi.mock factories
 // ---------------------------------------------------------------------------
-const { mockProfileMatch, mockPortraitMatch, mockRegenerateMatch, mockCaptureIdentity } =
-  vi.hoisted(() => ({
-    mockProfileMatch: vi.fn((_: unknown) => true),
-    mockPortraitMatch: vi.fn((_: unknown) => true),
-    mockRegenerateMatch: vi.fn((_: unknown) => true),
-    mockCaptureIdentity: vi.fn(() => 'id:test-project'),
-  }));
+const {
+  mockProfileMatch,
+  mockPortraitMatch,
+  mockRegenerateMatch,
+  mockCaptureIdentity,
+  mockIsStaleError,
+} = vi.hoisted(() => ({
+  mockProfileMatch: vi.fn((_: unknown) => true),
+  mockPortraitMatch: vi.fn((_: unknown) => true),
+  mockRegenerateMatch: vi.fn((_: unknown) => true),
+  mockCaptureIdentity: vi.fn(() => 'id:test-project'),
+  mockIsStaleError: vi.fn((_: unknown) => false),
+}));
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -60,7 +66,7 @@ vi.mock('../../../features/project/projectIdentity', () => ({
   getProjectTargetStorageId: () => 'c-project-1',
   identityUnchanged: (captured: string | null, live: string | null) =>
     captured !== null && captured === live,
-  isStaleProjectOperationError: () => false,
+  isStaleProjectOperationError: mockIsStaleError,
 }));
 
 vi.mock('../../../features/project/thunks/characterThunks', () => {
@@ -126,6 +132,7 @@ beforeEach(() => {
   mockPortraitMatch.mockReturnValue(true);
   mockRegenerateMatch.mockReturnValue(true);
   mockCaptureIdentity.mockReturnValue('id:test-project');
+  mockIsStaleError.mockReturnValue(false);
 });
 
 // ---------------------------------------------------------------------------
@@ -405,6 +412,25 @@ describe('handleGeneratePortrait', () => {
 
     expect(mockToast.error).toHaveBeenCalled();
     expect(result.current.errorMessage).not.toBeNull();
+  });
+
+  it('silently discards stale portrait results without marking an avatar', async () => {
+    mockDispatch.mockResolvedValue({
+      type: 'project/generateCharacterPortrait/rejected',
+      error: { name: 'StaleProjectOperationError' },
+    });
+    mockPortraitMatch.mockReturnValue(false);
+    mockIsStaleError.mockReturnValue(true);
+
+    const char = makeCharacter('c1');
+    const { result } = renderHook(() => useCharacterView());
+    act(() => result.current.handleSelect(char));
+    await act(async () => {
+      await result.current.handleGeneratePortrait();
+    });
+
+    expect(result.current.selectedCharacter?.hasAvatar).toBe(false);
+    expect(mockToast.error).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/unit/hooks/useWorldView.test.ts
+++ b/tests/unit/hooks/useWorldView.test.ts
@@ -413,6 +413,7 @@ describe('handleGenerateImage', () => {
     });
 
     expect(mockToast.error).not.toHaveBeenCalled();
+    expect(mockIsStaleError).toHaveBeenCalledWith({ name: 'StaleProjectOperationError' });
     expect(result.current.isGeneratingImage).toBe(false);
   });
 });

--- a/tests/unit/hooks/useWorldView.test.ts
+++ b/tests/unit/hooks/useWorldView.test.ts
@@ -63,6 +63,9 @@ vi.mock('../../../features/project/projectIdentity', () => ({
   getProjectTargetStorageId: () => 'w-project-1',
   identityUnchanged: (captured: string | null, live: string | null) =>
     captured !== null && captured === live,
+  assertProjectIdentityUnchanged: (captured: string | null, live: string | null) => {
+    if (captured === null || captured !== live) throw new Error('stale project operation');
+  },
   isStaleProjectOperationError: mockIsStaleError,
 }));
 
@@ -417,6 +420,27 @@ describe('handleGenerateImage', () => {
     expect(mockIsStaleError).toHaveBeenCalledWith({ name: 'StaleProjectOperationError' });
     expect(result.current.isGeneratingImage).toBe(false);
   });
+
+  it('silently discards a stale refined image result', async () => {
+    mockDispatch.mockResolvedValue({
+      type: 'project/generateWorldImage/rejected',
+      error: { name: 'StaleProjectOperationError' },
+    });
+    mockImageMatch.mockReturnValue(false);
+    mockIsStaleError.mockReturnValue(true);
+
+    const { result } = renderHook(() => useWorldView());
+    act(() => {
+      result.current.handleSelect(makeWorld('w1'));
+      result.current.setRefinementPrompt('more atmosphere');
+    });
+    await act(async () => {
+      await result.current.handleRefineImage();
+    });
+
+    expect(mockToast.error).not.toHaveBeenCalled();
+    expect(result.current.isRefiningImage).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -461,6 +485,8 @@ describe('confirmDelete', () => {
     );
     expect(result.current.isAtlasOpen).toBe(false);
     expect(result.current.selectedWorld).toBeNull();
+    const admission = mockDeleteImage.mock.calls[0]?.[2] as (() => void) | undefined;
+    admission?.();
   });
 
   it('clears a stale delete confirmation without dispatching a deletion', async () => {
@@ -470,6 +496,37 @@ describe('confirmDelete', () => {
     act(() => result.current.handleDelete('w1'));
     mockIsStaleError.mockReturnValue(true);
     mockDeleteImage.mockRejectedValueOnce({ name: 'StaleProjectOperationError' });
+
+    await act(async () => {
+      await result.current.confirmDelete();
+    });
+
+    expect(result.current.worldToDelete).toBeNull();
+    expect(mockDispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'project/deleteWorld', payload: 'w1' }),
+    );
+  });
+
+  it('clears a confirmation when the active project changes before delete starts', async () => {
+    const { result } = renderHook(() => useWorldView());
+    act(() => result.current.setWorldToDelete(makeWorld('w1')));
+    mockCaptureIdentity.mockReturnValue('id:replacement');
+
+    await act(async () => {
+      await result.current.confirmDelete();
+    });
+
+    expect(result.current.worldToDelete).toBeNull();
+    expect(mockDeleteImage).not.toHaveBeenCalled();
+  });
+
+  it('clears a confirmation when the active project changes after storage', async () => {
+    const world = makeWorld('w1', 'Arda');
+    const { result } = renderHook(() => useWorldView());
+    act(() => result.current.setWorldToDelete(world));
+    mockDeleteImage.mockImplementationOnce(async () => {
+      mockCaptureIdentity.mockReturnValue('id:replacement');
+    });
 
     await act(async () => {
       await result.current.confirmDelete();

--- a/tests/unit/hooks/useWorldView.test.ts
+++ b/tests/unit/hooks/useWorldView.test.ts
@@ -57,6 +57,7 @@ vi.mock('../../../features/project/projectIdentity', () => ({
   captureActiveProjectIdentity: mockCaptureIdentity,
   identityUnchanged: (captured: string | null, live: string | null) =>
     captured !== null && captured === live,
+  isStaleProjectOperationError: () => false,
 }));
 
 vi.mock('../../../features/project/thunks/worldThunks', () => {

--- a/tests/unit/hooks/useWorldView.test.ts
+++ b/tests/unit/hooks/useWorldView.test.ts
@@ -94,7 +94,8 @@ vi.mock('../../../services/storageService', () => ({
   storageService: {
     saveImage: (id: unknown, data: unknown, projectId: unknown) =>
       mockSaveImage(id, data, projectId),
-    deleteImage: (id: unknown, projectId: unknown) => mockDeleteImage(id, projectId),
+    deleteImage: (id: unknown, projectId: unknown, admission: unknown) =>
+      mockDeleteImage(id, projectId, admission),
   },
 }));
 
@@ -454,7 +455,7 @@ describe('confirmDelete', () => {
       await result.current.confirmDelete();
     });
     // QNBS-v3: asserts the real active project id (not a hardcoded fallback every project would share) is forwarded to deleteImage.
-    expect(mockDeleteImage).toHaveBeenCalledWith('w1', 'w-project-1');
+    expect(mockDeleteImage).toHaveBeenCalledWith('w1', 'w-project-1', expect.any(Function));
     expect(mockDispatch).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'project/deleteWorld', payload: 'w1' }),
     );

--- a/tests/unit/hooks/useWorldView.test.ts
+++ b/tests/unit/hooks/useWorldView.test.ts
@@ -55,6 +55,7 @@ vi.mock('../../../features/project/projectSelectors', () => ({
 
 vi.mock('../../../features/project/projectIdentity', () => ({
   captureActiveProjectIdentity: mockCaptureIdentity,
+  getProjectTargetStorageId: () => 'w-project-1',
   identityUnchanged: (captured: string | null, live: string | null) =>
     captured !== null && captured === live,
   isStaleProjectOperationError: () => false,

--- a/tests/unit/hooks/useWorldView.test.ts
+++ b/tests/unit/hooks/useWorldView.test.ts
@@ -463,6 +463,24 @@ describe('confirmDelete', () => {
     expect(result.current.selectedWorld).toBeNull();
   });
 
+  it('clears a stale delete confirmation without dispatching a deletion', async () => {
+    const world = makeWorld('w1');
+    mockWorlds = [world];
+    const { result } = renderHook(() => useWorldView());
+    act(() => result.current.handleDelete('w1'));
+    mockIsStaleError.mockReturnValue(true);
+    mockDeleteImage.mockRejectedValueOnce({ name: 'StaleProjectOperationError' });
+
+    await act(async () => {
+      await result.current.confirmDelete();
+    });
+
+    expect(result.current.worldToDelete).toBeNull();
+    expect(mockDispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'project/deleteWorld', payload: 'w1' }),
+    );
+  });
+
   it('does nothing when worldToDelete is null', async () => {
     const { result } = renderHook(() => useWorldView());
     await act(async () => {

--- a/tests/unit/hooks/useWorldView.test.ts
+++ b/tests/unit/hooks/useWorldView.test.ts
@@ -6,14 +6,19 @@ import type { World } from '../../../types';
 // ---------------------------------------------------------------------------
 // vi.hoisted — thunk match fns must be stable references inside vi.mock factories
 // ---------------------------------------------------------------------------
-const { mockProfileMatch, mockRegenerateMatch, mockImageMatch, mockCaptureIdentity } = vi.hoisted(
-  () => ({
-    mockProfileMatch: vi.fn((_: unknown) => true),
-    mockRegenerateMatch: vi.fn((_: unknown) => true),
-    mockImageMatch: vi.fn((_: unknown) => true),
-    mockCaptureIdentity: vi.fn(() => 'id:test-project'),
-  }),
-);
+const {
+  mockProfileMatch,
+  mockRegenerateMatch,
+  mockImageMatch,
+  mockCaptureIdentity,
+  mockIsStaleError,
+} = vi.hoisted(() => ({
+  mockProfileMatch: vi.fn((_: unknown) => true),
+  mockRegenerateMatch: vi.fn((_: unknown) => true),
+  mockImageMatch: vi.fn((_: unknown) => true),
+  mockCaptureIdentity: vi.fn(() => 'id:test-project'),
+  mockIsStaleError: vi.fn((_: unknown) => false),
+}));
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -58,7 +63,7 @@ vi.mock('../../../features/project/projectIdentity', () => ({
   getProjectTargetStorageId: () => 'w-project-1',
   identityUnchanged: (captured: string | null, live: string | null) =>
     captured !== null && captured === live,
-  isStaleProjectOperationError: () => false,
+  isStaleProjectOperationError: mockIsStaleError,
 }));
 
 vi.mock('../../../features/project/thunks/worldThunks', () => {
@@ -121,6 +126,7 @@ beforeEach(() => {
   mockRegenerateMatch.mockReturnValue(true);
   mockImageMatch.mockReturnValue(true);
   mockCaptureIdentity.mockReturnValue('id:test-project');
+  mockIsStaleError.mockReturnValue(false);
 });
 
 // ---------------------------------------------------------------------------
@@ -388,6 +394,25 @@ describe('handleGenerateImage', () => {
     await act(async () => {
       await result.current.handleGenerateImage();
     });
+    expect(result.current.isGeneratingImage).toBe(false);
+  });
+
+  it('silently discards stale image results without showing a toast', async () => {
+    const world = makeWorld('w1');
+    mockDispatch.mockResolvedValue({
+      type: 'project/generateWorldImage/rejected',
+      error: { name: 'StaleProjectOperationError' },
+    });
+    mockImageMatch.mockReturnValue(false);
+    mockIsStaleError.mockReturnValue(true);
+
+    const { result } = renderHook(() => useWorldView());
+    act(() => result.current.handleSelect(world));
+    await act(async () => {
+      await result.current.handleGenerateImage();
+    });
+
+    expect(mockToast.error).not.toHaveBeenCalled();
     expect(result.current.isGeneratingImage).toBe(false);
   });
 });

--- a/tests/unit/projectSlice.interviews.test.ts
+++ b/tests/unit/projectSlice.interviews.test.ts
@@ -27,10 +27,16 @@ function makeMessage(overrides: Partial<InterviewMessage> = {}): InterviewMessag
   };
 }
 
-type PartialState = { data: { characterInterviews?: Record<string, CharacterInterview[]> } };
+type PartialState = {
+  generation?: number;
+  data: {
+    id?: string;
+    characterInterviews?: Record<string, CharacterInterview[]>;
+  };
+};
 
 function s(interviews: Record<string, CharacterInterview[]> = {}): PartialState {
-  return { data: { characterInterviews: interviews } };
+  return { generation: 0, data: { id: 'default', characterInterviews: interviews } };
 }
 
 describe('projectSlice — characterInterview reducers', () => {
@@ -107,10 +113,28 @@ describe('projectSlice — characterInterview reducers', () => {
         interviewId: 'iv-1',
         aiMsgId: 'ai-msg',
         content: 'Streaming response so far',
+        originIdentity: 'id:default:gen:0',
       },
     });
     expect(next.data.characterInterviews?.['char-1']?.[0]?.messages?.[0]?.content).toBe(
       'Streaming response so far',
     );
+  });
+
+  it('ignores a chunk whose origin identity is no longer current', () => {
+    const aiMsg = makeMessage({ id: 'ai-msg', role: 'ai', content: '' });
+    const interview = makeInterview({ messages: [aiMsg] });
+    const state = s({ 'char-1': [interview] });
+    const next = projectReducer(state as unknown as Parameters<typeof projectReducer>[0], {
+      type: 'project/streamInterviewChunk',
+      payload: {
+        characterId: 'char-1',
+        interviewId: 'iv-1',
+        aiMsgId: 'ai-msg',
+        content: 'stale response',
+        originIdentity: 'id:default:gen:1',
+      },
+    });
+    expect(next.data.characterInterviews?.['char-1']?.[0]?.messages?.[0]?.content).toBe('');
   });
 });

--- a/tests/unit/projectSlice.interviews.test.ts
+++ b/tests/unit/projectSlice.interviews.test.ts
@@ -125,6 +125,7 @@ describe('projectSlice — characterInterview reducers', () => {
     const aiMsg = makeMessage({ id: 'ai-msg', role: 'ai', content: '' });
     const interview = makeInterview({ messages: [aiMsg] });
     const state = s({ 'char-1': [interview] });
+    // QNBS-v3: [Stale generation fixture / Prove reducer-level rejection / Preserve active interview content]
     const next = projectReducer(state as unknown as Parameters<typeof projectReducer>[0], {
       type: 'project/streamInterviewChunk',
       payload: {

--- a/tests/unit/projectSlice.interviews.test.ts
+++ b/tests/unit/projectSlice.interviews.test.ts
@@ -125,7 +125,7 @@ describe('projectSlice — characterInterview reducers', () => {
     const aiMsg = makeMessage({ id: 'ai-msg', role: 'ai', content: '' });
     const interview = makeInterview({ messages: [aiMsg] });
     const state = s({ 'char-1': [interview] });
-    // QNBS-v3: [Stale generation fixture / Prove reducer-level rejection / Preserve active interview content]
+    // QNBS-v3: [Grund: stale generation fixture / Impact: prove reducer-level rejection / Kreativer Mehrwert: preserve active interview content]
     const next = projectReducer(state as unknown as Parameters<typeof projectReducer>[0], {
       type: 'project/streamInterviewChunk',
       payload: {

--- a/tests/unit/services/fs/fsStores.test.ts
+++ b/tests/unit/services/fs/fsStores.test.ts
@@ -1953,6 +1953,31 @@ describe('FsAssetStore — images + binder assets', () => {
     expect(await store.getImage('delete-guarded', 'proj-1')).toBe('data:image/png;base64,OLD');
   });
 
+  it('rechecks delete admission after a transient filesystem retry', async () => {
+    await store.saveImage('delete-retry', 'data:image/png;base64,OLD', 'proj-1');
+    const qualified = qualifiedImageKey('delete-retry');
+    expect(qualified).toBeDefined();
+    const originalRemove = fake.apis.remove;
+    let removeAttempts = 0;
+    fake.apis.remove = (path: string, options?: { recursive?: boolean }) => {
+      if (path === qualified && removeAttempts++ === 0) {
+        return Promise.reject(new Error('resource busy'));
+      }
+      return originalRemove(path, options);
+    };
+    const admission = vi.fn();
+
+    try {
+      await store.deleteImage('delete-retry', 'proj-1', admission);
+    } finally {
+      fake.apis.remove = originalRemove;
+    }
+
+    expect(removeAttempts).toBe(2);
+    expect(admission).toHaveBeenCalledTimes(2);
+    expect(await store.getImage('delete-retry', 'proj-1')).toBeNull();
+  });
+
   it('treats legacy raw image payloads as PNG', async () => {
     await store.saveImage('legacy-char', 'QUJD', 'proj-1');
     expect(await store.getImage('legacy-char', 'proj-1')).toBe('data:image/png;base64,QUJD');

--- a/tests/unit/services/fs/fsStores.test.ts
+++ b/tests/unit/services/fs/fsStores.test.ts
@@ -1953,6 +1953,18 @@ describe('FsAssetStore — images + binder assets', () => {
     expect(await store.getImage('delete-guarded', 'proj-1')).toBe('data:image/png;base64,OLD');
   });
 
+  // QNBS-v3: [Grund: stale no-op deletion / Impact: reject obsolete entity removal / Kreativer Mehrwert: keep missing-file cleanup under project authority]
+  it('checks delete admission even when both image files are already absent', async () => {
+    const admission = vi.fn(() => {
+      throw new Error('stale project incarnation');
+    });
+
+    await expect(store.deleteImage('missing-image', 'proj-1', admission)).rejects.toThrow(
+      'stale project incarnation',
+    );
+    expect(admission).toHaveBeenCalledTimes(1);
+  });
+
   it('rechecks delete admission after a transient filesystem retry', async () => {
     await store.saveImage('delete-retry', 'data:image/png;base64,OLD', 'proj-1');
     const qualified = qualifiedImageKey('delete-retry');
@@ -1974,7 +1986,7 @@ describe('FsAssetStore — images + binder assets', () => {
     }
 
     expect(removeAttempts).toBe(2);
-    expect(admission).toHaveBeenCalledTimes(2);
+    expect(admission).toHaveBeenCalledTimes(3);
     expect(await store.getImage('delete-retry', 'proj-1')).toBeNull();
   });
 

--- a/tests/unit/services/fs/fsStores.test.ts
+++ b/tests/unit/services/fs/fsStores.test.ts
@@ -1922,6 +1922,19 @@ describe('FsAssetStore — images + binder assets', () => {
     expect(await store.getImage('char-1', 'proj-1')).toBeNull();
   });
 
+  it('does not replace an image when final write admission rejects the incarnation', async () => {
+    await store.saveImage('guarded', 'data:image/png;base64,OLD', 'proj-1');
+    const admission = vi.fn(() => {
+      throw new Error('stale project incarnation');
+    });
+
+    await expect(
+      store.saveImage('guarded', 'data:image/png;base64,NEW', 'proj-1', admission),
+    ).rejects.toThrow('stale project incarnation');
+    expect(admission).toHaveBeenCalledTimes(1);
+    expect(await store.getImage('guarded', 'proj-1')).toBe('data:image/png;base64,OLD');
+  });
+
   it('treats legacy raw image payloads as PNG', async () => {
     await store.saveImage('legacy-char', 'QUJD', 'proj-1');
     expect(await store.getImage('legacy-char', 'proj-1')).toBe('data:image/png;base64,QUJD');

--- a/tests/unit/services/fs/fsStores.test.ts
+++ b/tests/unit/services/fs/fsStores.test.ts
@@ -1924,6 +1924,7 @@ describe('FsAssetStore — images + binder assets', () => {
 
   it('does not replace an image when final write admission rejects the incarnation', async () => {
     await store.saveImage('guarded', 'data:image/png;base64,OLD', 'proj-1');
+    const filesBeforeRejectedWrite = new Map(fake.text);
     const admission = vi.fn(() => {
       throw new Error('stale project incarnation');
     });
@@ -1932,6 +1933,7 @@ describe('FsAssetStore — images + binder assets', () => {
       store.saveImage('guarded', 'data:image/png;base64,NEW', 'proj-1', admission),
     ).rejects.toThrow('stale project incarnation');
     expect(admission).toHaveBeenCalledTimes(1);
+    expect(fake.text).toEqual(filesBeforeRejectedWrite);
     expect(await store.getImage('guarded', 'proj-1')).toBe('data:image/png;base64,OLD');
   });
 

--- a/tests/unit/services/fs/fsStores.test.ts
+++ b/tests/unit/services/fs/fsStores.test.ts
@@ -1925,14 +1925,17 @@ describe('FsAssetStore — images + binder assets', () => {
   it('does not replace an image when final write admission rejects the incarnation', async () => {
     await store.saveImage('guarded', 'data:image/png;base64,OLD', 'proj-1');
     const filesBeforeRejectedWrite = new Map(fake.text);
-    const admission = vi.fn(() => {
-      throw new Error('stale project incarnation');
-    });
+    const admission = vi
+      .fn()
+      .mockImplementationOnce(() => undefined)
+      .mockImplementationOnce(() => {
+        throw new Error('stale project incarnation');
+      });
 
     await expect(
       store.saveImage('guarded', 'data:image/png;base64,NEW', 'proj-1', admission),
     ).rejects.toThrow('stale project incarnation');
-    expect(admission).toHaveBeenCalledTimes(1);
+    expect(admission).toHaveBeenCalledTimes(2);
     expect(fake.text).toEqual(filesBeforeRejectedWrite);
     expect(await store.getImage('guarded', 'proj-1')).toBe('data:image/png;base64,OLD');
   });

--- a/tests/unit/services/fs/fsStores.test.ts
+++ b/tests/unit/services/fs/fsStores.test.ts
@@ -1937,6 +1937,19 @@ describe('FsAssetStore — images + binder assets', () => {
     expect(await store.getImage('guarded', 'proj-1')).toBe('data:image/png;base64,OLD');
   });
 
+  it('does not delete an image when delete admission rejects the incarnation', async () => {
+    await store.saveImage('delete-guarded', 'data:image/png;base64,OLD', 'proj-1');
+    const admission = vi.fn(() => {
+      throw new Error('stale project incarnation');
+    });
+
+    await expect(store.deleteImage('delete-guarded', 'proj-1', admission)).rejects.toThrow(
+      'stale project incarnation',
+    );
+    expect(admission).toHaveBeenCalledTimes(1);
+    expect(await store.getImage('delete-guarded', 'proj-1')).toBe('data:image/png;base64,OLD');
+  });
+
   it('treats legacy raw image payloads as PNG', async () => {
     await store.saveImage('legacy-char', 'QUJD', 'proj-1');
     expect(await store.getImage('legacy-char', 'proj-1')).toBe('data:image/png;base64,QUJD');

--- a/tests/unit/services/storage/idbAssetStore.test.ts
+++ b/tests/unit/services/storage/idbAssetStore.test.ts
@@ -269,6 +269,19 @@ describe('IdbAssetStore', () => {
       mockIdbStore.delete.mockImplementation(() => makeErrorReq(new DOMException('del failed')));
       await expect(store.deleteImage('img-1', 'proj-1')).rejects.toBeDefined();
     });
+
+    it('refuses deletion when the current incarnation no longer has authority', async () => {
+      mockIdbStore.delete.mockImplementation(() => makeSuccessReq(undefined));
+      const admission = vi.fn(() => {
+        throw new Error('stale project incarnation');
+      });
+
+      await expect(store.deleteImage('img-1', 'proj-1', admission)).rejects.toThrow(
+        'stale project incarnation',
+      );
+      expect(admission).toHaveBeenCalledTimes(1);
+      expect(mockIdbStore.delete).not.toHaveBeenCalled();
+    });
   });
 
   describe('legacy image ownership', () => {

--- a/tests/unit/services/storage/idbAssetStore.test.ts
+++ b/tests/unit/services/storage/idbAssetStore.test.ts
@@ -270,6 +270,7 @@ describe('IdbAssetStore', () => {
       await expect(store.deleteImage('img-1', 'proj-1')).rejects.toBeDefined();
     });
 
+    // QNBS-v3: [Grund: incarnation authority rejection / Impact: prevent stale deletion / Kreativer Mehrwert: guard the admission check]
     it('refuses deletion when the current incarnation no longer has authority', async () => {
       mockIdbStore.delete.mockImplementation(() => makeSuccessReq(undefined));
       const admission = vi.fn(() => {

--- a/tests/unit/services/storage/idbAssetStore.test.ts
+++ b/tests/unit/services/storage/idbAssetStore.test.ts
@@ -186,6 +186,18 @@ describe('IdbAssetStore', () => {
       expect(mockIdbStore.put).toHaveBeenCalledWith('data:image/png;base64,abc', 'proj-1::img-1');
     });
 
+    it('refuses the image write when final admission no longer proves authority', async () => {
+      const admission = vi.fn(() => {
+        throw new Error('stale project incarnation');
+      });
+
+      await expect(
+        store.saveImage('img-1', 'data:image/png;base64,abc', 'proj-1', admission),
+      ).rejects.toThrow('stale project incarnation');
+      expect(admission).toHaveBeenCalledTimes(1);
+      expect(mockIdbStore.put).not.toHaveBeenCalled();
+    });
+
     it('rejects when IDB put errors', async () => {
       mockIdbStore.put.mockImplementation(() => makeErrorReq(new DOMException('put failed')));
       await expect(store.saveImage('img-1', 'abc', 'proj-1')).rejects.toBeDefined();

--- a/tests/unit/storageService.test.ts
+++ b/tests/unit/storageService.test.ts
@@ -190,7 +190,7 @@ describe('storageService (IndexedDB backend in browser)', () => {
     expect(result).toBe(true);
 
     await storageService.deleteImage('img-1', 'proj-1');
-    expect(mockDb.deleteImage).toHaveBeenCalledWith('img-1', 'proj-1');
+    expect(mockDb.deleteImage).toHaveBeenCalledWith('img-1', 'proj-1', undefined);
   });
 
   it('reports indexeddb storage backend in web context', async () => {

--- a/tests/unit/storageService.test.ts
+++ b/tests/unit/storageService.test.ts
@@ -190,7 +190,7 @@ describe('storageService (IndexedDB backend in browser)', () => {
     expect(result).toBe(true);
 
     await storageService.deleteImage('img-1', 'proj-1');
-    expect(mockDb.deleteImage).toHaveBeenCalledWith('img-1', 'proj-1', undefined);
+    expect(mockDb.deleteImage).toHaveBeenCalledWith('img-1', 'proj-1');
   });
 
   it('reports indexeddb storage backend in web context', async () => {

--- a/tests/unit/thunks/interviewThunks.test.ts
+++ b/tests/unit/thunks/interviewThunks.test.ts
@@ -236,6 +236,7 @@ describe('streamInterviewResponseThunk', () => {
   });
 
   it('does not dispatch late chunks after the project incarnation changes', async () => {
+    // QNBS-v3: [Incarnation switch during stream / Prove late chunks are discarded / Preserve project-owned dialogue]
     const state = makeState();
     mockStreamText.mockImplementationOnce(
       async (_prompt: string, _creativity: unknown, onChunk: (chunk: string) => void) => {

--- a/tests/unit/thunks/interviewThunks.test.ts
+++ b/tests/unit/thunks/interviewThunks.test.ts
@@ -236,7 +236,7 @@ describe('streamInterviewResponseThunk', () => {
   });
 
   it('does not dispatch late chunks after the project incarnation changes', async () => {
-    // QNBS-v3: [Incarnation switch during stream / Prove late chunks are discarded / Preserve project-owned dialogue]
+    // QNBS-v3: [Grund: incarnation switch during stream / Impact: prove late chunks are discarded / Kreativer Mehrwert: preserve project-owned dialogue]
     const state = makeState();
     mockStreamText.mockImplementationOnce(
       async (_prompt: string, _creativity: unknown, onChunk: (chunk: string) => void) => {

--- a/tests/unit/thunks/interviewThunks.test.ts
+++ b/tests/unit/thunks/interviewThunks.test.ts
@@ -257,4 +257,22 @@ describe('streamInterviewResponseThunk', () => {
       dispatch.mock.calls.some(([action]) => action?.type === 'project/streamInterviewChunk'),
     ).toBe(false);
   });
+
+  it('rejects when the project changes before a chunkless stream completes', async () => {
+    const state = makeState();
+    mockStreamText.mockImplementationOnce(async () => {
+      state.project.present.generation = 1;
+    });
+    const dispatch = vi.fn();
+    const getState = vi.fn().mockReturnValue(state);
+
+    // QNBS-v3: completion-only coverage proves a stream cannot fulfill after a silent incarnation switch.
+    const result = await streamInterviewResponseThunk({
+      characterId: 'char-1',
+      interviewId: 'interview-1',
+      question: 'Hello?',
+    })(dispatch, getState, undefined);
+
+    expect((result as { type: string }).type).toBe('project/streamInterviewResponse/rejected');
+  });
 });

--- a/tests/unit/thunks/interviewThunks.test.ts
+++ b/tests/unit/thunks/interviewThunks.test.ts
@@ -117,6 +117,7 @@ describe('streamInterviewResponseThunk', () => {
       project: {
         present: {
           data: {
+            id: 'default',
             characters: {
               ids: ['char-1'],
               entities: { 'char-1': CHARACTER },
@@ -125,6 +126,7 @@ describe('streamInterviewResponseThunk', () => {
               'char-1': [INTERVIEW],
             },
           },
+          generation: 0,
         },
       },
       settings: {
@@ -231,5 +233,28 @@ describe('streamInterviewResponseThunk', () => {
     const result = await thunk(dispatch, getState, undefined);
     expect((result as { type: string }).type).toBe('project/streamInterviewResponse/rejected');
     expect((result as { error: { message: string } }).error.message).toContain('interview-1');
+  });
+
+  it('does not dispatch late chunks after the project incarnation changes', async () => {
+    const state = makeState();
+    mockStreamText.mockImplementationOnce(
+      async (_prompt: string, _creativity: unknown, onChunk: (chunk: string) => void) => {
+        state.project.present.generation = 1;
+        onChunk('late chunk');
+      },
+    );
+    const dispatch = vi.fn();
+    const getState = vi.fn().mockReturnValue(state);
+
+    const result = await streamInterviewResponseThunk({
+      characterId: 'char-1',
+      interviewId: 'interview-1',
+      question: 'Hello?',
+    })(dispatch, getState, undefined);
+
+    expect((result as { type: string }).type).toBe('project/streamInterviewResponse/rejected');
+    expect(
+      dispatch.mock.calls.some(([action]) => action?.type === 'project/streamInterviewChunk'),
+    ).toBe(false);
   });
 });

--- a/tests/unit/thunks/outlineAndWorldThunks.test.ts
+++ b/tests/unit/thunks/outlineAndWorldThunks.test.ts
@@ -263,7 +263,12 @@ describe('generateWorldImageThunk', () => {
     );
 
     // QNBS-v3: id, data, projectId order, matching the reordered saveImage signature.
-    expect(storageService.saveImage).toHaveBeenCalledWith('w42', 'worldimagedata', 'default');
+    expect(storageService.saveImage).toHaveBeenCalledWith(
+      'w42',
+      'worldimagedata',
+      'default',
+      expect.any(Function),
+    );
   });
 
   it('rejects on AI error', async () => {
@@ -296,7 +301,12 @@ describe('uploadWorldImageThunk', () => {
 
     expect(action.type).toBe('project/uploadWorldImage/fulfilled');
     // QNBS-v3: id, data, projectId order, matching the reordered saveImage signature.
-    expect(storageService.saveImage).toHaveBeenCalledWith('w99', fakeDataUrl, 'default');
+    expect(storageService.saveImage).toHaveBeenCalledWith(
+      'w99',
+      fakeDataUrl,
+      'default',
+      expect.any(Function),
+    );
   });
 
   it('rejects when the FileReader errors', async () => {

--- a/tests/unit/thunks/outlineAndWorldThunks.test.ts
+++ b/tests/unit/thunks/outlineAndWorldThunks.test.ts
@@ -269,6 +269,9 @@ describe('generateWorldImageThunk', () => {
       'default',
       expect.any(Function),
     );
+    const writeAdmission = vi.mocked(storageService.saveImage).mock.calls[0]?.[3];
+    expect(writeAdmission).toEqual(expect.any(Function));
+    (writeAdmission as (() => void) | undefined)?.();
   });
 
   it('rejects on AI error', async () => {
@@ -307,6 +310,40 @@ describe('uploadWorldImageThunk', () => {
       'default',
       expect.any(Function),
     );
+    const writeAdmission = vi.mocked(storageService.saveImage).mock.calls[0]?.[3];
+    expect(writeAdmission).toEqual(expect.any(Function));
+    (writeAdmission as (() => void) | undefined)?.();
+  });
+
+  it('rejects when the project changes before the upload reaches storage', async () => {
+    let triggerLoad: (() => void) | undefined;
+    vi.spyOn(FileReader.prototype, 'readAsDataURL').mockImplementation(function (this: FileReader) {
+      Object.defineProperty(this, 'result', {
+        value: 'data:image/png;base64,late-upload',
+        configurable: true,
+      });
+      triggerLoad = () => this.onload?.(new ProgressEvent('load') as ProgressEvent<FileReader>);
+    });
+
+    const store = makeStore();
+    const pending = store.dispatch(
+      uploadWorldImageThunk({
+        worldId: 'w-before-storage',
+        file: new File(['data'], 'atlas.png', { type: 'image/png' }),
+      }),
+    );
+    store.dispatch(
+      projectActions.resetProject({
+        title: 'Replacement',
+        logline: '',
+        chapter1Title: 'Chapter 1',
+      }),
+    );
+    triggerLoad?.();
+
+    const action = await pending;
+    expect(action.type).toBe('project/uploadWorldImage/rejected');
+    expect(storageService.saveImage).not.toHaveBeenCalled();
   });
 
   it('rejects when the FileReader errors', async () => {

--- a/tests/unit/thunks/writingAndCharacterThunks.test.ts
+++ b/tests/unit/thunks/writingAndCharacterThunks.test.ts
@@ -539,7 +539,12 @@ describe('uploadCharacterImageThunk', () => {
 
     expect(action.type).toBe('project/uploadCharacterImage/fulfilled');
     // QNBS-v3: id, data, projectId order, matching the reordered saveImage signature.
-    expect(storageService.saveImage).toHaveBeenCalledWith('c99', fakeDataUrl, 'default');
+    expect(storageService.saveImage).toHaveBeenCalledWith(
+      'c99',
+      fakeDataUrl,
+      'default',
+      expect.any(Function),
+    );
   });
 
   it('dispatches fulfilled with characterId', async () => {
@@ -564,6 +569,7 @@ describe('uploadCharacterImageThunk', () => {
       'c7',
       'data:image/jpeg;base64,abc123',
       'default',
+      expect.any(Function),
     );
   });
 

--- a/tests/unit/thunks/writingAndCharacterThunks.test.ts
+++ b/tests/unit/thunks/writingAndCharacterThunks.test.ts
@@ -23,7 +23,7 @@ vi.mock('../../../services/storageService', () => ({
 }));
 
 import featureFlagsReducer from '../../../features/featureFlags/featureFlagsSlice';
-import projectReducer from '../../../features/project/projectSlice';
+import projectReducer, { projectActions } from '../../../features/project/projectSlice';
 import {
   generateCharacterPortraitThunk,
   generateCharacterProfileThunk,
@@ -224,6 +224,56 @@ describe('generateSceneImageThunk', () => {
 
     const result = (action as { payload: { imageKey: string; dataUrl: string } }).payload;
     expect(result.dataUrl).toBe('data:image/png;base64,alreadyprefixed');
+  });
+
+  it('rejects and skips storage when the project changes before the write', async () => {
+    let resolveImage: ((value: string) => void) | undefined;
+    mockGenerateImage.mockReturnValueOnce(
+      new Promise<string>((resolve) => {
+        resolveImage = resolve;
+      }),
+    );
+    const store = makeStore();
+    const pending = store.dispatch(generateSceneImageThunk(payload));
+
+    store.dispatch(
+      projectActions.resetProject({
+        title: 'New project',
+        logline: '',
+        chapter1Title: 'Chapter One',
+      }),
+    );
+    resolveImage?.('late-image');
+
+    const action = await pending;
+    expect(action.type).toBe('project/generateSceneImage/rejected');
+    expect(storageService.saveImage).not.toHaveBeenCalled();
+  });
+
+  it('rejects after a project changes during the storage operation', async () => {
+    mockGenerateImage.mockResolvedValueOnce('late-image');
+    let resolveSave: (() => void) | undefined;
+    vi.mocked(storageService.saveImage).mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSave = resolve;
+        }),
+    );
+    const store = makeStore();
+    const pending = store.dispatch(generateSceneImageThunk(payload));
+
+    await vi.waitFor(() => expect(storageService.saveImage).toHaveBeenCalled());
+    store.dispatch(
+      projectActions.resetProject({
+        title: 'New project',
+        logline: '',
+        chapter1Title: 'Chapter One',
+      }),
+    );
+    resolveSave?.();
+
+    const action = await pending;
+    expect(action.type).toBe('project/generateSceneImage/rejected');
   });
 });
 

--- a/tests/unit/thunks/writingAndCharacterThunks.test.ts
+++ b/tests/unit/thunks/writingAndCharacterThunks.test.ts
@@ -202,8 +202,11 @@ describe('generateSceneImageThunk', () => {
     const store = makeStore();
     await store.dispatch(generateSceneImageThunk(payload));
 
-    // QNBS-v3: id, data, projectId order, matching the reordered saveImage signature.
-    expect(storageService.saveImage).toHaveBeenCalledWith('scene-sec-1', 'rawbase64', 'default');
+    // QNBS-v3: the final-write admission callback prevents an in-flight save from crossing an incarnation boundary.
+    const [imageId, imageData, projectId, writeAdmission] = vi.mocked(storageService.saveImage).mock
+      .calls[0]!;
+    expect([imageId, imageData, projectId]).toEqual(['scene-sec-1', 'rawbase64', 'default']);
+    expect(writeAdmission).toEqual(expect.any(Function));
   });
 
   it('prefixes plain base64 with data:image/png;base64,', async () => {
@@ -270,6 +273,33 @@ describe('generateSceneImageThunk', () => {
         chapter1Title: 'Chapter One',
       }),
     );
+    resolveSave?.();
+
+    const action = await pending;
+    expect(action.type).toBe('project/generateSceneImage/rejected');
+  });
+
+  it('rejects a same-ID generation change at the backend write-admission point', async () => {
+    mockGenerateImage.mockResolvedValueOnce('late-image');
+    let resolveSave: (() => void) | undefined;
+    let writeAdmission: (() => void) | undefined;
+    vi.mocked(storageService.saveImage).mockImplementationOnce(
+      (_id, _data, _projectId, admission) => {
+        writeAdmission = admission;
+        return new Promise<void>((resolve) => {
+          resolveSave = resolve;
+        });
+      },
+    );
+    const store = makeStore();
+    const pending = store.dispatch(generateSceneImageThunk(payload));
+
+    await vi.waitFor(() => expect(storageService.saveImage).toHaveBeenCalled());
+    store.dispatch(
+      projectActions.resetProject({ title: 'Replaced', logline: '', chapter1Title: 'Chapter One' }),
+    );
+    expect(writeAdmission).toEqual(expect.any(Function));
+    expect(() => writeAdmission?.()).toThrow('Discarded stale project operation');
     resolveSave?.();
 
     const action = await pending;
@@ -441,8 +471,10 @@ describe('generateCharacterPortraitThunk', () => {
       }),
     );
 
-    // QNBS-v3: id, data, projectId order, matching the reordered saveImage signature.
-    expect(storageService.saveImage).toHaveBeenCalledWith('c42', 'portraitdata', 'default');
+    const [imageId, imageData, projectId, writeAdmission] = vi.mocked(storageService.saveImage).mock
+      .calls[0]!;
+    expect([imageId, imageData, projectId]).toEqual(['c42', 'portraitdata', 'default']);
+    expect(writeAdmission).toEqual(expect.any(Function));
   });
 
   it('appends style to description when style is provided', async () => {

--- a/tests/unit/thunks/writingAndCharacterThunks.test.ts
+++ b/tests/unit/thunks/writingAndCharacterThunks.test.ts
@@ -475,6 +475,7 @@ describe('generateCharacterPortraitThunk', () => {
       .calls[0]!;
     expect([imageId, imageData, projectId]).toEqual(['c42', 'portraitdata', 'default']);
     expect(writeAdmission).toEqual(expect.any(Function));
+    writeAdmission?.();
   });
 
   it('appends style to description when style is provided', async () => {
@@ -545,6 +546,40 @@ describe('uploadCharacterImageThunk', () => {
       'default',
       expect.any(Function),
     );
+    const writeAdmission = vi.mocked(storageService.saveImage).mock.calls[0]?.[3];
+    expect(writeAdmission).toEqual(expect.any(Function));
+    (writeAdmission as (() => void) | undefined)?.();
+  });
+
+  it('rejects when the project changes before the upload reaches storage', async () => {
+    let triggerLoad: (() => void) | undefined;
+    vi.spyOn(FileReader.prototype, 'readAsDataURL').mockImplementation(function (this: FileReader) {
+      Object.defineProperty(this, 'result', {
+        value: 'data:image/png;base64,late-upload',
+        configurable: true,
+      });
+      triggerLoad = () => this.onload?.(new ProgressEvent('load') as ProgressEvent<FileReader>);
+    });
+
+    const store = makeStore();
+    const pending = store.dispatch(
+      uploadCharacterImageThunk({
+        characterId: 'c-before-storage',
+        file: new File(['data'], 'portrait.png', { type: 'image/png' }),
+      }),
+    );
+    store.dispatch(
+      projectActions.resetProject({
+        title: 'Replacement',
+        logline: '',
+        chapter1Title: 'Chapter 1',
+      }),
+    );
+    triggerLoad?.();
+
+    const action = await pending;
+    expect(action.type).toBe('project/uploadCharacterImage/rejected');
+    expect(storageService.saveImage).not.toHaveBeenCalled();
   });
 
   it('dispatches fulfilled with characterId', async () => {


### PR DESCRIPTION
## **User description**
## Scope

Refs #708

This bounded slice enforces project-incarnation authority for direct asynchronous AI mutations:

- character portrait generation/refinement
- world image generation/refinement
- scene image persistent writes
- Character Interview streaming

The originating project identity is captured before asynchronous work and checked before/after persistence or before accepting stream chunks. Late results from a switched project, including same-ID/new-incarnation changes, are rejected or ignored without mutating the active project.

## Verification

- Focused Vitest: 4 files, 65 tests passed
- pnpm run ci:prepush passed
- README test-count projection updated mechanically for this slice

## Non-goals

- project-qualified storage redesign (terminal #719)
- deferred/apply-later ownership (#713)
- cancellation/supersession lifecycle (#714)
- pending delete, FileReader upload, and view-invalidation paths unless separately owned by their direct-mutation contract
- #602-A encryption-remanence propagation
- #704 model/provider currency work

## Summary by Sourcery

Enforce project-incarnation ownership for asynchronous AI mutations so late results cannot modify the active project.

Bug Fixes:
- Reject stale asynchronous AI image results and Character Interview stream updates when the originating project has been switched or replaced, including same-ID project incarnations.
- Prevent stale image reads, uploads, writes, and deletes from affecting the active project across browser and desktop storage backends.
- Suppress expected stale-operation errors and notifications during project changes.

Enhancements:
- Centralize project-incarnation identity checks and storage identity handling for asynchronous project mutations.
- Add final-point authority checks to image persistence and deletion operations.

Documentation:
- Update the changelog and README test-count metrics for the added regression coverage.

Tests:
- Add regression coverage for stale project reads, writes, uploads, streams, deletions, retries, and same-ID incarnation changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented outdated image generations, uploads, deletions, and Character Interview stream updates from affecting the active project after switching projects.
  - Improved handling of delayed image loading so stale results no longer overwrite current project content.
  - Suppressed expected stale-operation error notifications while preserving alerts for genuine failures.
  - Added safeguards around image storage writes and deletes to prevent race-condition data loss.

- **Documentation**
  - Updated test-count metrics and added an Unreleased changelog entry.

- **Tests**
  - Added comprehensive regression coverage for project switches, delayed operations, and storage admission checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Prevent stale asynchronous project results from changing the active project

### What Changed
- AI-generated and uploaded character, world, and scene images are discarded when the originating project is switched or replaced, including same-ID replacements
- Character Interview stream chunks and completion results no longer update a different project
- Deferred image loads and delete confirmations are ignored when the active project changes
- Image storage writes and deletes recheck project ownership at the final operation point across browser and desktop storage
- Expected stale-operation failures no longer show misleading error notifications or toasts
- Added regression coverage for stale reads, writes, uploads, streams, deletes, retries, and project identity changes

### Impact
`✅ No cross-project image overwrites`
`✅ No stale interview content after project switches`
`✅ Quieter project switching without false error messages`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>