### PR TITLE
fix(project): fence async image authority by incarnation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Async AI image writes and Character Interview chunks now reject stale project
   incarnations:** direct image persistence and interview-stream updates capture the originating
   project identity and refuse late results after a project switch or same-ID replacement, with
-  focused regression coverage. PR #734 (successor to saturated PR #733).
+  focused regression coverage. PR #734 (successor to PR #733).
 - **AI-generated character/world/scene images can no longer overwrite another project's image
   (#704, #708):** image storage keys on both the IndexedDB and desktop filesystem backends are
   now project-qualified using a collision-resistant hash of the full project id (not a lossy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Async AI image writes and Character Interview chunks now reject stale project
   incarnations:** direct image persistence and interview-stream updates capture the originating
   project identity and refuse late results after a project switch or same-ID replacement, with
-  focused regression coverage. PR #733.
+  focused regression coverage. PR #734 (successor to saturated PR #733).
 - **AI-generated character/world/scene images can no longer overwrite another project's image
   (#704, #708):** image storage keys on both the IndexedDB and desktop filesystem backends are
   now project-qualified using a collision-resistant hash of the full project id (not a lossy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Async AI image writes and Character Interview chunks now reject stale project
+  incarnations:** direct image persistence and interview-stream updates capture the originating
+  project identity and refuse late results after a project switch or same-ID replacement, with
+  focused regression coverage. PR #733.
 - **AI-generated character/world/scene images can no longer overwrite another project's image
   (#704, #708):** image storage keys on both the IndexedDB and desktop filesystem backends are
   now project-qualified using a collision-resistant hash of the full project id (not a lossy

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <img src="https://img.shields.io/badge/TypeScript-tsgo_native_preview-3178C6?logo=typescript&logoColor=white" alt="TypeScript native preview (tsgo)">
   <img src="https://img.shields.io/badge/Desktop-Tauri_2-FFC131?logo=tauri&logoColor=black" alt="Tauri 2">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7791%2B_%2F_606_files-22C55E" alt="7791+ tests / 606 files">
+  <img src="https://img.shields.io/badge/Tests-7792%2B_%2F_606_files-22C55E" alt="7792+ tests / 606 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github&label=CI" alt="CI status">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="MIT License">
@@ -809,7 +809,7 @@ The normal web PR pipeline is not the complete native release qualification surf
 | DOCX | `docx` + JSZip | Word-compatible export |
 | PWA | Service Worker + Web App Manifest | Offline shell/installability |
 | i18n | Custom React i18n context | 2942 keys × 19 locales |
-| Testing | Vitest 4.x (7791+ tests / 606 files) + Playwright | Unit/integration/E2E |
+| Testing | Vitest 4.x (7792+ tests / 606 files) + Playwright | Unit/integration/E2E |
 | Quality | Biome + tsgo + CodeQL/security tooling | Static and CI gates |
 | Desktop | Tauri 2 | Current native shell |
 
@@ -886,7 +886,7 @@ WorldScript-Studio/
 ├── locales/                 # Source locale trees
 ├── public/                  # PWA assets, manifest, SW, runtime locale bundles
 ├── tests/
-│   ├── unit/                # Vitest unit tests (7791+ tests; file count includes package test directories)
+│   ├── unit/                # Vitest unit tests (7792+ tests; file count includes package test directories)
 │   └── e2e/                 # Playwright
 ├── docs/                    # Canonical product/engineering documentation + ADRs
 ├── src-tauri/               # Tauri v2 desktop shell / Rust
@@ -1031,7 +1031,7 @@ Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendo
 
 Current source-synchronized README metrics:
 
-- **7791+ unit tests** across **606 test files**
+- **7792+ unit tests** across **606 test files**
 - i18n: **2942 keys × 19 locales**
 
 CI remains authoritative for actual pass/fail and live coverage.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <img src="https://img.shields.io/badge/TypeScript-tsgo_native_preview-3178C6?logo=typescript&logoColor=white" alt="TypeScript native preview (tsgo)">
   <img src="https://img.shields.io/badge/Desktop-Tauri_2-FFC131?logo=tauri&logoColor=black" alt="Tauri 2">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7789%2B_%2F_606_files-22C55E" alt="7789+ tests / 606 files">
+  <img src="https://img.shields.io/badge/Tests-7790%2B_%2F_606_files-22C55E" alt="7790+ tests / 606 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github&label=CI" alt="CI status">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="MIT License">
@@ -809,7 +809,7 @@ The normal web PR pipeline is not the complete native release qualification surf
 | DOCX | `docx` + JSZip | Word-compatible export |
 | PWA | Service Worker + Web App Manifest | Offline shell/installability |
 | i18n | Custom React i18n context | 2942 keys × 19 locales |
-| Testing | Vitest 4.x (7789+ tests / 606 files) + Playwright | Unit/integration/E2E |
+| Testing | Vitest 4.x (7790+ tests / 606 files) + Playwright | Unit/integration/E2E |
 | Quality | Biome + tsgo + CodeQL/security tooling | Static and CI gates |
 | Desktop | Tauri 2 | Current native shell |
 
@@ -886,7 +886,7 @@ WorldScript-Studio/
 ├── locales/                 # Source locale trees
 ├── public/                  # PWA assets, manifest, SW, runtime locale bundles
 ├── tests/
-│   ├── unit/                # Vitest unit tests (7789+ tests; file count includes package test directories)
+│   ├── unit/                # Vitest unit tests (7790+ tests; file count includes package test directories)
 │   └── e2e/                 # Playwright
 ├── docs/                    # Canonical product/engineering documentation + ADRs
 ├── src-tauri/               # Tauri v2 desktop shell / Rust
@@ -1031,7 +1031,7 @@ Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendo
 
 Current source-synchronized README metrics:
 
-- **7789+ unit tests** across **606 test files**
+- **7790+ unit tests** across **606 test files**
 - i18n: **2942 keys × 19 locales**
 
 CI remains authoritative for actual pass/fail and live coverage.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <img src="https://img.shields.io/badge/TypeScript-tsgo_native_preview-3178C6?logo=typescript&logoColor=white" alt="TypeScript native preview (tsgo)">
   <img src="https://img.shields.io/badge/Desktop-Tauri_2-FFC131?logo=tauri&logoColor=black" alt="Tauri 2">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7785%2B_%2F_606_files-22C55E" alt="7785+ tests / 606 files">
+  <img src="https://img.shields.io/badge/Tests-7789%2B_%2F_606_files-22C55E" alt="7789+ tests / 606 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github&label=CI" alt="CI status">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="MIT License">
@@ -809,7 +809,7 @@ The normal web PR pipeline is not the complete native release qualification surf
 | DOCX | `docx` + JSZip | Word-compatible export |
 | PWA | Service Worker + Web App Manifest | Offline shell/installability |
 | i18n | Custom React i18n context | 2942 keys × 19 locales |
-| Testing | Vitest 4.x (7785+ tests / 606 files) + Playwright | Unit/integration/E2E |
+| Testing | Vitest 4.x (7789+ tests / 606 files) + Playwright | Unit/integration/E2E |
 | Quality | Biome + tsgo + CodeQL/security tooling | Static and CI gates |
 | Desktop | Tauri 2 | Current native shell |
 
@@ -886,7 +886,7 @@ WorldScript-Studio/
 ├── locales/                 # Source locale trees
 ├── public/                  # PWA assets, manifest, SW, runtime locale bundles
 ├── tests/
-│   ├── unit/                # Vitest unit tests (7785+ tests; file count includes package test directories)
+│   ├── unit/                # Vitest unit tests (7789+ tests; file count includes package test directories)
 │   └── e2e/                 # Playwright
 ├── docs/                    # Canonical product/engineering documentation + ADRs
 ├── src-tauri/               # Tauri v2 desktop shell / Rust
@@ -1031,7 +1031,7 @@ Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendo
 
 Current source-synchronized README metrics:
 
-- **7785+ unit tests** across **606 test files**
+- **7789+ unit tests** across **606 test files**
 - i18n: **2942 keys × 19 locales**
 
 CI remains authoritative for actual pass/fail and live coverage.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <img src="https://img.shields.io/badge/TypeScript-tsgo_native_preview-3178C6?logo=typescript&logoColor=white" alt="TypeScript native preview (tsgo)">
   <img src="https://img.shields.io/badge/Desktop-Tauri_2-FFC131?logo=tauri&logoColor=black" alt="Tauri 2">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7790%2B_%2F_606_files-22C55E" alt="7790+ tests / 606 files">
+  <img src="https://img.shields.io/badge/Tests-7791%2B_%2F_606_files-22C55E" alt="7791+ tests / 606 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github&label=CI" alt="CI status">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="MIT License">
@@ -809,7 +809,7 @@ The normal web PR pipeline is not the complete native release qualification surf
 | DOCX | `docx` + JSZip | Word-compatible export |
 | PWA | Service Worker + Web App Manifest | Offline shell/installability |
 | i18n | Custom React i18n context | 2942 keys × 19 locales |
-| Testing | Vitest 4.x (7790+ tests / 606 files) + Playwright | Unit/integration/E2E |
+| Testing | Vitest 4.x (7791+ tests / 606 files) + Playwright | Unit/integration/E2E |
 | Quality | Biome + tsgo + CodeQL/security tooling | Static and CI gates |
 | Desktop | Tauri 2 | Current native shell |
 
@@ -886,7 +886,7 @@ WorldScript-Studio/
 ├── locales/                 # Source locale trees
 ├── public/                  # PWA assets, manifest, SW, runtime locale bundles
 ├── tests/
-│   ├── unit/                # Vitest unit tests (7790+ tests; file count includes package test directories)
+│   ├── unit/                # Vitest unit tests (7791+ tests; file count includes package test directories)
 │   └── e2e/                 # Playwright
 ├── docs/                    # Canonical product/engineering documentation + ADRs
 ├── src-tauri/               # Tauri v2 desktop shell / Rust
@@ -1031,7 +1031,7 @@ Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendo
 
 Current source-synchronized README metrics:
 
-- **7790+ unit tests** across **606 test files**
+- **7791+ unit tests** across **606 test files**
 - i18n: **2942 keys × 19 locales**
 
 CI remains authoritative for actual pass/fail and live coverage.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <img src="https://img.shields.io/badge/TypeScript-tsgo_native_preview-3178C6?logo=typescript&logoColor=white" alt="TypeScript native preview (tsgo)">
   <img src="https://img.shields.io/badge/Desktop-Tauri_2-FFC131?logo=tauri&logoColor=black" alt="Tauri 2">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7782%2B_%2F_606_files-22C55E" alt="7782+ tests / 606 files">
+  <img src="https://img.shields.io/badge/Tests-7785%2B_%2F_606_files-22C55E" alt="7785+ tests / 606 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github&label=CI" alt="CI status">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="MIT License">
@@ -809,7 +809,7 @@ The normal web PR pipeline is not the complete native release qualification surf
 | DOCX | `docx` + JSZip | Word-compatible export |
 | PWA | Service Worker + Web App Manifest | Offline shell/installability |
 | i18n | Custom React i18n context | 2942 keys × 19 locales |
-| Testing | Vitest 4.x (7782+ tests / 606 files) + Playwright | Unit/integration/E2E |
+| Testing | Vitest 4.x (7785+ tests / 606 files) + Playwright | Unit/integration/E2E |
 | Quality | Biome + tsgo + CodeQL/security tooling | Static and CI gates |
 | Desktop | Tauri 2 | Current native shell |
 
@@ -886,7 +886,7 @@ WorldScript-Studio/
 ├── locales/                 # Source locale trees
 ├── public/                  # PWA assets, manifest, SW, runtime locale bundles
 ├── tests/
-│   ├── unit/                # Vitest unit tests (7782+ tests; file count includes package test directories)
+│   ├── unit/                # Vitest unit tests (7785+ tests; file count includes package test directories)
 │   └── e2e/                 # Playwright
 ├── docs/                    # Canonical product/engineering documentation + ADRs
 ├── src-tauri/               # Tauri v2 desktop shell / Rust
@@ -1031,7 +1031,7 @@ Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendo
 
 Current source-synchronized README metrics:
 
-- **7782+ unit tests** across **606 test files**
+- **7785+ unit tests** across **606 test files**
 - i18n: **2942 keys × 19 locales**
 
 CI remains authoritative for actual pass/fail and live coverage.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <img src="https://img.shields.io/badge/TypeScript-tsgo_native_preview-3178C6?logo=typescript&logoColor=white" alt="TypeScript native preview (tsgo)">
   <img src="https://img.shields.io/badge/Desktop-Tauri_2-FFC131?logo=tauri&logoColor=black" alt="Tauri 2">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7750%2B_%2F_606_files-22C55E" alt="7750+ tests / 606 files">
+  <img src="https://img.shields.io/badge/Tests-7782%2B_%2F_606_files-22C55E" alt="7782+ tests / 606 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github&label=CI" alt="CI status">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="MIT License">
@@ -809,7 +809,7 @@ The normal web PR pipeline is not the complete native release qualification surf
 | DOCX | `docx` + JSZip | Word-compatible export |
 | PWA | Service Worker + Web App Manifest | Offline shell/installability |
 | i18n | Custom React i18n context | 2942 keys × 19 locales |
-| Testing | Vitest 4.x (7750+ tests / 606 files) + Playwright | Unit/integration/E2E |
+| Testing | Vitest 4.x (7782+ tests / 606 files) + Playwright | Unit/integration/E2E |
 | Quality | Biome + tsgo + CodeQL/security tooling | Static and CI gates |
 | Desktop | Tauri 2 | Current native shell |
 
@@ -886,7 +886,7 @@ WorldScript-Studio/
 ├── locales/                 # Source locale trees
 ├── public/                  # PWA assets, manifest, SW, runtime locale bundles
 ├── tests/
-│   ├── unit/                # Vitest unit tests (7750+ tests, 606 files)
+│   ├── unit/                # Vitest unit tests (7782+ tests; file count includes package test directories)
 │   └── e2e/                 # Playwright
 ├── docs/                    # Canonical product/engineering documentation + ADRs
 ├── src-tauri/               # Tauri v2 desktop shell / Rust
@@ -1031,7 +1031,7 @@ Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendo
 
 Current source-synchronized README metrics:
 
-- **7750+ unit tests** across **606 test files**
+- **7782+ unit tests** across **606 test files**
 - i18n: **2942 keys × 19 locales**
 
 CI remains authoritative for actual pass/fail and live coverage.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <img src="https://img.shields.io/badge/TypeScript-tsgo_native_preview-3178C6?logo=typescript&logoColor=white" alt="TypeScript native preview (tsgo)">
   <img src="https://img.shields.io/badge/Desktop-Tauri_2-FFC131?logo=tauri&logoColor=black" alt="Tauri 2">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7793%2B_%2F_606_files-22C55E" alt="7793+ tests / 606 files">
+  <img src="https://img.shields.io/badge/Tests-7795%2B_%2F_606_files-22C55E" alt="7795+ tests / 606 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github&label=CI" alt="CI status">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="MIT License">
@@ -809,7 +809,7 @@ The normal web PR pipeline is not the complete native release qualification surf
 | DOCX | `docx` + JSZip | Word-compatible export |
 | PWA | Service Worker + Web App Manifest | Offline shell/installability |
 | i18n | Custom React i18n context | 2942 keys × 19 locales |
-| Testing | Vitest 4.x (7793+ tests / 606 files) + Playwright | Unit/integration/E2E |
+| Testing | Vitest 4.x (7795+ tests / 606 files) + Playwright | Unit/integration/E2E |
 | Quality | Biome + tsgo + CodeQL/security tooling | Static and CI gates |
 | Desktop | Tauri 2 | Current native shell |
 
@@ -886,7 +886,7 @@ WorldScript-Studio/
 ├── locales/                 # Source locale trees
 ├── public/                  # PWA assets, manifest, SW, runtime locale bundles
 ├── tests/
-│   ├── unit/                # Vitest unit tests (7793+ tests; file count includes package test directories)
+│   ├── unit/                # Vitest unit tests (7795+ tests; file count includes package test directories)
 │   └── e2e/                 # Playwright
 ├── docs/                    # Canonical product/engineering documentation + ADRs
 ├── src-tauri/               # Tauri v2 desktop shell / Rust
@@ -1031,7 +1031,7 @@ Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendo
 
 Current source-synchronized README metrics:
 
-- **7793+ unit tests** across **606 test files**
+- **7795+ unit tests** across **606 test files**
 - i18n: **2942 keys × 19 locales**
 
 CI remains authoritative for actual pass/fail and live coverage.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <img src="https://img.shields.io/badge/TypeScript-tsgo_native_preview-3178C6?logo=typescript&logoColor=white" alt="TypeScript native preview (tsgo)">
   <img src="https://img.shields.io/badge/Desktop-Tauri_2-FFC131?logo=tauri&logoColor=black" alt="Tauri 2">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7790%2B_%2F_606_files-22C55E" alt="7790+ tests / 606 files">
+  <img src="https://img.shields.io/badge/Tests-7793%2B_%2F_606_files-22C55E" alt="7793+ tests / 606 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github&label=CI" alt="CI status">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="MIT License">
@@ -809,7 +809,7 @@ The normal web PR pipeline is not the complete native release qualification surf
 | DOCX | `docx` + JSZip | Word-compatible export |
 | PWA | Service Worker + Web App Manifest | Offline shell/installability |
 | i18n | Custom React i18n context | 2942 keys × 19 locales |
-| Testing | Vitest 4.x (7790+ tests / 606 files) + Playwright | Unit/integration/E2E |
+| Testing | Vitest 4.x (7793+ tests / 606 files) + Playwright | Unit/integration/E2E |
 | Quality | Biome + tsgo + CodeQL/security tooling | Static and CI gates |
 | Desktop | Tauri 2 | Current native shell |
 
@@ -886,7 +886,7 @@ WorldScript-Studio/
 ├── locales/                 # Source locale trees
 ├── public/                  # PWA assets, manifest, SW, runtime locale bundles
 ├── tests/
-│   ├── unit/                # Vitest unit tests (7790+ tests; file count includes package test directories)
+│   ├── unit/                # Vitest unit tests (7793+ tests; file count includes package test directories)
 │   └── e2e/                 # Playwright
 ├── docs/                    # Canonical product/engineering documentation + ADRs
 ├── src-tauri/               # Tauri v2 desktop shell / Rust
@@ -1031,7 +1031,7 @@ Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendo
 
 Current source-synchronized README metrics:
 
-- **7790+ unit tests** across **606 test files**
+- **7793+ unit tests** across **606 test files**
 - i18n: **2942 keys × 19 locales**
 
 CI remains authoritative for actual pass/fail and live coverage.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <img src="https://img.shields.io/badge/TypeScript-tsgo_native_preview-3178C6?logo=typescript&logoColor=white" alt="TypeScript native preview (tsgo)">
   <img src="https://img.shields.io/badge/Desktop-Tauri_2-FFC131?logo=tauri&logoColor=black" alt="Tauri 2">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7795%2B_%2F_606_files-22C55E" alt="7795+ tests / 606 files">
+  <img src="https://img.shields.io/badge/Tests-7789%2B_%2F_606_files-22C55E" alt="7789+ tests / 606 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github&label=CI" alt="CI status">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="MIT License">
@@ -809,7 +809,7 @@ The normal web PR pipeline is not the complete native release qualification surf
 | DOCX | `docx` + JSZip | Word-compatible export |
 | PWA | Service Worker + Web App Manifest | Offline shell/installability |
 | i18n | Custom React i18n context | 2942 keys × 19 locales |
-| Testing | Vitest 4.x (7795+ tests / 606 files) + Playwright | Unit/integration/E2E |
+| Testing | Vitest 4.x (7789+ tests / 606 files) + Playwright | Unit/integration/E2E |
 | Quality | Biome + tsgo + CodeQL/security tooling | Static and CI gates |
 | Desktop | Tauri 2 | Current native shell |
 
@@ -886,7 +886,7 @@ WorldScript-Studio/
 ├── locales/                 # Source locale trees
 ├── public/                  # PWA assets, manifest, SW, runtime locale bundles
 ├── tests/
-│   ├── unit/                # Vitest unit tests (7795+ tests; file count includes package test directories)
+│   ├── unit/                # Vitest unit tests (7789+ tests; file count includes package test directories)
 │   └── e2e/                 # Playwright
 ├── docs/                    # Canonical product/engineering documentation + ADRs
 ├── src-tauri/               # Tauri v2 desktop shell / Rust
@@ -1031,7 +1031,7 @@ Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendo
 
 Current source-synchronized README metrics:
 
-- **7795+ unit tests** across **606 test files**
+- **7789+ unit tests** across **606 test files**
 - i18n: **2942 keys × 19 locales**
 
 CI remains authoritative for actual pass/fail and live coverage.

--- a/app/listenerMiddleware.ts
+++ b/app/listenerMiddleware.ts
@@ -3,6 +3,7 @@ import { createListenerMiddleware, isRejected } from '@reduxjs/toolkit';
 import { analyticsActions } from '../features/analytics/analyticsSlice';
 // QNBS-v3: canonical selector — replaces a local type that misapplied the persisted-state shape to the live store
 import { proForgeActions } from '../features/proForge/proForgeSlice';
+import { isStaleProjectOperationError } from '../features/project/projectIdentity';
 import { selectProjectData } from '../features/project/projectSelectors';
 import type { ProjectData } from '../features/project/projectSlice';
 import { statusActions } from '../features/status/statusSlice';
@@ -358,7 +359,8 @@ addDebouncedListener(
 listenerMiddleware.startListening({
   matcher: isRejected,
   effect: (action, listenerApi) => {
-    if (action.meta.aborted) return;
+    // QNBS-v3: [Grund: expected stale rejection / Impact: suppress false failure notifications / Kreativer Mehrwert: keep project switches quiet]
+    if (action.meta.aborted || isStaleProjectOperationRejection(action)) return;
 
     let errorDescription = action.error?.message ?? 'An unexpected error occurred.';
     if (errorDescription.includes('quota') || errorDescription.includes('API key')) {
@@ -374,6 +376,10 @@ listenerMiddleware.startListening({
     );
   },
 });
+
+function isStaleProjectOperationRejection(action: { error?: unknown }): boolean {
+  return isStaleProjectOperationError(action.error);
+}
 
 listenerMiddleware.startListening({
   predicate: (_action, currentState, previousState) => {

--- a/components/CharacterView.tsx
+++ b/components/CharacterView.tsx
@@ -3,7 +3,12 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useAppDispatch, useAppSelector } from '../app/hooks';
 import { ICONS } from '../constants';
 import { CharacterViewContext, useCharacterViewContext } from '../contexts/CharacterViewContext';
-import { selectProjectData } from '../features/project/projectSelectors';
+import {
+  captureActiveProjectIdentity,
+  getProjectTargetIdentity,
+  getProjectTargetStorageId,
+  identityUnchanged,
+} from '../features/project/projectIdentity';
 import { uploadCharacterImageThunk } from '../features/project/thunks/characterThunks';
 import { useCharacterView } from '../hooks/useCharacterView';
 import { logger } from '../services/logger';
@@ -31,32 +36,58 @@ import { Select } from './ui/Select';
 import { Spinner } from './ui/Spinner';
 
 // QNBS-v3: reads through the selected backend so Tauri uploads and views use the same storage location.
+const loadStoredCharacterImage = async (id: string, projectId: string): Promise<string | null> => {
+  const image = await storageService.getImage(id, projectId);
+  return image
+    ? image.startsWith('data:image/')
+      ? image
+      : `data:image/png;base64,${image}`
+    : null;
+};
+
+const startCharacterImageLoad = ({
+  id,
+  hasImage,
+  projectId,
+  projectIdentity,
+  setImageUrl,
+}: {
+  id: string | undefined;
+  hasImage: boolean | undefined;
+  projectId: string;
+  projectIdentity: string | null;
+  setImageUrl: (imageUrl: string | null) => void;
+}): (() => void) => {
+  setImageUrl(null);
+  if (!id || !hasImage) return () => {};
+
+  let isMounted = true;
+  void loadStoredCharacterImage(id, projectId)
+    .then((image) => {
+      const isCurrentProject = identityUnchanged(projectIdentity, captureActiveProjectIdentity());
+      if (isMounted && isCurrentProject) setImageUrl(image);
+    })
+    .catch((error) => {
+      // QNBS-v3: an unavailable image must retain the placeholder instead of causing an unhandled async rejection.
+      logger.warn('Failed to load character image', { error: String(error) });
+    });
+  return () => {
+    isMounted = false;
+  };
+};
+
 const useStoredImage = (id: string | undefined, hasImage: boolean | undefined) => {
-  const projectId = useAppSelector((state) => selectProjectData(state)?.id || 'default');
+  const projectId = useAppSelector(
+    (state) => getProjectTargetStorageId(state.project?.present) ?? 'default',
+  );
+  const projectIdentity = useAppSelector((state) =>
+    getProjectTargetIdentity(state.project?.present),
+  );
   const [imageUrl, setImageUrl] = useState<string | null>(null);
-  useEffect(() => {
-    setImageUrl(null); // Reset on change
-    if (!id || !hasImage) {
-      return;
-    }
-    let isMounted = true;
-    const fetchImage = async () => {
-      try {
-        // QNBS-v3: passes projectId so the lookup resolves the project-qualified key, not a bare entity id shared across projects.
-        const image = await storageService.getImage(id, projectId);
-        if (isMounted && image) {
-          setImageUrl(image.startsWith('data:image/') ? image : `data:image/png;base64,${image}`);
-        }
-      } catch (error) {
-        // QNBS-v3: an unavailable image must retain the placeholder instead of causing an unhandled async rejection.
-        logger.warn('Failed to load character image', { error: String(error) });
-      }
-    };
-    fetchImage();
-    return () => {
-      isMounted = false;
-    };
-  }, [id, hasImage, projectId]);
+  useEffect(
+    () => startCharacterImageLoad({ id, hasImage, projectId, projectIdentity, setImageUrl }),
+    [id, hasImage, projectId, projectIdentity],
+  );
   return imageUrl;
 };
 

--- a/components/WorldView.tsx
+++ b/components/WorldView.tsx
@@ -3,7 +3,12 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useAppDispatch, useAppSelector } from '../app/hooks';
 import { ICONS } from '../constants';
 import { useWorldViewContext, WorldViewContext } from '../contexts/WorldViewContext';
-import { selectProjectData } from '../features/project/projectSelectors';
+import {
+  captureActiveProjectIdentity,
+  getProjectTargetIdentity,
+  getProjectTargetStorageId,
+  identityUnchanged,
+} from '../features/project/projectIdentity';
 import { uploadWorldImageThunk } from '../features/project/thunks/worldThunks';
 import { useWorldView } from '../hooks/useWorldView';
 import { logger } from '../services/logger';
@@ -31,32 +36,58 @@ import { Spinner } from './ui/Spinner';
 import { Textarea } from './ui/Textarea';
 
 // QNBS-v3: reads through the selected backend so Tauri uploads and views use the same storage location.
+const loadStoredWorldImage = async (id: string, projectId: string): Promise<string | null> => {
+  const image = await storageService.getImage(id, projectId);
+  return image
+    ? image.startsWith('data:image/')
+      ? image
+      : `data:image/png;base64,${image}`
+    : null;
+};
+
+const startWorldImageLoad = ({
+  id,
+  hasImage,
+  projectId,
+  projectIdentity,
+  setImageUrl,
+}: {
+  id: string | undefined;
+  hasImage: boolean | undefined;
+  projectId: string;
+  projectIdentity: string | null;
+  setImageUrl: (imageUrl: string | null) => void;
+}): (() => void) => {
+  setImageUrl(null);
+  if (!id || !hasImage) return () => {};
+
+  let isMounted = true;
+  void loadStoredWorldImage(id, projectId)
+    .then((image) => {
+      const isCurrentProject = identityUnchanged(projectIdentity, captureActiveProjectIdentity());
+      if (isMounted && isCurrentProject) setImageUrl(image);
+    })
+    .catch((error) => {
+      // QNBS-v3: an unavailable image must retain the placeholder instead of causing an unhandled async rejection.
+      logger.warn('Failed to load world image', { error: String(error) });
+    });
+  return () => {
+    isMounted = false;
+  };
+};
+
 const useStoredImage = (id: string | undefined, hasImage: boolean | undefined) => {
-  const projectId = useAppSelector((state) => selectProjectData(state)?.id || 'default');
+  const projectId = useAppSelector(
+    (state) => getProjectTargetStorageId(state.project?.present) ?? 'default',
+  );
+  const projectIdentity = useAppSelector((state) =>
+    getProjectTargetIdentity(state.project?.present),
+  );
   const [imageUrl, setImageUrl] = useState<string | null>(null);
-  useEffect(() => {
-    setImageUrl(null); // Reset on change
-    if (!id || !hasImage) {
-      return;
-    }
-    let isMounted = true;
-    const fetchImage = async () => {
-      try {
-        // QNBS-v3: passes projectId so the lookup resolves the project-qualified key, not a bare entity id shared across projects.
-        const image = await storageService.getImage(id, projectId);
-        if (isMounted && image) {
-          setImageUrl(image.startsWith('data:image/') ? image : `data:image/png;base64,${image}`);
-        }
-      } catch (error) {
-        // QNBS-v3: an unavailable image must retain the placeholder instead of causing an unhandled async rejection.
-        logger.warn('Failed to load world image', { error: String(error) });
-      }
-    };
-    fetchImage();
-    return () => {
-      isMounted = false;
-    };
-  }, [id, hasImage, projectId]);
+  useEffect(
+    () => startWorldImageLoad({ id, hasImage, projectId, projectIdentity, setImageUrl }),
+    [id, hasImage, projectId, projectIdentity],
+  );
   return imageUrl;
 };
 

--- a/features/project/projectIdentity.ts
+++ b/features/project/projectIdentity.ts
@@ -14,6 +14,28 @@ interface ProjectIdentitySource {
   generation?: number;
 }
 
+export const STALE_PROJECT_OPERATION_ERROR_NAME = 'StaleProjectOperationError';
+
+/** Error used when an async result can no longer prove that its origin project is active. */
+export class StaleProjectOperationError extends Error {
+  readonly code = 'STALE_PROJECT_OPERATION';
+
+  constructor(operation: string) {
+    super(`Discarded stale project operation: ${operation}`);
+    this.name = STALE_PROJECT_OPERATION_ERROR_NAME;
+  }
+}
+
+// QNBS-v3: [Grund: serialized stale-error classification / Impact: suppress expected caller noise / Kreativer Mehrwert: keep global diagnostics actionable]
+export function isStaleProjectOperationError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'name' in error &&
+    error.name === STALE_PROJECT_OPERATION_ERROR_NAME
+  );
+}
+
 function baseTargetIdentity(project: unknown): string | null {
   if (typeof project !== 'object' || project === null) return null;
   const record = project as Record<string, unknown>;
@@ -24,13 +46,23 @@ function baseTargetIdentity(project: unknown): string | null {
     : null;
 }
 
-// QNBS-v3: incorporates the in-memory generation counter, not just the persisted id -- a fresh "New Project" always reuses id:'default' until explicitly saved elsewhere, so id alone cannot distinguish two different reset/import/restore sessions.
+// QNBS-v3: [Grund: generation fence / Impact: reject same-ID stale mutations / Kreativer Mehrwert: preserve project-incarnation ownership]
 export function getProjectTargetIdentity(
   source: ProjectIdentitySource | null | undefined,
 ): string | null {
   if (!source) return null;
   const base = baseTargetIdentity(source.data);
   return base === null ? null : `${base}:gen:${source.generation ?? 0}`;
+}
+
+// QNBS-v3: [Grund: legacy directory identity / Impact: keep storage owner stable / Kreativer Mehrwert: preserve compatibility without aliases]
+export function getProjectTargetStorageId(
+  source: ProjectIdentitySource | null | undefined,
+): string | null {
+  if (!source) return null;
+  const base = baseTargetIdentity(source.data);
+  if (base === null) return null;
+  return base.startsWith('id:') ? base.slice('id:'.length) : base;
 }
 
 // QNBS-v3: reads the live store directly (not a React selector) so a hook can capture identity at dispatch time and re-check it after an await, independent of that hook's own render cycle.
@@ -42,4 +74,16 @@ export function captureActiveProjectIdentity(): string | null {
 // QNBS-v3: null means identity could not be determined -- fail closed (never "unchanged") so a guard never allows a mutation it can't actually prove is still targeting the right project.
 export function identityUnchanged(captured: string | null, live: string | null): boolean {
   return captured !== null && captured === live;
+}
+
+// QNBS-v3: centralizes the fail-closed throw so direct async project mutations produce one
+// serialized rejection and the global error listener can suppress stale-result noise.
+export function assertProjectIdentityUnchanged(
+  captured: string | null,
+  live: string | null,
+  operation: string,
+): void {
+  if (!identityUnchanged(captured, live)) {
+    throw new StaleProjectOperationError(operation);
+  }
 }

--- a/features/project/projectSlice.ts
+++ b/features/project/projectSlice.ts
@@ -1,5 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit';
 import { charactersAdapter, worldsAdapter } from './adapters';
+import { getProjectTargetIdentity, identityUnchanged } from './projectIdentity';
 import { initialState, type ProjectData } from './projectState';
 // QNBS-v3: Reducer cases are split into domain modules under ./reducers/* so this slice stays thin.
 // Action names, the `project/*` namespace, the single redux-undo wrapper (app/store.ts), and the
@@ -117,9 +118,19 @@ const projectSlice = createSlice({
           action,
         ): action is {
           type: 'project/streamInterviewChunk';
-          payload: { characterId: string; interviewId: string; aiMsgId: string; content: string };
+          payload: {
+            characterId: string;
+            interviewId: string;
+            aiMsgId: string;
+            content: string;
+            originIdentity: string;
+          };
         } => action.type === 'project/streamInterviewChunk',
         (state, action) => {
+          // QNBS-v3: [Grund: origin chunk identity / Impact: reject stale stream mutation / Kreativer Mehrwert: preserve current-project interview state]
+          if (!identityUnchanged(action.payload.originIdentity, getProjectTargetIdentity(state))) {
+            return;
+          }
           const { characterId, interviewId, aiMsgId, content } = action.payload;
           const interviews = state.data.characterInterviews?.[characterId] ?? [];
           const interview = interviews.find((iv) => iv.id === interviewId);

--- a/features/project/thunks/characterThunks.ts
+++ b/features/project/thunks/characterThunks.ts
@@ -96,13 +96,14 @@ export const generateCharacterPortraitThunk = createDeduplicatedThunk(
       'character portrait generation before storage',
     );
     // QNBS-v3: [Origin persistence authority / Reject stale writes at the backend boundary / Preserve portrait asset ownership]
-    await storageService.saveImage(characterId, base64, projectId, () =>
+    await storageService.saveImage(characterId, base64, projectId, (): undefined => {
       assertProjectIdentityUnchanged(
         originIdentity,
         getProjectTargetIdentity((getState() as RootState).project.present),
         'character portrait persistence',
-      ),
-    );
+      );
+      return undefined;
+    });
     assertProjectIdentityUnchanged(
       originIdentity,
       getProjectTargetIdentity((getState() as RootState).project.present),
@@ -141,13 +142,14 @@ export const uploadCharacterImageThunk = createAsyncThunk(
         }
         // QNBS-v3: retain the data-URL MIME type so uploaded JPEG/WebP images survive filesystem round-trips.
         storageService
-          .saveImage(characterId, result, projectId, () =>
+          .saveImage(characterId, result, projectId, (): undefined => {
             assertProjectIdentityUnchanged(
               originIdentity,
               getProjectTargetIdentity((getState() as RootState).project.present),
               'character image upload persistence',
-            ),
-          )
+            );
+            return undefined;
+          })
           .then(() => {
             try {
               assertProjectIdentityUnchanged(

--- a/features/project/thunks/characterThunks.ts
+++ b/features/project/thunks/characterThunks.ts
@@ -6,6 +6,11 @@ import type { CharacterHeuristicLabels } from '../../../services/ai/heuristicFal
 import { storageService } from '../../../services/storageService';
 import type { Character } from '../../../types';
 import { createDeduplicatedThunk } from '../aiThunkUtils';
+import {
+  assertProjectIdentityUnchanged,
+  getProjectTargetIdentity,
+  getProjectTargetStorageId,
+} from '../projectIdentity';
 import { buildAiCreativity, buildAiOptions, loadAiProvider, loadPrompts } from './thunkUtils';
 
 export const generateCharacterProfileThunk = createDeduplicatedThunk(
@@ -75,15 +80,34 @@ export const generateCharacterPortraitThunk = createDeduplicatedThunk(
   ) => {
     const fullDescription = style ? `${description}. Style: ${style}` : description;
     const state = getState() as RootState;
+    // QNBS-v3: capture the incarnation before generation so a same-ID replacement cannot inherit the result.
+    const originIdentity = getProjectTargetIdentity(state.project.present);
     // QNBS-v3: threaded into saveImage so the stored key is project-qualified, not a bare entity id shared across projects.
-    const projectId = state.project.present?.data?.id || 'default';
+    const projectId = getProjectTargetStorageId(state.project.present) ?? 'default';
     const aiOptions = buildAiOptions(state);
     const { getPrompts } = await loadPrompts();
     const { generateImage } = await loadAiProvider();
     const { prompt } = getPrompts('characterPortrait', { description: fullDescription, lang });
     registerDuplicateRequest(prompt, 'characterPortrait');
     const base64 = await generateImage(prompt, aiOptions, signal);
-    await storageService.saveImage(characterId, base64, projectId);
+    assertProjectIdentityUnchanged(
+      originIdentity,
+      getProjectTargetIdentity((getState() as RootState).project.present),
+      'character portrait generation before storage',
+    );
+    // QNBS-v3: [Origin persistence authority / Reject stale writes at the backend boundary / Preserve portrait asset ownership]
+    await storageService.saveImage(characterId, base64, projectId, () =>
+      assertProjectIdentityUnchanged(
+        originIdentity,
+        getProjectTargetIdentity((getState() as RootState).project.present),
+        'character portrait persistence',
+      ),
+    );
+    assertProjectIdentityUnchanged(
+      originIdentity,
+      getProjectTargetIdentity((getState() as RootState).project.present),
+      'character portrait generation after storage',
+    );
     return { characterId };
   },
 );
@@ -91,8 +115,10 @@ export const generateCharacterPortraitThunk = createDeduplicatedThunk(
 export const uploadCharacterImageThunk = createAsyncThunk(
   'project/uploadCharacterImage',
   async ({ characterId, file }: { characterId: string; file: File }, { getState }) => {
-    // QNBS-v3: threaded into saveImage so the stored key is project-qualified, not a bare entity id shared across projects.
-    const projectId = (getState() as RootState).project.present?.data?.id || 'default';
+    const state = getState() as RootState;
+    const originIdentity = getProjectTargetIdentity(state.project.present);
+    // QNBS-v3: [Origin storage owner / Keep upload/read namespaces aligned / Preserve legacy project visibility]
+    const projectId = getProjectTargetStorageId(state.project.present) ?? 'default';
     return new Promise<{ characterId: string }>((resolve, reject) => {
       const reader = new FileReader();
       // QNBS-v3: onload/onerror/onabort (not onloadend) plus Promise.catch(reject) so every terminal FileReader/saveImage outcome settles this Promise instead of leaving it pending.
@@ -102,10 +128,38 @@ export const uploadCharacterImageThunk = createAsyncThunk(
           reject(new Error('FileReader did not produce a string result'));
           return;
         }
+        // QNBS-v3: [MIME-preserving upload / Keep backend round-trips lossless / Preserve user-selected image format]
+        try {
+          assertProjectIdentityUnchanged(
+            originIdentity,
+            getProjectTargetIdentity((getState() as RootState).project.present),
+            'character image upload before storage',
+          );
+        } catch (error) {
+          reject(error);
+          return;
+        }
         // QNBS-v3: retain the data-URL MIME type so uploaded JPEG/WebP images survive filesystem round-trips.
         storageService
-          .saveImage(characterId, result, projectId)
-          .then(() => resolve({ characterId }))
+          .saveImage(characterId, result, projectId, () =>
+            assertProjectIdentityUnchanged(
+              originIdentity,
+              getProjectTargetIdentity((getState() as RootState).project.present),
+              'character image upload persistence',
+            ),
+          )
+          .then(() => {
+            try {
+              assertProjectIdentityUnchanged(
+                originIdentity,
+                getProjectTargetIdentity((getState() as RootState).project.present),
+                'character image upload completion',
+              );
+              resolve({ characterId });
+            } catch (error) {
+              reject(error);
+            }
+          })
           .catch(reject);
       };
       reader.onerror = () =>

--- a/features/project/thunks/interviewThunks.ts
+++ b/features/project/thunks/interviewThunks.ts
@@ -62,6 +62,12 @@ export const streamInterviewResponseThunk = createAsyncThunk(
     const state = getState() as RootState;
     const { characterId, interviewId, question } = params;
     const originIdentity = getProjectTargetIdentity(state.project.present);
+    // QNBS-v3: reject before appending user/placeholder messages when the origin project cannot be proven.
+    assertProjectIdentityUnchanged(
+      originIdentity,
+      getProjectTargetIdentity(state.project.present),
+      'character interview start',
+    );
 
     const characters = selectAllCharacters(state);
     const character = characters.find((c) => c.id === characterId);
@@ -108,41 +114,53 @@ export const streamInterviewResponseThunk = createAsyncThunk(
 
     let accumulated = '';
     let stale = false;
-    await streamText(
-      prompt,
-      creativity,
-      (chunk) => {
-        if (stale) return;
-        const liveIdentity = getProjectTargetIdentity((getState() as RootState).project.present);
-        if (!identityUnchanged(originIdentity, liveIdentity)) {
-          // QNBS-v3: [Grund: origin stream identity / Impact: reject late chunks / Kreativer Mehrwert: preserve active interview ownership]
-          stale = true;
-          return;
-        }
-        accumulated += chunk;
-        // QNBS-v3: update the AI message in place via updateCharacterInterview to avoid N dispatches
-        dispatch(
-          projectActions.updateCharacterInterview({
-            characterId,
-            interviewId,
-            changes: { updatedAt: aiMsgTimestamp },
-          }),
-        );
-        // Directly mutate via a targeted appendInterviewMessage that overwrites the last AI msg
-        // We re-dispatch a synthetic update to keep Redux as the single source of truth
-        dispatch({
-          type: 'project/streamInterviewChunk',
-          payload: {
-            characterId,
-            interviewId,
-            aiMsgId,
-            content: accumulated,
-            originIdentity,
-          },
-        });
-      },
-      signal,
-    );
+    try {
+      await streamText(
+        prompt,
+        creativity,
+        (chunk) => {
+          if (stale) return;
+          const liveIdentity = getProjectTargetIdentity((getState() as RootState).project.present);
+          if (!identityUnchanged(originIdentity, liveIdentity)) {
+            // QNBS-v3: [Grund: origin stream identity / Impact: reject late chunks / Kreativer Mehrwert: preserve active interview ownership]
+            stale = true;
+            return;
+          }
+          accumulated += chunk;
+          // QNBS-v3: update the AI message in place via updateCharacterInterview to avoid N dispatches
+          dispatch(
+            projectActions.updateCharacterInterview({
+              characterId,
+              interviewId,
+              changes: { updatedAt: aiMsgTimestamp },
+            }),
+          );
+          // Directly mutate via a targeted appendInterviewMessage that overwrites the last AI msg
+          // We re-dispatch a synthetic update to keep Redux as the single source of truth
+          dispatch({
+            type: 'project/streamInterviewChunk',
+            payload: {
+              characterId,
+              interviewId,
+              aiMsgId,
+              content: accumulated,
+              originIdentity,
+            },
+          });
+        },
+        signal,
+      );
+    } catch (error) {
+      if (
+        !identityUnchanged(
+          originIdentity,
+          getProjectTargetIdentity((getState() as RootState).project.present),
+        )
+      ) {
+        throw new StaleProjectOperationError('character interview stream');
+      }
+      throw error;
+    }
 
     if (stale) throw new StaleProjectOperationError('character interview stream');
     // QNBS-v3: a stream can finish without another chunk after a project switch, so completion needs its own authority check.

--- a/features/project/thunks/interviewThunks.ts
+++ b/features/project/thunks/interviewThunks.ts
@@ -3,6 +3,12 @@ import { v4 as uuidv4 } from 'uuid';
 import type { RootState } from '../../../app/store';
 import { streamText } from '../../../services/geminiService';
 import type { CharacterArchetype, CharacterInterview, InterviewMessage } from '../../../types';
+import {
+  assertProjectIdentityUnchanged,
+  getProjectTargetIdentity,
+  identityUnchanged,
+  StaleProjectOperationError,
+} from '../projectIdentity';
 import { selectAllCharacters } from '../projectSelectors';
 import { projectActions } from '../projectSlice';
 import { buildAiCreativity, buildAiOptions } from './thunkUtils';
@@ -55,6 +61,7 @@ export const streamInterviewResponseThunk = createAsyncThunk(
   ) => {
     const state = getState() as RootState;
     const { characterId, interviewId, question } = params;
+    const originIdentity = getProjectTargetIdentity(state.project.present);
 
     const characters = selectAllCharacters(state);
     const character = characters.find((c) => c.id === characterId);
@@ -100,10 +107,18 @@ export const streamInterviewResponseThunk = createAsyncThunk(
     });
 
     let accumulated = '';
+    let stale = false;
     await streamText(
       prompt,
       creativity,
       (chunk) => {
+        if (stale) return;
+        const liveIdentity = getProjectTargetIdentity((getState() as RootState).project.present);
+        if (!identityUnchanged(originIdentity, liveIdentity)) {
+          // QNBS-v3: [Grund: origin stream identity / Impact: reject late chunks / Kreativer Mehrwert: preserve active interview ownership]
+          stale = true;
+          return;
+        }
         accumulated += chunk;
         // QNBS-v3: update the AI message in place via updateCharacterInterview to avoid N dispatches
         dispatch(
@@ -117,10 +132,24 @@ export const streamInterviewResponseThunk = createAsyncThunk(
         // We re-dispatch a synthetic update to keep Redux as the single source of truth
         dispatch({
           type: 'project/streamInterviewChunk',
-          payload: { characterId, interviewId, aiMsgId, content: accumulated },
+          payload: {
+            characterId,
+            interviewId,
+            aiMsgId,
+            content: accumulated,
+            originIdentity,
+          },
         });
       },
       signal,
+    );
+
+    if (stale) throw new StaleProjectOperationError('character interview stream');
+    // QNBS-v3: a stream can finish without another chunk after a project switch, so completion needs its own authority check.
+    assertProjectIdentityUnchanged(
+      originIdentity,
+      getProjectTargetIdentity((getState() as RootState).project.present),
+      'character interview stream completion',
     );
 
     void aiOptions; // aiOptions used in future multi-provider path

--- a/features/project/thunks/worldThunks.ts
+++ b/features/project/thunks/worldThunks.ts
@@ -5,6 +5,11 @@ import type { WorldHeuristicLabels } from '../../../services/ai/heuristicFallbac
 import { storageService } from '../../../services/storageService';
 import type { World } from '../../../types';
 import { createDeduplicatedThunk } from '../aiThunkUtils';
+import {
+  assertProjectIdentityUnchanged,
+  getProjectTargetIdentity,
+  getProjectTargetStorageId,
+} from '../projectIdentity';
 import { buildAiCreativity, buildAiOptions, loadAiProvider, loadPrompts } from './thunkUtils';
 
 export const generateWorldProfileThunk = createDeduplicatedThunk(
@@ -68,15 +73,34 @@ export const generateWorldImageThunk = createDeduplicatedThunk(
     { getState, signal, registerDuplicateRequest },
   ) => {
     const state = getState() as RootState;
+    // QNBS-v3: capture the incarnation before generation so a same-ID replacement cannot inherit the result.
+    const originIdentity = getProjectTargetIdentity(state.project.present);
     // QNBS-v3: threaded into saveImage so the stored key is project-qualified, not a bare entity id shared across projects.
-    const projectId = state.project.present?.data?.id || 'default';
+    const projectId = getProjectTargetStorageId(state.project.present) ?? 'default';
     const aiOptions = buildAiOptions(state);
     const { getPrompts } = await loadPrompts();
     const { generateImage } = await loadAiProvider();
     const { prompt } = getPrompts('worldImage', { description, lang });
     registerDuplicateRequest(prompt, 'worldImage');
     const base64 = await generateImage(prompt, aiOptions, signal);
-    await storageService.saveImage(worldId, base64, projectId);
+    assertProjectIdentityUnchanged(
+      originIdentity,
+      getProjectTargetIdentity((getState() as RootState).project.present),
+      'world image generation before storage',
+    );
+    // QNBS-v3: [Grund: origin persistence authority / Impact: reject stale writes at backend boundary / Kreativer Mehrwert: preserve world asset ownership]
+    await storageService.saveImage(worldId, base64, projectId, () =>
+      assertProjectIdentityUnchanged(
+        originIdentity,
+        getProjectTargetIdentity((getState() as RootState).project.present),
+        'world image persistence',
+      ),
+    );
+    assertProjectIdentityUnchanged(
+      originIdentity,
+      getProjectTargetIdentity((getState() as RootState).project.present),
+      'world image generation after storage',
+    );
     return { worldId };
   },
 );
@@ -84,8 +108,10 @@ export const generateWorldImageThunk = createDeduplicatedThunk(
 export const uploadWorldImageThunk = createAsyncThunk(
   'project/uploadWorldImage',
   async ({ worldId, file }: { worldId: string; file: File }, { getState }) => {
-    // QNBS-v3: threaded into saveImage so the stored key is project-qualified, not a bare entity id shared across projects.
-    const projectId = (getState() as RootState).project.present?.data?.id || 'default';
+    const state = getState() as RootState;
+    const originIdentity = getProjectTargetIdentity(state.project.present);
+    // QNBS-v3: [Origin storage owner / Keep upload/read namespaces aligned / Preserve legacy project visibility]
+    const projectId = getProjectTargetStorageId(state.project.present) ?? 'default';
     return new Promise<{ worldId: string }>((resolve, reject) => {
       const reader = new FileReader();
       // QNBS-v3: onload/onerror/onabort (not onloadend) plus Promise.catch(reject) so every terminal FileReader/saveImage outcome settles this Promise instead of leaving it pending.
@@ -95,10 +121,38 @@ export const uploadWorldImageThunk = createAsyncThunk(
           reject(new Error('FileReader did not produce a string result'));
           return;
         }
+        // QNBS-v3: [MIME-preserving upload / Keep backend round-trips lossless / Preserve user-selected image format]
+        try {
+          assertProjectIdentityUnchanged(
+            originIdentity,
+            getProjectTargetIdentity((getState() as RootState).project.present),
+            'world image upload before storage',
+          );
+        } catch (error) {
+          reject(error);
+          return;
+        }
         // QNBS-v3: retain the data-URL MIME type so uploaded JPEG/WebP images survive filesystem round-trips.
         storageService
-          .saveImage(worldId, result, projectId)
-          .then(() => resolve({ worldId }))
+          .saveImage(worldId, result, projectId, () =>
+            assertProjectIdentityUnchanged(
+              originIdentity,
+              getProjectTargetIdentity((getState() as RootState).project.present),
+              'world image upload persistence',
+            ),
+          )
+          .then(() => {
+            try {
+              assertProjectIdentityUnchanged(
+                originIdentity,
+                getProjectTargetIdentity((getState() as RootState).project.present),
+                'world image upload completion',
+              );
+              resolve({ worldId });
+            } catch (error) {
+              reject(error);
+            }
+          })
           .catch(reject);
       };
       reader.onerror = () =>

--- a/features/project/thunks/worldThunks.ts
+++ b/features/project/thunks/worldThunks.ts
@@ -89,13 +89,14 @@ export const generateWorldImageThunk = createDeduplicatedThunk(
       'world image generation before storage',
     );
     // QNBS-v3: [Grund: origin persistence authority / Impact: reject stale writes at backend boundary / Kreativer Mehrwert: preserve world asset ownership]
-    await storageService.saveImage(worldId, base64, projectId, () =>
+    await storageService.saveImage(worldId, base64, projectId, (): undefined => {
       assertProjectIdentityUnchanged(
         originIdentity,
         getProjectTargetIdentity((getState() as RootState).project.present),
         'world image persistence',
-      ),
-    );
+      );
+      return undefined;
+    });
     assertProjectIdentityUnchanged(
       originIdentity,
       getProjectTargetIdentity((getState() as RootState).project.present),
@@ -134,13 +135,14 @@ export const uploadWorldImageThunk = createAsyncThunk(
         }
         // QNBS-v3: retain the data-URL MIME type so uploaded JPEG/WebP images survive filesystem round-trips.
         storageService
-          .saveImage(worldId, result, projectId, () =>
+          .saveImage(worldId, result, projectId, (): undefined => {
             assertProjectIdentityUnchanged(
               originIdentity,
               getProjectTargetIdentity((getState() as RootState).project.present),
               'world image upload persistence',
-            ),
-          )
+            );
+            return undefined;
+          })
           .then(() => {
             try {
               assertProjectIdentityUnchanged(

--- a/features/project/thunks/writingThunks.ts
+++ b/features/project/thunks/writingThunks.ts
@@ -1,6 +1,11 @@
 import type { RootState } from '../../../app/store';
 import { storageService } from '../../../services/storageService';
 import { createDeduplicatedThunk } from '../aiThunkUtils';
+import {
+  assertProjectIdentityUnchanged,
+  getProjectTargetIdentity,
+  getProjectTargetStorageId,
+} from '../projectIdentity';
 import { buildAiCreativity, buildAiOptions, loadAiProvider, loadPrompts } from './thunkUtils';
 
 export const generateLoglineSuggestionsThunk = createDeduplicatedThunk(
@@ -69,8 +74,10 @@ export const generateSceneImageThunk = createDeduplicatedThunk(
     { getState, signal, registerDuplicateRequest },
   ) => {
     const state = getState() as RootState;
+    // QNBS-v3: capture the incarnation before generation so a same-ID replacement cannot inherit the result.
+    const originIdentity = getProjectTargetIdentity(state.project.present);
     // QNBS-v3: threaded into saveImage so the stored key is project-qualified, not a bare entity id shared across projects.
-    const projectId = state.project.present?.data?.id || 'default';
+    const projectId = getProjectTargetStorageId(state.project.present) ?? 'default';
     const aiOptions = buildAiOptions(state);
     const { getPrompts } = await loadPrompts();
     const { generateImage } = await loadAiProvider();
@@ -83,7 +90,24 @@ export const generateSceneImageThunk = createDeduplicatedThunk(
     registerDuplicateRequest(prompt, 'sceneVisualization');
     const base64 = await generateImage(prompt, aiOptions, signal);
     const imageKey = `scene-${payload.sectionId}`;
-    await storageService.saveImage(imageKey, base64, projectId);
+    assertProjectIdentityUnchanged(
+      originIdentity,
+      getProjectTargetIdentity((getState() as RootState).project.present),
+      'scene image generation before storage',
+    );
+    // QNBS-v3: the backend must re-check incarnation authority at its final image-write point, not only before/after the asynchronous storage call.
+    await storageService.saveImage(imageKey, base64, projectId, () =>
+      assertProjectIdentityUnchanged(
+        originIdentity,
+        getProjectTargetIdentity((getState() as RootState).project.present),
+        'scene image persistence',
+      ),
+    );
+    assertProjectIdentityUnchanged(
+      originIdentity,
+      getProjectTargetIdentity((getState() as RootState).project.present),
+      'scene image generation after storage',
+    );
     const dataUrl = base64.includes('data:image') ? base64 : `data:image/png;base64,${base64}`;
     return { imageKey, dataUrl };
   },

--- a/features/project/thunks/writingThunks.ts
+++ b/features/project/thunks/writingThunks.ts
@@ -96,13 +96,14 @@ export const generateSceneImageThunk = createDeduplicatedThunk(
       'scene image generation before storage',
     );
     // QNBS-v3: the backend must re-check incarnation authority at its final image-write point, not only before/after the asynchronous storage call.
-    await storageService.saveImage(imageKey, base64, projectId, () =>
+    await storageService.saveImage(imageKey, base64, projectId, (): undefined => {
       assertProjectIdentityUnchanged(
         originIdentity,
         getProjectTargetIdentity((getState() as RootState).project.present),
         'scene image persistence',
-      ),
-    );
+      );
+      return undefined;
+    });
     assertProjectIdentityUnchanged(
       originIdentity,
       getProjectTargetIdentity((getState() as RootState).project.present),

--- a/hooks/useCharacterView.ts
+++ b/hooks/useCharacterView.ts
@@ -237,9 +237,11 @@ export const useCharacterView = () => {
           ),
         );
       } catch (error) {
-        if (!isStaleProjectOperationError(error)) throw error;
         setCharacterToDeleteState(null);
         setCharacterDeleteIdentity(null);
+        if (!isStaleProjectOperationError(error)) {
+          toast.error(t('error.apiErrorTitle'));
+        }
         return;
       }
       if (!identityUnchanged(characterDeleteIdentity, captureActiveProjectIdentity())) {

--- a/hooks/useCharacterView.ts
+++ b/hooks/useCharacterView.ts
@@ -224,22 +224,28 @@ export const useCharacterView = () => {
       if (!identityUnchanged(characterDeleteIdentity, captureActiveProjectIdentity())) {
         setCharacterToDeleteState(null);
         setCharacterDeleteIdentity(null);
+        setIsDossierOpen(false);
+        setSelectedCharacter(null);
         return;
       }
       const deletingCharacter = characterToDelete;
       // QNBS-v3: the real delete API, not saveImage(id, '') -- an empty-string save only overwrote the project-qualified key, leaving any pre-qualification legacy blob for this id intact and resurfacable via getImage's fallback.
       try {
-        await storageService.deleteImage(deletingCharacter.id, projectId, () =>
+        await storageService.deleteImage(deletingCharacter.id, projectId, (): undefined => {
           assertProjectIdentityUnchanged(
             characterDeleteIdentity,
             captureActiveProjectIdentity(),
             'character image deletion',
-          ),
-        );
+          );
+          return undefined;
+        });
       } catch (error) {
         setCharacterToDeleteState(null);
         setCharacterDeleteIdentity(null);
-        if (!isStaleProjectOperationError(error)) {
+        if (isStaleProjectOperationError(error)) {
+          setIsDossierOpen(false);
+          setSelectedCharacter(null);
+        } else {
           toast.error(t('error.apiErrorTitle'));
         }
         return;
@@ -247,6 +253,8 @@ export const useCharacterView = () => {
       if (!identityUnchanged(characterDeleteIdentity, captureActiveProjectIdentity())) {
         setCharacterToDeleteState(null);
         setCharacterDeleteIdentity(null);
+        setIsDossierOpen(false);
+        setSelectedCharacter(null);
         return;
       }
       dispatch(projectActions.deleteCharacter(deletingCharacter.id));

--- a/hooks/useCharacterView.ts
+++ b/hooks/useCharacterView.ts
@@ -242,7 +242,11 @@ export const useCharacterView = () => {
       } catch (error) {
         setCharacterToDeleteState(null);
         setCharacterDeleteIdentity(null);
-        if (isStaleProjectOperationError(error)) {
+        const projectStillActive = identityUnchanged(
+          characterDeleteIdentity,
+          captureActiveProjectIdentity(),
+        );
+        if (isStaleProjectOperationError(error) || !projectStillActive) {
           setIsDossierOpen(false);
           setSelectedCharacter(null);
         } else {

--- a/hooks/useCharacterView.ts
+++ b/hooks/useCharacterView.ts
@@ -3,10 +3,13 @@ import { v4 as uuidv4 } from 'uuid';
 import { useAppDispatch, useAppSelector } from '../app/hooks';
 import { useToast } from '../components/ui/Toast';
 import {
+  assertProjectIdentityUnchanged,
   captureActiveProjectIdentity,
+  getProjectTargetStorageId,
   identityUnchanged,
+  isStaleProjectOperationError,
 } from '../features/project/projectIdentity';
-import { selectAllCharacters, selectProjectData } from '../features/project/projectSelectors';
+import { selectAllCharacters } from '../features/project/projectSelectors';
 import { projectActions } from '../features/project/projectSlice';
 import {
   generateCharacterPortraitThunk,
@@ -22,7 +25,9 @@ export const useCharacterView = () => {
   const { t, language } = useTranslation();
   const dispatch = useAppDispatch();
   const characters = useAppSelector(selectAllCharacters);
-  const projectId = useAppSelector((state) => selectProjectData(state)?.id || 'default');
+  const projectId = useAppSelector(
+    (state) => getProjectTargetStorageId(state.project.present) ?? 'default',
+  );
   const toast = useToast();
 
   const [selectedCharacter, setSelectedCharacter] = useState<Character | null>(null);
@@ -38,7 +43,13 @@ export const useCharacterView = () => {
   const [portraitStyle, setPortraitStyle] = useState('digital painting');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-  const [characterToDelete, setCharacterToDelete] = useState<Character | null>(null);
+  const [characterToDelete, setCharacterToDeleteState] = useState<Character | null>(null);
+  const [characterDeleteIdentity, setCharacterDeleteIdentity] = useState<string | null>(null);
+
+  const setCharacterToDelete = useCallback((character: Character | null) => {
+    setCharacterToDeleteState(character);
+    setCharacterDeleteIdentity(character ? captureActiveProjectIdentity() : null);
+  }, []);
 
   // QNBS-v3: Manual add must open the dossier immediately — dispatch-only left users on an empty grid and broke E2E + discoverability.
   const handleAddNewManually = useCallback(() => {
@@ -163,13 +174,13 @@ export const useCharacterView = () => {
         lang: language,
       }),
     );
-    if (!generateCharacterPortraitThunk.fulfilled.match(resultAction)) {
+    if (generateCharacterPortraitThunk.fulfilled.match(resultAction)) {
+      // QNBS-v3: only fulfilled generation may mark the local selection as having an avatar.
+      setSelectedCharacter((c) => (c ? { ...c, hasAvatar: true } : null));
+    } else if (!isStaleProjectOperationError(resultAction.error)) {
       const errorText = t('characters.error.portraitFailed');
       setErrorMessage(errorText);
       toast.error(errorText);
-    } else {
-      // Trigger re-render by updating local state, redux state will update via extraReducer
-      setSelectedCharacter((c) => (c ? { ...c, hasAvatar: true } : null));
     }
     setIsGeneratingPortrait(false);
   }, [dispatch, selectedCharacter, portraitStyle, language, t, toast]);
@@ -185,7 +196,10 @@ export const useCharacterView = () => {
         lang: language,
       }),
     );
-    if (!generateCharacterPortraitThunk.fulfilled.match(resultAction)) {
+    if (
+      !generateCharacterPortraitThunk.fulfilled.match(resultAction) &&
+      !isStaleProjectOperationError(resultAction.error)
+    ) {
       const errorText = t('characters.error.portraitFailed');
       setErrorMessage(errorText);
       toast.error(errorText);
@@ -201,20 +215,53 @@ export const useCharacterView = () => {
         setCharacterToDelete(char);
       }
     },
-    [characters],
+    [characters, setCharacterToDelete],
   );
 
   const confirmDelete = useCallback(async () => {
     if (characterToDelete) {
+      // QNBS-v3: [Delete intent identity / Reject a dialog opened in another incarnation / Preserve destructive-action authority]
+      if (!identityUnchanged(characterDeleteIdentity, captureActiveProjectIdentity())) {
+        setCharacterToDeleteState(null);
+        setCharacterDeleteIdentity(null);
+        return;
+      }
+      const deletingCharacter = characterToDelete;
       // QNBS-v3: the real delete API, not saveImage(id, '') -- an empty-string save only overwrote the project-qualified key, leaving any pre-qualification legacy blob for this id intact and resurfacable via getImage's fallback.
-      await storageService.deleteImage(characterToDelete.id, projectId);
-      dispatch(projectActions.deleteCharacter(characterToDelete.id));
+      try {
+        await storageService.deleteImage(deletingCharacter.id, projectId, () =>
+          assertProjectIdentityUnchanged(
+            characterDeleteIdentity,
+            captureActiveProjectIdentity(),
+            'character image deletion',
+          ),
+        );
+      } catch (error) {
+        if (!isStaleProjectOperationError(error)) throw error;
+        setCharacterToDeleteState(null);
+        setCharacterDeleteIdentity(null);
+        return;
+      }
+      if (!identityUnchanged(characterDeleteIdentity, captureActiveProjectIdentity())) {
+        setCharacterToDeleteState(null);
+        setCharacterDeleteIdentity(null);
+        return;
+      }
+      dispatch(projectActions.deleteCharacter(deletingCharacter.id));
       setCharacterToDelete(null);
       setIsDossierOpen(false);
       setSelectedCharacter(null);
-      toast.info(t('characters.deleteLabel', { name: characterToDelete.name }));
+      toast.info(t('characters.deleteLabel', { name: deletingCharacter.name }));
     }
-  }, [dispatch, characterToDelete, toast, t, projectId]);
+  }, [
+    dispatch,
+    characterToDelete,
+    characterDeleteIdentity,
+    toast,
+    t,
+    projectId,
+    setCharacterToDelete,
+  ]);
 
   return {
     t,

--- a/hooks/useManuscriptView.ts
+++ b/hooks/useManuscriptView.ts
@@ -330,6 +330,8 @@ export const useManuscriptView = ({
       // QNBS-v3: [Grund: stale scene result is expected after a project switch / Impact: suppress false error toasts / Kreativer Mehrwert: keep authoring feedback actionable]
       if (!isStaleProjectOperationError(error)) {
         toast.error(t('error.apiErrorTitle'));
+      } else {
+        setSceneImagePreviewUrl(null);
       }
     } finally {
       setIsSceneVisualizing(false);

--- a/hooks/useManuscriptView.ts
+++ b/hooks/useManuscriptView.ts
@@ -103,6 +103,7 @@ export const useManuscriptView = ({
   >([]);
   const [isSceneVisualizing, setIsSceneVisualizing] = useState(false);
   const [sceneImagePreviewUrl, setSceneImagePreviewUrl] = useState<string | null>(null);
+  const sceneVisualizationRequestRef = useRef(0);
 
   // Drag and drop state
   const draggedItem = useRef<number | null>(null);
@@ -313,6 +314,7 @@ export const useManuscriptView = ({
 
   const handleVisualizeScene = useCallback(async () => {
     if (!activeSection?.content?.trim() || !project) return;
+    const requestId = ++sceneVisualizationRequestRef.current;
     setIsSceneVisualizing(true);
     try {
       const result = await dispatch(
@@ -330,7 +332,8 @@ export const useManuscriptView = ({
       // QNBS-v3: [Grund: stale scene result is expected after a project switch / Impact: suppress false error toasts / Kreativer Mehrwert: keep authoring feedback actionable]
       if (!isStaleProjectOperationError(error)) {
         toast.error(t('error.apiErrorTitle'));
-      } else {
+      } else if (sceneVisualizationRequestRef.current === requestId) {
+        // QNBS-v3: [Grund: stale request ordering / Impact: do not erase a newer preview / Kreativer Mehrwert: keep current-project feedback visible]
         setSceneImagePreviewUrl(null);
       }
     } finally {

--- a/hooks/useManuscriptView.ts
+++ b/hooks/useManuscriptView.ts
@@ -126,7 +126,10 @@ export const useManuscriptView = ({
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: reset preview on active section change
   useEffect(() => {
+    // QNBS-v3: changing the visualization target invalidates any pending result from the prior section.
+    sceneVisualizationRequestRef.current += 1;
     setSceneImagePreviewUrl(null);
+    setIsSceneVisualizing(false);
   }, [activeSectionId]);
 
   const activeSectionStats = useMemo(() => {

--- a/hooks/useManuscriptView.ts
+++ b/hooks/useManuscriptView.ts
@@ -2,7 +2,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAppDispatch, useAppSelector } from '../app/hooks';
 import { useTransientUiStore } from '../app/transientUiStore';
 import { useToast } from '../components/ui/Toast';
-import { isStaleProjectOperationError } from '../features/project/projectIdentity';
+import {
+  getProjectTargetIdentity,
+  isStaleProjectOperationError,
+} from '../features/project/projectIdentity';
 import {
   selectAllCharacters,
   selectAllWorlds,
@@ -80,6 +83,9 @@ export const useManuscriptView = ({
   const { t, language } = useTranslation();
   const dispatch = useAppDispatch();
   const project = useAppSelector(selectProjectData);
+  const projectIdentity = useAppSelector((state) =>
+    getProjectTargetIdentity(state.project.present),
+  );
   const manuscript = useAppSelector((state) => state.project.present.data.manuscript);
   const characters = useAppSelector(selectAllCharacters);
   const worlds = useAppSelector(selectAllWorlds);
@@ -104,6 +110,10 @@ export const useManuscriptView = ({
   const [isSceneVisualizing, setIsSceneVisualizing] = useState(false);
   const [sceneImagePreviewUrl, setSceneImagePreviewUrl] = useState<string | null>(null);
   const sceneVisualizationRequestRef = useRef(0);
+  const sceneVisualizationTargetRef = useRef({
+    sectionId: activeSectionId,
+    projectIdentity,
+  });
 
   // Drag and drop state
   const draggedItem = useRef<number | null>(null);
@@ -124,13 +134,13 @@ export const useManuscriptView = ({
     return manuscript.find((s) => s.id === currentActiveId) || manuscript?.[0];
   }, [activeSectionId, manuscript]);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: reset preview on active section change
+  // QNBS-v3: changing the visualization target or project incarnation invalidates pending results.
   useEffect(() => {
-    // QNBS-v3: changing the visualization target invalidates any pending result from the prior section.
+    sceneVisualizationTargetRef.current = { sectionId: activeSectionId, projectIdentity };
     sceneVisualizationRequestRef.current += 1;
     setSceneImagePreviewUrl(null);
     setIsSceneVisualizing(false);
-  }, [activeSectionId]);
+  }, [activeSectionId, projectIdentity]);
 
   const activeSectionStats = useMemo(() => {
     if (!activeSection) return { wordCount: 0, charCount: 0, readTime: 0 };
@@ -318,6 +328,7 @@ export const useManuscriptView = ({
   const handleVisualizeScene = useCallback(async () => {
     if (!activeSection?.content?.trim() || !project) return;
     const requestId = ++sceneVisualizationRequestRef.current;
+    const requestTarget = sceneVisualizationTargetRef.current;
     setIsSceneVisualizing(true);
     try {
       const result = await dispatch(
@@ -330,12 +341,20 @@ export const useManuscriptView = ({
         }),
       ).unwrap();
       // QNBS-v3: only the newest request may publish preview, toast, or loading completion.
-      if (sceneVisualizationRequestRef.current !== requestId) return;
+      if (
+        sceneVisualizationRequestRef.current !== requestId ||
+        sceneVisualizationTargetRef.current !== requestTarget
+      )
+        return;
       setSceneImagePreviewUrl(result.dataUrl);
       toast.success(t('manuscript.visualize.successTitle'), t('manuscript.visualize.successBody'));
     } catch (error) {
       // QNBS-v3: [Grund: stale scene result is expected after a project switch / Impact: suppress false error toasts / Kreativer Mehrwert: keep authoring feedback actionable]
-      if (sceneVisualizationRequestRef.current !== requestId) return;
+      if (
+        sceneVisualizationRequestRef.current !== requestId ||
+        sceneVisualizationTargetRef.current !== requestTarget
+      )
+        return;
       if (!isStaleProjectOperationError(error)) {
         toast.error(t('error.apiErrorTitle'));
       } else {
@@ -343,7 +362,11 @@ export const useManuscriptView = ({
         setSceneImagePreviewUrl(null);
       }
     } finally {
-      if (sceneVisualizationRequestRef.current === requestId) setIsSceneVisualizing(false);
+      if (
+        sceneVisualizationRequestRef.current === requestId &&
+        sceneVisualizationTargetRef.current === requestTarget
+      )
+        setIsSceneVisualizing(false);
     }
   }, [activeSection, dispatch, language, project, t, toast]);
 

--- a/hooks/useManuscriptView.ts
+++ b/hooks/useManuscriptView.ts
@@ -326,18 +326,21 @@ export const useManuscriptView = ({
           lang: language,
         }),
       ).unwrap();
+      // QNBS-v3: only the newest request may publish preview, toast, or loading completion.
+      if (sceneVisualizationRequestRef.current !== requestId) return;
       setSceneImagePreviewUrl(result.dataUrl);
       toast.success(t('manuscript.visualize.successTitle'), t('manuscript.visualize.successBody'));
     } catch (error) {
       // QNBS-v3: [Grund: stale scene result is expected after a project switch / Impact: suppress false error toasts / Kreativer Mehrwert: keep authoring feedback actionable]
+      if (sceneVisualizationRequestRef.current !== requestId) return;
       if (!isStaleProjectOperationError(error)) {
         toast.error(t('error.apiErrorTitle'));
-      } else if (sceneVisualizationRequestRef.current === requestId) {
+      } else {
         // QNBS-v3: [Grund: stale request ordering / Impact: do not erase a newer preview / Kreativer Mehrwert: keep current-project feedback visible]
         setSceneImagePreviewUrl(null);
       }
     } finally {
-      setIsSceneVisualizing(false);
+      if (sceneVisualizationRequestRef.current === requestId) setIsSceneVisualizing(false);
     }
   }, [activeSection, dispatch, language, project, t, toast]);
 

--- a/hooks/useManuscriptView.ts
+++ b/hooks/useManuscriptView.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAppDispatch, useAppSelector } from '../app/hooks';
 import { useTransientUiStore } from '../app/transientUiStore';
 import { useToast } from '../components/ui/Toast';
+import { isStaleProjectOperationError } from '../features/project/projectIdentity';
 import {
   selectAllCharacters,
   selectAllWorlds,
@@ -325,8 +326,11 @@ export const useManuscriptView = ({
       ).unwrap();
       setSceneImagePreviewUrl(result.dataUrl);
       toast.success(t('manuscript.visualize.successTitle'), t('manuscript.visualize.successBody'));
-    } catch {
-      toast.error(t('error.apiErrorTitle'));
+    } catch (error) {
+      // QNBS-v3: [Grund: stale scene result is expected after a project switch / Impact: suppress false error toasts / Kreativer Mehrwert: keep authoring feedback actionable]
+      if (!isStaleProjectOperationError(error)) {
+        toast.error(t('error.apiErrorTitle'));
+      }
     } finally {
       setIsSceneVisualizing(false);
     }

--- a/hooks/useWorldView.ts
+++ b/hooks/useWorldView.ts
@@ -275,9 +275,11 @@ export const useWorldView = () => {
           ),
         );
       } catch (error) {
-        if (!isStaleProjectOperationError(error)) throw error;
         setWorldToDeleteState(null);
         setWorldDeleteIdentity(null);
+        if (!isStaleProjectOperationError(error)) {
+          toast.error(t('error.apiErrorTitle'));
+        }
         return;
       }
       if (!identityUnchanged(worldDeleteIdentity, captureActiveProjectIdentity())) {

--- a/hooks/useWorldView.ts
+++ b/hooks/useWorldView.ts
@@ -3,10 +3,13 @@ import { v4 as uuidv4 } from 'uuid';
 import { useAppDispatch, useAppSelector } from '../app/hooks';
 import { useToast } from '../components/ui/Toast';
 import {
+  assertProjectIdentityUnchanged,
   captureActiveProjectIdentity,
+  getProjectTargetStorageId,
   identityUnchanged,
+  isStaleProjectOperationError,
 } from '../features/project/projectIdentity';
-import { selectAllWorlds, selectProjectData } from '../features/project/projectSelectors';
+import { selectAllWorlds } from '../features/project/projectSelectors';
 import { projectActions } from '../features/project/projectSlice';
 import {
   generateWorldImageThunk,
@@ -22,7 +25,9 @@ export const useWorldView = () => {
   const { t, language } = useTranslation();
   const dispatch = useAppDispatch();
   const worlds = useAppSelector(selectAllWorlds);
-  const projectId = useAppSelector((state) => selectProjectData(state)?.id || 'default');
+  const projectId = useAppSelector(
+    (state) => getProjectTargetStorageId(state.project.present) ?? 'default',
+  );
   const toast = useToast();
 
   const [selectedWorld, setSelectedWorld] = useState<World | null>(null);
@@ -36,7 +41,13 @@ export const useWorldView = () => {
   const [isRefiningImage, setIsRefiningImage] = useState(false);
   const [refinementPrompt, setRefinementPrompt] = useState('');
 
-  const [worldToDelete, setWorldToDelete] = useState<World | null>(null);
+  const [worldToDelete, setWorldToDeleteState] = useState<World | null>(null);
+  const [worldDeleteIdentity, setWorldDeleteIdentity] = useState<string | null>(null);
+
+  const setWorldToDelete = useCallback((world: World | null) => {
+    setWorldToDeleteState(world);
+    setWorldDeleteIdentity(world ? captureActiveProjectIdentity() : null);
+  }, []);
 
   // QNBS-v3: Manual add must open the atlas immediately — dispatch-only left users on the grid
   //          with a silent "New World" card and no editor (inconsistent with Characters, which
@@ -157,7 +168,7 @@ export const useWorldView = () => {
     );
     if (generateWorldImageThunk.fulfilled.match(resultAction)) {
       setSelectedWorld((w) => (w ? { ...w, hasAmbianceImage: true } : null));
-    } else {
+    } else if (!isStaleProjectOperationError(resultAction.error)) {
       toast.error(t('worlds.error.imageFailed'));
     }
     setIsGeneratingImage(false);
@@ -170,7 +181,10 @@ export const useWorldView = () => {
     const resultAction = await dispatch(
       generateWorldImageThunk({ worldId: selectedWorld.id, description, lang: language }),
     );
-    if (!generateWorldImageThunk.fulfilled.match(resultAction)) {
+    if (
+      !generateWorldImageThunk.fulfilled.match(resultAction) &&
+      !isStaleProjectOperationError(resultAction.error)
+    ) {
       toast.error(t('worlds.error.imageFailed'));
     }
     setRefinementPrompt('');
@@ -239,20 +253,45 @@ export const useWorldView = () => {
       const world = worlds.find((w) => w.id === id);
       if (world) setWorldToDelete(world);
     },
-    [worlds],
+    [worlds, setWorldToDelete],
   );
 
   const confirmDelete = useCallback(async () => {
     if (worldToDelete) {
+      // QNBS-v3: [Delete intent identity / Reject a dialog opened in another incarnation / Preserve destructive-action authority]
+      if (!identityUnchanged(worldDeleteIdentity, captureActiveProjectIdentity())) {
+        setWorldToDeleteState(null);
+        setWorldDeleteIdentity(null);
+        return;
+      }
+      const deletingWorld = worldToDelete;
       // QNBS-v3: the real delete API, not saveImage(id, '') -- an empty-string save only overwrote the project-qualified key, leaving any pre-qualification legacy blob for this id intact and resurfacable via getImage's fallback.
-      await storageService.deleteImage(worldToDelete.id, projectId);
-      dispatch(projectActions.deleteWorld(worldToDelete.id));
+      try {
+        await storageService.deleteImage(deletingWorld.id, projectId, () =>
+          assertProjectIdentityUnchanged(
+            worldDeleteIdentity,
+            captureActiveProjectIdentity(),
+            'world image deletion',
+          ),
+        );
+      } catch (error) {
+        if (!isStaleProjectOperationError(error)) throw error;
+        setWorldToDeleteState(null);
+        setWorldDeleteIdentity(null);
+        return;
+      }
+      if (!identityUnchanged(worldDeleteIdentity, captureActiveProjectIdentity())) {
+        setWorldToDeleteState(null);
+        setWorldDeleteIdentity(null);
+        return;
+      }
+      dispatch(projectActions.deleteWorld(deletingWorld.id));
       setWorldToDelete(null);
       setIsAtlasOpen(false);
       setSelectedWorld(null);
-      toast.info(t('worlds.deleteLabel', { name: worldToDelete.name }));
+      toast.info(t('worlds.deleteLabel', { name: deletingWorld.name }));
     }
-  }, [dispatch, worldToDelete, toast, t, projectId]);
+  }, [dispatch, worldToDelete, worldDeleteIdentity, toast, t, projectId, setWorldToDelete]);
 
   return {
     t,

--- a/hooks/useWorldView.ts
+++ b/hooks/useWorldView.ts
@@ -262,6 +262,8 @@ export const useWorldView = () => {
       if (!identityUnchanged(worldDeleteIdentity, captureActiveProjectIdentity())) {
         setWorldToDeleteState(null);
         setWorldDeleteIdentity(null);
+        setIsAtlasOpen(false);
+        setSelectedWorld(null);
         return;
       }
       const deletingWorld = worldToDelete;
@@ -278,7 +280,14 @@ export const useWorldView = () => {
       } catch (error) {
         setWorldToDeleteState(null);
         setWorldDeleteIdentity(null);
-        if (!isStaleProjectOperationError(error)) {
+        const projectStillActive = identityUnchanged(
+          worldDeleteIdentity,
+          captureActiveProjectIdentity(),
+        );
+        if (isStaleProjectOperationError(error) || !projectStillActive) {
+          setIsAtlasOpen(false);
+          setSelectedWorld(null);
+        } else {
           toast.error(t('error.apiErrorTitle'));
         }
         return;
@@ -286,6 +295,8 @@ export const useWorldView = () => {
       if (!identityUnchanged(worldDeleteIdentity, captureActiveProjectIdentity())) {
         setWorldToDeleteState(null);
         setWorldDeleteIdentity(null);
+        setIsAtlasOpen(false);
+        setSelectedWorld(null);
         return;
       }
       dispatch(projectActions.deleteWorld(deletingWorld.id));

--- a/hooks/useWorldView.ts
+++ b/hooks/useWorldView.ts
@@ -267,13 +267,14 @@ export const useWorldView = () => {
       const deletingWorld = worldToDelete;
       // QNBS-v3: the real delete API, not saveImage(id, '') -- an empty-string save only overwrote the project-qualified key, leaving any pre-qualification legacy blob for this id intact and resurfacable via getImage's fallback.
       try {
-        await storageService.deleteImage(deletingWorld.id, projectId, () =>
+        await storageService.deleteImage(deletingWorld.id, projectId, (): undefined => {
           assertProjectIdentityUnchanged(
             worldDeleteIdentity,
             captureActiveProjectIdentity(),
             'world image deletion',
-          ),
-        );
+          );
+          return undefined;
+        });
       } catch (error) {
         setWorldToDeleteState(null);
         setWorldDeleteIdentity(null);

--- a/services/fs/assetFsStore.ts
+++ b/services/fs/assetFsStore.ts
@@ -144,21 +144,23 @@ export class FsAssetStore extends FsSnapshotStore {
         // QNBS-v3: preserve-first -- only remove the unattributed legacy copy when ownership is already provable; otherwise it may belong to a different (possibly already-deleted) project, so leave it untouched rather than risk destroying another project's image.
         const soleOwner = await this.checkLegacyImageOwnership(projectId);
         // QNBS-v3: legacy MUST be removed before the qualified file, not after -- if legacy removal throws, the catch below aborts before the qualified file is touched, so getImage's legacy fallback can never resurrect a half-deleted image. The reverse order would let a failure after the qualified delete leave the legacy copy to resurrect it.
-        const removeImageFile = async (path: string) => {
-          await retryFs(async () => {
-            // QNBS-v3: re-admit every retry attempt so a same-ID replacement cannot be deleted after a transient filesystem failure.
-            deleteAdmission?.();
-            await apis.remove(path);
-          });
-        };
+        // QNBS-v3: retries stay inside the serialized delete operation; one admission before both removals mirrors the IDB transaction boundary.
+        const removeImageFile = async (path: string) => retryFs(() => apis.remove(path));
+        const filesToRemove: string[] = [];
         if (soleOwner) {
           const legacyFile = await this.legacyImagePath(id);
           if (await apis.exists(legacyFile)) {
-            await removeImageFile(legacyFile);
+            filesToRemove.push(legacyFile);
           }
         }
         if (await apis.exists(qualifiedFile)) {
-          await removeImageFile(qualifiedFile);
+          filesToRemove.push(qualifiedFile);
+        }
+        if (filesToRemove.length > 0) {
+          deleteAdmission?.();
+          for (const path of filesToRemove) {
+            await removeImageFile(path);
+          }
         }
         // QNBS-v3: final delete admission / reject stale no-op deletions / keep entity mutation authority truthful.
         deleteAdmission?.();

--- a/services/fs/assetFsStore.ts
+++ b/services/fs/assetFsStore.ts
@@ -5,7 +5,12 @@
  */
 
 import { logger } from '../logger';
-import type { BinderAssetMeta, BinderAssetPayload } from '../storageBackend';
+import type {
+  BinderAssetMeta,
+  BinderAssetPayload,
+  ImageDeleteAdmission,
+  ImageWriteAdmission,
+} from '../storageBackend';
 import { retryFs, sanitizePathSegment, writeFileAtomic, writeTextFileAtomic } from './fsCore';
 import { FsSnapshotStore } from './snapshotFsStore';
 
@@ -79,14 +84,24 @@ export class FsAssetStore extends FsSnapshotStore {
     return existing === projectId;
   }
 
-  async saveImage(id: string, base64Data: string, projectId = 'default'): Promise<void> {
-    const apis = await this.getApis();
-    const { dir, file } = await this.qualifiedImagePaths(projectId, id);
-    if (!(await apis.exists(dir))) {
-      await apis.mkdir(dir, { recursive: true });
-    }
-    // QNBS-v3: data URLs retain an uploaded image's MIME type; legacy raw payloads remain readable as PNG below.
-    await writeTextFileAtomic(apis, file, base64Data);
+  async saveImage(
+    id: string,
+    base64Data: string,
+    projectId = 'default',
+    writeAdmission?: ImageWriteAdmission,
+  ): Promise<void> {
+    // QNBS-v3: serialize replacement writes with deletes so a pending remove cannot erase the newly committed image.
+    await this.withLegacyRoutingOperation(async () => {
+      // QNBS-v3: [Admission before temp-file creation / Reject already-stale writes without disk residue / Preserve filesystem authority]
+      writeAdmission?.();
+      const apis = await this.getApis();
+      const { dir, file } = await this.qualifiedImagePaths(projectId, id);
+      if (!(await apis.exists(dir))) {
+        await apis.mkdir(dir, { recursive: true });
+      }
+      // QNBS-v3: data URLs retain an uploaded image's MIME type; legacy raw payloads remain readable as PNG below.
+      await writeTextFileAtomic(apis, file, base64Data, writeAdmission);
+    }, projectId);
   }
 
   async getImage(id: string, projectId = 'default'): Promise<string | null> {
@@ -116,7 +131,11 @@ export class FsAssetStore extends FsSnapshotStore {
     }
   }
 
-  async deleteImage(id: string, projectId = 'default'): Promise<void> {
+  async deleteImage(
+    id: string,
+    projectId = 'default',
+    deleteAdmission?: ImageDeleteAdmission,
+  ): Promise<void> {
     try {
       // QNBS-v3: serialized + write-authority-checked like deleteBinderAsset -- an unserialized ownership check could go stale against a concurrent project creation and delete another project's unattributed legacy image.
       await this.withLegacyRoutingOperation(async () => {
@@ -125,18 +144,27 @@ export class FsAssetStore extends FsSnapshotStore {
         // QNBS-v3: preserve-first -- only remove the unattributed legacy copy when ownership is already provable; otherwise it may belong to a different (possibly already-deleted) project, so leave it untouched rather than risk destroying another project's image.
         const soleOwner = await this.checkLegacyImageOwnership(projectId);
         // QNBS-v3: legacy MUST be removed before the qualified file, not after -- if legacy removal throws, the catch below aborts before the qualified file is touched, so getImage's legacy fallback can never resurrect a half-deleted image. The reverse order would let a failure after the qualified delete leave the legacy copy to resurrect it.
+        const removeImageFile = async (path: string) => {
+          await retryFs(async () => {
+            // QNBS-v3: re-admit every retry attempt so a same-ID replacement cannot be deleted after a transient filesystem failure.
+            deleteAdmission?.();
+            await apis.remove(path);
+          });
+        };
         if (soleOwner) {
           const legacyFile = await this.legacyImagePath(id);
           if (await apis.exists(legacyFile)) {
-            await retryFs(() => apis.remove(legacyFile));
+            await removeImageFile(legacyFile);
           }
         }
         if (await apis.exists(qualifiedFile)) {
-          await retryFs(() => apis.remove(qualifiedFile));
+          await removeImageFile(qualifiedFile);
         }
+        // QNBS-v3: final delete admission / reject stale no-op deletions / keep entity mutation authority truthful.
+        deleteAdmission?.();
       }, projectId);
     } catch (error) {
-      if (this.isProjectWriteAuthorityError(error)) throw error;
+      if (deleteAdmission || this.isProjectWriteAuthorityError(error)) throw error;
       logger.error('Failed to delete image:', error);
     }
   }

--- a/services/fs/assetFsStore.ts
+++ b/services/fs/assetFsStore.ts
@@ -11,7 +11,13 @@ import type {
   ImageDeleteAdmission,
   ImageWriteAdmission,
 } from '../storageBackend';
-import { retryFs, sanitizePathSegment, writeFileAtomic, writeTextFileAtomic } from './fsCore';
+import {
+  retryFs,
+  sanitizePathSegment,
+  type TauriApis,
+  writeFileAtomic,
+  writeTextFileAtomic,
+} from './fsCore';
 import { FsSnapshotStore } from './snapshotFsStore';
 
 export class FsAssetStore extends FsSnapshotStore {
@@ -84,6 +90,20 @@ export class FsAssetStore extends FsSnapshotStore {
     return existing === projectId;
   }
 
+  // QNBS-v3: each retry and each file gets its own synchronous admission immediately before remove, so a transient retry cannot cross an incarnation boundary silently.
+  private async removeImageFiles(
+    apis: TauriApis,
+    files: string[],
+    deleteAdmission?: ImageDeleteAdmission,
+  ): Promise<void> {
+    for (const path of files) {
+      await retryFs(async () => {
+        deleteAdmission?.();
+        await apis.remove(path);
+      });
+    }
+  }
+
   async saveImage(
     id: string,
     base64Data: string,
@@ -144,8 +164,6 @@ export class FsAssetStore extends FsSnapshotStore {
         // QNBS-v3: preserve-first -- only remove the unattributed legacy copy when ownership is already provable; otherwise it may belong to a different (possibly already-deleted) project, so leave it untouched rather than risk destroying another project's image.
         const soleOwner = await this.checkLegacyImageOwnership(projectId);
         // QNBS-v3: legacy MUST be removed before the qualified file, not after -- if legacy removal throws, the catch below aborts before the qualified file is touched, so getImage's legacy fallback can never resurrect a half-deleted image. The reverse order would let a failure after the qualified delete leave the legacy copy to resurrect it.
-        // QNBS-v3: retries stay inside the serialized delete operation; one admission before both removals mirrors the IDB transaction boundary.
-        const removeImageFile = async (path: string) => retryFs(() => apis.remove(path));
         const filesToRemove: string[] = [];
         if (soleOwner) {
           const legacyFile = await this.legacyImagePath(id);
@@ -157,10 +175,7 @@ export class FsAssetStore extends FsSnapshotStore {
           filesToRemove.push(qualifiedFile);
         }
         if (filesToRemove.length > 0) {
-          deleteAdmission?.();
-          for (const path of filesToRemove) {
-            await removeImageFile(path);
-          }
+          await this.removeImageFiles(apis, filesToRemove, deleteAdmission);
         }
         // QNBS-v3: final delete admission / reject stale no-op deletions / keep entity mutation authority truthful.
         deleteAdmission?.();

--- a/services/fs/fsCore.ts
+++ b/services/fs/fsCore.ts
@@ -95,12 +95,15 @@ async function writeAndReplace(
   apis: TauriApis,
   path: string,
   write: (temporary: string) => Promise<void>,
+  beforeReplace?: () => void,
 ): Promise<void> {
   const previous = atomicWriteTails.get(path);
   const current = (previous?.catch(() => undefined) ?? Promise.resolve()).then(async () => {
     const temporary = temporaryPath(path);
     try {
       await retryFs(() => write(temporary));
+      // QNBS-v3: [Grund: final replace admission / Impact: reject stale filesystem mutations / Kreativer Mehrwert: preserve atomic project assets]
+      beforeReplace?.();
       await retryFs(() => apis.rename(temporary, path));
     } catch (error) {
       // QNBS-v3: retry cleanup, then log (not throw) — the caller must always see the original write/rename error, with an orphaned-temp-file warning surfaced for diagnostics.
@@ -126,8 +129,18 @@ async function writeAndReplace(
 }
 
 // QNBS-v3: replace authoritative files only after a complete sibling write, preserving the last valid file on interruption.
-export function writeTextFileAtomic(apis: TauriApis, path: string, content: string): Promise<void> {
-  return writeAndReplace(apis, path, (temporary) => apis.writeTextFile(temporary, content));
+export function writeTextFileAtomic(
+  apis: TauriApis,
+  path: string,
+  content: string,
+  beforeReplace?: () => void,
+): Promise<void> {
+  return writeAndReplace(
+    apis,
+    path,
+    (temporary) => apis.writeTextFile(temporary, content),
+    beforeReplace,
+  );
 }
 
 // QNBS-v3: binary assets use the same same-directory replace so readers never observe a partial file.

--- a/services/fs/fsCore.ts
+++ b/services/fs/fsCore.ts
@@ -102,9 +102,11 @@ async function writeAndReplace(
     const temporary = temporaryPath(path);
     try {
       await retryFs(() => write(temporary));
-      // QNBS-v3: [Grund: final replace admission / Impact: reject stale filesystem mutations / Kreativer Mehrwert: preserve atomic project assets]
-      beforeReplace?.();
-      await retryFs(() => apis.rename(temporary, path));
+      await retryFs(async () => {
+        // QNBS-v3: admit immediately before every irreversible rename attempt, including retries after a transient filesystem failure.
+        beforeReplace?.();
+        await apis.rename(temporary, path);
+      });
     } catch (error) {
       // QNBS-v3: retry cleanup, then log (not throw) — the caller must always see the original write/rename error, with an orphaned-temp-file warning surfaced for diagnostics.
       try {

--- a/services/storage/idbAssetStore.ts
+++ b/services/storage/idbAssetStore.ts
@@ -96,13 +96,26 @@ export class IdbAssetStore extends IdbSnapshotStore {
       const store = await this.getObjectStore(IMAGES_STORE, 'readwrite');
       writeAdmission?.();
       const transaction = store.transaction;
+      let admissionError: unknown;
+      let transactionAborted = false;
       return new Promise<void>((resolve, reject) => {
         const request = store.put(payload, key);
         request.onerror = () => reject(request.error);
+        request.onsuccess = () => {
+          try {
+            writeAdmission?.();
+          } catch (error) {
+            admissionError = error;
+            if (!transactionAborted) {
+              transactionAborted = true;
+              transaction.abort();
+            }
+          }
+        };
         // QNBS-v3: a successful request can still be rolled back by a later transaction abort; only commit grants persistence authority.
         transaction.oncomplete = () => resolve();
-        transaction.onerror = () => reject(transaction.error ?? request.error);
-        transaction.onabort = () => reject(transaction.error ?? request.error);
+        transaction.onerror = () => reject(admissionError ?? transaction.error ?? request.error);
+        transaction.onabort = () => reject(admissionError ?? transaction.error ?? request.error);
       });
     });
   }
@@ -155,14 +168,27 @@ export class IdbAssetStore extends IdbSnapshotStore {
       // QNBS-v3: clear both the qualified and legacy key so a stale legacy record can never resurface via getImage's fallback after an explicit delete. Both deletes share one IDB transaction, so a failure on either aborts and rolls back both -- no partial-delete resurrection risk here, unlike the filesystem backend's independent file operations.
       deleteAdmission?.();
       const transaction = store.transaction;
+      let admissionError: unknown;
+      let transactionAborted = false;
       await new Promise<void>((resolve, reject) => {
         // QNBS-v3: request success is not durable until this shared transaction commits.
         transaction.oncomplete = () => resolve();
-        transaction.onerror = () => reject(transaction.error);
-        transaction.onabort = () => reject(transaction.error);
+        transaction.onerror = () => reject(admissionError ?? transaction.error);
+        transaction.onabort = () => reject(admissionError ?? transaction.error);
         for (const key of keysToDelete) {
           const request = store.delete(key);
           request.onerror = () => reject(request.error);
+          request.onsuccess = () => {
+            try {
+              deleteAdmission?.();
+            } catch (error) {
+              admissionError = error;
+              if (!transactionAborted) {
+                transactionAborted = true;
+                transaction.abort();
+              }
+            }
+          };
         }
       });
     });

--- a/services/storage/idbAssetStore.ts
+++ b/services/storage/idbAssetStore.ts
@@ -95,10 +95,14 @@ export class IdbAssetStore extends IdbSnapshotStore {
       const key = await makeImageStorageKey(projectId, id);
       const store = await this.getObjectStore(IMAGES_STORE, 'readwrite');
       writeAdmission?.();
+      const transaction = store.transaction;
       return new Promise<void>((resolve, reject) => {
         const request = store.put(payload, key);
-        request.onsuccess = () => resolve();
         request.onerror = () => reject(request.error);
+        // QNBS-v3: a successful request can still be rolled back by a later transaction abort; only commit grants persistence authority.
+        transaction.oncomplete = () => resolve();
+        transaction.onerror = () => reject(transaction.error ?? request.error);
+        transaction.onabort = () => reject(transaction.error ?? request.error);
       });
     });
   }
@@ -150,16 +154,17 @@ export class IdbAssetStore extends IdbSnapshotStore {
       const store = await this.getObjectStore(IMAGES_STORE, 'readwrite');
       // QNBS-v3: clear both the qualified and legacy key so a stale legacy record can never resurface via getImage's fallback after an explicit delete. Both deletes share one IDB transaction, so a failure on either aborts and rolls back both -- no partial-delete resurrection risk here, unlike the filesystem backend's independent file operations.
       deleteAdmission?.();
-      await Promise.all(
-        keysToDelete.map(
-          (key) =>
-            new Promise<void>((resolve, reject) => {
-              const request = store.delete(key);
-              request.onsuccess = () => resolve();
-              request.onerror = () => reject(request.error);
-            }),
-        ),
-      );
+      const transaction = store.transaction;
+      await new Promise<void>((resolve, reject) => {
+        // QNBS-v3: request success is not durable until this shared transaction commits.
+        transaction.oncomplete = () => resolve();
+        transaction.onerror = () => reject(transaction.error);
+        transaction.onabort = () => reject(transaction.error);
+        for (const key of keysToDelete) {
+          const request = store.delete(key);
+          request.onerror = () => reject(request.error);
+        }
+      });
     });
   }
 

--- a/services/storage/idbAssetStore.ts
+++ b/services/storage/idbAssetStore.ts
@@ -10,7 +10,12 @@ import {
   IMAGES_STORE,
   LEGACY_IMAGE_OWNER_KEY,
 } from '../dbConstants';
-import type { BinderAssetMeta, BinderAssetPayload } from '../storageBackend';
+import type {
+  BinderAssetMeta,
+  BinderAssetPayload,
+  ImageDeleteAdmission,
+  ImageWriteAdmission,
+} from '../storageBackend';
 import {
   makeBinderAssetIdsPrefix,
   makeBinderAssetStorageKey,
@@ -72,7 +77,12 @@ export class IdbAssetStore extends IdbSnapshotStore {
     return existing === projectId;
   }
 
-  async saveImage(id: string, base64: string, projectId = 'default'): Promise<void> {
+  async saveImage(
+    id: string,
+    base64: string,
+    projectId = 'default',
+    writeAdmission?: ImageWriteAdmission,
+  ): Promise<void> {
     return withProtectedWriteAdmission(async () => {
       // QNBS-v3: Resolve the write key BEFORE opening the transaction — `await idbEncryptWithKey`
       //          yields the event loop, which auto-commits an already-open IDB transaction
@@ -84,6 +94,7 @@ export class IdbAssetStore extends IdbSnapshotStore {
       await assertNoActiveEncryptionMigration();
       const key = await makeImageStorageKey(projectId, id);
       const store = await this.getObjectStore(IMAGES_STORE, 'readwrite');
+      writeAdmission?.();
       return new Promise<void>((resolve, reject) => {
         const request = store.put(payload, key);
         request.onsuccess = () => resolve();
@@ -123,7 +134,11 @@ export class IdbAssetStore extends IdbSnapshotStore {
     return this.decodeImageRecord(legacy);
   }
 
-  async deleteImage(id: string, projectId = 'default'): Promise<void> {
+  async deleteImage(
+    id: string,
+    projectId = 'default',
+    deleteAdmission?: ImageDeleteAdmission,
+  ): Promise<void> {
     return withProtectedWriteAdmission(async () => {
       // QNBS-v3: A locked session must not be able to destroy protected images it cannot read.
       await assertIdbProtectedWriteAllowed();
@@ -134,6 +149,7 @@ export class IdbAssetStore extends IdbSnapshotStore {
       const keysToDelete = legacyOwned ? [qualifiedKey, id] : [qualifiedKey];
       const store = await this.getObjectStore(IMAGES_STORE, 'readwrite');
       // QNBS-v3: clear both the qualified and legacy key so a stale legacy record can never resurface via getImage's fallback after an explicit delete. Both deletes share one IDB transaction, so a failure on either aborts and rolls back both -- no partial-delete resurrection risk here, unlike the filesystem backend's independent file operations.
+      deleteAdmission?.();
       await Promise.all(
         keysToDelete.map(
           (key) =>

--- a/services/storage/idbAssetStore.ts
+++ b/services/storage/idbAssetStore.ts
@@ -177,7 +177,7 @@ export class IdbAssetStore extends IdbSnapshotStore {
         transaction.onabort = () => reject(admissionError ?? transaction.error);
         for (const key of keysToDelete) {
           const request = store.delete(key);
-          request.onerror = () => reject(request.error);
+          request.onerror = () => reject(admissionError ?? request.error);
           request.onsuccess = () => {
             try {
               deleteAdmission?.();

--- a/services/storageBackend.ts
+++ b/services/storageBackend.ts
@@ -13,6 +13,13 @@ export interface BinderAssetPayload {
   meta: BinderAssetMeta;
 }
 
+/** Synchronous admission check evaluated at the backend's image-write point. */
+export type ImageWriteAdmission = () => void;
+
+// QNBS-v3: [Grund: shared delete authority / Impact: reject stale image removals / Kreativer Mehrwert: keep every backend on one admission contract]
+/** Synchronous admission check evaluated at the backend's image-delete point. */
+export type ImageDeleteAdmission = () => void;
+
 // QNBS-v3: shared result keeps the affected identity and verified quarantine path explicit across backends.
 /** Result of moving a corrupt desktop project out of the active project namespace. */
 export interface ProjectQuarantineResult {
@@ -97,7 +104,12 @@ export interface StorageBackend {
   quarantineProject?(projectId: string): Promise<ProjectQuarantineResult>;
 
   // QNBS-v3: projectId is trailing/optional (defaults to 'default' at each implementer) so call sites that predate project-qualification keep compiling unchanged -- only call sites that need real qualification pass it explicitly.
-  saveImage(id: string, base64Data: string, projectId?: string): Promise<void>;
+  saveImage(
+    id: string,
+    base64Data: string,
+    projectId?: string,
+    writeAdmission?: ImageWriteAdmission,
+  ): Promise<void>;
   getImage(id: string, projectId?: string): Promise<string | null>;
   // QNBS-v3: qualified-only variants for transaction/rollback callers -- unlike getImage/deleteImage, these never consult the legacy fallback, never claim/touch legacy ownership, and never swallow a read/delete failure to null/success. A rollback needs to know the exact pre-mutation state of the exact key it is about to overwrite, not the UI-friendly merged view.
   getQualifiedImage(id: string, projectId?: string): Promise<string | null>;
@@ -122,7 +134,11 @@ export interface StorageBackend {
   listSnapshots(): Promise<ProjectSnapshot[]>;
   deleteSnapshot(snapshotId: number): Promise<void>;
 
-  deleteImage(id: string, projectId?: string): Promise<void>;
+  deleteImage(
+    id: string,
+    projectId?: string,
+    deleteAdmission?: ImageDeleteAdmission,
+  ): Promise<void>;
 
   hasSavedData(): Promise<boolean>;
 

--- a/services/storageBackend.ts
+++ b/services/storageBackend.ts
@@ -14,11 +14,11 @@ export interface BinderAssetPayload {
 }
 
 /** Synchronous admission check evaluated at the backend's image-write point. */
-export type ImageWriteAdmission = () => void;
+export type ImageWriteAdmission = () => undefined;
 
 // QNBS-v3: [Grund: shared delete authority / Impact: reject stale image removals / Kreativer Mehrwert: keep every backend on one admission contract]
 /** Synchronous admission check evaluated at the backend's image-delete point. */
-export type ImageDeleteAdmission = () => void;
+export type ImageDeleteAdmission = () => undefined;
 
 // QNBS-v3: shared result keeps the affected identity and verified quarantine path explicit across backends.
 /** Result of moving a corrupt desktop project out of the active project namespace. */

--- a/services/storageService.ts
+++ b/services/storageService.ts
@@ -2,6 +2,8 @@ import type { ProjectSnapshot, Settings, StoryCodex, StoryProject } from '../typ
 import type {
   BinderAssetMeta,
   BinderAssetPayload,
+  ImageDeleteAdmission,
+  ImageWriteAdmission,
   ProjectQuarantineResult,
   SaveProjectInput,
   SnapshotRestoreTarget,
@@ -11,6 +13,8 @@ import type {
 export type {
   BinderAssetMeta,
   BinderAssetPayload,
+  ImageDeleteAdmission,
+  ImageWriteAdmission,
   ProjectQuarantineResult,
   SaveProjectEnvelope,
   SaveProjectInput,
@@ -114,9 +118,17 @@ class StorageManager {
   }
 
   // QNBS-v3: projectId is trailing/optional, mirroring StorageBackend, so callers that predate project-qualification still compile unchanged and defer to each backend's own 'default' fallback.
-  async saveImage(id: string, base64Data: string, projectId?: string): Promise<void> {
+  async saveImage(
+    id: string,
+    base64Data: string,
+    projectId?: string,
+    writeAdmission?: ImageWriteAdmission,
+  ): Promise<void> {
     const backend = await this.getBackend();
-    return backend.saveImage(id, base64Data, projectId);
+    // QNBS-v3: preserve the legacy call shape while forwarding write authority at the persistence boundary.
+    return writeAdmission
+      ? backend.saveImage(id, base64Data, projectId, writeAdmission)
+      : backend.saveImage(id, base64Data, projectId);
   }
 
   async getImage(id: string, projectId?: string): Promise<string | null> {
@@ -200,9 +212,15 @@ class StorageManager {
   }
 
   // QNBS-v3: same trailing-optional projectId compatibility shape as saveImage/getImage above.
-  async deleteImage(id: string, projectId?: string): Promise<void> {
+  async deleteImage(
+    id: string,
+    projectId?: string,
+    deleteAdmission?: ImageDeleteAdmission,
+  ): Promise<void> {
     const backend = await this.getBackend();
-    return backend.deleteImage(id, projectId);
+    return deleteAdmission
+      ? backend.deleteImage(id, projectId, deleteAdmission)
+      : backend.deleteImage(id, projectId);
   }
 
   async hasSavedData(): Promise<boolean> {

--- a/tests/unit/CharacterView.test.tsx
+++ b/tests/unit/CharacterView.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen, waitFor } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { appStoreRef } from '../../app/storeRef';
 import { CharacterView } from '../../components/CharacterView';
 import { storageService } from '../../services/storageService';
 
@@ -11,6 +12,12 @@ const mockHandleAddNewManually = vi.fn();
 const mockHandleAddNewWithAI = vi.fn();
 const mockHandleSelect = vi.fn();
 const mockConfirmDelete = vi.fn();
+const mockProjectState = {
+  settings: { editorFont: 'serif', fontSize: 16, lineSpacing: 1.5 },
+  project: {
+    present: { data: { id: 'p1' }, generation: 0 },
+  },
+};
 
 const baseContextValue = {
   t: (k: string) => k,
@@ -51,9 +58,7 @@ vi.mock('../../hooks/useCharacterView', () => ({
 
 vi.mock('../../app/hooks', () => ({
   useAppDispatch: vi.fn(() => vi.fn()),
-  useAppSelector: vi.fn((selector: (s: unknown) => unknown) =>
-    selector({ settings: { editorFont: 'serif', fontSize: 16, lineSpacing: 1.5 } }),
-  ),
+  useAppSelector: vi.fn((selector: (s: unknown) => unknown) => selector(mockProjectState)),
 }));
 
 vi.mock('../../hooks/useSpeechRecognition', () => ({
@@ -78,6 +83,18 @@ vi.mock('../../services/storageService', () => ({
 vi.mock('../../features/project/thunks/characterThunks', () => ({
   uploadCharacterImageThunk: vi.fn(),
 }));
+
+beforeEach(() => {
+  mockProjectState.project.present = { data: { id: 'p1' }, generation: 0 };
+  appStoreRef.current = {
+    getState: () => mockProjectState,
+    dispatch: vi.fn(),
+  } as never;
+});
+
+afterEach(() => {
+  appStoreRef.current = null;
+});
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -194,9 +211,43 @@ describe('CharacterView', () => {
     } as never);
     render(<CharacterView />);
     // QNBS-v3: id now leads, projectId trails, matching the reordered getImage signature.
-    await waitFor(() =>
-      expect(storageService.getImage).toHaveBeenCalledWith('c-broken', 'default'),
-    );
+    await waitFor(() => expect(storageService.getImage).toHaveBeenCalledWith('c-broken', 'p1'));
     expect(screen.queryByAltText('Robin')).toBeNull();
+  });
+
+  // QNBS-v3: [Grund: deferred read identity fence / Impact: reject stale image completion / Kreativer Mehrwert: keep a replacement incarnation visually isolated]
+  it('does not apply a deferred avatar read after the project incarnation changes', async () => {
+    let resolveImage!: (value: string) => void;
+    vi.mocked(storageService.getImage).mockReturnValueOnce(
+      new Promise<string>((resolve) => {
+        resolveImage = resolve;
+      }),
+    );
+    const { useCharacterView } = await import('../../hooks/useCharacterView');
+    vi.mocked(useCharacterView).mockReturnValueOnce({
+      ...baseContextValue,
+      characters: [
+        {
+          id: 'c-stale',
+          name: 'Stale Avatar',
+          appearance: '',
+          motivation: '',
+          backstory: '',
+          notes: '',
+          personalityTraits: '',
+          hasAvatar: true,
+        },
+      ],
+    } as never);
+    render(<CharacterView />);
+    await waitFor(() => expect(storageService.getImage).toHaveBeenCalledWith('c-stale', 'p1'));
+
+    mockProjectState.project.present.generation = 1;
+    await act(async () => {
+      resolveImage('data:image/png;base64,STALE');
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByAltText('Stale Avatar')).toBeNull();
   });
 });

--- a/tests/unit/CharacterView.test.tsx
+++ b/tests/unit/CharacterView.test.tsx
@@ -224,7 +224,7 @@ describe('CharacterView', () => {
       }),
     );
     const { useCharacterView } = await import('../../hooks/useCharacterView');
-    vi.mocked(useCharacterView).mockReturnValueOnce({
+    vi.mocked(useCharacterView).mockReturnValue({
       ...baseContextValue,
       characters: [
         {

--- a/tests/unit/CharacterView.test.tsx
+++ b/tests/unit/CharacterView.test.tsx
@@ -92,7 +92,9 @@ beforeEach(() => {
   } as never;
 });
 
-afterEach(() => {
+afterEach(async () => {
+  const { useCharacterView } = await import('../../hooks/useCharacterView');
+  vi.mocked(useCharacterView).mockImplementation(() => baseContextValue);
   appStoreRef.current = null;
 });
 

--- a/tests/unit/CharacterView.test.tsx
+++ b/tests/unit/CharacterView.test.tsx
@@ -94,7 +94,7 @@ beforeEach(() => {
 
 afterEach(async () => {
   const { useCharacterView } = await import('../../hooks/useCharacterView');
-  vi.mocked(useCharacterView).mockImplementation(() => baseContextValue);
+  vi.mocked(useCharacterView).mockImplementation(() => baseContextValue as never);
   appStoreRef.current = null;
 });
 

--- a/tests/unit/WorldView.test.tsx
+++ b/tests/unit/WorldView.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen, waitFor } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { appStoreRef } from '../../app/storeRef';
 import { WorldView } from '../../components/WorldView';
 import { storageService } from '../../services/storageService';
 
@@ -44,15 +45,20 @@ const baseContextValue = {
   handleLocationChange: vi.fn(),
 };
 
+const mockProjectState = {
+  settings: { editorFont: 'serif', fontSize: 16, lineSpacing: 1.5 },
+  project: {
+    present: { data: { id: 'p1' }, generation: 0 },
+  },
+};
+
 vi.mock('../../hooks/useWorldView', () => ({
   useWorldView: vi.fn(() => baseContextValue),
 }));
 
 vi.mock('../../app/hooks', () => ({
   useAppDispatch: vi.fn(() => vi.fn()),
-  useAppSelector: vi.fn((selector: (s: unknown) => unknown) =>
-    selector({ settings: { editorFont: 'serif', fontSize: 16, lineSpacing: 1.5 } }),
-  ),
+  useAppSelector: vi.fn((selector: (s: unknown) => unknown) => selector(mockProjectState)),
 }));
 
 vi.mock('../../hooks/useSpeechRecognition', () => ({
@@ -73,6 +79,18 @@ vi.mock('../../services/storageService', () => ({
     getImage: vi.fn().mockResolvedValue(null),
   },
 }));
+
+beforeEach(() => {
+  mockProjectState.project.present = { data: { id: 'p1' }, generation: 0 };
+  appStoreRef.current = {
+    getState: () => mockProjectState,
+    dispatch: vi.fn(),
+  } as never;
+});
+
+afterEach(() => {
+  appStoreRef.current = null;
+});
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -193,9 +211,73 @@ describe('WorldView', () => {
     } as never);
     render(<WorldView />);
     // QNBS-v3: id now leads, projectId trails, matching the reordered getImage signature.
-    await waitFor(() =>
-      expect(storageService.getImage).toHaveBeenCalledWith('w-broken', 'default'),
-    );
+    await waitFor(() => expect(storageService.getImage).toHaveBeenCalledWith('w-broken', 'p1'));
     expect(screen.queryByAltText('Cindralis')).toBeNull();
+  });
+
+  // QNBS-v3: [Grund: deferred read identity fence / Impact: reject stale image completion / Kreativer Mehrwert: keep a replacement incarnation visually isolated]
+  it('does not apply a deferred ambiance read after the project incarnation changes', async () => {
+    let resolveInitialImage!: (value: string) => void;
+    vi.mocked(storageService.getImage).mockReturnValueOnce(
+      new Promise<string>((resolve) => {
+        resolveInitialImage = resolve;
+      }),
+    );
+    const { useWorldView } = await import('../../hooks/useWorldView');
+    vi.mocked(useWorldView).mockReturnValueOnce({
+      ...baseContextValue,
+      worlds: [
+        {
+          id: 'w-stable',
+          name: 'Stable Ambiance',
+          description: '',
+          geography: '',
+          magicSystem: '',
+          notes: '',
+          hasAmbianceImage: true,
+          locations: [],
+          timeline: [],
+        },
+      ],
+    } as never);
+    const { rerender } = render(<WorldView />);
+    await waitFor(() => expect(storageService.getImage).toHaveBeenCalledWith('w-stable', 'p1'));
+    await act(async () => {
+      resolveInitialImage('data:image/png;base64,INITIAL');
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(screen.getByAltText('Stable Ambiance')).toBeTruthy());
+
+    let resolveStaleImage!: (value: string) => void;
+    vi.mocked(storageService.getImage).mockReturnValueOnce(
+      new Promise<string>((resolve) => {
+        resolveStaleImage = resolve;
+      }),
+    );
+    vi.mocked(useWorldView).mockReturnValueOnce({
+      ...baseContextValue,
+      worlds: [
+        {
+          id: 'w-stale',
+          name: 'Stale Ambiance',
+          description: '',
+          geography: '',
+          magicSystem: '',
+          notes: '',
+          hasAmbianceImage: true,
+          locations: [],
+          timeline: [],
+        },
+      ],
+    } as never);
+    rerender(<WorldView />);
+    await waitFor(() => expect(storageService.getImage).toHaveBeenCalledWith('w-stale', 'p1'));
+    mockProjectState.project.present.generation = 1;
+    await act(async () => {
+      resolveStaleImage('data:image/png;base64,STALE');
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByAltText('Stale Ambiance')).toBeNull();
   });
 });

--- a/tests/unit/WorldView.test.tsx
+++ b/tests/unit/WorldView.test.tsx
@@ -224,7 +224,7 @@ describe('WorldView', () => {
       }),
     );
     const { useWorldView } = await import('../../hooks/useWorldView');
-    vi.mocked(useWorldView).mockReturnValueOnce({
+    vi.mocked(useWorldView).mockReturnValue({
       ...baseContextValue,
       worlds: [
         {

--- a/tests/unit/WorldView.test.tsx
+++ b/tests/unit/WorldView.test.tsx
@@ -88,7 +88,9 @@ beforeEach(() => {
   } as never;
 });
 
-afterEach(() => {
+afterEach(async () => {
+  const { useWorldView } = await import('../../hooks/useWorldView');
+  vi.mocked(useWorldView).mockImplementation(() => baseContextValue);
   appStoreRef.current = null;
 });
 

--- a/tests/unit/WorldView.test.tsx
+++ b/tests/unit/WorldView.test.tsx
@@ -90,7 +90,7 @@ beforeEach(() => {
 
 afterEach(async () => {
   const { useWorldView } = await import('../../hooks/useWorldView');
-  vi.mocked(useWorldView).mockImplementation(() => baseContextValue);
+  vi.mocked(useWorldView).mockImplementation(() => baseContextValue as never);
   appStoreRef.current = null;
 });
 

--- a/tests/unit/features/project/projectIdentity.test.ts
+++ b/tests/unit/features/project/projectIdentity.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
   getProjectTargetIdentity,
+  getProjectTargetStorageId,
   identityUnchanged,
+  isStaleProjectOperationError,
 } from '../../../../features/project/projectIdentity';
 
 describe('getProjectTargetIdentity', () => {
@@ -55,6 +57,26 @@ describe('getProjectTargetIdentity', () => {
   });
 });
 
+describe('getProjectTargetStorageId', () => {
+  it('keeps ordinary project IDs stable', () => {
+    expect(getProjectTargetStorageId({ data: { id: 'p1' }, generation: 4 })).toBe('p1');
+  });
+
+  it('uses stable legacy directory identity without the transient generation fence', () => {
+    // QNBS-v3: legacy image ownership must remain reloadable while still avoiding the shared default namespace.
+    expect(
+      getProjectTargetStorageId({
+        data: { __worldscriptLegacyProjectDirectory: 'legacy-dir' },
+        generation: 4,
+      }),
+    ).toBe('legacy:legacy-dir');
+  });
+
+  it('returns null when no stable storage identity exists', () => {
+    expect(getProjectTargetStorageId({ data: { title: 'Untitled' } })).toBeNull();
+  });
+});
+
 describe('identityUnchanged', () => {
   it('returns true when both identities are equal and non-null', () => {
     expect(identityUnchanged('id:p1:gen:0', 'id:p1:gen:0')).toBe(true);
@@ -71,5 +93,16 @@ describe('identityUnchanged', () => {
 
   it('returns false when only the captured identity is null', () => {
     expect(identityUnchanged(null, 'id:p1:gen:0')).toBe(false);
+  });
+});
+
+describe('isStaleProjectOperationError', () => {
+  it('recognizes serialized stale-operation rejections', () => {
+    expect(isStaleProjectOperationError({ name: 'StaleProjectOperationError' })).toBe(true);
+  });
+
+  it('does not classify unrelated errors or non-errors as stale', () => {
+    expect(isStaleProjectOperationError(new Error('other failure'))).toBe(false);
+    expect(isStaleProjectOperationError(null)).toBe(false);
   });
 });

--- a/tests/unit/features/project/projectIdentity.test.ts
+++ b/tests/unit/features/project/projectIdentity.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   getProjectTargetIdentity,
-  getProjectTargetStorageId,
   identityUnchanged,
-  isStaleProjectOperationError,
 } from '../../../../features/project/projectIdentity';
 
 describe('getProjectTargetIdentity', () => {
@@ -57,26 +55,6 @@ describe('getProjectTargetIdentity', () => {
   });
 });
 
-describe('getProjectTargetStorageId', () => {
-  it('keeps ordinary project IDs stable', () => {
-    expect(getProjectTargetStorageId({ data: { id: 'p1' }, generation: 4 })).toBe('p1');
-  });
-
-  it('uses stable legacy directory identity without the transient generation fence', () => {
-    // QNBS-v3: legacy image ownership must remain reloadable while still avoiding the shared default namespace.
-    expect(
-      getProjectTargetStorageId({
-        data: { __worldscriptLegacyProjectDirectory: 'legacy-dir' },
-        generation: 4,
-      }),
-    ).toBe('legacy:legacy-dir');
-  });
-
-  it('returns null when no stable storage identity exists', () => {
-    expect(getProjectTargetStorageId({ data: { title: 'Untitled' } })).toBeNull();
-  });
-});
-
 describe('identityUnchanged', () => {
   it('returns true when both identities are equal and non-null', () => {
     expect(identityUnchanged('id:p1:gen:0', 'id:p1:gen:0')).toBe(true);
@@ -93,16 +71,5 @@ describe('identityUnchanged', () => {
 
   it('returns false when only the captured identity is null', () => {
     expect(identityUnchanged(null, 'id:p1:gen:0')).toBe(false);
-  });
-});
-
-describe('isStaleProjectOperationError', () => {
-  it('recognizes serialized stale-operation rejections', () => {
-    expect(isStaleProjectOperationError({ name: 'StaleProjectOperationError' })).toBe(true);
-  });
-
-  it('does not classify unrelated errors or non-errors as stale', () => {
-    expect(isStaleProjectOperationError(new Error('other failure'))).toBe(false);
-    expect(isStaleProjectOperationError(null)).toBe(false);
   });
 });

--- a/tests/unit/hooks/useCharacterView.test.ts
+++ b/tests/unit/hooks/useCharacterView.test.ts
@@ -527,6 +527,21 @@ describe('confirmDelete', () => {
     expect(mockDispatch).not.toHaveBeenCalledWith(projectActions.deleteCharacter('c1'));
   });
 
+  it('clears the confirmation and shows an error when image deletion fails', async () => {
+    const char = makeCharacter('c1', 'Hero');
+    const { result } = renderHook(() => useCharacterView());
+    act(() => result.current.setCharacterToDelete(char));
+    mockDeleteImage.mockRejectedValueOnce(new Error('storage failed'));
+
+    await act(async () => {
+      await result.current.confirmDelete();
+    });
+
+    expect(result.current.characterToDelete).toBeNull();
+    expect(mockToast.error).toHaveBeenCalledWith('error.apiErrorTitle');
+    expect(mockDispatch).not.toHaveBeenCalledWith(projectActions.deleteCharacter('c1'));
+  });
+
   it('clears a confirmation when the active project changes before delete starts', async () => {
     const { result } = renderHook(() => useCharacterView());
     act(() => result.current.setCharacterToDelete(makeCharacter('c1')));

--- a/tests/unit/hooks/useCharacterView.test.ts
+++ b/tests/unit/hooks/useCharacterView.test.ts
@@ -63,7 +63,8 @@ vi.mock('../../../features/project/projectSelectors', () => ({
 
 vi.mock('../../../features/project/projectIdentity', () => ({
   captureActiveProjectIdentity: mockCaptureIdentity,
-  getProjectTargetStorageId: () => 'c-project-1',
+  getProjectTargetStorageId: (source: { data?: { id?: string } } | null | undefined) =>
+    source?.data?.id ?? null,
   identityUnchanged: (captured: string | null, live: string | null) =>
     captured !== null && captured === live,
   assertProjectIdentityUnchanged: (captured: string | null, live: string | null) => {
@@ -516,6 +517,10 @@ describe('confirmDelete', () => {
     const char = makeCharacter('c1', 'Hero');
     const { result } = renderHook(() => useCharacterView());
     act(() => result.current.setCharacterToDelete(char));
+    act(() => {
+      result.current.setSelectedCharacter(char);
+      result.current.setIsDossierOpen(true);
+    });
     mockIsStaleError.mockReturnValue(true);
     mockDeleteImage.mockRejectedValueOnce({ name: 'StaleProjectOperationError' });
 
@@ -524,6 +529,8 @@ describe('confirmDelete', () => {
     });
 
     expect(result.current.characterToDelete).toBeNull();
+    expect(result.current.selectedCharacter).toBeNull();
+    expect(result.current.isDossierOpen).toBe(false);
     expect(mockDispatch).not.toHaveBeenCalledWith(projectActions.deleteCharacter('c1'));
   });
 
@@ -543,8 +550,13 @@ describe('confirmDelete', () => {
   });
 
   it('clears a confirmation when the active project changes before delete starts', async () => {
+    const char = makeCharacter('c1', 'Hero');
     const { result } = renderHook(() => useCharacterView());
-    act(() => result.current.setCharacterToDelete(makeCharacter('c1')));
+    act(() => {
+      result.current.setCharacterToDelete(char);
+      result.current.setSelectedCharacter(char);
+      result.current.setIsDossierOpen(true);
+    });
     mockCaptureIdentity.mockReturnValue('id:replacement');
 
     await act(async () => {
@@ -552,13 +564,19 @@ describe('confirmDelete', () => {
     });
 
     expect(result.current.characterToDelete).toBeNull();
+    expect(result.current.selectedCharacter).toBeNull();
+    expect(result.current.isDossierOpen).toBe(false);
     expect(mockDeleteImage).not.toHaveBeenCalled();
   });
 
   it('clears a confirmation when the active project changes after storage', async () => {
     const char = makeCharacter('c1', 'Hero');
     const { result } = renderHook(() => useCharacterView());
-    act(() => result.current.setCharacterToDelete(char));
+    act(() => {
+      result.current.setCharacterToDelete(char);
+      result.current.setSelectedCharacter(char);
+      result.current.setIsDossierOpen(true);
+    });
     mockDeleteImage.mockImplementationOnce(async () => {
       mockCaptureIdentity.mockReturnValue('id:replacement');
     });
@@ -568,6 +586,8 @@ describe('confirmDelete', () => {
     });
 
     expect(result.current.characterToDelete).toBeNull();
+    expect(result.current.selectedCharacter).toBeNull();
+    expect(result.current.isDossierOpen).toBe(false);
     expect(mockDispatch).not.toHaveBeenCalledWith(projectActions.deleteCharacter('c1'));
   });
 

--- a/tests/unit/hooks/useCharacterView.test.ts
+++ b/tests/unit/hooks/useCharacterView.test.ts
@@ -591,6 +591,7 @@ describe('confirmDelete', () => {
     expect(mockDispatch).not.toHaveBeenCalledWith(projectActions.deleteCharacter('c1'));
   });
 
+  // QNBS-v3: [Grund: a backend failure can arrive after an incarnation switch / Impact: suppress stale error UI and selection / Kreativer Mehrwert: keep feedback scoped to the active project]
   it('suppresses a backend error after the active project changes', async () => {
     const char = makeCharacter('c1', 'Hero');
     const { result } = renderHook(() => useCharacterView());

--- a/tests/unit/hooks/useCharacterView.test.ts
+++ b/tests/unit/hooks/useCharacterView.test.ts
@@ -7,13 +7,19 @@ import type { Character } from '../../../types';
 // ---------------------------------------------------------------------------
 // vi.hoisted — match mocks referenced in vi.mock factories
 // ---------------------------------------------------------------------------
-const { mockProfileMatch, mockPortraitMatch, mockRegenerateMatch, mockCaptureIdentity } =
-  vi.hoisted(() => ({
-    mockProfileMatch: vi.fn((_: unknown) => true),
-    mockPortraitMatch: vi.fn((_: unknown) => true),
-    mockRegenerateMatch: vi.fn((_: unknown) => true),
-    mockCaptureIdentity: vi.fn(() => 'id:test-project'),
-  }));
+const {
+  mockProfileMatch,
+  mockPortraitMatch,
+  mockRegenerateMatch,
+  mockCaptureIdentity,
+  mockIsStaleError,
+} = vi.hoisted(() => ({
+  mockProfileMatch: vi.fn((_: unknown) => true),
+  mockPortraitMatch: vi.fn((_: unknown) => true),
+  mockRegenerateMatch: vi.fn((_: unknown) => true),
+  mockCaptureIdentity: vi.fn(() => 'id:test-project'),
+  mockIsStaleError: vi.fn((_: unknown) => false),
+}));
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -28,8 +34,11 @@ let mockCharacters: Character[] = [];
 
 vi.mock('../../../app/hooks', () => ({
   useAppDispatch: () => mockDispatch,
-  useAppSelector: (selector: (s: { characters: Character[] }) => unknown) =>
-    selector({ characters: mockCharacters }),
+  useAppSelector: (selector: (s: unknown) => unknown) =>
+    selector({
+      characters: mockCharacters,
+      project: { present: { data: { id: 'c-project-1' } } },
+    }),
 }));
 
 vi.mock('../../../hooks/useTranslation', () => ({
@@ -54,8 +63,13 @@ vi.mock('../../../features/project/projectSelectors', () => ({
 
 vi.mock('../../../features/project/projectIdentity', () => ({
   captureActiveProjectIdentity: mockCaptureIdentity,
+  getProjectTargetStorageId: () => 'c-project-1',
   identityUnchanged: (captured: string | null, live: string | null) =>
     captured !== null && captured === live,
+  assertProjectIdentityUnchanged: (captured: string | null, live: string | null) => {
+    if (captured === null || captured !== live) throw new Error('stale project operation');
+  },
+  isStaleProjectOperationError: mockIsStaleError,
 }));
 
 vi.mock('../../../features/project/thunks/characterThunks', () => {
@@ -86,7 +100,8 @@ vi.mock('../../../services/storageService', () => ({
   storageService: {
     saveImage: (id: unknown, data: unknown, projectId: unknown) =>
       mockSaveImage(id, data, projectId),
-    deleteImage: (id: unknown, projectId: unknown) => mockDeleteImage(id, projectId),
+    deleteImage: (id: unknown, projectId: unknown, admission: unknown) =>
+      mockDeleteImage(id, projectId, admission),
   },
 }));
 
@@ -121,6 +136,7 @@ beforeEach(() => {
   mockPortraitMatch.mockReturnValue(true);
   mockRegenerateMatch.mockReturnValue(true);
   mockCaptureIdentity.mockReturnValue('id:test-project');
+  mockIsStaleError.mockReturnValue(false);
 });
 
 // ---------------------------------------------------------------------------
@@ -401,6 +417,46 @@ describe('handleGeneratePortrait', () => {
     expect(mockToast.error).toHaveBeenCalled();
     expect(result.current.errorMessage).not.toBeNull();
   });
+
+  it('silently discards stale portrait results without marking an avatar', async () => {
+    mockDispatch.mockResolvedValue({
+      type: 'project/generateCharacterPortrait/rejected',
+      error: { name: 'StaleProjectOperationError' },
+    });
+    mockPortraitMatch.mockReturnValue(false);
+    mockIsStaleError.mockReturnValue(true);
+
+    const char = makeCharacter('c1');
+    const { result } = renderHook(() => useCharacterView());
+    act(() => result.current.handleSelect(char));
+    await act(async () => {
+      await result.current.handleGeneratePortrait();
+    });
+
+    expect(result.current.selectedCharacter?.hasAvatar).toBe(false);
+    expect(mockToast.error).not.toHaveBeenCalled();
+  });
+
+  it('silently discards a stale refined portrait result', async () => {
+    mockDispatch.mockResolvedValue({
+      type: 'project/generateCharacterPortrait/rejected',
+      error: { name: 'StaleProjectOperationError' },
+    });
+    mockPortraitMatch.mockReturnValue(false);
+    mockIsStaleError.mockReturnValue(true);
+
+    const { result } = renderHook(() => useCharacterView());
+    act(() => {
+      result.current.handleSelect(makeCharacter('c1'));
+      result.current.setRefinementPrompt('more detail');
+    });
+    await act(async () => {
+      await result.current.handleRefinePortrait();
+    });
+
+    expect(mockToast.error).not.toHaveBeenCalled();
+    expect(result.current.isRefiningPortrait).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -434,8 +490,10 @@ describe('confirmDelete', () => {
     });
 
     // QNBS-v3: asserts the real active project id (not a hardcoded fallback every project would share) is forwarded to deleteImage.
-    expect(mockDeleteImage).toHaveBeenCalledWith('c1', 'c-project-1');
+    expect(mockDeleteImage).toHaveBeenCalledWith('c1', 'c-project-1', expect.any(Function));
     expect(mockDispatch).toHaveBeenCalledWith(projectActions.deleteCharacter('c1'));
+    const admission = mockDeleteImage.mock.calls[0]?.[2] as (() => void) | undefined;
+    admission?.();
   });
 
   it('resets state and calls toast.info after deletion', async () => {
@@ -452,6 +510,50 @@ describe('confirmDelete', () => {
     expect(result.current.isDossierOpen).toBe(false);
     expect(result.current.selectedCharacter).toBeNull();
     expect(mockToast.info).toHaveBeenCalled();
+  });
+
+  it('clears a stale delete confirmation without dispatching a deletion', async () => {
+    const char = makeCharacter('c1', 'Hero');
+    const { result } = renderHook(() => useCharacterView());
+    act(() => result.current.setCharacterToDelete(char));
+    mockIsStaleError.mockReturnValue(true);
+    mockDeleteImage.mockRejectedValueOnce({ name: 'StaleProjectOperationError' });
+
+    await act(async () => {
+      await result.current.confirmDelete();
+    });
+
+    expect(result.current.characterToDelete).toBeNull();
+    expect(mockDispatch).not.toHaveBeenCalledWith(projectActions.deleteCharacter('c1'));
+  });
+
+  it('clears a confirmation when the active project changes before delete starts', async () => {
+    const { result } = renderHook(() => useCharacterView());
+    act(() => result.current.setCharacterToDelete(makeCharacter('c1')));
+    mockCaptureIdentity.mockReturnValue('id:replacement');
+
+    await act(async () => {
+      await result.current.confirmDelete();
+    });
+
+    expect(result.current.characterToDelete).toBeNull();
+    expect(mockDeleteImage).not.toHaveBeenCalled();
+  });
+
+  it('clears a confirmation when the active project changes after storage', async () => {
+    const char = makeCharacter('c1', 'Hero');
+    const { result } = renderHook(() => useCharacterView());
+    act(() => result.current.setCharacterToDelete(char));
+    mockDeleteImage.mockImplementationOnce(async () => {
+      mockCaptureIdentity.mockReturnValue('id:replacement');
+    });
+
+    await act(async () => {
+      await result.current.confirmDelete();
+    });
+
+    expect(result.current.characterToDelete).toBeNull();
+    expect(mockDispatch).not.toHaveBeenCalledWith(projectActions.deleteCharacter('c1'));
   });
 
   it('does nothing when characterToDelete is null', async () => {

--- a/tests/unit/hooks/useCharacterView.test.ts
+++ b/tests/unit/hooks/useCharacterView.test.ts
@@ -591,6 +591,29 @@ describe('confirmDelete', () => {
     expect(mockDispatch).not.toHaveBeenCalledWith(projectActions.deleteCharacter('c1'));
   });
 
+  it('suppresses a backend error after the active project changes', async () => {
+    const char = makeCharacter('c1', 'Hero');
+    const { result } = renderHook(() => useCharacterView());
+    act(() => {
+      result.current.setCharacterToDelete(char);
+      result.current.setSelectedCharacter(char);
+      result.current.setIsDossierOpen(true);
+    });
+    mockDeleteImage.mockImplementationOnce(async () => {
+      mockCaptureIdentity.mockReturnValue('id:replacement');
+      throw new Error('storage failed');
+    });
+
+    await act(async () => {
+      await result.current.confirmDelete();
+    });
+
+    expect(result.current.characterToDelete).toBeNull();
+    expect(result.current.selectedCharacter).toBeNull();
+    expect(result.current.isDossierOpen).toBe(false);
+    expect(mockToast.error).not.toHaveBeenCalled();
+  });
+
   it('does nothing when characterToDelete is null', async () => {
     const { result } = renderHook(() => useCharacterView());
     await act(async () => {

--- a/tests/unit/hooks/useManuscriptView.test.ts
+++ b/tests/unit/hooks/useManuscriptView.test.ts
@@ -23,6 +23,7 @@ const mockToast = { success: vi.fn(), error: vi.fn(), info: vi.fn() };
 const mockState = {
   project: {
     present: {
+      generation: 0,
       data: {
         id: 'p1',
         title: 'My Novel',
@@ -497,6 +498,48 @@ describe('handleVisualizeScene', () => {
 
     await act(async () => {
       resolveVisualization({ imageKey: 'scene-old', dataUrl: 'data:image/png;base64,old' });
+      await visualizationRequest;
+    });
+    expect(result.current.sceneImagePreviewUrl).toBeNull();
+    expect(result.current.isSceneVisualizing).toBe(false);
+  });
+
+  it('clears a visualization when the project incarnation changes without changing section', async () => {
+    mockUnwrap.mockResolvedValueOnce({
+      imageKey: 'scene-before-replacement',
+      dataUrl: 'data:image/png;base64,before-replacement',
+    });
+    setManuscript([makeSection('s1', 'Ch1', 'Scene one')]);
+    const { result, rerender } = renderHook(() => useManuscriptView({ onNavigate }));
+
+    await act(async () => {
+      await result.current.handleVisualizeScene();
+    });
+    expect(result.current.sceneImagePreviewUrl).toBe('data:image/png;base64,before-replacement');
+
+    let resolveVisualization!: (value: { imageKey: string; dataUrl: string }) => void;
+    mockUnwrap.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveVisualization = resolve;
+      }),
+    );
+    let visualizationRequest!: Promise<void>;
+    act(() => {
+      visualizationRequest = result.current.handleVisualizeScene();
+    });
+
+    act(() => {
+      mockState.project.present.generation = 1;
+      rerender();
+    });
+    expect(result.current.sceneImagePreviewUrl).toBeNull();
+    expect(result.current.isSceneVisualizing).toBe(false);
+
+    await act(async () => {
+      resolveVisualization({
+        imageKey: 'scene-after-replacement',
+        dataUrl: 'data:image/png;base64,after-replacement',
+      });
       await visualizationRequest;
     });
     expect(result.current.sceneImagePreviewUrl).toBeNull();

--- a/tests/unit/hooks/useManuscriptView.test.ts
+++ b/tests/unit/hooks/useManuscriptView.test.ts
@@ -476,4 +476,30 @@ describe('handleVisualizeScene', () => {
     act(() => result.current.setActiveSectionId('s2'));
     expect(result.current.sceneImagePreviewUrl).toBeNull();
   });
+
+  it('rejects a pending visualization after the active section changes', async () => {
+    let resolveVisualization!: (value: { imageKey: string; dataUrl: string }) => void;
+    mockUnwrap.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveVisualization = resolve;
+      }),
+    );
+    setManuscript([makeSection('s1', 'Ch1', 'Scene one'), makeSection('s2', 'Ch2', 'Scene two')]);
+    const { result } = renderHook(() => useManuscriptView({ onNavigate }));
+
+    let visualizationRequest!: Promise<void>;
+    act(() => {
+      visualizationRequest = result.current.handleVisualizeScene();
+    });
+    act(() => result.current.setActiveSectionId('s2'));
+    expect(result.current.sceneImagePreviewUrl).toBeNull();
+    expect(result.current.isSceneVisualizing).toBe(false);
+
+    await act(async () => {
+      resolveVisualization({ imageKey: 'scene-old', dataUrl: 'data:image/png;base64,old' });
+      await visualizationRequest;
+    });
+    expect(result.current.sceneImagePreviewUrl).toBeNull();
+    expect(result.current.isSceneVisualizing).toBe(false);
+  });
 });

--- a/tests/unit/hooks/useManuscriptView.test.ts
+++ b/tests/unit/hooks/useManuscriptView.test.ts
@@ -404,6 +404,45 @@ describe('handleVisualizeScene', () => {
     expect(result.current.sceneImagePreviewUrl).toBe('data:image/png;base64,abc');
   });
 
+  it('keeps an older visualization from replacing a newer preview', async () => {
+    let resolveFirst!: (value: { imageKey: string; dataUrl: string }) => void;
+    let resolveSecond!: (value: { imageKey: string; dataUrl: string }) => void;
+    mockUnwrap
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveFirst = resolve;
+        }),
+      )
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveSecond = resolve;
+        }),
+      );
+    setManuscript([makeSection('s1', 'Ch1', 'A scene with action')]);
+    const { result } = renderHook(() => useManuscriptView({ onNavigate }));
+
+    let firstRequest!: Promise<void>;
+    let secondRequest!: Promise<void>;
+    act(() => {
+      firstRequest = result.current.handleVisualizeScene();
+      secondRequest = result.current.handleVisualizeScene();
+    });
+
+    await act(async () => {
+      resolveFirst({ imageKey: 'scene-old', dataUrl: 'data:image/png;base64,old' });
+      await firstRequest;
+    });
+    expect(result.current.sceneImagePreviewUrl).toBeNull();
+    expect(result.current.isSceneVisualizing).toBe(true);
+
+    await act(async () => {
+      resolveSecond({ imageKey: 'scene-new', dataUrl: 'data:image/png;base64,new' });
+      await secondRequest;
+    });
+    expect(result.current.sceneImagePreviewUrl).toBe('data:image/png;base64,new');
+    expect(result.current.isSceneVisualizing).toBe(false);
+  });
+
   it('calls toast.error on rejection', async () => {
     mockUnwrap.mockRejectedValue(new Error('Image gen failed'));
     setManuscript([makeSection('s1', 'Ch1', 'Scene content')]);

--- a/tests/unit/hooks/useWorldView.test.ts
+++ b/tests/unit/hooks/useWorldView.test.ts
@@ -496,6 +496,10 @@ describe('confirmDelete', () => {
     mockWorlds = [world];
     const { result } = renderHook(() => useWorldView());
     act(() => result.current.handleDelete('w1'));
+    act(() => {
+      result.current.setSelectedWorld(world);
+      result.current.setIsAtlasOpen(true);
+    });
     mockIsStaleError.mockReturnValue(true);
     mockDeleteImage.mockRejectedValueOnce({ name: 'StaleProjectOperationError' });
 
@@ -504,6 +508,8 @@ describe('confirmDelete', () => {
     });
 
     expect(result.current.worldToDelete).toBeNull();
+    expect(result.current.selectedWorld).toBeNull();
+    expect(result.current.isAtlasOpen).toBe(false);
     expect(mockDispatch).not.toHaveBeenCalledWith(
       expect.objectContaining({ type: 'project/deleteWorld', payload: 'w1' }),
     );
@@ -527,8 +533,13 @@ describe('confirmDelete', () => {
   });
 
   it('clears a confirmation when the active project changes before delete starts', async () => {
+    const world = makeWorld('w1');
     const { result } = renderHook(() => useWorldView());
-    act(() => result.current.setWorldToDelete(makeWorld('w1')));
+    act(() => {
+      result.current.setWorldToDelete(world);
+      result.current.setSelectedWorld(world);
+      result.current.setIsAtlasOpen(true);
+    });
     mockCaptureIdentity.mockReturnValue('id:replacement');
 
     await act(async () => {
@@ -536,13 +547,19 @@ describe('confirmDelete', () => {
     });
 
     expect(result.current.worldToDelete).toBeNull();
+    expect(result.current.selectedWorld).toBeNull();
+    expect(result.current.isAtlasOpen).toBe(false);
     expect(mockDeleteImage).not.toHaveBeenCalled();
   });
 
   it('clears a confirmation when the active project changes after storage', async () => {
     const world = makeWorld('w1', 'Arda');
     const { result } = renderHook(() => useWorldView());
-    act(() => result.current.setWorldToDelete(world));
+    act(() => {
+      result.current.setWorldToDelete(world);
+      result.current.setSelectedWorld(world);
+      result.current.setIsAtlasOpen(true);
+    });
     mockDeleteImage.mockImplementationOnce(async () => {
       mockCaptureIdentity.mockReturnValue('id:replacement');
     });
@@ -552,9 +569,34 @@ describe('confirmDelete', () => {
     });
 
     expect(result.current.worldToDelete).toBeNull();
+    expect(result.current.selectedWorld).toBeNull();
+    expect(result.current.isAtlasOpen).toBe(false);
     expect(mockDispatch).not.toHaveBeenCalledWith(
       expect.objectContaining({ type: 'project/deleteWorld', payload: 'w1' }),
     );
+  });
+
+  it('suppresses a backend error after the active project changes', async () => {
+    const world = makeWorld('w1', 'Arda');
+    const { result } = renderHook(() => useWorldView());
+    act(() => {
+      result.current.setWorldToDelete(world);
+      result.current.setSelectedWorld(world);
+      result.current.setIsAtlasOpen(true);
+    });
+    mockDeleteImage.mockImplementationOnce(async () => {
+      mockCaptureIdentity.mockReturnValue('id:replacement');
+      throw new Error('storage failed');
+    });
+
+    await act(async () => {
+      await result.current.confirmDelete();
+    });
+
+    expect(result.current.worldToDelete).toBeNull();
+    expect(result.current.selectedWorld).toBeNull();
+    expect(result.current.isAtlasOpen).toBe(false);
+    expect(mockToast.error).not.toHaveBeenCalled();
   });
 
   it('does nothing when worldToDelete is null', async () => {

--- a/tests/unit/hooks/useWorldView.test.ts
+++ b/tests/unit/hooks/useWorldView.test.ts
@@ -6,14 +6,19 @@ import type { World } from '../../../types';
 // ---------------------------------------------------------------------------
 // vi.hoisted — thunk match fns must be stable references inside vi.mock factories
 // ---------------------------------------------------------------------------
-const { mockProfileMatch, mockRegenerateMatch, mockImageMatch, mockCaptureIdentity } = vi.hoisted(
-  () => ({
-    mockProfileMatch: vi.fn((_: unknown) => true),
-    mockRegenerateMatch: vi.fn((_: unknown) => true),
-    mockImageMatch: vi.fn((_: unknown) => true),
-    mockCaptureIdentity: vi.fn(() => 'id:test-project'),
-  }),
-);
+const {
+  mockProfileMatch,
+  mockRegenerateMatch,
+  mockImageMatch,
+  mockCaptureIdentity,
+  mockIsStaleError,
+} = vi.hoisted(() => ({
+  mockProfileMatch: vi.fn((_: unknown) => true),
+  mockRegenerateMatch: vi.fn((_: unknown) => true),
+  mockImageMatch: vi.fn((_: unknown) => true),
+  mockCaptureIdentity: vi.fn(() => 'id:test-project'),
+  mockIsStaleError: vi.fn((_: unknown) => false),
+}));
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -55,8 +60,13 @@ vi.mock('../../../features/project/projectSelectors', () => ({
 
 vi.mock('../../../features/project/projectIdentity', () => ({
   captureActiveProjectIdentity: mockCaptureIdentity,
+  getProjectTargetStorageId: () => 'w-project-1',
   identityUnchanged: (captured: string | null, live: string | null) =>
     captured !== null && captured === live,
+  assertProjectIdentityUnchanged: (captured: string | null, live: string | null) => {
+    if (captured === null || captured !== live) throw new Error('stale project operation');
+  },
+  isStaleProjectOperationError: mockIsStaleError,
 }));
 
 vi.mock('../../../features/project/thunks/worldThunks', () => {
@@ -87,7 +97,8 @@ vi.mock('../../../services/storageService', () => ({
   storageService: {
     saveImage: (id: unknown, data: unknown, projectId: unknown) =>
       mockSaveImage(id, data, projectId),
-    deleteImage: (id: unknown, projectId: unknown) => mockDeleteImage(id, projectId),
+    deleteImage: (id: unknown, projectId: unknown, admission: unknown) =>
+      mockDeleteImage(id, projectId, admission),
   },
 }));
 
@@ -119,6 +130,7 @@ beforeEach(() => {
   mockRegenerateMatch.mockReturnValue(true);
   mockImageMatch.mockReturnValue(true);
   mockCaptureIdentity.mockReturnValue('id:test-project');
+  mockIsStaleError.mockReturnValue(false);
 });
 
 // ---------------------------------------------------------------------------
@@ -388,6 +400,47 @@ describe('handleGenerateImage', () => {
     });
     expect(result.current.isGeneratingImage).toBe(false);
   });
+
+  it('silently discards stale image results without showing a toast', async () => {
+    const world = makeWorld('w1');
+    mockDispatch.mockResolvedValue({
+      type: 'project/generateWorldImage/rejected',
+      error: { name: 'StaleProjectOperationError' },
+    });
+    mockImageMatch.mockReturnValue(false);
+    mockIsStaleError.mockReturnValue(true);
+
+    const { result } = renderHook(() => useWorldView());
+    act(() => result.current.handleSelect(world));
+    await act(async () => {
+      await result.current.handleGenerateImage();
+    });
+
+    expect(mockToast.error).not.toHaveBeenCalled();
+    expect(mockIsStaleError).toHaveBeenCalledWith({ name: 'StaleProjectOperationError' });
+    expect(result.current.isGeneratingImage).toBe(false);
+  });
+
+  it('silently discards a stale refined image result', async () => {
+    mockDispatch.mockResolvedValue({
+      type: 'project/generateWorldImage/rejected',
+      error: { name: 'StaleProjectOperationError' },
+    });
+    mockImageMatch.mockReturnValue(false);
+    mockIsStaleError.mockReturnValue(true);
+
+    const { result } = renderHook(() => useWorldView());
+    act(() => {
+      result.current.handleSelect(makeWorld('w1'));
+      result.current.setRefinementPrompt('more atmosphere');
+    });
+    await act(async () => {
+      await result.current.handleRefineImage();
+    });
+
+    expect(mockToast.error).not.toHaveBeenCalled();
+    expect(result.current.isRefiningImage).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -426,12 +479,63 @@ describe('confirmDelete', () => {
       await result.current.confirmDelete();
     });
     // QNBS-v3: asserts the real active project id (not a hardcoded fallback every project would share) is forwarded to deleteImage.
-    expect(mockDeleteImage).toHaveBeenCalledWith('w1', 'w-project-1');
+    expect(mockDeleteImage).toHaveBeenCalledWith('w1', 'w-project-1', expect.any(Function));
     expect(mockDispatch).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'project/deleteWorld', payload: 'w1' }),
     );
     expect(result.current.isAtlasOpen).toBe(false);
     expect(result.current.selectedWorld).toBeNull();
+    const admission = mockDeleteImage.mock.calls[0]?.[2] as (() => void) | undefined;
+    admission?.();
+  });
+
+  it('clears a stale delete confirmation without dispatching a deletion', async () => {
+    const world = makeWorld('w1');
+    mockWorlds = [world];
+    const { result } = renderHook(() => useWorldView());
+    act(() => result.current.handleDelete('w1'));
+    mockIsStaleError.mockReturnValue(true);
+    mockDeleteImage.mockRejectedValueOnce({ name: 'StaleProjectOperationError' });
+
+    await act(async () => {
+      await result.current.confirmDelete();
+    });
+
+    expect(result.current.worldToDelete).toBeNull();
+    expect(mockDispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'project/deleteWorld', payload: 'w1' }),
+    );
+  });
+
+  it('clears a confirmation when the active project changes before delete starts', async () => {
+    const { result } = renderHook(() => useWorldView());
+    act(() => result.current.setWorldToDelete(makeWorld('w1')));
+    mockCaptureIdentity.mockReturnValue('id:replacement');
+
+    await act(async () => {
+      await result.current.confirmDelete();
+    });
+
+    expect(result.current.worldToDelete).toBeNull();
+    expect(mockDeleteImage).not.toHaveBeenCalled();
+  });
+
+  it('clears a confirmation when the active project changes after storage', async () => {
+    const world = makeWorld('w1', 'Arda');
+    const { result } = renderHook(() => useWorldView());
+    act(() => result.current.setWorldToDelete(world));
+    mockDeleteImage.mockImplementationOnce(async () => {
+      mockCaptureIdentity.mockReturnValue('id:replacement');
+    });
+
+    await act(async () => {
+      await result.current.confirmDelete();
+    });
+
+    expect(result.current.worldToDelete).toBeNull();
+    expect(mockDispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'project/deleteWorld', payload: 'w1' }),
+    );
   });
 
   it('does nothing when worldToDelete is null', async () => {

--- a/tests/unit/hooks/useWorldView.test.ts
+++ b/tests/unit/hooks/useWorldView.test.ts
@@ -507,6 +507,23 @@ describe('confirmDelete', () => {
     );
   });
 
+  it('clears the confirmation and shows an error when image deletion fails', async () => {
+    const world = makeWorld('w1');
+    const { result } = renderHook(() => useWorldView());
+    act(() => result.current.setWorldToDelete(world));
+    mockDeleteImage.mockRejectedValueOnce(new Error('storage failed'));
+
+    await act(async () => {
+      await result.current.confirmDelete();
+    });
+
+    expect(result.current.worldToDelete).toBeNull();
+    expect(mockToast.error).toHaveBeenCalledWith('error.apiErrorTitle');
+    expect(mockDispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'project/deleteWorld', payload: 'w1' }),
+    );
+  });
+
   it('clears a confirmation when the active project changes before delete starts', async () => {
     const { result } = renderHook(() => useWorldView());
     act(() => result.current.setWorldToDelete(makeWorld('w1')));

--- a/tests/unit/hooks/useWorldView.test.ts
+++ b/tests/unit/hooks/useWorldView.test.ts
@@ -408,7 +408,9 @@ describe('handleGenerateImage', () => {
       error: { name: 'StaleProjectOperationError' },
     });
     mockImageMatch.mockReturnValue(false);
-    mockIsStaleError.mockReturnValue(true);
+    mockIsStaleError.mockImplementation(
+      (error: unknown) => (error as { name?: string })?.name === 'StaleProjectOperationError',
+    );
 
     const { result } = renderHook(() => useWorldView());
     act(() => result.current.handleSelect(world));

--- a/tests/unit/projectSlice.interviews.test.ts
+++ b/tests/unit/projectSlice.interviews.test.ts
@@ -120,4 +120,22 @@ describe('projectSlice — characterInterview reducers', () => {
       'Streaming response so far',
     );
   });
+
+  it('ignores a chunk whose origin identity is no longer current', () => {
+    const aiMsg = makeMessage({ id: 'ai-msg', role: 'ai', content: '' });
+    const interview = makeInterview({ messages: [aiMsg] });
+    const state = s({ 'char-1': [interview] });
+    // QNBS-v3: [Grund: stale generation fixture / Impact: prove reducer-level rejection / Kreativer Mehrwert: preserve active interview content]
+    const next = projectReducer(state as unknown as Parameters<typeof projectReducer>[0], {
+      type: 'project/streamInterviewChunk',
+      payload: {
+        characterId: 'char-1',
+        interviewId: 'iv-1',
+        aiMsgId: 'ai-msg',
+        content: 'stale response',
+        originIdentity: 'id:default:gen:1',
+      },
+    });
+    expect(next.data.characterInterviews?.['char-1']?.[0]?.messages?.[0]?.content).toBe('');
+  });
 });

--- a/tests/unit/projectSlice.interviews.test.ts
+++ b/tests/unit/projectSlice.interviews.test.ts
@@ -120,22 +120,4 @@ describe('projectSlice — characterInterview reducers', () => {
       'Streaming response so far',
     );
   });
-
-  it('ignores a chunk whose origin identity is no longer current', () => {
-    const aiMsg = makeMessage({ id: 'ai-msg', role: 'ai', content: '' });
-    const interview = makeInterview({ messages: [aiMsg] });
-    const state = s({ 'char-1': [interview] });
-    // QNBS-v3: [Grund: stale generation fixture / Impact: prove reducer-level rejection / Kreativer Mehrwert: preserve active interview content]
-    const next = projectReducer(state as unknown as Parameters<typeof projectReducer>[0], {
-      type: 'project/streamInterviewChunk',
-      payload: {
-        characterId: 'char-1',
-        interviewId: 'iv-1',
-        aiMsgId: 'ai-msg',
-        content: 'stale response',
-        originIdentity: 'id:default:gen:1',
-      },
-    });
-    expect(next.data.characterInterviews?.['char-1']?.[0]?.messages?.[0]?.content).toBe('');
-  });
 });

--- a/tests/unit/projectSlice.interviews.test.ts
+++ b/tests/unit/projectSlice.interviews.test.ts
@@ -27,10 +27,16 @@ function makeMessage(overrides: Partial<InterviewMessage> = {}): InterviewMessag
   };
 }
 
-type PartialState = { data: { characterInterviews?: Record<string, CharacterInterview[]> } };
+type PartialState = {
+  generation?: number;
+  data: {
+    id?: string;
+    characterInterviews?: Record<string, CharacterInterview[]>;
+  };
+};
 
 function s(interviews: Record<string, CharacterInterview[]> = {}): PartialState {
-  return { data: { characterInterviews: interviews } };
+  return { generation: 0, data: { id: 'default', characterInterviews: interviews } };
 }
 
 describe('projectSlice — characterInterview reducers', () => {
@@ -107,10 +113,29 @@ describe('projectSlice — characterInterview reducers', () => {
         interviewId: 'iv-1',
         aiMsgId: 'ai-msg',
         content: 'Streaming response so far',
+        originIdentity: 'id:default:gen:0',
       },
     });
     expect(next.data.characterInterviews?.['char-1']?.[0]?.messages?.[0]?.content).toBe(
       'Streaming response so far',
     );
+  });
+
+  it('ignores a chunk whose origin identity is no longer current', () => {
+    const aiMsg = makeMessage({ id: 'ai-msg', role: 'ai', content: '' });
+    const interview = makeInterview({ messages: [aiMsg] });
+    const state = s({ 'char-1': [interview] });
+    // QNBS-v3: [Grund: stale generation fixture / Impact: prove reducer-level rejection / Kreativer Mehrwert: preserve active interview content]
+    const next = projectReducer(state as unknown as Parameters<typeof projectReducer>[0], {
+      type: 'project/streamInterviewChunk',
+      payload: {
+        characterId: 'char-1',
+        interviewId: 'iv-1',
+        aiMsgId: 'ai-msg',
+        content: 'stale response',
+        originIdentity: 'id:default:gen:1',
+      },
+    });
+    expect(next.data.characterInterviews?.['char-1']?.[0]?.messages?.[0]?.content).toBe('');
   });
 });

--- a/tests/unit/services/fs/fsStores.test.ts
+++ b/tests/unit/services/fs/fsStores.test.ts
@@ -1986,7 +1986,7 @@ describe('FsAssetStore — images + binder assets', () => {
     }
 
     expect(removeAttempts).toBe(2);
-    expect(admission).toHaveBeenCalledTimes(2);
+    expect(admission).toHaveBeenCalledTimes(3);
     expect(await store.getImage('delete-retry', 'proj-1')).toBeNull();
   });
 
@@ -2130,8 +2130,8 @@ describe('FsAssetStore — images + binder assets', () => {
     expect(fake.text.has('/app/images/dual.png')).toBe(false);
   });
 
-  // QNBS-v3: filesystem deletion mirrors the IDB transaction boundary -- a stale final admission cannot interrupt the ordered legacy/qualified cleanup between files.
-  it('finishes both image removals before rejecting a stale delete completion', async () => {
+  // QNBS-v3: each irreversible filesystem removal is independently admitted, so a stale boundary stops the ordered cleanup before the next file while preserving the qualified image as the safe fallback.
+  it('stops before the next image removal when authority changes between files', async () => {
     simulateLegacyImageOwner('proj-1');
     fake.text.set('/app/images/delete-boundary.png', 'data:image/png;base64,LEGACY');
     await store.saveImage('delete-boundary', 'data:image/png;base64,QUALIFIED', 'proj-1');
@@ -2144,7 +2144,10 @@ describe('FsAssetStore — images + binder assets', () => {
       'stale project incarnation',
     );
     expect(fake.text.has('/app/images/delete-boundary.png')).toBe(false);
-    expect(qualifiedImageKey('delete-boundary')).toBeUndefined();
+    expect(qualifiedImageKey('delete-boundary')).toBeDefined();
+    expect(await store.getImage('delete-boundary', 'proj-1')).toBe(
+      'data:image/png;base64,QUALIFIED',
+    );
   });
 
   // QNBS-v3: writes the persisted legacy-image-ownership marker directly, simulating a prior claim by projectId (as if it had already consulted the legacy fallback once).

--- a/tests/unit/services/fs/fsStores.test.ts
+++ b/tests/unit/services/fs/fsStores.test.ts
@@ -1977,7 +1977,7 @@ describe('FsAssetStore — images + binder assets', () => {
       }
       return originalRemove(path, options);
     };
-    const admission = vi.fn();
+    const admission = vi.fn(() => undefined);
 
     try {
       await store.deleteImage('delete-retry', 'proj-1', admission);
@@ -1999,18 +1999,15 @@ describe('FsAssetStore — images + binder assets', () => {
     const originalRemove = fake.apis.remove;
     const originalWriteTextFile = fake.apis.writeTextFile;
     let releaseRemoval!: () => void;
-    let removalStarted!: () => void;
+    let removalStarted = false;
     const removalReleased = new Promise<void>((resolve) => {
       releaseRemoval = resolve;
-    });
-    const removalObserved = new Promise<void>((resolve) => {
-      removalStarted = resolve;
     });
     let replacementWriteStarted = false;
 
     fake.apis.remove = async (path: string, options?: { recursive?: boolean }) => {
       if (path === qualified) {
-        removalStarted();
+        removalStarted = true;
         await removalReleased;
       }
       return originalRemove(path, options);
@@ -2022,7 +2019,7 @@ describe('FsAssetStore — images + binder assets', () => {
 
     try {
       const deletePromise = store.deleteImage('replace-race', 'proj-1');
-      await removalObserved;
+      await vi.waitFor(() => expect(removalStarted).toBe(true));
       const replacementPromise = store.saveImage(
         'replace-race',
         'data:image/png;base64,NEW',
@@ -2140,6 +2137,7 @@ describe('FsAssetStore — images + binder assets', () => {
     await store.saveImage('delete-boundary', 'data:image/png;base64,QUALIFIED', 'proj-1');
     const admission = vi.fn(() => {
       if (admission.mock.calls.length > 1) throw new Error('stale project incarnation');
+      return undefined;
     });
 
     await expect(store.deleteImage('delete-boundary', 'proj-1', admission)).rejects.toThrow(

--- a/tests/unit/services/fs/fsStores.test.ts
+++ b/tests/unit/services/fs/fsStores.test.ts
@@ -1922,6 +1922,125 @@ describe('FsAssetStore — images + binder assets', () => {
     expect(await store.getImage('char-1', 'proj-1')).toBeNull();
   });
 
+  it('does not replace an image when final write admission rejects the incarnation', async () => {
+    await store.saveImage('guarded', 'data:image/png;base64,OLD', 'proj-1');
+    const filesBeforeRejectedWrite = new Map(fake.text);
+    const admission = vi
+      .fn()
+      .mockImplementationOnce(() => undefined)
+      .mockImplementationOnce(() => {
+        throw new Error('stale project incarnation');
+      });
+
+    await expect(
+      store.saveImage('guarded', 'data:image/png;base64,NEW', 'proj-1', admission),
+    ).rejects.toThrow('stale project incarnation');
+    expect(admission).toHaveBeenCalledTimes(2);
+    expect(fake.text).toEqual(filesBeforeRejectedWrite);
+    expect(await store.getImage('guarded', 'proj-1')).toBe('data:image/png;base64,OLD');
+  });
+
+  it('does not delete an image when delete admission rejects the incarnation', async () => {
+    await store.saveImage('delete-guarded', 'data:image/png;base64,OLD', 'proj-1');
+    const admission = vi.fn(() => {
+      throw new Error('stale project incarnation');
+    });
+
+    await expect(store.deleteImage('delete-guarded', 'proj-1', admission)).rejects.toThrow(
+      'stale project incarnation',
+    );
+    expect(admission).toHaveBeenCalledTimes(1);
+    expect(await store.getImage('delete-guarded', 'proj-1')).toBe('data:image/png;base64,OLD');
+  });
+
+  // QNBS-v3: [Grund: stale no-op deletion / Impact: reject obsolete entity removal / Kreativer Mehrwert: keep missing-file cleanup under project authority]
+  it('checks delete admission even when both image files are already absent', async () => {
+    const admission = vi.fn(() => {
+      throw new Error('stale project incarnation');
+    });
+
+    await expect(store.deleteImage('missing-image', 'proj-1', admission)).rejects.toThrow(
+      'stale project incarnation',
+    );
+    expect(admission).toHaveBeenCalledTimes(1);
+  });
+
+  it('rechecks delete admission after a transient filesystem retry', async () => {
+    await store.saveImage('delete-retry', 'data:image/png;base64,OLD', 'proj-1');
+    const qualified = qualifiedImageKey('delete-retry');
+    expect(qualified).toBeDefined();
+    const originalRemove = fake.apis.remove;
+    let removeAttempts = 0;
+    fake.apis.remove = (path: string, options?: { recursive?: boolean }) => {
+      if (path === qualified && removeAttempts++ === 0) {
+        return Promise.reject(new Error('resource busy'));
+      }
+      return originalRemove(path, options);
+    };
+    const admission = vi.fn();
+
+    try {
+      await store.deleteImage('delete-retry', 'proj-1', admission);
+    } finally {
+      fake.apis.remove = originalRemove;
+    }
+
+    expect(removeAttempts).toBe(2);
+    expect(admission).toHaveBeenCalledTimes(3);
+    expect(await store.getImage('delete-retry', 'proj-1')).toBeNull();
+  });
+
+  // QNBS-v3: a replacement must wait for a pending delete so the delete cannot remove the replacement after its atomic rename.
+  it('serializes a replacement behind a deferred image removal', async () => {
+    await store.saveImage('replace-race', 'data:image/png;base64,OLD', 'proj-1');
+    const qualified = qualifiedImageKey('replace-race');
+    expect(qualified).toBeDefined();
+
+    const originalRemove = fake.apis.remove;
+    const originalWriteTextFile = fake.apis.writeTextFile;
+    let releaseRemoval!: () => void;
+    let removalStarted!: () => void;
+    const removalReleased = new Promise<void>((resolve) => {
+      releaseRemoval = resolve;
+    });
+    const removalObserved = new Promise<void>((resolve) => {
+      removalStarted = resolve;
+    });
+    let replacementWriteStarted = false;
+
+    fake.apis.remove = async (path: string, options?: { recursive?: boolean }) => {
+      if (path === qualified) {
+        removalStarted();
+        await removalReleased;
+      }
+      return originalRemove(path, options);
+    };
+    fake.apis.writeTextFile = (path: string, content: string) => {
+      if (path.includes('.tmp-')) replacementWriteStarted = true;
+      return originalWriteTextFile(path, content);
+    };
+
+    try {
+      const deletePromise = store.deleteImage('replace-race', 'proj-1');
+      await removalObserved;
+      const replacementPromise = store.saveImage(
+        'replace-race',
+        'data:image/png;base64,NEW',
+        'proj-1',
+      );
+
+      expect(replacementWriteStarted).toBe(false);
+      releaseRemoval();
+      await Promise.all([deletePromise, replacementPromise]);
+    } finally {
+      fake.apis.remove = originalRemove;
+      fake.apis.writeTextFile = originalWriteTextFile;
+      releaseRemoval();
+    }
+
+    expect(await store.getImage('replace-race', 'proj-1')).toBe('data:image/png;base64,NEW');
+  });
+
   it('treats legacy raw image payloads as PNG', async () => {
     await store.saveImage('legacy-char', 'QUJD', 'proj-1');
     expect(await store.getImage('legacy-char', 'proj-1')).toBe('data:image/png;base64,QUJD');

--- a/tests/unit/services/fs/fsStores.test.ts
+++ b/tests/unit/services/fs/fsStores.test.ts
@@ -1986,7 +1986,7 @@ describe('FsAssetStore — images + binder assets', () => {
     }
 
     expect(removeAttempts).toBe(2);
-    expect(admission).toHaveBeenCalledTimes(3);
+    expect(admission).toHaveBeenCalledTimes(2);
     expect(await store.getImage('delete-retry', 'proj-1')).toBeNull();
   });
 
@@ -2131,6 +2131,22 @@ describe('FsAssetStore — images + binder assets', () => {
     await store.deleteImage('dual', 'proj-1');
     expect(await store.getImage('dual', 'proj-1')).toBeNull();
     expect(fake.text.has('/app/images/dual.png')).toBe(false);
+  });
+
+  // QNBS-v3: filesystem deletion mirrors the IDB transaction boundary -- a stale final admission cannot interrupt the ordered legacy/qualified cleanup between files.
+  it('finishes both image removals before rejecting a stale delete completion', async () => {
+    simulateLegacyImageOwner('proj-1');
+    fake.text.set('/app/images/delete-boundary.png', 'data:image/png;base64,LEGACY');
+    await store.saveImage('delete-boundary', 'data:image/png;base64,QUALIFIED', 'proj-1');
+    const admission = vi.fn(() => {
+      if (admission.mock.calls.length > 1) throw new Error('stale project incarnation');
+    });
+
+    await expect(store.deleteImage('delete-boundary', 'proj-1', admission)).rejects.toThrow(
+      'stale project incarnation',
+    );
+    expect(fake.text.has('/app/images/delete-boundary.png')).toBe(false);
+    expect(qualifiedImageKey('delete-boundary')).toBeUndefined();
   });
 
   // QNBS-v3: writes the persisted legacy-image-ownership marker directly, simulating a prior claim by projectId (as if it had already consulted the legacy fallback once).

--- a/tests/unit/services/storage/idbAssetStore.test.ts
+++ b/tests/unit/services/storage/idbAssetStore.test.ts
@@ -222,6 +222,7 @@ describe('IdbAssetStore', () => {
       await expect(store.saveImage('img-1', 'abc', 'proj-1')).rejects.toBeDefined();
     });
 
+    // QNBS-v3: [Grund: request success precedes transaction commit / Impact: reject a rolled-back stale write / Kreativer Mehrwert: keep persistence authority fail-closed]
     it('aborts a successful put when commit-time authority no longer holds', async () => {
       const admission = vi
         .fn<() => undefined>()
@@ -323,6 +324,7 @@ describe('IdbAssetStore', () => {
       await expect(store.deleteImage('img-1', 'proj-1')).rejects.toBeDefined();
     });
 
+    // QNBS-v3: [Grund: delete admission can fail after one request succeeds / Impact: roll back the whole atomic deletion / Kreativer Mehrwert: preserve project ownership]
     it('aborts a delete when commit-time authority no longer holds', async () => {
       const admission = vi
         .fn<() => undefined>()
@@ -338,6 +340,7 @@ describe('IdbAssetStore', () => {
       expect(mockImagesTransaction.abort).toHaveBeenCalledTimes(1);
     });
 
+    // QNBS-v3: [Grund: a queued sibling request may surface AbortError first / Impact: retain the causal stale-operation error / Kreativer Mehrwert: keep retry and UI handling truthful]
     it('preserves the stale admission error if another delete request aborts', async () => {
       mockAppDataStore.get.mockImplementation(() => appDataTracker.success('proj-1'));
       const abortError = new DOMException('transaction aborted', 'AbortError');

--- a/tests/unit/services/storage/idbAssetStore.test.ts
+++ b/tests/unit/services/storage/idbAssetStore.test.ts
@@ -14,10 +14,22 @@ type MockTransaction = {
   onerror: (() => void) | null;
   onabort: (() => void) | null;
   error: unknown;
+  abort: () => void;
 };
 
 function makeMockTransaction(): MockTransaction {
-  return { oncomplete: null, onerror: null, onabort: null, error: null };
+  const transaction: MockTransaction = {
+    oncomplete: null,
+    onerror: null,
+    onabort: null,
+    error: null,
+    abort: vi.fn(),
+  };
+  transaction.abort = vi.fn(() => {
+    transaction.error = new DOMException('simulated transaction abort');
+    transaction.onabort?.();
+  });
+  return transaction;
 }
 
 const mockImagesTransaction = makeMockTransaction();
@@ -207,6 +219,21 @@ describe('IdbAssetStore', () => {
       mockIdbStore.put.mockImplementation(() => makeErrorReq(new DOMException('put failed')));
       await expect(store.saveImage('img-1', 'abc', 'proj-1')).rejects.toBeDefined();
     });
+
+    it('aborts a successful put when commit-time authority no longer holds', async () => {
+      const admission = vi
+        .fn<() => undefined>()
+        .mockImplementationOnce(() => undefined)
+        .mockImplementationOnce(() => {
+          throw new Error('stale project incarnation');
+        });
+      mockIdbStore.put.mockImplementation(() => imagesTracker.success(undefined));
+
+      await expect(store.saveImage('img-1', 'abc', 'proj-1', admission)).rejects.toThrow(
+        'stale project incarnation',
+      );
+      expect(mockImagesTransaction.abort).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('getImage', () => {
@@ -292,6 +319,21 @@ describe('IdbAssetStore', () => {
     it('rejects when the delete request succeeds but its transaction aborts', async () => {
       mockIdbStore.delete.mockImplementation(() => imagesTracker.successThatThenAborts(undefined));
       await expect(store.deleteImage('img-1', 'proj-1')).rejects.toBeDefined();
+    });
+
+    it('aborts a delete when commit-time authority no longer holds', async () => {
+      const admission = vi
+        .fn<() => undefined>()
+        .mockImplementationOnce(() => undefined)
+        .mockImplementationOnce(() => {
+          throw new Error('stale project incarnation');
+        });
+      mockIdbStore.delete.mockImplementation(() => imagesTracker.success(undefined));
+
+      await expect(store.deleteImage('img-1', 'proj-1', admission)).rejects.toThrow(
+        'stale project incarnation',
+      );
+      expect(mockImagesTransaction.abort).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/tests/unit/services/storage/idbAssetStore.test.ts
+++ b/tests/unit/services/storage/idbAssetStore.test.ts
@@ -186,6 +186,18 @@ describe('IdbAssetStore', () => {
       expect(mockIdbStore.put).toHaveBeenCalledWith('data:image/png;base64,abc', 'proj-1::img-1');
     });
 
+    it('refuses the image write when final admission no longer proves authority', async () => {
+      const admission = vi.fn(() => {
+        throw new Error('stale project incarnation');
+      });
+
+      await expect(
+        store.saveImage('img-1', 'data:image/png;base64,abc', 'proj-1', admission),
+      ).rejects.toThrow('stale project incarnation');
+      expect(admission).toHaveBeenCalledTimes(1);
+      expect(mockIdbStore.put).not.toHaveBeenCalled();
+    });
+
     it('rejects when IDB put errors', async () => {
       mockIdbStore.put.mockImplementation(() => makeErrorReq(new DOMException('put failed')));
       await expect(store.saveImage('img-1', 'abc', 'proj-1')).rejects.toBeDefined();
@@ -256,6 +268,20 @@ describe('IdbAssetStore', () => {
       mockAppDataStore.get.mockImplementation(() => appDataTracker.success('proj-1'));
       mockIdbStore.delete.mockImplementation(() => makeErrorReq(new DOMException('del failed')));
       await expect(store.deleteImage('img-1', 'proj-1')).rejects.toBeDefined();
+    });
+
+    // QNBS-v3: [Grund: incarnation authority rejection / Impact: prevent stale deletion / Kreativer Mehrwert: guard the admission check]
+    it('refuses deletion when the current incarnation no longer has authority', async () => {
+      mockIdbStore.delete.mockImplementation(() => makeSuccessReq(undefined));
+      const admission = vi.fn(() => {
+        throw new Error('stale project incarnation');
+      });
+
+      await expect(store.deleteImage('img-1', 'proj-1', admission)).rejects.toThrow(
+        'stale project incarnation',
+      );
+      expect(admission).toHaveBeenCalledTimes(1);
+      expect(mockIdbStore.delete).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/unit/services/storage/idbAssetStore.test.ts
+++ b/tests/unit/services/storage/idbAssetStore.test.ts
@@ -181,9 +181,14 @@ describe('IdbAssetStore', () => {
 
   describe('saveImage', () => {
     it('calls put with base64 payload and the project-qualified key', async () => {
-      mockIdbStore.put.mockImplementation(() => makeSuccessReq(undefined));
+      mockIdbStore.put.mockImplementation(() => imagesTracker.success(undefined));
       await store.saveImage('img-1', 'data:image/png;base64,abc', 'proj-1');
       expect(mockIdbStore.put).toHaveBeenCalledWith('data:image/png;base64,abc', 'proj-1::img-1');
+    });
+
+    it('rejects when the put request succeeds but its transaction aborts', async () => {
+      mockIdbStore.put.mockImplementation(() => imagesTracker.successThatThenAborts(undefined));
+      await expect(store.saveImage('img-1', 'abc', 'proj-1')).rejects.toBeDefined();
     });
 
     it('refuses the image write when final admission no longer proves authority', async () => {
@@ -241,7 +246,7 @@ describe('IdbAssetStore', () => {
     // QNBS-v3: both keys must be cleared so a stale legacy record can never resurface via getImage's fallback -- but only once ownership of the legacy namespace is already provable for this project (simulated here via a pre-existing claim).
     it('deletes both the qualified and legacy key when this project already owns the legacy namespace', async () => {
       mockAppDataStore.get.mockImplementation(() => appDataTracker.success('proj-1'));
-      mockIdbStore.delete.mockImplementation(() => makeSuccessReq(undefined));
+      mockIdbStore.delete.mockImplementation(() => imagesTracker.success(undefined));
       await store.deleteImage('img-1', 'proj-1');
       expect(mockIdbStore.delete).toHaveBeenCalledWith('proj-1::img-1');
       expect(mockIdbStore.delete).toHaveBeenCalledWith('img-1');
@@ -249,7 +254,7 @@ describe('IdbAssetStore', () => {
 
     // QNBS-v3: preserve-first -- a delete must never itself establish a first ownership claim, so with no prior claim the unattributed legacy copy is left untouched rather than guessed-and-destroyed.
     it('does not delete the legacy key when this project has not yet claimed the legacy namespace', async () => {
-      mockIdbStore.delete.mockImplementation(() => makeSuccessReq(undefined));
+      mockIdbStore.delete.mockImplementation(() => imagesTracker.success(undefined));
       await store.deleteImage('img-1', 'proj-1');
       expect(mockIdbStore.delete).toHaveBeenCalledWith('proj-1::img-1');
       expect(mockIdbStore.delete).not.toHaveBeenCalledWith('img-1');
@@ -258,7 +263,7 @@ describe('IdbAssetStore', () => {
     // QNBS-v3: a legacy blob already claimed by a DIFFERENT project must never be deleted by this one either.
     it('does not delete the legacy key when a different project already owns the legacy namespace', async () => {
       mockAppDataStore.get.mockImplementation(() => appDataTracker.success('other-project'));
-      mockIdbStore.delete.mockImplementation(() => makeSuccessReq(undefined));
+      mockIdbStore.delete.mockImplementation(() => imagesTracker.success(undefined));
       await store.deleteImage('img-1', 'proj-1');
       expect(mockIdbStore.delete).toHaveBeenCalledWith('proj-1::img-1');
       expect(mockIdbStore.delete).not.toHaveBeenCalledWith('img-1');
@@ -272,7 +277,7 @@ describe('IdbAssetStore', () => {
 
     // QNBS-v3: [Grund: incarnation authority rejection / Impact: prevent stale deletion / Kreativer Mehrwert: guard the admission check]
     it('refuses deletion when the current incarnation no longer has authority', async () => {
-      mockIdbStore.delete.mockImplementation(() => makeSuccessReq(undefined));
+      mockIdbStore.delete.mockImplementation(() => imagesTracker.success(undefined));
       const admission = vi.fn(() => {
         throw new Error('stale project incarnation');
       });
@@ -282,6 +287,11 @@ describe('IdbAssetStore', () => {
       );
       expect(admission).toHaveBeenCalledTimes(1);
       expect(mockIdbStore.delete).not.toHaveBeenCalled();
+    });
+
+    it('rejects when the delete request succeeds but its transaction aborts', async () => {
+      mockIdbStore.delete.mockImplementation(() => imagesTracker.successThatThenAborts(undefined));
+      await expect(store.deleteImage('img-1', 'proj-1')).rejects.toBeDefined();
     });
   });
 

--- a/tests/unit/services/storage/idbAssetStore.test.ts
+++ b/tests/unit/services/storage/idbAssetStore.test.ts
@@ -23,7 +23,7 @@ function makeMockTransaction(): MockTransaction {
     onerror: null,
     onabort: null,
     error: null,
-    abort: vi.fn(),
+    abort: () => {},
   };
   transaction.abort = vi.fn(() => {
     transaction.error = new DOMException('simulated transaction abort');
@@ -33,6 +33,7 @@ function makeMockTransaction(): MockTransaction {
 }
 
 const mockImagesTransaction = makeMockTransaction();
+const defaultImagesAbort = mockImagesTransaction.abort;
 
 const mockIdbStore = {
   put: vi.fn(),
@@ -185,6 +186,7 @@ describe('IdbAssetStore', () => {
     vi.clearAllMocks();
     appDataTracker.reset();
     imagesTracker.reset();
+    mockImagesTransaction.abort = defaultImagesAbort;
     // QNBS-v3: default "no legacy-image-owner claim yet" so every test's first legacy-fallback access claims for its own project id, matching prior (pre-ownership-check) fallback behavior unless a test deliberately overrides this to simulate a rival claim.
     mockAppDataStore.get.mockImplementation(() => appDataTracker.success(undefined));
     mockAppDataStore.put.mockImplementation(() => appDataTracker.success(undefined));
@@ -334,6 +336,48 @@ describe('IdbAssetStore', () => {
         'stale project incarnation',
       );
       expect(mockImagesTransaction.abort).toHaveBeenCalledTimes(1);
+    });
+
+    it('preserves the stale admission error if another delete request aborts', async () => {
+      mockAppDataStore.get.mockImplementation(() => appDataTracker.success('proj-1'));
+      const abortError = new DOMException('transaction aborted', 'AbortError');
+      let secondRequest: MockReq<undefined> | null = null;
+      mockImagesTransaction.abort = vi.fn(() => {
+        mockImagesTransaction.error = abortError;
+        secondRequest?.onerror?.(abortError);
+        mockImagesTransaction.onabort?.();
+      });
+      let deleteCall = 0;
+      mockIdbStore.delete.mockImplementation(() => {
+        deleteCall += 1;
+        if (deleteCall === 1) {
+          const request: MockReq<undefined> = {
+            result: undefined,
+            error: null,
+            onsuccess: null,
+            onerror: null,
+          };
+          setTimeout(() => request.onsuccess?.(), 0);
+          return request;
+        }
+        secondRequest = {
+          result: undefined,
+          error: abortError,
+          onsuccess: null,
+          onerror: null,
+        };
+        return secondRequest;
+      });
+      const admission = vi
+        .fn<() => undefined>()
+        .mockImplementationOnce(() => undefined)
+        .mockImplementationOnce(() => {
+          throw new Error('stale project incarnation');
+        });
+
+      await expect(store.deleteImage('img-1', 'proj-1', admission)).rejects.toThrow(
+        'stale project incarnation',
+      );
     });
   });
 

--- a/tests/unit/thunks/interviewThunks.test.ts
+++ b/tests/unit/thunks/interviewThunks.test.ts
@@ -117,6 +117,7 @@ describe('streamInterviewResponseThunk', () => {
       project: {
         present: {
           data: {
+            id: 'default',
             characters: {
               ids: ['char-1'],
               entities: { 'char-1': CHARACTER },
@@ -125,6 +126,7 @@ describe('streamInterviewResponseThunk', () => {
               'char-1': [INTERVIEW],
             },
           },
+          generation: 0,
         },
       },
       settings: {
@@ -231,5 +233,47 @@ describe('streamInterviewResponseThunk', () => {
     const result = await thunk(dispatch, getState, undefined);
     expect((result as { type: string }).type).toBe('project/streamInterviewResponse/rejected');
     expect((result as { error: { message: string } }).error.message).toContain('interview-1');
+  });
+
+  it('does not dispatch late chunks after the project incarnation changes', async () => {
+    // QNBS-v3: [Grund: incarnation switch during stream / Impact: prove late chunks are discarded / Kreativer Mehrwert: preserve project-owned dialogue]
+    const state = makeState();
+    mockStreamText.mockImplementationOnce(
+      async (_prompt: string, _creativity: unknown, onChunk: (chunk: string) => void) => {
+        state.project.present.generation = 1;
+        onChunk('late chunk');
+      },
+    );
+    const dispatch = vi.fn();
+    const getState = vi.fn().mockReturnValue(state);
+
+    const result = await streamInterviewResponseThunk({
+      characterId: 'char-1',
+      interviewId: 'interview-1',
+      question: 'Hello?',
+    })(dispatch, getState, undefined);
+
+    expect((result as { type: string }).type).toBe('project/streamInterviewResponse/rejected');
+    expect(
+      dispatch.mock.calls.some(([action]) => action?.type === 'project/streamInterviewChunk'),
+    ).toBe(false);
+  });
+
+  it('rejects when the project changes before a chunkless stream completes', async () => {
+    const state = makeState();
+    mockStreamText.mockImplementationOnce(async () => {
+      state.project.present.generation = 1;
+    });
+    const dispatch = vi.fn();
+    const getState = vi.fn().mockReturnValue(state);
+
+    // QNBS-v3: completion-only coverage proves a stream cannot fulfill after a silent incarnation switch.
+    const result = await streamInterviewResponseThunk({
+      characterId: 'char-1',
+      interviewId: 'interview-1',
+      question: 'Hello?',
+    })(dispatch, getState, undefined);
+
+    expect((result as { type: string }).type).toBe('project/streamInterviewResponse/rejected');
   });
 });

--- a/tests/unit/thunks/interviewThunks.test.ts
+++ b/tests/unit/thunks/interviewThunks.test.ts
@@ -235,6 +235,25 @@ describe('streamInterviewResponseThunk', () => {
     expect((result as { error: { message: string } }).error.message).toContain('interview-1');
   });
 
+  it('rejects before appending messages when the origin identity is unavailable', async () => {
+    const state = makeState();
+    state.project.present.data.id = '';
+    const dispatch = vi.fn();
+    const getState = vi.fn().mockReturnValue(state);
+
+    const result = await streamInterviewResponseThunk({
+      characterId: 'char-1',
+      interviewId: 'interview-1',
+      question: 'Hello?',
+    })(dispatch, getState, undefined);
+
+    expect((result as { type: string }).type).toBe('project/streamInterviewResponse/rejected');
+    expect(
+      dispatch.mock.calls.some(([action]) => action?.type === 'project/appendInterviewMessage'),
+    ).toBe(false);
+    expect(mockStreamText).not.toHaveBeenCalled();
+  });
+
   it('does not dispatch late chunks after the project incarnation changes', async () => {
     // QNBS-v3: [Grund: incarnation switch during stream / Impact: prove late chunks are discarded / Kreativer Mehrwert: preserve project-owned dialogue]
     const state = makeState();
@@ -275,5 +294,24 @@ describe('streamInterviewResponseThunk', () => {
     })(dispatch, getState, undefined);
 
     expect((result as { type: string }).type).toBe('project/streamInterviewResponse/rejected');
+  });
+
+  it('reclassifies a stream failure as stale after a project change', async () => {
+    const state = makeState();
+    mockStreamText.mockImplementationOnce(async () => {
+      state.project.present.generation = 1;
+      throw new Error('provider failed');
+    });
+    const dispatch = vi.fn();
+    const getState = vi.fn().mockReturnValue(state);
+
+    const result = await streamInterviewResponseThunk({
+      characterId: 'char-1',
+      interviewId: 'interview-1',
+      question: 'Hello?',
+    })(dispatch, getState, undefined);
+
+    expect((result as { type: string }).type).toBe('project/streamInterviewResponse/rejected');
+    expect((result as { error: { name: string } }).error.name).toBe('StaleProjectOperationError');
   });
 });

--- a/tests/unit/thunks/outlineAndWorldThunks.test.ts
+++ b/tests/unit/thunks/outlineAndWorldThunks.test.ts
@@ -263,7 +263,15 @@ describe('generateWorldImageThunk', () => {
     );
 
     // QNBS-v3: id, data, projectId order, matching the reordered saveImage signature.
-    expect(storageService.saveImage).toHaveBeenCalledWith('w42', 'worldimagedata', 'default');
+    expect(storageService.saveImage).toHaveBeenCalledWith(
+      'w42',
+      'worldimagedata',
+      'default',
+      expect.any(Function),
+    );
+    const writeAdmission = vi.mocked(storageService.saveImage).mock.calls[0]?.[3];
+    expect(writeAdmission).toEqual(expect.any(Function));
+    (writeAdmission as (() => void) | undefined)?.();
   });
 
   it('rejects on AI error', async () => {
@@ -296,7 +304,46 @@ describe('uploadWorldImageThunk', () => {
 
     expect(action.type).toBe('project/uploadWorldImage/fulfilled');
     // QNBS-v3: id, data, projectId order, matching the reordered saveImage signature.
-    expect(storageService.saveImage).toHaveBeenCalledWith('w99', fakeDataUrl, 'default');
+    expect(storageService.saveImage).toHaveBeenCalledWith(
+      'w99',
+      fakeDataUrl,
+      'default',
+      expect.any(Function),
+    );
+    const writeAdmission = vi.mocked(storageService.saveImage).mock.calls[0]?.[3];
+    expect(writeAdmission).toEqual(expect.any(Function));
+    (writeAdmission as (() => void) | undefined)?.();
+  });
+
+  it('rejects when the project changes before the upload reaches storage', async () => {
+    let triggerLoad: (() => void) | undefined;
+    vi.spyOn(FileReader.prototype, 'readAsDataURL').mockImplementation(function (this: FileReader) {
+      Object.defineProperty(this, 'result', {
+        value: 'data:image/png;base64,late-upload',
+        configurable: true,
+      });
+      triggerLoad = () => this.onload?.(new ProgressEvent('load') as ProgressEvent<FileReader>);
+    });
+
+    const store = makeStore();
+    const pending = store.dispatch(
+      uploadWorldImageThunk({
+        worldId: 'w-before-storage',
+        file: new File(['data'], 'atlas.png', { type: 'image/png' }),
+      }),
+    );
+    store.dispatch(
+      projectActions.resetProject({
+        title: 'Replacement',
+        logline: '',
+        chapter1Title: 'Chapter 1',
+      }),
+    );
+    triggerLoad?.();
+
+    const action = await pending;
+    expect(action.type).toBe('project/uploadWorldImage/rejected');
+    expect(storageService.saveImage).not.toHaveBeenCalled();
   });
 
   it('rejects when the FileReader errors', async () => {

--- a/tests/unit/thunks/writingAndCharacterThunks.test.ts
+++ b/tests/unit/thunks/writingAndCharacterThunks.test.ts
@@ -239,6 +239,7 @@ describe('generateSceneImageThunk', () => {
     const store = makeStore();
     const pending = store.dispatch(generateSceneImageThunk(payload));
 
+    await vi.waitFor(() => expect(resolveImage).toEqual(expect.any(Function)));
     store.dispatch(
       projectActions.resetProject({
         title: 'New project',

--- a/tests/unit/thunks/writingAndCharacterThunks.test.ts
+++ b/tests/unit/thunks/writingAndCharacterThunks.test.ts
@@ -23,7 +23,7 @@ vi.mock('../../../services/storageService', () => ({
 }));
 
 import featureFlagsReducer from '../../../features/featureFlags/featureFlagsSlice';
-import projectReducer from '../../../features/project/projectSlice';
+import projectReducer, { projectActions } from '../../../features/project/projectSlice';
 import {
   generateCharacterPortraitThunk,
   generateCharacterProfileThunk,
@@ -202,8 +202,11 @@ describe('generateSceneImageThunk', () => {
     const store = makeStore();
     await store.dispatch(generateSceneImageThunk(payload));
 
-    // QNBS-v3: id, data, projectId order, matching the reordered saveImage signature.
-    expect(storageService.saveImage).toHaveBeenCalledWith('scene-sec-1', 'rawbase64', 'default');
+    // QNBS-v3: the final-write admission callback prevents an in-flight save from crossing an incarnation boundary.
+    const [imageId, imageData, projectId, writeAdmission] = vi.mocked(storageService.saveImage).mock
+      .calls[0]!;
+    expect([imageId, imageData, projectId]).toEqual(['scene-sec-1', 'rawbase64', 'default']);
+    expect(writeAdmission).toEqual(expect.any(Function));
   });
 
   it('prefixes plain base64 with data:image/png;base64,', async () => {
@@ -224,6 +227,83 @@ describe('generateSceneImageThunk', () => {
 
     const result = (action as { payload: { imageKey: string; dataUrl: string } }).payload;
     expect(result.dataUrl).toBe('data:image/png;base64,alreadyprefixed');
+  });
+
+  it('rejects and skips storage when the project changes before the write', async () => {
+    let resolveImage: ((value: string) => void) | undefined;
+    mockGenerateImage.mockReturnValueOnce(
+      new Promise<string>((resolve) => {
+        resolveImage = resolve;
+      }),
+    );
+    const store = makeStore();
+    const pending = store.dispatch(generateSceneImageThunk(payload));
+
+    store.dispatch(
+      projectActions.resetProject({
+        title: 'New project',
+        logline: '',
+        chapter1Title: 'Chapter One',
+      }),
+    );
+    resolveImage?.('late-image');
+
+    const action = await pending;
+    expect(action.type).toBe('project/generateSceneImage/rejected');
+    expect(storageService.saveImage).not.toHaveBeenCalled();
+  });
+
+  it('rejects after a project changes during the storage operation', async () => {
+    mockGenerateImage.mockResolvedValueOnce('late-image');
+    let resolveSave: (() => void) | undefined;
+    vi.mocked(storageService.saveImage).mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSave = resolve;
+        }),
+    );
+    const store = makeStore();
+    const pending = store.dispatch(generateSceneImageThunk(payload));
+
+    await vi.waitFor(() => expect(storageService.saveImage).toHaveBeenCalled());
+    store.dispatch(
+      projectActions.resetProject({
+        title: 'New project',
+        logline: '',
+        chapter1Title: 'Chapter One',
+      }),
+    );
+    resolveSave?.();
+
+    const action = await pending;
+    expect(action.type).toBe('project/generateSceneImage/rejected');
+  });
+
+  it('rejects a same-ID generation change at the backend write-admission point', async () => {
+    mockGenerateImage.mockResolvedValueOnce('late-image');
+    let resolveSave: (() => void) | undefined;
+    let writeAdmission: (() => void) | undefined;
+    vi.mocked(storageService.saveImage).mockImplementationOnce(
+      (_id, _data, _projectId, admission) => {
+        writeAdmission = admission;
+        return new Promise<void>((resolve) => {
+          resolveSave = resolve;
+        });
+      },
+    );
+    const store = makeStore();
+    const pending = store.dispatch(generateSceneImageThunk(payload));
+
+    await vi.waitFor(() => expect(storageService.saveImage).toHaveBeenCalled());
+    store.dispatch(
+      projectActions.resetProject({ title: 'Replaced', logline: '', chapter1Title: 'Chapter One' }),
+    );
+    expect(writeAdmission).toEqual(expect.any(Function));
+    expect(() => writeAdmission?.()).toThrow('Discarded stale project operation');
+    resolveSave?.();
+
+    const action = await pending;
+    expect(action.type).toBe('project/generateSceneImage/rejected');
   });
 });
 
@@ -391,8 +471,11 @@ describe('generateCharacterPortraitThunk', () => {
       }),
     );
 
-    // QNBS-v3: id, data, projectId order, matching the reordered saveImage signature.
-    expect(storageService.saveImage).toHaveBeenCalledWith('c42', 'portraitdata', 'default');
+    const [imageId, imageData, projectId, writeAdmission] = vi.mocked(storageService.saveImage).mock
+      .calls[0]!;
+    expect([imageId, imageData, projectId]).toEqual(['c42', 'portraitdata', 'default']);
+    expect(writeAdmission).toEqual(expect.any(Function));
+    writeAdmission?.();
   });
 
   it('appends style to description when style is provided', async () => {
@@ -457,7 +540,46 @@ describe('uploadCharacterImageThunk', () => {
 
     expect(action.type).toBe('project/uploadCharacterImage/fulfilled');
     // QNBS-v3: id, data, projectId order, matching the reordered saveImage signature.
-    expect(storageService.saveImage).toHaveBeenCalledWith('c99', fakeDataUrl, 'default');
+    expect(storageService.saveImage).toHaveBeenCalledWith(
+      'c99',
+      fakeDataUrl,
+      'default',
+      expect.any(Function),
+    );
+    const writeAdmission = vi.mocked(storageService.saveImage).mock.calls[0]?.[3];
+    expect(writeAdmission).toEqual(expect.any(Function));
+    (writeAdmission as (() => void) | undefined)?.();
+  });
+
+  it('rejects when the project changes before the upload reaches storage', async () => {
+    let triggerLoad: (() => void) | undefined;
+    vi.spyOn(FileReader.prototype, 'readAsDataURL').mockImplementation(function (this: FileReader) {
+      Object.defineProperty(this, 'result', {
+        value: 'data:image/png;base64,late-upload',
+        configurable: true,
+      });
+      triggerLoad = () => this.onload?.(new ProgressEvent('load') as ProgressEvent<FileReader>);
+    });
+
+    const store = makeStore();
+    const pending = store.dispatch(
+      uploadCharacterImageThunk({
+        characterId: 'c-before-storage',
+        file: new File(['data'], 'portrait.png', { type: 'image/png' }),
+      }),
+    );
+    store.dispatch(
+      projectActions.resetProject({
+        title: 'Replacement',
+        logline: '',
+        chapter1Title: 'Chapter 1',
+      }),
+    );
+    triggerLoad?.();
+
+    const action = await pending;
+    expect(action.type).toBe('project/uploadCharacterImage/rejected');
+    expect(storageService.saveImage).not.toHaveBeenCalled();
   });
 
   it('dispatches fulfilled with characterId', async () => {
@@ -482,6 +604,7 @@ describe('uploadCharacterImageThunk', () => {
       'c7',
       'data:image/jpeg;base64,abc123',
       'default',
+      expect.any(Function),
     );
   });
 


### PR DESCRIPTION
## **User description**
## Scope

Refs #708

This is a clean successor to PR #733. PR #733 remains the saturated predecessor and read-only evidence/review carrier after late review and regression-test convergence exceeded the repository's normal absolute commit-ceiling budget. This PR carries forward the reviewed semantic net state rather than replaying that history.

## Included

- canonical project-incarnation authority for direct asynchronous image and interview mutation/read paths;
- Character, World, Scene, upload, stale delete, view invalidation, and Character Interview authority fences already admitted under #708;
- IDB/filesystem write and delete admission at irreversible persistence points;
- focused regression coverage, including same-ID/new-generation, deferred image reads, FileReader/project-switch, stale delete confirmation, interview stream completion, and deferred image-removal/replacement ordering;
- required README test-count truth update.

## Explicitly out of scope

- #713 deferred/apply-later ownership;
- #714 cancellation/supersession lifecycle;
- #602-A encryption-remanence work;
- #704 provider/model currency;
- general storage redesign, unrelated cleanup, and native roadmap work.

## Validation

- 11 focused Vitest files: 318 tests passed;
- Biome passed on successor-only changes;
- `pnpm run typecheck` passed;
- `pnpm run ci:prepush` passed;
- signed one-commit successor; 30 changed files / 1,561 meaningful changed lines.

Review the current successor head, not intermediate #733 commits. #733 remains untouched by this PR.

## Summary by Sourcery

Fence asynchronous project image and interview operations by project incarnation so stale results cannot affect the active project.

Bug Fixes:
- Prevent stale asynchronous image operations and Character Interview stream updates from mutating the active project after a project switch or same-ID project replacement.
- Reject stale image writes, uploads, reads, replacements, and deletions at persistence boundaries while preserving image replacement ordering.
- Suppress misleading error notifications and invalidate destructive image confirmations when their originating project is no longer active.

Enhancements:
- Centralize project-incarnation identity checks and storage targeting across project image and interview workflows.
- Protect scene previews and deferred image loads from stale or superseded asynchronous results.

Documentation:
- Update the README and changelog with the current test count and stale-operation protections.

Tests:
- Add focused regression coverage for project-incarnation changes, deferred reads and uploads, stale deletes, interview streams, scene preview ordering, and IndexedDB/filesystem persistence admission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented outdated character, world, scene, and portrait results from overwriting content after switching or replacing projects.
  - Improved image generation and upload safety by preventing stale results from being saved to the wrong project.
  - Stopped outdated interview stream content from appearing in the active project.
  - Reduced misleading error notifications for operations cancelled by project changes.
  - Ensured only the latest scene visualization request controls the preview and loading state.

- **Documentation**
  - Updated documented test metrics to reflect the current test count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Prevent stale asynchronous project operations from changing the active project

### What Changed
- Image generation, uploads, reads, replacements, and deletions now stop when the originating project has been switched or replaced, including same-ID projects.
- Late Character Interview chunks and scene previews are discarded instead of updating current-project content or replacing newer results.
- Destructive image confirmations are invalidated after a project change, and expected stale-operation failures no longer show misleading error notifications.
- Image storage checks authority at the final write or delete point, preventing cross-project asset changes and preserving replacement ordering.
- Added regression coverage and updated the documented test count.

### Impact
`✅ No stale images in the active project`
`✅ Safer project-switch image deletion`
`✅ No misleading errors from discarded async work`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>