### PR TITLE
fix(local-first): propagate encryption-transition wipe failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Local-first encryption transitions now preserve wipe failures instead of treating plaintext
+  cleanup as successful:** a failed `clearData()` aborts the current shadow sync, tears down the
+  cached persistence handle, and keeps subsequent encryption-active sync memory-only. PR #738.
 - **Async AI image writes and Character Interview chunks now reject stale project
   incarnations:** direct image persistence and interview-stream updates capture the originating
   project identity and refuse late results after a project switch or same-ID replacement, with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Local-first encryption transitions now preserve wipe failures instead of treating plaintext
-  cleanup as successful:** a failed `clearData()` aborts the current shadow sync, tears down the
-  cached persistence handle, and keeps subsequent encryption-active sync memory-only. PR #738.
+  cleanup as successful:** a failed `clearData()` aborts the current shadow sync, attempts strict
+  provider teardown, clears the cached persistence handle, and keeps subsequent encryption-active
+  sync memory-only. PR #738.
 - **Async AI image writes and Character Interview chunks now reject stale project
   incarnations:** direct image persistence and interview-stream updates capture the originating
   project identity and refuse late results after a project switch or same-ID replacement, with

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <img src="https://img.shields.io/badge/TypeScript-tsgo_native_preview-3178C6?logo=typescript&logoColor=white" alt="TypeScript native preview (tsgo)">
   <img src="https://img.shields.io/badge/Desktop-Tauri_2-FFC131?logo=tauri&logoColor=black" alt="Tauri 2">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7801%2B_%2F_606_files-22C55E" alt="7801+ tests / 606 files">
+  <img src="https://img.shields.io/badge/Tests-7803%2B_%2F_607_files-22C55E" alt="7803+ tests / 607 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github&label=CI" alt="CI status">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="MIT License">
@@ -809,7 +809,7 @@ The normal web PR pipeline is not the complete native release qualification surf
 | DOCX | `docx` + JSZip | Word-compatible export |
 | PWA | Service Worker + Web App Manifest | Offline shell/installability |
 | i18n | Custom React i18n context | 2942 keys × 19 locales |
-| Testing | Vitest 4.x (7801+ tests / 606 files) + Playwright | Unit/integration/E2E |
+| Testing | Vitest 4.x (7803+ tests / 607 files) + Playwright | Unit/integration/E2E |
 | Quality | Biome + tsgo + CodeQL/security tooling | Static and CI gates |
 | Desktop | Tauri 2 | Current native shell |
 
@@ -886,7 +886,7 @@ WorldScript-Studio/
 ├── locales/                 # Source locale trees
 ├── public/                  # PWA assets, manifest, SW, runtime locale bundles
 ├── tests/
-│   ├── unit/                # Vitest unit tests (7801+ tests; file count includes package test directories)
+│   ├── unit/                # Vitest unit tests (7803+ tests; file count includes package test directories)
 │   └── e2e/                 # Playwright
 ├── docs/                    # Canonical product/engineering documentation + ADRs
 ├── src-tauri/               # Tauri v2 desktop shell / Rust
@@ -1031,7 +1031,7 @@ Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendo
 
 Current source-synchronized README metrics:
 
-- **7801+ unit tests** across **606 test files**
+- **7803+ unit tests** across **607 test files**
 - i18n: **2942 keys × 19 locales**
 
 CI remains authoritative for actual pass/fail and live coverage.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <img src="https://img.shields.io/badge/TypeScript-tsgo_native_preview-3178C6?logo=typescript&logoColor=white" alt="TypeScript native preview (tsgo)">
   <img src="https://img.shields.io/badge/Desktop-Tauri_2-FFC131?logo=tauri&logoColor=black" alt="Tauri 2">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7803%2B_%2F_607_files-22C55E" alt="7803+ tests / 607 files">
+  <img src="https://img.shields.io/badge/Tests-7804%2B_%2F_607_files-22C55E" alt="7804+ tests / 607 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github&label=CI" alt="CI status">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="MIT License">
@@ -809,7 +809,7 @@ The normal web PR pipeline is not the complete native release qualification surf
 | DOCX | `docx` + JSZip | Word-compatible export |
 | PWA | Service Worker + Web App Manifest | Offline shell/installability |
 | i18n | Custom React i18n context | 2942 keys × 19 locales |
-| Testing | Vitest 4.x (7803+ tests / 607 files) + Playwright | Unit/integration/E2E |
+| Testing | Vitest 4.x (7804+ tests / 607 files) + Playwright | Unit/integration/E2E |
 | Quality | Biome + tsgo + CodeQL/security tooling | Static and CI gates |
 | Desktop | Tauri 2 | Current native shell |
 
@@ -886,7 +886,7 @@ WorldScript-Studio/
 ├── locales/                 # Source locale trees
 ├── public/                  # PWA assets, manifest, SW, runtime locale bundles
 ├── tests/
-│   ├── unit/                # Vitest unit tests (7803+ tests; file count includes package test directories)
+│   ├── unit/                # Vitest unit tests (7804+ tests; file count includes package test directories)
 │   └── e2e/                 # Playwright
 ├── docs/                    # Canonical product/engineering documentation + ADRs
 ├── src-tauri/               # Tauri v2 desktop shell / Rust
@@ -1031,7 +1031,7 @@ Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendo
 
 Current source-synchronized README metrics:
 
-- **7803+ unit tests** across **607 test files**
+- **7804+ unit tests** across **607 test files**
 - i18n: **2942 keys × 19 locales**
 
 CI remains authoritative for actual pass/fail and live coverage.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   <img src="https://img.shields.io/badge/TypeScript-tsgo_native_preview-3178C6?logo=typescript&logoColor=white" alt="TypeScript native preview (tsgo)">
   <img src="https://img.shields.io/badge/Desktop-Tauri_2-FFC131?logo=tauri&logoColor=black" alt="Tauri 2">
   <img src="https://img.shields.io/badge/i18n-19_locales-2942_keys-0EA5E9" alt="19 locales — 2942 keys">
-  <img src="https://img.shields.io/badge/Tests-7804%2B_%2F_607_files-22C55E" alt="7804+ tests / 607 files">
+  <img src="https://img.shields.io/badge/Tests-7805%2B_%2F_607_files-22C55E" alt="7805+ tests / 607 files">
   <img src="https://img.shields.io/codecov/c/github/qnbs/WorldScript-Studio?logo=codecov&label=Coverage" alt="Codecov Coverage">
   <img src="https://img.shields.io/github/actions/workflow/status/qnbs/WorldScript-Studio/.github/workflows/ci.yml?branch=main&logo=github&label=CI" alt="CI status">
   <img src="https://img.shields.io/badge/License-MIT-22C55E" alt="MIT License">
@@ -809,7 +809,7 @@ The normal web PR pipeline is not the complete native release qualification surf
 | DOCX | `docx` + JSZip | Word-compatible export |
 | PWA | Service Worker + Web App Manifest | Offline shell/installability |
 | i18n | Custom React i18n context | 2942 keys × 19 locales |
-| Testing | Vitest 4.x (7804+ tests / 607 files) + Playwright | Unit/integration/E2E |
+| Testing | Vitest 4.x (7805+ tests / 607 files) + Playwright | Unit/integration/E2E |
 | Quality | Biome + tsgo + CodeQL/security tooling | Static and CI gates |
 | Desktop | Tauri 2 | Current native shell |
 
@@ -886,7 +886,7 @@ WorldScript-Studio/
 ├── locales/                 # Source locale trees
 ├── public/                  # PWA assets, manifest, SW, runtime locale bundles
 ├── tests/
-│   ├── unit/                # Vitest unit tests (7804+ tests; file count includes package test directories)
+│   ├── unit/                # Vitest unit tests (7805+ tests; file count includes package test directories)
 │   └── e2e/                 # Playwright
 ├── docs/                    # Canonical product/engineering documentation + ADRs
 ├── src-tauri/               # Tauri v2 desktop shell / Rust
@@ -1031,7 +1031,7 @@ Raw bundle-budget ceilings (KB per uncompressed asset): entry **2500 KB**, vendo
 
 Current source-synchronized README metrics:
 
-- **7804+ unit tests** across **607 test files**
+- **7805+ unit tests** across **607 test files**
 - i18n: **2942 keys × 19 locales**
 
 CI remains authoritative for actual pass/fail and live coverage.

--- a/app/listenerMiddleware.ts
+++ b/app/listenerMiddleware.ts
@@ -762,8 +762,22 @@ async function reconcileLocalFirstHandle(
       await handle.persistence.clearData();
     } catch (error) {
       // QNBS-v3: a failed plaintext wipe must abort this sync and force the encryption-active NOOP path instead of silently treating remanence as removed.
+      let teardownFailed = false;
+      let teardownError: unknown;
+      try {
+        await handle.persistence.destroyStrict();
+      } catch (error) {
+        teardownFailed = true;
+        teardownError = error;
+      }
+      // QNBS-v3: use the strict teardown boundary before dropping the cached handle, so a failed provider detach is observable instead of leaving an untracked persistence instance behind.
       localFirstHandle = null;
-      await handle.persistence.destroy().catch(() => undefined);
+      if (teardownFailed) {
+        logger.error(
+          'Local-First plaintext cleanup and provider teardown both failed; persistence disabled:',
+          teardownError,
+        );
+      }
       throw new LocalFirstPlaintextCleanupError(error);
     }
     await handle.persistence.destroy().catch(() => undefined);

--- a/app/listenerMiddleware.ts
+++ b/app/listenerMiddleware.ts
@@ -723,6 +723,13 @@ type LocalFirstHandle = {
 };
 let localFirstHandle: LocalFirstHandle | null = null;
 
+class LocalFirstPlaintextCleanupError extends Error {
+  constructor(readonly cause: unknown) {
+    super('Local-First plaintext cleanup failed during encryption transition');
+    this.name = 'LocalFirstPlaintextCleanupError';
+  }
+}
+
 // QNBS-v3 (CodeAnt): serialize all handle create/teardown so an overlapping sync run and an
 // enable/disable run can't race on the shared module-global and leave the wrong handle active.
 let localFirstLock: Promise<void> = Promise.resolve();
@@ -750,8 +757,16 @@ async function reconcileLocalFirstHandle(
   }
   // QNBS-v3 (CodeAnt): the persistence backend is chosen at handle creation — if at-rest encryption became active after a plaintext-persisting handle was made, tear it down (wiping the plaintext already written) so no further plaintext is persisted.
   if (isIdbEncryptionReady() && localFirstHandle.persistence.active) {
-    await localFirstHandle.persistence.clearData().catch(() => undefined);
-    await localFirstHandle.persistence.destroy().catch(() => undefined);
+    const handle = localFirstHandle;
+    try {
+      await handle.persistence.clearData();
+    } catch (error) {
+      // QNBS-v3: a failed plaintext wipe must abort this sync and force the encryption-active NOOP path instead of silently treating remanence as removed.
+      localFirstHandle = null;
+      await handle.persistence.destroy().catch(() => undefined);
+      throw new LocalFirstPlaintextCleanupError(error);
+    }
+    await handle.persistence.destroy().catch(() => undefined);
     localFirstHandle = null;
     return null;
   }
@@ -833,6 +848,13 @@ async function runLocalFirstShadowSync(
       handle.binding.reproject(presentData);
     }
   } catch (err) {
+    if (err instanceof LocalFirstPlaintextCleanupError) {
+      logger.error(
+        'Local-First plaintext cleanup failed; shadow sync aborted and persistence disabled:',
+        err.cause,
+      );
+      return;
+    }
     logger.warn('Local-First shadow sync failed (non-critical):', err);
   }
 }

--- a/services/localFirst/docPersistence.ts
+++ b/services/localFirst/docPersistence.ts
@@ -38,7 +38,7 @@ export interface DocPersistence {
   readonly active: boolean;
   /** Detach the provider (does not delete data). */
   destroy(): Promise<void>;
-  /** Delete the persisted data for this project. */
+  /** Delete the persisted data for this project; rejects when the underlying wipe fails. */
   clearData(): Promise<void>;
 }
 
@@ -82,6 +82,7 @@ export function persistProjectDoc(projectId: string, doc: Y.Doc): DocPersistence
   // in-flight destroy (no double-destroy, and no flag flipped to "destroyed" before destroy actually
   // finishes).
   let rawDestroyPromise: Promise<void> | null = null;
+  let rawClearDataPromise: Promise<void> | null = null;
   // QNBS-v3: starts as a no-op and gets replaced right after registration — a reset already in progress would otherwise invoke this closer synchronously while unregister is still mid-TDZ.
   let unregister: () => void = () => {};
   // QNBS-v3 (CodeAnt): unregisters only once the underlying teardown actually settles, not synchronously before it starts — a reset draining right after this call would otherwise no longer track (and never await) a still-in-flight destroy.
@@ -91,6 +92,14 @@ export function persistProjectDoc(projectId: string, doc: Y.Doc): DocPersistence
       rawDestroyPromise.finally(unregister).catch(() => undefined);
     }
     return rawDestroyPromise;
+  };
+  // QNBS-v3: a plaintext wipe failure is a security-boundary failure and must reach the reconciliation caller instead of being mistaken for successful removal.
+  const beginClearData = (): Promise<void> => {
+    if (rawDestroyPromise) return Promise.resolve();
+    if (!rawClearDataPromise) {
+      rawClearDataPromise = Promise.resolve().then(() => provider.clearData());
+    }
+    return rawClearDataPromise;
   };
   // QNBS-v3 (CodeAnt): the public destroy() stays no-throw for its many defensive `.catch(() => undefined)` callers, but the reset closer below calls beginDestroy() directly so a genuine teardown failure still reaches the reset gate's fail-closed check instead of being swallowed before it gets there.
   const destroy = (): Promise<void> => beginDestroy().catch(() => undefined);
@@ -114,8 +123,6 @@ export function persistProjectDoc(projectId: string, doc: Y.Doc): DocPersistence
       return rawDestroyPromise === null;
     },
     destroy,
-    // After teardown the provider can no longer clear its store — degrade to a resolved no-op.
-    clearData: () =>
-      rawDestroyPromise ? Promise.resolve() : provider.clearData().catch(() => undefined),
+    clearData: beginClearData,
   };
 }

--- a/services/localFirst/docPersistence.ts
+++ b/services/localFirst/docPersistence.ts
@@ -38,6 +38,8 @@ export interface DocPersistence {
   readonly active: boolean;
   /** Detach the provider (does not delete data). */
   destroy(): Promise<void>;
+  /** Detach the provider and preserve any underlying teardown failure for security boundaries. */
+  destroyStrict(): Promise<void>;
   /** Delete the persisted data for this project; rejects when the underlying wipe fails. */
   clearData(): Promise<void>;
 }
@@ -47,6 +49,7 @@ export const NOOP_PERSISTENCE: DocPersistence = {
   whenSynced: Promise.resolve(),
   active: false,
   destroy: () => Promise.resolve(),
+  destroyStrict: () => Promise.resolve(),
   clearData: () => Promise.resolve(),
 };
 
@@ -56,6 +59,7 @@ function createTransientResetDeniedPersistence(): DocPersistence {
     whenSynced: Promise.resolve(),
     active: false,
     destroy: () => Promise.resolve(),
+    destroyStrict: () => Promise.resolve(),
     clearData: () => Promise.resolve(),
   };
 }
@@ -95,7 +99,9 @@ export function persistProjectDoc(projectId: string, doc: Y.Doc): DocPersistence
   };
   // QNBS-v3: a plaintext wipe failure is a security-boundary failure and must reach the reconciliation caller instead of being mistaken for successful removal.
   const beginClearData = (): Promise<void> => {
-    if (rawDestroyPromise) return Promise.resolve();
+    if (rawDestroyPromise) {
+      return Promise.reject(new Error('Cannot clear persisted data after destruction has started'));
+    }
     if (!rawClearDataPromise) {
       rawClearDataPromise = Promise.resolve().then(() => provider.clearData());
     }
@@ -123,6 +129,7 @@ export function persistProjectDoc(projectId: string, doc: Y.Doc): DocPersistence
       return rawDestroyPromise === null;
     },
     destroy,
+    destroyStrict: beginDestroy,
     clearData: beginClearData,
   };
 }

--- a/services/localFirst/docPersistence.ts
+++ b/services/localFirst/docPersistence.ts
@@ -103,7 +103,12 @@ export function persistProjectDoc(projectId: string, doc: Y.Doc): DocPersistence
       return Promise.reject(new Error('Cannot clear persisted data after destruction has started'));
     }
     if (!rawClearDataPromise) {
-      rawClearDataPromise = Promise.resolve().then(() => provider.clearData());
+      rawClearDataPromise = Promise.resolve().then(() => {
+        if (rawDestroyPromise) {
+          throw new Error('Cannot clear persisted data after destruction has started');
+        }
+        return provider.clearData();
+      });
     }
     return rawClearDataPromise;
   };

--- a/tests/unit/listenerMiddleware.test.ts
+++ b/tests/unit/listenerMiddleware.test.ts
@@ -760,6 +760,7 @@ describe('local-first shadow sync (B1.1)', () => {
     const { persistProjectDoc } = await import('../../services/localFirst/docPersistence');
     const clearData = vi.fn().mockRejectedValue(new Error('wipe failed'));
     const destroy = vi.fn().mockResolvedValue(undefined);
+    const destroyStrict = vi.fn().mockRejectedValue(new Error('teardown failed'));
 
     vi.mocked(isIdbEncryptionReady).mockReturnValue(false);
     vi.mocked(persistProjectDoc).mockReturnValue({
@@ -767,7 +768,7 @@ describe('local-first shadow sync (B1.1)', () => {
       whenSynced: Promise.resolve(),
       clearData,
       destroy,
-      destroyStrict: destroy,
+      destroyStrict,
     });
 
     // localFirstHandle is module-global; explicitly tear down any handle left by a preceding test.
@@ -777,6 +778,7 @@ describe('local-first shadow sync (B1.1)', () => {
     warmupStore.dispatch(featureFlagsActions.setEnableLocalFirstSync(false));
     await vi.advanceTimersByTimeAsync(100);
     destroy.mockClear();
+    destroyStrict.mockClear();
     vi.mocked(persistProjectDoc).mockClear();
 
     const store = makeFullStore();
@@ -789,7 +791,12 @@ describe('local-first shadow sync (B1.1)', () => {
     await vi.advanceTimersByTimeAsync(1300);
 
     expect(clearData).toHaveBeenCalledTimes(1);
-    expect(destroy).toHaveBeenCalledTimes(1);
+    expect(destroy).not.toHaveBeenCalled();
+    expect(destroyStrict).toHaveBeenCalledTimes(1);
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      'Local-First plaintext cleanup and provider teardown both failed; persistence disabled:',
+      expect.any(Error),
+    );
     expect(mockLoggerError).toHaveBeenCalledWith(
       'Local-First plaintext cleanup failed; shadow sync aborted and persistence disabled:',
       expect.any(Error),

--- a/tests/unit/listenerMiddleware.test.ts
+++ b/tests/unit/listenerMiddleware.test.ts
@@ -105,19 +105,21 @@ class MockProjectDocBinding {
 vi.mock('../../services/localFirst/docBinding', () => ({
   ProjectDocBinding: MockProjectDocBinding,
 }));
-// QNBS-v3: destroy/clearData must be present since real listener teardown code can call either on any persistence handle. mockNoopDestroy is a stable reference because a test below asserts teardownLocalFirst() actually invoked it; the other three stay plain no-op closures since nothing currently asserts on them.
+// QNBS-v3: destroy/destroyStrict/clearData must be present since real listener teardown code can call any of them on a persistence handle. mockNoopDestroy is a stable reference because a test below asserts teardownLocalFirst() actually invoked it; the other four stay plain no-op closures since nothing currently asserts on them.
 const mockNoopDestroy = vi.fn().mockResolvedValue(undefined);
 vi.mock('../../services/localFirst/docPersistence', () => ({
   NOOP_PERSISTENCE: {
     active: false,
     whenSynced: Promise.resolve(),
     destroy: (...args: unknown[]) => mockNoopDestroy(...args),
+    destroyStrict: (...args: unknown[]) => mockNoopDestroy(...args),
     clearData: () => Promise.resolve(),
   },
   persistProjectDoc: vi.fn(() => ({
     active: true,
     whenSynced: Promise.resolve(),
     destroy: () => Promise.resolve(),
+    destroyStrict: () => Promise.resolve(),
     clearData: () => Promise.resolve(),
   })),
 }));
@@ -694,6 +696,7 @@ describe('local-first shadow sync (B1.1)', () => {
       active: false,
       whenSynced: Promise.resolve(),
       destroy: () => Promise.resolve(),
+      destroyStrict: () => Promise.resolve(),
       clearData: () => Promise.resolve(),
     };
     const realActive = {
@@ -763,6 +766,7 @@ describe('local-first shadow sync (B1.1)', () => {
       whenSynced: Promise.resolve(),
       clearData,
       destroy,
+      destroyStrict: destroy,
     });
 
     // localFirstHandle is module-global; explicitly tear down any handle left by a preceding test.
@@ -771,6 +775,7 @@ describe('local-first shadow sync (B1.1)', () => {
     await vi.advanceTimersByTimeAsync(100);
     warmupStore.dispatch(featureFlagsActions.setEnableLocalFirstSync(false));
     await vi.advanceTimersByTimeAsync(100);
+    destroy.mockClear();
     vi.mocked(persistProjectDoc).mockClear();
 
     const store = makeFullStore();

--- a/tests/unit/listenerMiddleware.test.ts
+++ b/tests/unit/listenerMiddleware.test.ts
@@ -748,6 +748,52 @@ describe('local-first shadow sync (B1.1)', () => {
     await vi.advanceTimersByTimeAsync(1300);
     expect(persistProjectDoc).toHaveBeenCalledTimes(1);
   });
+
+  it('fails closed when encryption transition cannot clear plaintext local-first data', async () => {
+    const { isIdbEncryptionReady } = await import(
+      '../../services/storage/storageEncryptionService'
+    );
+    const { persistProjectDoc } = await import('../../services/localFirst/docPersistence');
+    const clearData = vi.fn().mockRejectedValue(new Error('wipe failed'));
+    const destroy = vi.fn().mockResolvedValue(undefined);
+
+    vi.mocked(isIdbEncryptionReady).mockReturnValue(false);
+    vi.mocked(persistProjectDoc).mockReturnValue({
+      active: true,
+      whenSynced: Promise.resolve(),
+      clearData,
+      destroy,
+    });
+
+    // localFirstHandle is module-global; explicitly tear down any handle left by a preceding test.
+    const warmupStore = makeFullStore();
+    warmupStore.dispatch(featureFlagsActions.setEnableLocalFirstSync(true));
+    await vi.advanceTimersByTimeAsync(100);
+    warmupStore.dispatch(featureFlagsActions.setEnableLocalFirstSync(false));
+    await vi.advanceTimersByTimeAsync(100);
+    vi.mocked(persistProjectDoc).mockClear();
+
+    const store = makeFullStore();
+    store.dispatch(featureFlagsActions.setEnableLocalFirstSync(true));
+    await vi.advanceTimersByTimeAsync(100);
+    expect(persistProjectDoc).toHaveBeenCalledTimes(1);
+
+    vi.mocked(isIdbEncryptionReady).mockReturnValue(true);
+    store.dispatch(projectActions.updateTitle('Encryption transition'));
+    await vi.advanceTimersByTimeAsync(1300);
+
+    expect(clearData).toHaveBeenCalledTimes(1);
+    expect(destroy).toHaveBeenCalledTimes(1);
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      'Local-First plaintext cleanup failed; shadow sync aborted and persistence disabled:',
+      expect.any(Error),
+    );
+
+    // The failed handle is not reused, and encryption-active follow-up sync stays memory-only.
+    store.dispatch(projectActions.updateTitle('After failed cleanup'));
+    await vi.advanceTimersByTimeAsync(1300);
+    expect(persistProjectDoc).toHaveBeenCalledTimes(1);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/listenerMiddleware.test.ts
+++ b/tests/unit/listenerMiddleware.test.ts
@@ -703,6 +703,7 @@ describe('local-first shadow sync (B1.1)', () => {
       active: true,
       whenSynced: Promise.resolve(),
       destroy: () => Promise.resolve(),
+      destroyStrict: () => Promise.resolve(),
       clearData: () => Promise.resolve(),
     };
     vi.mocked(persistProjectDoc)

--- a/tests/unit/localFirst/docPersistenceErrors.test.ts
+++ b/tests/unit/localFirst/docPersistenceErrors.test.ts
@@ -33,6 +33,14 @@ describe('docPersistence clearData error propagation', () => {
     await destroyPromise;
   });
 
+  it('rejects a wipe requested after provider teardown begins', async () => {
+    const persistence = persistProjectDoc('clear-after-destroy-sync', new Y.Doc());
+
+    await persistence.destroy();
+
+    await expect(persistence.clearData()).rejects.toThrow('destruction has started');
+  });
+
   // QNBS-v3: [Grund: regression for wipe failure propagation / Impact: prevents false cleanup success / Kreativer Mehrwert: keeps encryption transitions fail-closed]
   it('propagates a provider wipe failure to the caller', async () => {
     const failure = new Error('provider wipe failed');

--- a/tests/unit/localFirst/docPersistenceErrors.test.ts
+++ b/tests/unit/localFirst/docPersistenceErrors.test.ts
@@ -23,6 +23,15 @@ describe('docPersistence clearData error propagation', () => {
     mockClearData.mockResolvedValue(undefined);
   });
 
+  // QNBS-v3: prove teardown cannot make a later wipe appear successful / keep the encryption transition from mistaking a detached provider for cleared data.
+  it('rejects a wipe requested after provider teardown begins', async () => {
+    const persistence = persistProjectDoc('clear-after-destroy', new Y.Doc());
+
+    await persistence.destroy();
+
+    await expect(persistence.clearData()).rejects.toThrow('destruction has started');
+  });
+
   it('propagates a provider wipe failure to the caller', async () => {
     const failure = new Error('provider wipe failed');
     mockClearData.mockRejectedValue(failure);

--- a/tests/unit/localFirst/docPersistenceErrors.test.ts
+++ b/tests/unit/localFirst/docPersistenceErrors.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as Y from 'yjs';
+
+const { mockClearData } = vi.hoisted(() => ({
+  mockClearData: vi.fn(),
+}));
+
+vi.mock('y-indexeddb', () => ({
+  IndexeddbPersistence: class {
+    whenSynced = Promise.resolve();
+    destroy = vi.fn().mockResolvedValue(undefined);
+    clearData() {
+      return mockClearData();
+    }
+  },
+}));
+
+import { persistProjectDoc } from '../../../services/localFirst/docPersistence';
+
+describe('docPersistence clearData error propagation', () => {
+  beforeEach(() => {
+    mockClearData.mockReset();
+    mockClearData.mockResolvedValue(undefined);
+  });
+
+  it('propagates a provider wipe failure to the caller', async () => {
+    const failure = new Error('provider wipe failed');
+    mockClearData.mockRejectedValue(failure);
+    const persistence = persistProjectDoc('clear-failure', new Y.Doc());
+
+    try {
+      await expect(persistence.clearData()).rejects.toBe(failure);
+    } finally {
+      await persistence.destroy();
+    }
+  });
+});

--- a/tests/unit/localFirst/docPersistenceErrors.test.ts
+++ b/tests/unit/localFirst/docPersistenceErrors.test.ts
@@ -23,15 +23,17 @@ describe('docPersistence clearData error propagation', () => {
     mockClearData.mockResolvedValue(undefined);
   });
 
-  // QNBS-v3: prove teardown cannot make a later wipe appear successful / keep the encryption transition from mistaking a detached provider for cleared data.
-  it('rejects a wipe requested after provider teardown begins', async () => {
+  // QNBS-v3: prove teardown cannot make a deferred wipe appear successful / keep the encryption transition from mistaking an already-detached provider for cleared data.
+  it('rejects a deferred wipe when provider teardown begins first', async () => {
     const persistence = persistProjectDoc('clear-after-destroy', new Y.Doc());
+    const clearPromise = persistence.clearData();
+    const destroyPromise = persistence.destroy();
 
-    await persistence.destroy();
-
-    await expect(persistence.clearData()).rejects.toThrow('destruction has started');
+    await expect(clearPromise).rejects.toThrow('destruction has started');
+    await destroyPromise;
   });
 
+  // QNBS-v3: [Grund: regression for wipe failure propagation / Impact: prevents false cleanup success / Kreativer Mehrwert: keeps encryption transitions fail-closed]
   it('propagates a provider wipe failure to the caller', async () => {
     const failure = new Error('provider wipe failed');
     mockClearData.mockRejectedValue(failure);


### PR DESCRIPTION
## **User description**
Refs #602

## Summary
- propagate DocPersistence.clearData() provider failures instead of treating a failed plaintext wipe as success;
- abort the current local-first shadow sync and tear down the cached handle on cleanup failure;
- keep subsequent encryption-active local-first operation memory-only;
- add focused provider-propagation and reconciliation fail-closed regression coverage.

## Scope
This is the bounded #602-A encryption-remanence slice. It addresses the direct clearData()/reconcileLocalFirstHandle() failure-truth invariant only.

## Non-goals
Safari dynamic local-first database enumeration, IdbConnectionManager test-closer disposal, general cancellation/lifecycle, provider/model work, reset redesign, and unrelated cleanup remain separate durable work. #602 stays open for those residuals.

## Verification
- focused Vitest: 2 files, 38 tests passing;
- explicit-base pnpm run ci:prepush: passing sequentially;
- PR budget: 5 files / 132 meaningful lines / 1 commit;
- no secrets or provider calls.

This PR is intentionally a slice and does not close umbrella #602.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates local-first plaintext wipe failures during encryption transitions instead of silently treating a failed wipe as success, so leftover plaintext can no longer persist after encryption is enabled.

**Bug Fixes**
- Failing `clearData()` now aborts the shadow sync, tears down the cached handle, and keeps subsequent encryption-active operations memory-only.
- Adds a strict `destroyStrict()` teardown path so a failed provider detach is observable instead of swallowed.
- A deferred wipe that races with teardown now rejects instead of resolving as a no-op.
- Adds regression coverage for wipe failure propagation and the fail-closed reconciliation path; README test metrics updated.

<sup>Written for commit ad4fc3b58ab3a4c2ce16a95aae6ed13358f4248d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/qnbs/WorldScript-Studio/pull/738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Summary by Sourcery

Fail closed when local-first plaintext cleanup fails during encryption transitions.

Bug Fixes:
- Propagate local-first plaintext wipe failures during encryption transitions instead of treating cleanup as successful.
- Fail closed by aborting shadow sync, removing the cached persistence handle, and keeping subsequent encryption-active operations memory-only when cleanup fails.

Enhancements:
- Expose strict persistence teardown failures and reject cleanup requests that race with provider destruction.

Tests:
- Add regression coverage for provider wipe propagation, teardown races, and fail-closed local-first reconciliation.

Chores:
- Update documented test counts and changelog entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of failed local data cleanup during encryption transitions.
  - Ensured invalid persistence handles are not reused after cleanup failures.
  - Persistence wipe and teardown errors are now surfaced appropriately.
  - Subsequent synchronization safely remains in memory-only mode when cleanup fails.

- **Tests**
  - Added regression coverage for cleanup and persistence destruction failures.

- **Documentation**
  - Updated the README with current repository test metrics.
  - Documented local-first encryption transition behavior in the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Fail closed when local-first plaintext cleanup fails during encryption transitions

### What Changed
- Failed plaintext cleanup is now reported instead of being treated as successful.
- Encryption transitions abort the current local-first sync, remove the cached persistence handle, and keep follow-up syncs memory-only.
- Cleanup requests that race with provider shutdown now fail clearly, and provider teardown failures remain observable.
- Added regression coverage for cleanup, teardown, and fail-closed behavior.

### Impact
`✅ Prevented reuse of local-first persistence after failed plaintext cleanup`
`✅ Fewer silent encryption-transition failures`
`✅ Clearer local-first cleanup errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>